### PR TITLE
Correct gold check comparision in recall dialog

### DIFF
--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -693,7 +693,11 @@ void menu_handler::recall(int side_num, const map_location &last_hex)
 	if (res < 0) { 
 		return;
 	}
-	else if(recall_list_team[res]->recall_cost() < 0) {
+	// we need to check if unit has a specific recall cost
+	// if it does we use it elsewise we use the team.recall_cost()
+	// the magic number -1 is what it gets set to if the unit doesn't
+	// have a special recall_cost of its own.
+	else if(recall_list_team[res]->recall_cost() > -1) {
 		unit_cost = recall_list_team[res]->recall_cost();
 	}
 


### PR DESCRIPTION
By correcting the assignment of the cost of the unit it now correctly
says whether or not the play actually has the gold to recall a unit, as
after this check it is assumed they do by the program which creates
the possibility of recalling when you have no gold, or negative gold.

Added comments so that the magic number is explained.
