### PR TITLE
Coffee recruitment facing direction

### DIFF
--- a/src/actions/create.cpp
+++ b/src/actions/create.cpp
@@ -962,21 +962,21 @@ bool place_recruit(const unit &u, const map_location &recruit_location, const ma
 		}
 		if (y >= y1) {
 			if (x < x1) {
-				facing_dir.push_back (map_location::SOUTH_EAST);
+				facing_dir.push_back (map_location::NORTH_EAST);
 			}
 			else if (x < x2) {
-				facing_dir.push_back (map_location::SOUTH_EAST);
-				facing_dir.push_back (map_location::SOUTH);
+				facing_dir.push_back (map_location::NORTH_EAST);
+				facing_dir.push_back (map_location::NORTH);
 			}
 			else if (x < x3) {
-				facing_dir.push_back (map_location::SOUTH);
+				facing_dir.push_back (map_location::NORTH);
 			}
 			else if (x < x4) {
-				facing_dir.push_back (map_location::SOUTH);
-				facing_dir.push_back (map_location::SOUTH_WEST);
+				facing_dir.push_back (map_location::NORTH);
+				facing_dir.push_back (map_location::NORTH_WEST);
 			}
 			else {
-				facing_dir.push_back (map_location::SOUTH_WEST);
+				facing_dir.push_back (map_location::NORTH_WEST);
 			}
 		}
 		if (y >= y1 && y < y2) {


### PR DESCRIPTION
For Fabi, et al.

This pull request adds an initial recruitment facing direction, instead of the old random direction. It works like so:

If an enemy unit is visible, the one with the shortest distance - unit level is chosen and the direction of the new recruit faces this visible enemy unit. Otherwise, the newly recruited unit faces towards the centre, but with increasing randomness as the map coordinates approach the centre, where it may face in any direction.
