### PR TITLE
Default value for 'allow_player' attribute.

### DIFF
--- a/changelog
+++ b/changelog
@@ -23,6 +23,8 @@ Version 1.11.2+dev:
      variables (bug #20385).
    * fix negative gold carried over (bug #20676)
    * Allow filtering on controller= in SSFs. Cannot be used in networked multiplayer.
+   * When controller in 'side' tag is ai, use 'no' as default value
+     for 'allow_player' attribute.
  * Miscellaneous and bug fixes
    * Switched to git version control. Hosting moved to SourceForge
    * Improved: Autorevision based revision numbers in CMake.

--- a/src/multiplayer_connect.cpp
+++ b/src/multiplayer_connect.cpp
@@ -99,7 +99,6 @@ connect::side::side(connect& parent, const config& cfg, int index) :
 	slider_income_(parent.video()),
 	label_gold_(parent.video(), "100", font::SIZE_SMALL, font::LOBBY_COLOR),
 	label_income_(parent.video(), _("Normal"), font::SIZE_SMALL, font::LOBBY_COLOR),
-	allow_player_(cfg["allow_player"].to_bool(true)),
 	allow_changes_(cfg["allow_changes"].to_bool(true)),
 	enabled_(!parent_->params_.saved_game), changed_(false),
 	llm_(parent.era_sides_, enabled_ ? &combo_leader_ : NULL, enabled_ ? &combo_gender_ : NULL)
@@ -109,6 +108,9 @@ connect::side::side(connect& parent, const config& cfg, int index) :
 	if (cfg_["controller"] == "human_ai"
 			|| cfg_["controller"] == "network_ai")
 		cfg_["controller"] = "ai";
+
+	allow_player_ = (cfg_["controller"] == "ai" && cfg_["allow_player"].empty() ? false : cfg_["allow_player"].to_bool(true));
+
 	if(allow_player_ && enabled_) {
 		controller_ = parent_->default_controller_;
 	} else {


### PR DESCRIPTION
To remove some redundancy from SideWML, I've added a default value 'no' for 'allow_player' attribute when the controller is ai.

Wiki will be updated if pull request is accepted.
