### PR TITLE
Changes to the movetypes of some undead units

### DIFF
--- a/data/campaigns/Liberty/units/Death_Squire.cfg
+++ b/data/campaigns/Liberty/units/Death_Squire.cfg
@@ -8,6 +8,11 @@
     {LEADING_ANIM "units/undead-skeletal/deathsquire-leading.png" "units/undead-skeletal/deathsquire.png" -16,-30}
     hitpoints=66
     movement_type=undeadfoot
+    [resistance]
+        blade=60
+        impact=120
+        pierce=40
+    [/resistance]
     movement=5
     experience=144
     level=2

--- a/data/core/units/undead/Skele_Chocobone.cfg
+++ b/data/core/units/undead/Skele_Chocobone.cfg
@@ -6,10 +6,15 @@
     image="units/undead-skeletal/chocobone.png"
     {MAGENTA_IS_THE_TEAM_COLOR}
     hitpoints=45
-    movement_type=undeadfoot
-    [defense]
-        village=60
-    [/defense]
+    movement_type=mounted
+    [resistance]
+        blade=80
+        pierce=70
+        impact=110
+        fire=120
+        cold=40
+        arcane=150
+    [/resistance]
     movement=9
     experience=100
     level=2

--- a/data/core/units/undead/Skele_Death_Knight.cfg
+++ b/data/core/units/undead/Skele_Death_Knight.cfg
@@ -9,6 +9,11 @@
     {LEADING_ANIM "units/undead-skeletal/deathknight-lead-2.png" "units/undead-skeletal/deathknight-lead-1.png" -17,-37}
     hitpoints=66
     movement_type=undeadfoot
+    [resistance]
+        blade=60
+        impact=120
+        pierce=40
+    [/resistance]
     movement=5
     experience=150
     level=3


### PR DESCRIPTION
I changed the Death Squire and Death Knight to have the 'regular' Skeleton resistances. Also, I changed the Chocobone so it now uses the mounted movetype, which the regular undeadfoot resistances, like the Skeleton Rider in both Liberty and UtBS does.
