### PR TITLE
append pango code to message about color spec requiring manual fix

### DIFF
--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -782,8 +782,16 @@ def pangoize(message, filename, line):
         amper = message.find('&')
         if message[amper:amper+1].isspace():
             message = message[:amper] + "&amp;" + message[amper+1:]
-    if re.search("<[0-9]+,[0-9]+,[0-9]+>", message):
-        print '"%s", line %d: color spec in line requires manual fix.' % (filename, line)
+    rgb = re.search("(?:<|&lt;)([0-9]+),([0-9]+),([0-9]+)(>|&gt;)", message)
+    if rgb:
+        r = int(rgb.group(1))
+        g = int(rgb.group(2))
+        b = int(rgb.group(3))
+        if ( r or g or b) > 255:
+            print '"%s", line %d: RGB color value over 255 requires manual fix (%s).' % (filename, line, rgb.group())
+        else:
+            hexed = hex(r).replace('0x', '0')[-2:] + hex(g).replace('0x', '0')[-2:] + hex(b).replace('0x', '0')[-2:]
+            print '"%s", line %d: color spec (%s) requires manual fix (<span color=\'#%s\'>, </span>).' % (filename, line, rgb.group(), hexed)
     # Hack old-style Wesnoth markup
     for (oldstyle, newstart, newend) in pango_conversions:
         if oldstyle not in message:


### PR DESCRIPTION
The commit message has the relevant details.

I consider this commit to be something of a stopgap. In the long term, there are a lot of improvements to be made to pangoize, such as:
- It only works on a message= key, inside a [message] tag. There are other places where markup is used; at the least, pangoize should probably check all translatables.
- It does not work when there is more than one markup symbol, for example for both large text and bold.
- Other stuff.

For now, this is a modest improvement; let's not make perfect the enemy of better.
