### PR TITLE
Speed up AI turns 5-10% by deferring tod creation

### DIFF
--- a/src/terrain_filter.cpp
+++ b/src/terrain_filter.cpp
@@ -231,41 +231,44 @@ bool terrain_filter::match_internal(const map_location& loc, const bool ignore_x
 	const t_string& t_tod_id = cfg_["time_of_day_id"];
 	const std::string& tod_type = t_tod_type;
 	const std::string& tod_id = t_tod_id;
-	static config const dummy_cfg;
-	time_of_day tod(dummy_cfg);
 	if(!tod_type.empty() || !tod_id.empty()) {
+		// creating a time_of_day from a config is expensive, only do it if we will use it
+		static config const dummy_cfg;
+		time_of_day tod(dummy_cfg);
+
 		if(flat_) {
 			tod = resources::tod_manager->get_time_of_day(loc);
 		} else {
 			tod = resources::tod_manager->get_illuminated_time_of_day(loc);
 		}
-	}
-	if(!tod_type.empty()) {
-		const std::vector<std::string>& vals = utils::split(tod_type);
-		if(tod.lawful_bonus<0) {
-			if(std::find(vals.begin(),vals.end(),std::string("chaotic")) == vals.end()) {
-				return false;
-			}
-		} else if(tod.lawful_bonus>0) {
-			if(std::find(vals.begin(),vals.end(),std::string("lawful")) == vals.end()) {
-				return false;
-			}
-		} else if(std::find(vals.begin(),vals.end(),std::string("neutral")) == vals.end()) {
-			return false;
-		}
-	}
 
-	if(!tod_id.empty()) {
-		if(tod_id != tod.id) {
-			if(std::find(tod_id.begin(),tod_id.end(),',') != tod_id.end() &&
-				std::search(tod_id.begin(),tod_id.end(),
-				tod.id.begin(),tod.id.end()) != tod_id.end()) {
-				const std::vector<std::string>& vals = utils::split(tod_id);
-				if(std::find(vals.begin(),vals.end(),tod.id) == vals.end()) {
+		if(!tod_type.empty()) {
+			const std::vector<std::string>& vals = utils::split(tod_type);
+			if(tod.lawful_bonus<0) {
+				if(std::find(vals.begin(),vals.end(),std::string("chaotic")) == vals.end()) {
 					return false;
 				}
-			} else {
+			} else if(tod.lawful_bonus>0) {
+				if(std::find(vals.begin(),vals.end(),std::string("lawful")) == vals.end()) {
+					return false;
+				}
+			} else if(std::find(vals.begin(),vals.end(),std::string("neutral")) == vals.end()) {
 				return false;
+			}
+		}
+
+		if(!tod_id.empty()) {
+			if(tod_id != tod.id) {
+				if(std::find(tod_id.begin(),tod_id.end(),',') != tod_id.end() &&
+					std::search(tod_id.begin(),tod_id.end(),
+					tod.id.begin(),tod.id.end()) != tod_id.end()) {
+					const std::vector<std::string>& vals = utils::split(tod_id);
+					if(std::find(vals.begin(),vals.end(),tod.id) == vals.end()) {
+						return false;
+					}
+				} else {
+					return false;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Profiling --no-gui runs (I used a commercial tool) showed a surprising
amount of time is spent inside terrain_filter::match_internal. This
appears to mostly be as a result of checking every single terrain tile
to determine where the leader location is, which seems ripe for
optimization itself.

However, within this function 5-10% of the time is spent creating a
time_of_day that is rarely used by these AI matches:

One sample run:
![terrain_filter_run1](https://f.cloud.github.com/assets/946653/1018472/fc8bdcc6-0c29-11e3-98b1-87654d7a46f5.png)

A second sample run (there's a lot of variability as I'm not forcing the PRNG seed here; the AI is playing different matches each time):
![terrain_filter_run2](https://f.cloud.github.com/assets/946653/1018474/0f841000-0c2a-11e3-9120-50b7a1f6cc26.png)

Simply reordering the lines to defer its creation until inside the if 
block that checks whether tod is a factor eliminates this part of the
overhead.

This patch speeds AI turns up by 5-10% on my test machine (an 8-core
Linode 2048).
