### PR TITLE
[Mispell] have lead → have led

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
@@ -868,7 +868,7 @@
             [else]
                 [message]
                     speaker=unit
-                    message= _ "I don’t see any spiders, but the water is rising to the southeast as well. The river must have lead to more tunnels than we first thought."
+                    message= _ "I don’t see any spiders, but the water is rising to the southeast as well. The river must have led to more tunnels than we first thought."
                 [/message]
             [/else]
         [/if]


### PR DESCRIPTION
I have to say I only noticed thanks to translation memories, because there is a similar string which says «have led» (the correct spelling) instead.
