### PR TITLE
Fix 'end turn' button's state issue.

### DIFF
--- a/changelog
+++ b/changelog
@@ -9,6 +9,7 @@ Version 1.11.2+dev:
      text box overflow occurs.
    * Change Difficulty checkbox in Load Game dialog in GUI1 gets disabled if
      change in difficulty of a loading game won't take effect (bug #20381).
+   * Fixed 'end turn' button's state issue: button stays disabled after the first turn.
  * WML engine:
    * Fixed invalid memory access issues caused by subnamespaced persistent WML
      variables (bug #20385).

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -693,6 +693,7 @@ void playsingle_controller::before_human_turn(bool save)
 	browse_ = false;
 	linger_ = false;
 
+	set_button_state(*gui_);
 
 	ai::manager::raise_turn_started();
 


### PR DESCRIPTION
The issue: the 'end turn' button remains disabled after the first turn unless its state is set by triggered action of recruit, recall etc.

My solution is to call 'set_button_state()' inside 'before_human_turn()' function in order to make sure that 'end turn' button's state is correct.
