### PR TITLE
convert a couple of Windows-isms (backslashes, 'userdata/') to be more x-platform friendly

### DIFF
--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -1496,6 +1496,13 @@ def hack_syntax(filename, lines):
                 precomment = precomment[:backslash.start()] + fronted + precomment[backslash.end():]
                 print '"%s", line %d: %s -> %s -- please use frontslash (/) for cross-platform compatibility' \
                       % (filename, i+1, backslash.group(), fronted)
+        # Then get rid of the 'userdata/' headache.
+        if 'userdata/' in precomment:
+            while re.search(r'user(data/)?data/[ac]', precomment):
+                userdata = re.search(r'(?:\.\./)?user(?:data/)?(data/[ac][^/]*/?)', precomment)
+                precomment = precomment[:userdata.start()] + userdata.group(1) + precomment[userdata.end():]
+                print '"%s", line %d: %s -> %s -- DO NOT PREFIX PATHS WITH "userdata/"' \
+                      % (filename, i+1, userdata.group(), userdata.group(1))
         lines[i] = precomment + comment
     # Ensure that every attack has a translatable description.
     for i in range(len(lines)):


### PR DESCRIPTION
First off, while looking at the conventions of hack_syntax, I noticed that many operations pass on lines that start with "#". Given that many comments are indented, I inserted .lstrip() into them.

As for the other commits:

Why did I place them at the top of hack_syntax instead of at the bottom? First, typically new operations are added to hack_syntax due to changes in WML, but these commits fix problems that transcend any particular Wesnoth version. Second, they would have to go before my code for updating old UMC paths to 'data/add-ons', since the regexes there assume forward slashes.

My log message about "userdata/" includes an ALL CAPS admonition. Perhaps it's too strong, but given how UNIX-centric the dev team is, I'm sure you at least sympathize. (Originally, my log message about backslashes also included caps, but I decided on a more polite approach.) Windows devs can't see the problem because it doesn't affect them, and we have Windows users switching to installing in the program directory, and regarding the problem as "fixed".
