### PR TITLE
Fixes bug #20765

### DIFF
--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -1809,7 +1809,9 @@ void unit::start_animation(int start_time, const unit_animation *animation,
 {
 	const display * disp =  display::get_singleton();
 	if (!animation) {
-		if (!anim_ || state_ != STATE_STANDING)
+		if (state == STATE_STANDING)
+			state_ = state;
+		if (!anim_ && state_ != STATE_STANDING)
 			set_standing(with_bars);
 		return ;
 	}


### PR DESCRIPTION
The change is small, but it took some time to hunt this bug down.

....

A call to unit::redraw_unit would check if the unit contains any animation. If
no animation is found, then it would call set_standing to put a new animation.

States are usually changed through unit::start_animation. unit::set_standing
uses this approach also. If unit::start_animation is unable to change the unit
to the animation passed as argument, it would try to animate the object calling
unit::set_standing (infinite recursion).

unit::start_animation had a check (maybe to prevent the infinite recursion), but
this check was buggy (if the intent was to prevent the infinite recursion).

The solution add a instruction to successfully set the unit to the state
STATE_STANDING and fixes the check that was using the wrong logical operator.
