### PR TITLE
Fix two textual errors in data/lan_server.cfg.

### DIFF
--- a/data/lan_server.cfg
+++ b/data/lan_server.cfg
@@ -1,5 +1,5 @@
 motd="Welcome to Wesnoth's LAN server!
-This server allows *any* wesnoth version, so make sure all players have clients with compatible versions! Otherwise, you will run into problems.
-This server will automatically shutdown after all players have left."
+This server allows *any* Wesnoth version, so make sure all players have clients with compatible versions! Otherwise, you will run into problems.
+This server will automatically shut down after all players have left."
 versions_accepted="*"
 lan_server="60"


### PR DESCRIPTION
Fix two minor textual errors in the value of the `motd` attribute in
data/lan_server.cfg:
- “Wesnoth” was not capitalized when it ought to have been capitalized.
- “shutdown” was used as a verb. “shutdown” is a noun; the verb is “shut
  down”.
