### PR TITLE
New WEAPON_SPECIAL_DRAIN_VALUE Macro

### DIFF
--- a/data/core/macros/abilities.cfg
+++ b/data/core/macros/abilities.cfg
@@ -678,6 +678,17 @@ Enemy units cannot see this unit while it is in deep water, except if they have 
     [/drains]
 #enddef
 
+#define WEAPON_SPECIAL_DRAIN_VALUE VALUE
+    # Canned definition of the Drain ability to be included in a
+    # [specials] clause.
+    [drains]
+        id=drains_{VALUE}
+        name= _ "drains"
+        description= _ "This unit drains health from living units, healing itself for {VALUE}% the amount of damage it deals (rounded down)."
+		value={VALUE}
+    [/drains]
+#enddef
+
 #define WEAPON_SPECIAL_FIRSTSTRIKE
     # Canned definition of the First-strike ability to be included in a
     # [specials] clause.


### PR DESCRIPTION
This is a macro that allows for any unit to have a drain percentage of any value, and can be used directly in unit definitions. It provides easy support for the new 'value' attribute in the drains WML.

Even the {VALUE} notation in the description works correctly based on my tests, so the hover description for this macro gives the correct percentage for each unit.
