### PR TITLE
Drake animation file name extension was missing

### DIFF
--- a/changelog
+++ b/changelog
@@ -32,6 +32,7 @@ Version 1.11.4+dev:
    * Fix "Shuffle sides" incorrect behaviour: children inside [side] were also
      swapped.
  * Miscellaneous and bug fixes
+   * Fixed minor issue with Drake Clasher animations
    * Added a new playlist FULL_MUSIC_PLAYLIST, which contains all Wesnoth tracks
      in alphabetical order
    * Added -Wno-null-conversion to the CMake pedantic flags.

--- a/data/core/units/drakes/Clasher.cfg
+++ b/data/core/units/drakes/Clasher.cfg
@@ -73,7 +73,7 @@ This is also the only caste that is allowed to break taboo and fight with spears
         offset=0.0~0.1:200,0.1~0.4:150,0.4~0.0:150
         start_time=-300
         [frame]
-            image="units/drakes/clasher-spear-se-1:100,units/drakes/clasher-spear-s-[2~6].png:100"
+            image="units/drakes/clasher-spear-se-1.png:100,units/drakes/clasher-spear-s-[2~6].png:100"
         [/frame]
         {SOUND:HIT_AND_MISS spear.ogg spear-miss.ogg -100}
     [/attack_anim]

--- a/data/core/units/drakes/Enforcer.cfg
+++ b/data/core/units/drakes/Enforcer.cfg
@@ -77,7 +77,7 @@
         offset=0.0~0.1:200,0.1~0.4:150,0.4~0.0:150
         start_time=-300
         [frame]
-            image="units/drakes/enforcer-spear-se-1,units/drakes/enforcer-spear-s-[2~6].png:100"
+            image="units/drakes/enforcer-spear-se-1.png,units/drakes/enforcer-spear-s-[2~6].png:100"
         [/frame]
         {SOUND:HIT_AND_MISS spear.ogg spear-miss.ogg -100}
     [/attack_anim]

--- a/data/core/units/drakes/Thrasher.cfg
+++ b/data/core/units/drakes/Thrasher.cfg
@@ -76,7 +76,7 @@
         offset=0.0~0.1:200,0.1~0.4:150,0.4~0.0:150
         start_time=-300
         [frame]
-            image="units/drakes/thrasher-spear-se-1,units/drakes/thrasher-spear-s-[2~6].png:100"
+            image="units/drakes/thrasher-spear-se-1.png,units/drakes/thrasher-spear-s-[2~6].png:100"
         [/frame]
         {SOUND:HIT_AND_MISS spear.ogg spear-miss.ogg -100}
     [/attack_anim]


### PR DESCRIPTION
Some of the drake .cfg files were missing a file name extension for part of the animation sequence.
