### PR TITLE
Fixed 'end turn' button's state in MP and title2 issues

### DIFF
--- a/changelog
+++ b/changelog
@@ -11,6 +11,7 @@ Version 1.11.2+dev:
    * Updated translations: Chinese (Traditional), Indonesian, Italian, Polish,
      Portuguese, Russian, Vietnamese
  * User interface:
+   * Fixed 'end turn' button's state in MP and title2 issues.
    * Fixed (bug #17220): Cursor in gui2 text box now behaves appropriately after
      text box overflow occurs.
    * Change Difficulty checkbox in Load Game dialog in GUI1 gets disabled if

--- a/src/playmp_controller.cpp
+++ b/src/playmp_controller.cpp
@@ -292,6 +292,7 @@ void playmp_controller::linger()
 	reset_countdown();
 
 	set_end_scenario_button();
+	set_button_state(*gui_);
 
 	if ( get_end_level_data_const().transient.reveal_map ) {
 		// Change the view of all players and observers

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -615,11 +615,18 @@ bool theme::set_resolution(const SDL_Rect& screen)
 		return false;
 	}
 
-	std::map<std::string,std::string> title_stash;
+	std::map<std::string,std::string> title_stash_menus;
 	std::vector<theme::menu>::iterator m;
 	for (m = menus_.begin(); m != menus_.end(); ++m) {
 		if (!m->title().empty() && !m->get_id().empty())
-			title_stash[m->get_id()] = m->title();
+			title_stash_menus[m->get_id()] = m->title();
+	}
+
+	std::map<std::string,std::string> title_stash_actions;
+	std::vector<theme::action>::iterator a;
+	for (a = actions_.begin(); a != actions_.end(); ++a) {
+		if (!a->title().empty() && !a->get_id().empty())
+			title_stash_actions[a->get_id()] = a->title();
 	}
 
 	panels_.clear();
@@ -631,8 +638,13 @@ bool theme::set_resolution(const SDL_Rect& screen)
 	add_object(*current);
 
 	for (m = menus_.begin(); m != menus_.end(); ++m) {
-		if (title_stash.find(m->get_id()) != title_stash.end())
-			m->set_title(title_stash[m->get_id()]);
+		if (title_stash_menus.find(m->get_id()) != title_stash_menus.end())
+			m->set_title(title_stash_menus[m->get_id()]);
+	}
+
+	for (a = actions_.begin(); a != actions_.end(); ++a) {
+		if (title_stash_actions.find(a->get_id()) != title_stash_actions.end())
+			a->set_title(title_stash_actions[a->get_id()]);
 	}
 
 	theme_reset_event_.notify_observers();
@@ -886,7 +898,7 @@ theme::object* theme::refresh_title(const std::string& id, const std::string& ne
 
 	for (std::vector<theme::action>::iterator a = actions_.begin(); a != actions_.end(); ++a){
 		if (a->get_id() == id) {
-			res  = &(*a);
+			res = &(*a);
 			a->set_title(new_title);
 		}
 	}


### PR DESCRIPTION
The 'end turn' button no longer stays disabled on linger in MP and title stash for action buttons were added to keep previous titles after display.redraw_everything().
