### PR TITLE
Using scoped_ptr in unit class (refactor)

### DIFF
--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -613,8 +613,6 @@ unit::~unit()
 {
 	clear_haloes();
 
-	delete anim_;
-
 	// Remove us from the status cache
 	std::vector<const unit *>::iterator itor =
 	std::find(units_with_cache.begin(), units_with_cache.end(), this);
@@ -854,8 +852,7 @@ void unit::advance_to(const config &old_cfg, const unit_type &u_type,
 	cfg_.clear_children("event");
 
 	refreshing_ = false;
-	delete anim_;
-	anim_ = NULL;
+        anim_.reset();
 }
 
 std::string unit::big_profile() const
@@ -1819,8 +1816,7 @@ void unit::start_animation(int start_time, const unit_animation *animation,
 	// everything except standing select and idle
 	bool accelerate = (state != STATE_FORGET && state != STATE_STANDING);
 	draw_bars_ =  with_bars;
-	delete anim_;
-	anim_ = new unit_animation(*animation);
+	anim_.reset(new unit_animation(*animation));
 	const int real_start_time = start_time == INT_MAX ? anim_->get_begin_time() : start_time;
 	anim_->start_animation(real_start_time, loc_, loc_.get_direction(facing_),
 		 text, text_color, accelerate);

--- a/src/unit.hpp
+++ b/src/unit.hpp
@@ -18,6 +18,7 @@
 #define UNIT_H_INCLUDED
 
 #include <boost/tuple/tuple.hpp>
+#include <boost/scoped_ptr.hpp>
 
 #include "formula_callable.hpp"
 #include "portrait.hpp"
@@ -244,8 +245,8 @@ public:
 
 	void set_idling();
 	void set_selecting();
-	unit_animation* get_animation() {  return anim_;};
-	const unit_animation* get_animation() const {  return anim_;};
+	unit_animation* get_animation() {  return anim_.get();};
+	const unit_animation* get_animation() const {  return anim_.get();};
 	void set_facing(map_location::DIRECTION dir);
 	map_location::DIRECTION facing() const { return facing_; }
 
@@ -491,7 +492,7 @@ private:
 	// Animations:
 	std::vector<unit_animation> animations_;
 
-	unit_animation *anim_;
+	boost::scoped_ptr<unit_animation> anim_;
 	int next_idling_;
 	int frame_begin_time_;
 


### PR DESCRIPTION
This change aims to simplify the code, making the intents more explicit.
There wasn't a memory leak in the previous version, but it could easily be
introduced in the future.

Also, RAII is part of the coding standards of Wesnoth, as noted in the wiki.

There are other raw pointers in the unit class, but unit don't own them, then
I leave them unchanged.
