### PR TITLE
Dugi/addon reviews

### DIFF
--- a/data/gui/default/window/addon_description.cfg
+++ b/data/gui/default/window/addon_description.cfg
@@ -506,7 +506,7 @@
 
 											[label]
 												definition = "default"
-												label = _ "Players' rating:"
+												label = _ "Players’ rating:"
 											[/label]
 
 										[/column]
@@ -540,9 +540,9 @@
 														horizontal_alignment = "right"		
 
 														[button]
-															id = "vote_button"
+															id = "rate_button"
 															definition = "default"
-															label = _ "Vote"
+															label = _ "Rate"
 															tooltip = _ "Upload your rating to the server. You're helping other players with this, so be honest!"
 														[/button]
 

--- a/data/gui/default/window/addon_description.cfg
+++ b/data/gui/default/window/addon_description.cfg
@@ -319,6 +319,7 @@
 										grow_factor = 1
 
 										[column]
+											grow_factor = 1
 											border = "all"
 											border_size = 5
 											vertical_alignment = "top"
@@ -330,7 +331,38 @@
 											[/label]
 
 										[/column]
+
+										[column]
+											grow_factor = 1
+											border = "all"
+											border_size = 5
+											vertical_alignment = "top"
+											horizontal_alignment = "right"		
+
+											[button]
+												id = "view_reviews_button"
+												definition = "default"
+												label = _ "Reviews"
+												tooltip = _ "See what other users think about this add-on."
+											[/button]
+
+										[/column]
+
 									[/row]
+
+								[/grid]
+
+							[/column]
+
+						[/row]
+
+						[row]
+
+							[column]
+
+								horizontal_alignment = "left"
+
+								[grid]
 
 									[row]
 
@@ -338,7 +370,7 @@
 											border = "all"
 											border_size = 5
 											vertical_alignment = "top"
-											horizontal_grow = "true"
+											horizontal_alignment = "left"
 
 											[scroll_label]
 												id = "description"
@@ -459,6 +491,99 @@
 												[/stack]
 
 											[/stacked_widget]
+
+										[/column]
+
+									[/row]
+
+									[row]
+										grow_factor = 1
+
+										[column]
+											border = "all"
+											border_size = 5
+											horizontal_alignment = "left"
+
+											[label]
+												definition = "default"
+												label = _ "Players' rating:"
+											[/label]
+
+										[/column]
+
+										[column]
+											grow_factor = 1
+											horizontal_alignment = "left"
+
+											[grid]
+
+												[row]
+
+													[column]
+														border = "all"
+														border_size = 5
+														vertical_alignment = "top"
+														horizontal_alignment = "left"
+
+														[label]
+															id = "players_rating"
+															definition = "default"
+															label = _ "players_rating^None yet"
+														[/label]
+
+													[/column]
+
+													[column]
+														grow_factor = 1
+														border = "all"
+														border_size = 5
+														horizontal_alignment = "right"		
+
+														[button]
+															id = "vote_button"
+															definition = "default"
+															label = _ "Vote"
+															tooltip = _ "Upload your rating to the server. You're helping other players with this, so be honest!"
+														[/button]
+
+													[/column]
+
+												[/row]
+
+											[/grid]
+
+										[/column]
+
+									[/row]
+
+									[row]
+										grow_factor = 1
+
+										[column]
+											border = "all"
+											border_size = 5
+											vertical_alignment = "top"
+											horizontal_alignment = "left"
+
+											[label]
+												definition = "default"
+												label = _ "Hours spent playing:"
+											[/label]
+
+										[/column]
+
+										[column]
+											border = "all"
+											border_size = 5
+											vertical_alignment = "top"
+											horizontal_alignment = "left"
+
+											[scroll_label]
+												id = "hours_spent_playing"
+												definition = "default"
+												label = "0"
+												tooltip = _ "This is the total time players spent playing this add-on."
+											[/scroll_label]
 
 										[/column]
 

--- a/data/gui/default/window/addon_filter_options.cfg
+++ b/data/gui/default/window/addon_filter_options.cfg
@@ -382,7 +382,7 @@
 								[grid]
 									[row]
 										grow_factor = 0
-										{_GUI_ADDON_SORT_OPTION by_rating ( _ "sort^By rating")}
+										{_GUI_ADDON_SORT_OPTION by_score ( _ "sort^By score")}
 									[/row]
 
 									[row]

--- a/data/gui/default/window/addon_filter_options.cfg
+++ b/data/gui/default/window/addon_filter_options.cfg
@@ -349,6 +349,10 @@
 								vertical_alignment = "top"
 
 								[grid]
+									[row]
+										grow_factor = 0
+										{_GUI_ADDON_SORT_OPTION by_rating ( _ "sort^By rating")}
+									[/row]
 
 									[row]
 										grow_factor = 0

--- a/data/gui/default/window/addon_filter_options.cfg
+++ b/data/gui/default/window/addon_filter_options.cfg
@@ -316,6 +316,37 @@
 				grow_factor = 0
 
 				[column]
+					horizontal_alignment = "left"
+
+					[grid]
+
+						[row]
+							grow_factor = 0
+
+							[column]
+								border = "all"
+								border_size = 5
+								horizontal_alignment = "left"
+
+								[toggle_button]
+									id = "upload_statistics"
+									definition = "default"
+									label = _"Upload statistics of playing add-ons"
+								[/toggle_button]
+
+							[/column]
+
+						[/row]
+
+					[/grid]
+				[/column]
+
+			[/row]
+
+			[row]
+				grow_factor = 0
+
+				[column]
 					border = "all"
 					border_size = 5
 					horizontal_alignment = "left"

--- a/data/gui/default/window/addon_rate.cfg
+++ b/data/gui/default/window/addon_rate.cfg
@@ -39,7 +39,7 @@
 						id = "window_title"
 						definition = "title"
 
-						label = _ "Rate This Add-on"
+						label = _ "Rate Add-on"
 					[/label]
 
 				[/column]

--- a/data/gui/default/window/addon_rate.cfg
+++ b/data/gui/default/window/addon_rate.cfg
@@ -86,9 +86,9 @@
 								 	definition = "default"
 									best_slider_length = 220
 									minimum_value = 0
-									maximum_value = 100
+									maximum_value = 10
 									step_size = 1
-									tooltip = _ "Insert the rating from 0 to 10. You are helping others, so be honest! If the add-on is only a dependency of some other add-on, rate this add-on and not the one depending on it."
+									tooltip = _ "Insert the rating from 0 to 10. You are helping others, so be honest! If the add-on is only a dependency of some other add-on, try to rate this add-on as standalone and not the one depending on it."
 								[/slider]
 
 							[/column]

--- a/data/gui/default/window/addon_rate.cfg
+++ b/data/gui/default/window/addon_rate.cfg
@@ -1,0 +1,156 @@
+#textdomain wesnoth-lib
+###
+### Definition of the window to learn the player's rating of an add-on
+###
+
+[window]
+	id = "addon_rate"
+	description = "Add-on rating dialog."
+
+	[resolution]
+		definition = "default"
+
+		automatic_placement = "true"
+		vertical_placement = "center"
+		horizontal_placement = "center"
+		maximum_width = 500
+		maximum_height = 600
+
+		[tooltip]
+			id = "tooltip_large"
+		[/tooltip]
+
+		[helptip]
+			id = "tooltip_large"
+		[/helptip]
+
+		[grid]
+
+			[row]
+				grow_factor = 0
+
+				[column]
+					grow_factor = 1
+
+					border = "all"
+					border_size = 5
+					horizontal_alignment = "left"
+					[label]
+						id = "window_title"
+						definition = "title"
+
+						label = _ "Rate this add-on"
+					[/label]
+
+				[/column]
+
+			[/row]
+
+			[row]
+				grow_factor = 1
+
+				[column]
+					grow_factor = 1
+
+					horizontal_grow = "true"
+
+					[grid]
+
+						[row]
+							grow_factor = 1
+
+							[column]
+								grow_factor = 0
+
+								border = "all"
+								border_size = 5
+								horizontal_alignment = "left"
+
+								[label]
+									definition = "default"
+
+									label = _ "Your rating:"
+								[/label]
+
+							[/column]
+
+							[column]
+								grow_factor = 1
+
+								border = "all"
+								border_size = 5
+								horizontal_grow = "true"
+
+								[slider]
+									id = "rating_input"
+								 	definition = "default"
+									best_slider_length = 220
+									minimum_value = 0
+									maximum_value = 100
+									step_size = 1
+									tooltip = _ "Insert the rating from 0 to 10. You are helping others, so be honest! If the add-on is only a dependency of some other add-on, rate this add-on and not the one depending on it."
+								[/slider]
+
+							[/column]
+
+						[/row]
+
+					[/grid]
+
+				[/column]
+
+			[/row]
+
+			[row]
+				grow_factor = 0
+
+				[column]
+					horizontal_alignment = "right"
+
+					[grid]
+
+						[row]
+							grow_factor = 0
+
+							[column]
+								border = "all"
+								border_size = 5
+								horizontal_alignment = "right"
+
+								[button]
+									id = "ok"
+									definition = "default"
+
+									size_text = _ "OK"
+									label = _ "OK"
+								[/button]
+
+							[/column]
+
+							[column]
+								border = "all"
+								border_size = 5
+								horizontal_alignment = "right"
+
+								[button]
+									id = "cancel"
+									definition = "default"
+
+									label = _ "Cancel"
+								[/button]
+
+							[/column]
+
+						[/row]
+
+					[/grid]
+
+				[/column]
+
+			[/row]
+
+		[/grid]
+
+	[/resolution]
+
+[/window]

--- a/data/gui/default/window/addon_rate.cfg
+++ b/data/gui/default/window/addon_rate.cfg
@@ -39,7 +39,7 @@
 						id = "window_title"
 						definition = "title"
 
-						label = _ "Rate this add-on"
+						label = _ "Rate This Add-on"
 					[/label]
 
 				[/column]
@@ -121,8 +121,7 @@
 									id = "ok"
 									definition = "default"
 
-									size_text = _ "OK"
-									label = _ "OK"
+									label = _ "Rate"
 								[/button]
 
 							[/column]

--- a/data/gui/default/window/addon_review_write.cfg
+++ b/data/gui/default/window/addon_review_write.cfg
@@ -1,0 +1,321 @@
+#textdomain wesnoth-lib
+###
+### Definition of the window to learn the player's rating of an add-on
+###
+
+[window]
+	id = "addon_review_write"
+	description = "Add-on review writing dialog."
+
+	[resolution]
+		definition = "default"
+
+		automatic_placement = "true"
+		vertical_placement = "center"
+		horizontal_placement = "center"
+#		maximum_width = 800
+		maximum_height = 600
+
+		[tooltip]
+			id = "tooltip_large"
+		[/tooltip]
+
+		[helptip]
+			id = "tooltip_large"
+		[/helptip]
+
+		[grid]
+
+			[row]
+				grow_factor = 0
+
+				[column]
+					grow_factor = 1
+
+					border = "all"
+					border_size = 5
+					horizontal_alignment = "left"
+					[label]
+						id = "title"
+						definition = "title"
+
+						label = _ "Review this add-on"
+					[/label]
+
+				[/column]
+
+			[/row]
+
+			[row]
+				grow_factor = 1
+
+				[column]
+					grow_factor = 1
+
+					horizontal_grow = "true"
+
+					[grid]
+
+						[row]
+							grow_factor = 1
+
+							[column]
+								grow_factor = 0
+
+								border = "all"
+								border_size = 5
+								horizontal_alignment = "left"
+
+								[label]
+									definition = "default"
+
+									label = _ "Gameplay - describe how playing this add-on feels like and what are its pecularities that make it differ."
+								[/label]
+
+							[/column]
+
+						[/row]
+
+						[row]
+							grow_factor = 1
+
+							[column]
+								grow_factor = 1
+
+								border = "all"
+								border_size = 5
+								horizontal_grow = "true"
+
+								[text_box]
+									id = "gameplay_input"
+									definition = "default"
+									label = ""
+									tooltip = _ "Write what belongs to the gameplay section of the review. Leave blank if you have nothing to write here."
+								[/text_box]
+
+							[/column]
+
+						[/row]
+
+						[row]
+							grow_factor = 1
+
+							[column]
+								grow_factor = 0
+
+								border = "all"
+								border_size = 5
+								horizontal_alignment = "left"
+
+								[label]
+									definition = "default"
+
+									label = _ "Visuals - write about the visual impression this add-on gives and how good are its custom graphics if it has any."
+								[/label]
+
+							[/column]
+
+						[/row]
+
+						[row]
+							grow_factor = 1
+
+							[column]
+								grow_factor = 1
+
+								border = "all"
+								border_size = 5
+								horizontal_grow = "true"
+
+								[text_box]
+									id = "visuals_input"
+									definition = "default"
+									label = ""
+									tooltip = _ "Write what belongs to the visuals section of the review. Leave blank if irrelevant."
+								[/text_box]
+
+							[/column]
+
+						[/row]
+
+						[row]
+							grow_factor = 1
+
+							[column]
+								grow_factor = 0
+
+								border = "all"
+								border_size = 5
+								horizontal_alignment = "left"
+
+								[label]
+									definition = "default"
+
+									label = _ "Story - don't describe the events that happen, focus rather on its immersiveness and quality."
+								[/label]
+
+							[/column]
+
+						[/row]
+
+						[row]
+							grow_factor = 1
+
+							[column]
+								grow_factor = 1
+
+								border = "all"
+								border_size = 5
+								horizontal_grow = "true"
+
+								[text_box]
+									id = "story_input"
+									definition = "default"
+									label = ""
+									tooltip = _ "Write what belongs to the story section of the review. Leave blank if irrelevant."
+								[/text_box]
+
+							[/column]
+
+						[/row]
+
+						[row]
+							grow_factor = 1
+
+							[column]
+								grow_factor = 0
+
+								border = "all"
+								border_size = 5
+								horizontal_alignment = "left"
+
+								[label]
+									definition = "default"
+
+									label = _ "Balance - comment how balanced is this add-on, how difficult is it and if its difficulty doesn't vary too much."
+								[/label]
+
+							[/column]
+
+						[/row]
+
+						[row]
+							grow_factor = 1
+
+							[column]
+								grow_factor = 1
+
+								border = "all"
+								border_size = 5
+								horizontal_grow = "true"
+
+								[text_box]
+									id = "balance_input"
+									definition = "default"
+									label = ""
+									tooltip = _ "Write what belongs to the balance section of the review. Leave blank if you have nothing to write here."
+								[/text_box]
+
+							[/column]
+
+						[/row]
+
+						[row]
+							grow_factor = 1
+
+							[column]
+								grow_factor = 0
+
+								border = "all"
+								border_size = 5
+								horizontal_alignment = "left"
+
+								[label]
+									definition = "default"
+
+									label = _ "Overall - describe the overall impression this add-on gives and what kind of players would you recommend it to."
+								[/label]
+
+							[/column]
+
+						[/row]
+
+						[row]
+							grow_factor = 1
+
+							[column]
+								grow_factor = 1
+
+								border = "all"
+								border_size = 5
+								horizontal_grow = "true"
+
+								[text_box]
+									id = "balance_input"
+									definition = "default"
+									label = ""
+									tooltip = _ "Write what belongs to the overall section of the review. Leave blank if you have nothing to write here."
+								[/text_box]
+
+							[/column]
+
+						[/row]
+					[/grid]
+
+				[/column]
+
+			[/row]
+
+			[row]
+				grow_factor = 0
+
+				[column]
+					horizontal_alignment = "right"
+
+					[grid]
+
+						[row]
+							grow_factor = 0
+
+							[column]
+								border = "all"
+								border_size = 5
+								horizontal_alignment = "right"
+
+								[button]
+									id = "ok"
+									definition = "default"
+
+									size_text = _ "OK"
+									label = _ "OK"
+								[/button]
+
+							[/column]
+
+							[column]
+								border = "all"
+								border_size = 5
+								horizontal_alignment = "right"
+
+								[button]
+									id = "cancel"
+									definition = "default"
+
+									label = _ "Cancel"
+								[/button]
+
+							[/column]
+
+						[/row]
+
+					[/grid]
+
+				[/column]
+
+			[/row]
+
+		[/grid]
+
+	[/resolution]
+
+[/window]

--- a/data/gui/default/window/addon_review_write.cfg
+++ b/data/gui/default/window/addon_review_write.cfg
@@ -251,7 +251,7 @@
 								horizontal_grow = "true"
 
 								[text_box]
-									id = "balance_input"
+									id = "overall_input"
 									definition = "default"
 									label = ""
 									tooltip = _ "Write what belongs to the overall section of the review. Leave blank if you have nothing to write here."

--- a/data/gui/default/window/addon_review_write.cfg
+++ b/data/gui/default/window/addon_review_write.cfg
@@ -39,7 +39,7 @@
 						id = "title"
 						definition = "title"
 
-						label = _ "Review this add-on"
+						label = _ "Write Review"
 					[/label]
 
 				[/column]
@@ -151,7 +151,7 @@
 								[label]
 									definition = "default"
 
-									label = _ "Story - don't describe the events that happen, focus rather on its immersiveness and quality."
+									label = _ "Story - do not describe the events that happen, focus rather on its immersiveness and quality."
 								[/label]
 
 							[/column]
@@ -192,7 +192,7 @@
 								[label]
 									definition = "default"
 
-									label = _ "Balance - comment how balanced is this add-on, how difficult is it and if its difficulty doesn't vary too much."
+									label = _ "Balance - comment how balanced is this add-on, how difficult is it and if its difficulty does not vary too much."
 								[/label]
 
 							[/column]

--- a/data/gui/default/window/addon_reviews_list.cfg
+++ b/data/gui/default/window/addon_reviews_list.cfg
@@ -56,6 +56,25 @@
 			[/row]
 
 			[row]
+				grow_factor = 0
+
+				[column]
+					grow_factor = 1
+
+					border = "all"
+					border_size = 5
+					horizontal_alignment = "left"
+					[label]
+						id = "initial_comment"
+						definition = "default"
+						label = _ "There are no reviews for this add-on yet. If you know this add-on, help fellow players and add your own review!"
+					[/label]
+
+				[/column]
+
+			[/row]
+
+			[row]
 				grow_factor = 1
 
 				[column]
@@ -163,7 +182,7 @@
 								[button]
 									id = "ok"
 									definition = "default"
-									label = _ "Back"
+									label = _ "Close"
 								[/button]
 
 							[/column]

--- a/data/gui/default/window/addon_reviews_list.cfg
+++ b/data/gui/default/window/addon_reviews_list.cfg
@@ -48,7 +48,7 @@
 					horizontal_alignment = "left"
 					[label]
 						definition = "title"
-						label = _ "Add-on reviews"
+						label = _ "Add-on Reviews"
 					[/label]
 
 				[/column]
@@ -64,11 +64,11 @@
 					border = "all"
 					border_size = 5
 					horizontal_alignment = "left"
-					[label]
+					[scroll_label]
 						id = "initial_comment"
 						definition = "default"
 						label = _ "There are no reviews for this add-on yet. If you know this add-on, help fellow players and add your own review!"
-					[/label]
+					[/scroll_label]
 
 				[/column]
 
@@ -129,7 +129,7 @@
 																[label]
 																	id = "people_who_agree"
 																	definition = "default"
-																	label = _ "0 people like this review. Do you like it too?"
+																	label = _ "This review has not been rated before. Do you like this review?"
 																	linked_group = "X_people_like_this"
 																[/label]
 															[/column]

--- a/data/gui/default/window/addon_reviews_list.cfg
+++ b/data/gui/default/window/addon_reviews_list.cfg
@@ -1,0 +1,197 @@
+#textdomain wesnoth-lib
+###
+### Definition of the window to view the descriptions of a selected add-on.
+###
+
+[window]
+	id = "addon_reviews_list"
+	description = "Show the reviews written for an add-on."
+
+	[resolution]
+		definition = "default"
+
+		automatic_placement = "true"
+		vertical_placement = "center"
+		horizontal_placement = "center"
+
+		maximum_width = 800
+		maximum_height = 600
+		
+		[linked_group]
+			id = "X_people_like_this"
+			fixed_width = "true"
+		[/linked_group]
+
+		[linked_group]
+			id = "checkbox"
+			fixed_width = "true"
+		[/linked_group]
+
+		[tooltip]
+			id = "tooltip_large"
+		[/tooltip]
+
+		[helptip]
+			id = "tooltip_large"
+		[/helptip]
+
+		[grid]
+
+			[row]
+				grow_factor = 0
+
+				[column]
+					grow_factor = 1
+
+					border = "all"
+					border_size = 5
+					horizontal_alignment = "left"
+					[label]
+						definition = "title"
+						label = _ "Add-on reviews"
+					[/label]
+
+				[/column]
+
+			[/row]
+
+			[row]
+				grow_factor = 1
+
+				[column]
+					grow_factor = 1
+
+					horizontal_grow = "true"
+					vertical_grow = "true"
+
+					border = "all"
+					border_size = 5
+
+					[listbox]
+						id = "reviews_list"
+						definition = "default"
+
+						[list_definition]
+
+							[row]
+
+								[column]
+								 	vertical_grow = "true"
+								 	horizontal_grow = "true"
+								 	[toggle_panel]
+										definition = "default"
+										return_value_id = "ok"
+										[grid]
+											[row]
+												[column]
+													grow_factor = 1
+													horizontal_grow = "true"
+													border = "all"
+													border_size = 5
+													[scroll_label]
+														id = "review_box"
+														definition = "default"
+													[/scroll_label]
+												[/column]
+											[/row]
+											[row]
+												[column]
+													grow_factor = 1
+													horizontal_alignment = "left"
+													border = "all"
+													border_size = 5
+													[grid]
+														[row]
+															[column]
+																grow_factor = 1
+																horizontal_grow = "true"
+																border = "all"
+																border_size = 5
+																[label]
+																	id = "people_who_agree"
+																	definition = "default"
+																	label = _ "0 people like this review. Do you like it too?"
+																	linked_group = "X_people_like_this"
+																[/label]
+															[/column]
+															[column]
+																grow_factor = 1
+																horizontal_alignment = "left"
+																border = "all"
+																border_size = 5
+																[toggle_button]
+																	id = "player_agrees"
+																	definition = "default"
+																	tooltip = _ "Check it if you like this review."
+																	linked_group = "checkbox"
+																[/toggle_button]
+															[/column]
+														[/row]
+													[/grid]
+												[/column]
+											[/row]
+										[/grid]
+									[/toggle_panel]
+								[/column]
+
+							[/row]
+
+						[/list_definition]
+
+					[/listbox]
+
+				[/column]
+
+			[/row]
+
+			[row]
+				grow_factor = 0
+
+				[column]
+					horizontal_alignment = "right"
+
+					[grid]
+
+						[row]
+							grow_factor = 0
+
+							[column]
+								border = "all"
+								border_size = 5
+								horizontal_alignment = "right"
+
+								[button]
+									id = "ok"
+									definition = "default"
+									label = _ "Back"
+								[/button]
+
+							[/column]
+
+							[column]
+								border = "all"
+								border_size = 5
+								horizontal_alignment = "right"
+
+								[button]
+									id = "write_a_review"
+									definition = "default"
+									label = _ "Write a review"
+									tooltip = _ "Click here to open a window to help fellow players and write your own review about this add-on."
+								[/button]
+
+							[/column]
+
+						[/row]
+
+					[/grid]
+
+				[/column]
+
+			[/row]
+
+		[/grid]
+
+	[/resolution]
+
+[/window]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -795,7 +795,9 @@ set(wesnoth-main_SRC
 	gui/auxiliary/timer.cpp
 	gui/dialogs/addon/description.cpp
 	gui/dialogs/addon/addon_rate.cpp
+	gui/dialogs/addon/addon_review_write.cpp
 	gui/dialogs/addon/filter_options.cpp
+	gui/dialogs/addon/reviews_list.cpp
 	gui/dialogs/addon/uninstall_list.cpp
 	gui/dialogs/addon_connect.cpp
 	gui/dialogs/addon_list.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -794,6 +794,7 @@ set(wesnoth-main_SRC
 	gui/auxiliary/old_markup.cpp
 	gui/auxiliary/timer.cpp
 	gui/dialogs/addon/description.cpp
+	gui/dialogs/addon/addon_rate.cpp
 	gui/dialogs/addon/filter_options.cpp
 	gui/dialogs/addon/uninstall_list.cpp
 	gui/dialogs/addon_connect.cpp

--- a/src/SConscript
+++ b/src/SConscript
@@ -364,8 +364,11 @@ wesnoth_sources = Split("""
     gui/auxiliary/window_builder/tree_view.cpp
     gui/auxiliary/window_builder/vertical_scrollbar.cpp
     gui/auxiliary/window_builder/viewport.cpp
+    gui/dialogs/addon/addon_rate.cpp
+    gui/dialogs/addon/addon_review_write.cpp
     gui/dialogs/addon/description.cpp
     gui/dialogs/addon/filter_options.cpp
+    gui/dialogs/addon/reviews_list.cpp
     gui/dialogs/addon/uninstall_list.cpp
     gui/dialogs/addon_connect.cpp
     gui/dialogs/addon_list.cpp

--- a/src/addon/client.cpp
+++ b/src/addon/client.cpp
@@ -100,7 +100,6 @@ bool addons_client::submit_gameplay_times()
 		added["time"] = entry["time"];
 		LOG_ADDONS << "Uploading_gameplay_times for " << entry["name"] << std::endl;
 	}
-	prefs->clear_children("gameplay_times");
 
 	this->send_request(request, response_buf);
 	this->wait_for_transfer_done(_("Sending information about the add-ons you spent playing"));

--- a/src/addon/client.cpp
+++ b/src/addon/client.cpp
@@ -98,11 +98,12 @@ bool addons_client::submit_gameplay_times()
 		config& added = request_body.add_child("played_addon");
 		added["name"] = entry["name"];
 		added["time"] = entry["time"];
-		std::cout << "Uploading_gameplay_times for " << entry["name"] << std::endl;
+		LOG_ADDONS << "Uploading_gameplay_times for " << entry["name"] << std::endl;
 	}
 	prefs->clear_children("gameplay_times");
 
 	this->send_request(request, response_buf);
+	this->wait_for_transfer_done(_("Sending information about the add-ons you spent playing"));
 
 	return !this->update_last_error(response_buf);
 }
@@ -114,6 +115,7 @@ bool addons_client::request_distribution_terms(std::string& terms)
 	config response_buf;
 
 	this->send_simple_request("request_terms", response_buf);
+
 	this->wait_for_transfer_done(_("Requesting distribution terms..."));
 
 	if(const config& msg_cfg = response_buf.child("message")) {
@@ -313,7 +315,7 @@ bool addons_client::rate_addon(config& archive_cfg, addon_info::this_users_ratin
 	LOG_ADDONS << "rating add-on " << rating.id << '\n';
 
 	this->send_request(request_buf, archive_cfg);
-	//this->wait_for_transfer_done(vgettext("Sending information about your rating of the <i>$addon_title</i> add-on...", i18n_symbols));
+	this->wait_for_transfer_done(vgettext("Sending information about your rating of the <i>$addon_title</i> add-on...", i18n_symbols));
 
 	return !this->update_last_error(archive_cfg);
 }

--- a/src/addon/client.cpp
+++ b/src/addon/client.cpp
@@ -262,6 +262,39 @@ bool addons_client::install_addon(config& archive_cfg, const addon_info& info)
 	return true;
 }
 
+bool addons_client::rate_addon(config& archive_cfg, addon_info::this_users_rating rating)
+{
+
+	config request_buf;
+	config& request_body = request_buf.add_child("rate_addon");
+
+	request_body["addon_name"] = rating.id;
+	if (rating.numerical != -1) {
+		request_body["rating"] = rating.numerical;
+	}
+	for (unsigned int i = 0; i < rating.liked_reviews.size(); i++) {
+		request_body.add_child("liked_review")["number"] = rating.liked_reviews[i];
+	}
+	if (rating.submitted_review == true) {
+		config& review = request_body.add_child("user_review");
+		if (!rating.custom_review.gameplay.empty())  review["gameplay"] = rating.custom_review.gameplay;
+		if (!rating.custom_review.visuals.empty())  review["visuals"] = rating.custom_review.visuals;
+		if (!rating.custom_review.story.empty())  review["story"] = rating.custom_review.story;
+		if (!rating.custom_review.balance.empty())  review["balance"] = rating.custom_review.balance;
+		if (!rating.custom_review.overall.empty())  review["overall"] = rating.custom_review.overall;
+	}
+
+	utils::string_map i18n_symbols;
+	i18n_symbols["addon_title"] = rating.id;
+
+	LOG_ADDONS << "rating add-on " << rating.id << '\n';
+
+	this->send_request(request_buf, archive_cfg);
+	//this->wait_for_transfer_done(vgettext("Sending information about your rating of the <i>$addon_title</i> add-on...", i18n_symbols));
+
+	return !this->update_last_error(archive_cfg);
+}
+
 bool addons_client::update_last_error(config& response_cfg)
 {
 	if(config const &error = response_cfg.child("error")) {

--- a/src/addon/client.cpp
+++ b/src/addon/client.cpp
@@ -24,6 +24,7 @@
 #include "log.hpp"
 #include "serialization/parser.hpp"
 #include "serialization/string_utils.hpp"
+#include "preferences.hpp"
 
 #include "addon/client.hpp"
 
@@ -80,6 +81,28 @@ bool addons_client::request_addons_list(config& cfg)
 	this->wait_for_transfer_done(_("Downloading list of add-ons..."));
 
 	cfg = response_buf.child("campaigns");
+
+	return !this->update_last_error(response_buf);
+}
+
+bool addons_client::submit_gameplay_times()
+{
+	config response_buf;
+
+	config request;
+	config& request_body = request.add_child("submit_gameplay_times");
+	config* prefs = preferences::get_prefs();
+
+	BOOST_FOREACH(const config &entry, prefs->child_range("gameplay_times"))
+	{
+		config& added = request_body.add_child("played_addon");
+		added["name"] = entry["name"];
+		added["time"] = entry["time"];
+		std::cout << "Uploading_gameplay_times for " << entry["name"] << std::endl;
+	}
+	prefs->clear_children("gameplay_times");
+
+	this->send_request(request, response_buf);
 
 	return !this->update_last_error(response_buf);
 }

--- a/src/addon/client.hpp
+++ b/src/addon/client.hpp
@@ -103,6 +103,19 @@ public:
 	bool install_addon(config& archive_cfg, const addon_info& info);
 
 	/**
+	 * Uploads the player's rating of an add-on
+	 *
+	 * @return @a true on success, @a false on failure. Retrieve the error message with @a get_last_server_error.
+	 *
+	 * @param id          Add-on id.
+	 * @param rating      The users numerical rating
+	 * @param liked_review One or more tags with the number key that mark which add-ons were marked as liked
+	 * @param user_review Review the player wrote, keys gameplay, visuals, balance, story and overall are the
+	 *                    player's ratings
+	 */
+	bool rate_addon(config& archive_cfg, addon_info::this_users_rating rating);
+
+	/**
 	 * Requests the specified add-on to be uploaded.
 	 *
 	 * This method reads the add-on upload passphrase and other data

--- a/src/addon/client.hpp
+++ b/src/addon/client.hpp
@@ -65,6 +65,17 @@ public:
 	bool request_addons_list(config& cfg);
 
 	/**
+	 * Uploads the player's gameplay statistics
+	 *
+	 * @return @a true on success, @a false on failure. Retrieve the error message with @a get_last_server_error.
+	 *
+	 * @param entry       Several entries about add-ons
+	 * @param name        Add-on name.
+	 * @param time        Time he spent playing it.
+	 */
+	bool submit_gameplay_times();
+
+	/**
 	 * Request the add-ons server distribution terms message.
 	 */
 	bool request_distribution_terms(std::string& terms);

--- a/src/addon/info.cpp
+++ b/src/addon/info.cpp
@@ -106,7 +106,7 @@ void addon_info::read(const config& cfg)
 	// are rather dependencies and files for UMC authors, not playable stuff players
 	// want to download.
 
-	this->general_rating = rating;
+	this->score = rating;
 
 	const config::const_child_itors& reviews = cfg.child_range("review");
 	BOOST_FOREACH(const config& review, reviews) {

--- a/src/addon/info.hpp
+++ b/src/addon/info.hpp
@@ -27,6 +27,25 @@ typedef std::map<std::string, addon_info> addons_list;
 
 struct addon_info
 {
+	typedef struct {
+		int id;
+		std::string overall;
+		std::string gameplay;
+		std::string visuals;
+		std::string story;
+		std::string balance;
+		int likes;
+		bool sorted;
+	} addon_review;
+
+	typedef struct {
+		std::string id;
+		int numerical;
+		addon_review custom_review;
+		std::vector<int> liked_reviews;
+		bool submitted_review;
+	} this_users_rating;
+
 	std::string id;
 	std::string title;
 	std::string description;
@@ -40,6 +59,8 @@ struct addon_info
 	int size;
 	int downloads;
 	int uploads;
+
+	std::vector<addon_review> reviews;
 
 	ADDON_TYPE type;
 

--- a/src/addon/info.hpp
+++ b/src/addon/info.hpp
@@ -27,6 +27,7 @@ typedef std::map<std::string, addon_info> addons_list;
 
 struct addon_info
 {
+
 	typedef struct {
 		int id;
 		std::string overall;
@@ -60,6 +61,10 @@ struct addon_info
 	int downloads;
 	int uploads;
 
+	int user_rating;
+	int hours_played;
+	int this_user_rating;
+
 	std::vector<addon_review> reviews;
 
 	ADDON_TYPE type;
@@ -73,6 +78,8 @@ struct addon_info
 
 	std::string feedback_url;
 
+	int general_rating;
+
 	time_t updated;
 	time_t created;
 
@@ -84,7 +91,8 @@ struct addon_info
 	addon_info()
 		: id(), title(), description(), icon()
 		, version(), author(), size(), downloads()
-		, uploads(), type(), locales()
+		, uploads(), user_rating(), hours_played()
+		, this_user_rating(), reviews(), type(), locales()
 		, core()
 		, depends()
 		, feedback_url()
@@ -97,6 +105,8 @@ struct addon_info
 		: id(), title(), description(), icon()
 		, version(), author(), size(), downloads()
 		, uploads(), type(), locales()
+		, uploads(), user_rating(), hours_played()
+		, this_user_rating(), reviews(), type(), locales()
 		, core()
 		, depends()
 		, feedback_url()
@@ -119,6 +129,10 @@ struct addon_info
 			this->downloads = o.downloads;
 			this->uploads = o.uploads;
 			this->type = o.type;
+			this->user_rating = o.user_rating;
+			this->hours_played = o.hours_played;
+			this->this_user_rating = o.this_user_rating;
+			this->reviews = o.reviews;
 			this->locales = o.locales;
 			this->core = o.core;
 			this->depends = o.depends;

--- a/src/addon/info.hpp
+++ b/src/addon/info.hpp
@@ -104,7 +104,6 @@ struct addon_info
 	explicit addon_info(const config& cfg)
 		: id(), title(), description(), icon()
 		, version(), author(), size(), downloads()
-		, uploads(), type(), locales()
 		, uploads(), user_rating(), hours_played()
 		, this_user_rating(), reviews(), type(), locales()
 		, core()

--- a/src/addon/manager_ui.cpp
+++ b/src/addon/manager_ui.cpp
@@ -398,7 +398,7 @@ struct addons_filter_state
 		: keywords()
 		, types(ADDON_TYPES_COUNT, true)
 		, status(FILTER_ALL)
-		, sort(SORT_NAMES)
+		, sort(SORT_RATING)
 		, direction(DIRECTION_ASCENDING)
 		, changed(false)
 	{}
@@ -469,6 +469,10 @@ struct addon_pointer_list_sorter
 		}
 
 		switch(sort_) {
+		case SORT_RATING:
+			// These are technically strings, but comparing will work as well.
+			// They have to be strings, because sometimes there is no rating.
+			return a->second.general_rating > b->second.general_rating;
 		case SORT_NAMES:
 			// Alphanumerical by name, case insensitive.
 			return utf8::lowercase(a->second.title) < utf8::lowercase(b->second.title);
@@ -599,7 +603,7 @@ void show_addons_manager_dialog(display& disp, addons_client& client, addons_lis
 	// if its translated contents don't fit, instead of truncating other, more
 	// important columns such as Size.
 	if(!updates_only) {
-		header += sep + _("Downloads") + sep + _("Type");
+		header += sep + _("Rating") + sep + _("Type");
 	}
 	// end of list header
 
@@ -642,9 +646,16 @@ void show_addons_manager_dialog(display& disp, addons_client& client, addons_lis
 		const std::string& display_sep = sep;
 		const std::string& display_size = size_display_string(addon.size);
 		const std::string& display_type = addon.display_type();
-		const std::string& display_down = str_cast(addon.downloads);
 		const std::string& display_icon = addon.display_icon();
 		const std::string& display_status = describe_addon_status(tracking[addon.id]);
+
+		std::string general_rating;
+		if (addon.general_rating == 0) {
+			general_rating = "None";
+		} else {
+			general_rating = str_cast(addon.general_rating / 10.0);
+		}
+		const std::string& display_down = general_rating;
 
 		std::string display_version = addon.version.str();
 		std::string display_old_version = tracking[addon.id].installed_version;

--- a/src/addon/manager_ui.cpp
+++ b/src/addon/manager_ui.cpp
@@ -82,6 +82,8 @@ bool get_addons_list(addons_client& client, addons_list& list)
 		return false;
 	}
 
+	client.submit_gameplay_times();
+
 	read_addons_list(cfg, list);
 
 	return true;
@@ -973,6 +975,9 @@ bool addons_manager_ui(display& disp, const std::string& remote_address)
 								"add-ons list from the server."));
 					return need_wml_cache_refresh;
 				}
+
+				client.submit_gameplay_times();
+
 				gui2::taddon_list dlg(cfg);
 				dlg.show(disp.video());
 				return need_wml_cache_refresh;

--- a/src/addon/state.hpp
+++ b/src/addon/state.hpp
@@ -88,7 +88,7 @@ enum ADDON_STATUS_FILTER {
  * Add-on fallback/default sorting criteria for the user interface.
  */
 enum ADDON_SORT {
-	SORT_RATING,		/**< Sort by the add-on's calculated rating. */
+	SORT_SCORE,		/**< Sort by the add-on's calculated rating. */
 	SORT_NAMES,			/**< Sort by add-on name. */
 	SORT_UPDATED,		/**< Sort by last upload time. */
 	SORT_CREATED		/**< Sort by creation time. */

--- a/src/addon/state.hpp
+++ b/src/addon/state.hpp
@@ -88,6 +88,7 @@ enum ADDON_STATUS_FILTER {
  * Add-on fallback/default sorting criteria for the user interface.
  */
 enum ADDON_SORT {
+	SORT_RATING,		/**< Sort by the add-on's calculated rating. */
 	SORT_NAMES,			/**< Sort by add-on name. */
 	SORT_UPDATED,		/**< Sort by last upload time. */
 	SORT_CREATED		/**< Sort by creation time. */

--- a/src/campaign_server/addon_utils.hpp
+++ b/src/campaign_server/addon_utils.hpp
@@ -18,6 +18,27 @@
 
 #include <string>
 
+
+class initialised_int
+{
+public:
+	// This class is used to check if some strings are already in the map
+	// and to count them; we can't use a std::map<std::string,int> because
+	// int would not always be initialised to 0 and we need it because std::map
+	// automatically creates new fields when they're accessed
+	int num;
+	initialised_int() : num(0) {}
+	int operator() () {
+		return num;
+	}
+	void operator+= (int added) {
+		num += added;
+	}
+	void operator= (int set) {
+		num = set;
+	}
+};
+
 class config;
 
 namespace campaignd {

--- a/src/campaign_server/addon_utils.hpp
+++ b/src/campaign_server/addon_utils.hpp
@@ -18,27 +18,6 @@
 
 #include <string>
 
-
-class initialised_int
-{
-public:
-	// This class is used to check if some strings are already in the map
-	// and to count them; we can't use a std::map<std::string,int> because
-	// int would not always be initialised to 0 and we need it because std::map
-	// automatically creates new fields when they're accessed
-	int num;
-	initialised_int() : num(0) {}
-	int operator() () {
-		return num;
-	}
-	void operator+= (int added) {
-		num += added;
-	}
-	void operator= (int set) {
-		num = set;
-	}
-};
-
 class config;
 
 namespace campaignd {

--- a/src/campaign_server/campaign_server.cpp
+++ b/src/campaign_server/campaign_server.cpp
@@ -113,6 +113,7 @@ server::server(const std::string& cfg_file, size_t min_threads, size_t max_threa
 
 server::~server()
 {
+	recalculate_player_data();
 	write_config();
 }
 
@@ -181,6 +182,78 @@ void server::load_blacklist()
 	} catch(const config::error&) {
 		ERR_CS << "failed to read blacklist from " << blacklist_file_ << ", blacklist disabled\n";
 	}
+}
+
+void server::recalculate_player_data()
+{
+	BOOST_FOREACH(config &campaign, campaigns().child_range("campaign"))
+	{
+		long int hours_played = 0;
+		BOOST_FOREACH(config &entry, campaign.child_range("played"))
+		{
+			hours_played += entry["time"].to_int(0) / 10;
+		}
+		campaign["hours_played"] = str_cast(hours_played);
+
+		recalculate_campaign_ratings(campaign["name"]);
+	}
+
+}
+
+void server::recalculate_campaign_ratings(std::string campaign_name)
+{
+	config& campaign = campaigns().find_child("campaign", "name", campaign_name);
+
+	long int total_votes = 0;
+	long int total_points = 0;
+	std::map< std::string, initialised_int> ips;
+	BOOST_REVERSE_FOREACH(const config &rate, campaign.child_range("rate"))
+	{
+		if (ips[rate["ip"]]() == 0) {
+			total_points += rate["num"];
+			total_votes++;
+		}
+		ips[rate["ip"]] += 1;
+	}
+
+	for (std::map< std::string, initialised_int>::iterator iter = ips.begin(); iter != ips.end(); iter++) {
+		if (iter->second() >= 10) {
+			std::cerr << "Suspiciously many votes from a single IP address for campaign " << campaign["title"] << " from address " << iter->first << ", please check it out.\n";
+		}
+	}
+
+	if (total_votes != 0) {
+		campaign["user_rating"] = total_points/total_votes;
+	} else {
+		campaign["user_rating"] = -1;
+	}
+
+	BOOST_FOREACH(config &review, campaign.child_range("review"))
+	{
+		long int likes = 0;
+		std::map< std::string, initialised_int> likers_ips;
+		likers_ips[review["ip"]] = 1;
+		std::string ips_string = review["likers_ips"];
+		unsigned long int i = 0;
+
+		while (i < ips_string.size()) {
+			long int start = i;
+			for ( ; i < ips_string.size(); i++) if (ips_string[i] == 44) break;
+			std::string this_ip = ips_string.substr(start,i - start);
+			if (likers_ips[this_ip]() == 0) likes++;
+			likers_ips[this_ip] += 1;
+			i++;
+		}
+
+		for (std::map< std::string, initialised_int>::iterator iter = ips.begin(); iter != ips.end(); iter++) {
+			if (iter->second() >= 10) {
+				std::cerr << "Suspiciously many votes from a single IP address for review " << review["id"] << " from address " << iter->first << ", please check it out.\n";
+			}
+		}
+
+		review["likes"] = likes;
+	}
+
 }
 
 void server::write_config()
@@ -265,6 +338,7 @@ void server::run()
 			const time_t cur_ts = time(NULL);
 			// Write config to disk every ten minutes.
 			if(cur_ts - last_ts >= 10*60) {
+				recalculate_player_data();
 				write_config();
 				last_ts = cur_ts;
 			}
@@ -469,13 +543,14 @@ void server::handle_request_campaign(const server::request& req)
 
 void server::handle_submit_gameplay_times(const server::request& req)
 {
+	LOG_CS << "received information about add-on gameplay times from '" << network::ip_address(req.sock);
 	time_t epoch = time(NULL);
-	BOOST_FOREACH(const config &entry, req.child_range("played_addon"))
+	BOOST_FOREACH(const config &entry, req.cfg.child_range("played_addon"))
 	{
 		if (entry["name"].empty() || entry["time"].empty()) continue;
 		config& campaign = campaigns().find_child("campaign", "name", entry["name"]);
 		if (!campaign) continue;
-		config& gameplay_entry = campaign.find_child("played", "ip", network::ip_address(sock) );
+		config& gameplay_entry = campaign.find_child("played", "ip", network::ip_address(req.sock) );
 		if (gameplay_entry) {
 			if (epoch - gameplay_entry["timestamp"].to_int() < entry["time"].to_int() / 30) {
 				gameplay_entry["time"] = (epoch - gameplay_entry["timestamp"].to_int()) / 30;
@@ -486,7 +561,7 @@ void server::handle_submit_gameplay_times(const server::request& req)
 			gameplay_entry["timestamp"] = lexical_cast<std::string>(epoch);
 		} else {
 			config& new_entry = campaign.add_child("played");
-			new_entry["ip"] = network::ip_address(sock);
+			new_entry["ip"] = network::ip_address(req.sock);
 			if (epoch - campaign["timestamp"].to_int() < entry["time"].to_int() / 100) {
 				std::cerr << "Somebody tried to upload too many gameplay hours for add-on: " << entry["name"] << std::endl;
 			} else {
@@ -495,6 +570,7 @@ void server::handle_submit_gameplay_times(const server::request& req)
 			new_entry["timestamp"] = lexical_cast<std::string>(epoch);
 		}
 	}
+	send_message("Information received.", req.sock);
 }
 
 void server::handle_request_terms(const server::request& req)
@@ -577,7 +653,6 @@ void server::handle_upload(const server::request& req)
 		const time_t upload_ts = time(NULL);
 
 		LOG_CS << "Upload is owner upload.\n";
-
 		if(blacklist_.is_blacklisted(name,
 									 upload["title"].str(),
 									 upload["description"].str(),
@@ -615,6 +690,9 @@ void server::handle_upload(const server::request& req)
 		(*campaign)["type"] = upload["type"];
 		(*campaign)["email"] = upload["email"];
 
+		if((*campaign)["highest_review_id"].empty()) {
+			(*campaign)["highest_review_id"] = 0;
+		}
 		if((*campaign)["downloads"].empty()) {
 			(*campaign)["downloads"] = 0;
 		}
@@ -704,194 +782,16 @@ void server::handle_delete(const server::request& req)
 		}
 	}
 
-<<<<<<< HEAD
 	write_config();
-=======
-		network::connection sock = 0;
-		for(int increment = 0; ; ++increment) {
-			try {
- 				std::string admin_cmd;
- 				if (input_ && input_->read_line(admin_cmd))
- 				{
- 					// process command
- 					if (admin_cmd == "shut_down")
- 					{
- 						break;
- 					}
- 				}
-			//write config to disk every ten minutes
-				if((increment%(60*10*50)) == 0) {
-					BOOST_FOREACH(config &campaign, campaigns().child_range("campaign"))
-					{
-						long int total_votes = 0;
-						long int total_points = 0;
-						std::map< std::string, initialised_int> ips;
-						BOOST_REVERSE_FOREACH(const config &rate, campaign.child_range("rate"))
-						{
-							if (ips[rate["ip"]]() == 0) {
-								total_points += rate["num"];
-								total_votes++;
-							}
-							ips[rate["ip"]] += 1;
-						}
-						for (std::map< std::string, initialised_int>::iterator iter = ips.begin(); iter != ips.end(); iter++) {
-							if (iter->second() >= 10) {
-								std::cerr << "Suspiciously many votes from a single IP address for campaign " << campaign["title"] << " from address " << iter->first << ", please check it out.\n";
-							}
-						}
-						if (total_votes != 0) {
-							campaign["user_rating"] = total_points/total_votes;
-						} else {
-							campaign["user_rating"] = -1;
-						}
-						BOOST_FOREACH(config &review, campaign.child_range("review"))
-						{
-							long int likes = 0;
-							std::map< std::string, initialised_int> likers_ips;
-							likers_ips[review["ip"]] = 1;
-							std::string ips_string = review["likers_ips"];
-							unsigned long int i = 0;
-							while (i < ips_string.size()) {
-								long int start = i;
-								for ( ; i < ips_string.size(); i++) if (ips_string[i] == 44) break;
-								std::string this_ip = ips_string.substr(start,i - start);
-								if (likers_ips[this_ip]() == 0) likes++;
-								likers_ips[this_ip] += 1;
-								i++;
-							}
-							for (std::map< std::string, initialised_int>::iterator iter = ips.begin(); iter != ips.end(); iter++) {
-								if (iter->second() >= 10) {
-									std::cerr << "Suspiciously many votes from a single IP address for review " << review["id"] << " from address " << iter->first << ", please check it out.\n";
-								}
-							}
-							review["likes"] = likes;
-						}
-						long int hours_played = 0;
-						BOOST_FOREACH(config &entry, campaign.child_range("played"))
-						{
-							hours_played += entry["time"].to_int(0) / 10;
-						}
-						campaign["hours_played"] = str_cast(hours_played);
-					}
-
-					scoped_ostream cfgfile = ostream_file(file_);
-					write(*cfgfile, cfg_);
-				}
->>>>>>> 2a9491e... Made add-ons's list window display ratings instead of download counts, made the
 
 	send_message("Add-on deleted.", req.sock);
 
 	fire("hook_post_erase", erase["name"]);
 }
 
-<<<<<<< HEAD
 void server::handle_change_passphrase(const server::request& req)
 {
 	const config& cpass = req.cfg;
-=======
-				config data;
-				while((sock = network::receive_data(data, 0)) != network::null_connection) {
-					if (const config &req = data.child("request_campaign_list"))
-					{
-						LOG_CS << "sending campaign list to " << network::ip_address(sock) << " using gzip";
-						time_t epoch = time(NULL);
-						config campaign_list;
-						campaign_list["timestamp"] = lexical_cast<std::string>(epoch);
-						if (req["times_relative_to"] != "now") {
-							epoch = 0;
-						}
-
-						bool before_flag = false;
-						time_t before = epoch;
-						try {
-							before = before + lexical_cast<time_t>(req["before"]);
-							before_flag = true;
-						} catch(bad_lexical_cast) {}
-
-						bool after_flag = false;
-						time_t after = epoch;
-						try {
-							after = after + lexical_cast<time_t>(req["after"]);
-							after_flag = true;
-						} catch(bad_lexical_cast) {}
-
-						std::string name = req["name"], lang = req["language"];
-						BOOST_FOREACH(const config &i, campaigns().child_range("campaign"))
-						{
-							if (!name.empty() && name != i["name"]) continue;
-							std::string tm = i["timestamp"];
-							if (before_flag && (tm.empty() || lexical_cast_default<time_t>(tm, 0) >= before)) continue;
-							if (after_flag && (tm.empty() || lexical_cast_default<time_t>(tm, 0) <= after)) continue;
-							if (!lang.empty()) {
-								bool found = false;
-								BOOST_FOREACH(const config &j, i.child_range("translation")) {
-									if (j["language"] == lang) {
-										found = true;
-										break;
-									}
-								}
-								if (!found) continue;
-							}
-							campaign_list.add_child("campaign", i);
-						}
-
-						BOOST_FOREACH(config &j, campaign_list.child_range("campaign")) {
-							j["passphrase"] = t_string();
-							j["upload_ip"] = t_string();
-							j["email"] = t_string();
-							j["feedback_url"] = t_string();
-							j.clear_children("rate");
-
-
-							BOOST_FOREACH(config &review, j.child_range("review")) {
-								review["likers_ips"] = t_string();
-								review["ip"] = t_string();
-							}
-
-							// Build a feedback_url string attribute from the
-							// internal [feedback] data.
-							config url_params = j.child_or_empty("feedback");
-							j.clear_children("feedback");
-
-							if(!url_params.empty() && !feedback_url_format_.empty()) {
-								j["feedback_url"] = format_addon_feedback_url(feedback_url_format_, url_params);
-							}
-						}
-
-						config response;
-						response.add_child("campaigns",campaign_list);
-
-						std::cerr << " size: " << (network::send_data(response, sock)/1024) << "KiB\n";
-					}
-					else if (const config &req = data.child("submit_gameplay_times"))
-					{
-						time_t epoch = time(NULL);
-						BOOST_FOREACH(const config &entry, req.child_range("played_addon"))
-						{
-							if (entry["name"].empty() || entry["time"].empty()) continue;
-							config& campaign = campaigns().find_child("campaign", "name", entry["name"]);
-							if (!campaign) continue;
-							config& gameplay_entry = campaign.find_child("played", "ip", network::ip_address(sock) );
-							if (gameplay_entry) {
-								if (epoch - gameplay_entry["timestamp"].to_int() < entry["time"].to_int() / 30) {
-									gameplay_entry["time"] = (epoch - gameplay_entry["timestamp"].to_int()) / 30;
-									std::cerr << "Somebody tried to upload too many gameplay hours for add-on: " << entry["name"] << std::endl;
-								} else {
-									gameplay_entry["time"] = str_cast(gameplay_entry["time"].to_int() + entry["time"].to_int());
-								}
-								gameplay_entry["timestamp"] = lexical_cast<std::string>(epoch);
-							} else {
-								config& new_entry = campaign.add_child("played");
-								new_entry["ip"] = network::ip_address(sock);
-								if (epoch - campaign["timestamp"].to_int() < entry["time"].to_int() / 100) {
-									std::cerr << "Somebody tried to upload too many gameplay hours for add-on: " << entry["name"] << std::endl;
-								} else {
-									new_entry["time"] = entry["time"];
-								}
-								new_entry["timestamp"] = lexical_cast<std::string>(epoch);
-							}
-						}
->>>>>>> 2a9491e... Made add-ons's list window display ratings instead of download counts, made the
 
 	if(read_only_) {
 		LOG_CS << "in read-only mode, request to change passphrase denied\n";
@@ -899,7 +799,6 @@ void server::handle_change_passphrase(const server::request& req)
 		return;
 	}
 
-<<<<<<< HEAD
 	config& campaign = campaigns().find_child("campaign", "name", cpass["name"]);
 
 	if(!campaign) {
@@ -919,19 +818,19 @@ void server::handle_change_passphrase(const server::request& req)
 
 void server::handle_rate_addon(const server::request& req)
 {
-	LOG_CS << "received rating of '" << req["addon_name"] << "' from " << network::ip_address(sock) << std::endl;
-	config &campaign = campaigns().find_child("campaign", "name", req["addon_name"]);
+	LOG_CS << "received rating of '" << req.cfg["addon_name"] << "' from " << network::ip_address(req.sock) << std::endl;
+	config &campaign = campaigns().find_child("campaign", "name", req.cfg["addon_name"]);
 	if (!campaign) {
-		network::send_data(construct_error("Add-on '" + req["addon_name"].str() + "' not found."), sock);
+		send_error("Add-on '" + req.cfg["addon_name"].str() + "' not found.", req.sock);
 	} else {
-		if (!req["rating"].empty()) {
+		if (!req.cfg["rating"].empty()) {
 			config& new_rating = campaign.add_child("rate");
-			new_rating["num"] = req["rating"];
-			new_rating["ip"] = network::ip_address(sock);
+			new_rating["num"] = req.cfg["rating"];
+			new_rating["ip"] = network::ip_address(req.sock);
 			new_rating["time"] = lexical_cast<std::string>(time(NULL));
-			campaign["user_rating"] = req["rating"];
+			campaign["user_rating"] = req.cfg["rating"];
 		}
-		const config& users_review = req.child_or_empty("user_review");
+		const config& users_review = req.cfg.child_or_empty("user_review");
 		if (!users_review.empty()) {
 			config& new_review = campaign.add_child("review");
 			if (!users_review["gameplay"].empty()) {
@@ -952,308 +851,23 @@ void server::handle_rate_addon(const server::request& req)
 			{
 				new_review["overall"] = users_review["overall"];
 			}
-			new_review["ip"] = network::ip_address(sock);
+			new_review["ip"] = network::ip_address(req.sock);
 			new_review["time"] = lexical_cast<std::string>(time(NULL));
 			campaign["highest_review_id"] = campaign["highest_review_id"].to_int() + 1;
 			new_review["id"] = campaign["highest_review_id"];
 		}
-		BOOST_FOREACH(const config &liked_review, req.child_range("liked_review"))
+		BOOST_FOREACH(const config &liked_review, req.cfg.child_range("liked_review"))
 		{
 			config& review = campaign.find_child("review", "id", liked_review["number"]);
 			if (review) {
 				if (!review["likers_ips"].empty()) {
-					review["likers_ips"] = review["likers_ips"] + std::string(",") + network::ip_address(sock);
-=======
-					}
-					else if (data.child("request_terms"))
-					{
-						// This usually means the client wants to upload content, so tell it
-						// to give up when we're in read-only mode.
-						if(read_only_) {
-							LOG_CS << "in read-only mode, request for upload terms denied\n";
-							network::send_data(construct_error("The server is currently in read-only mode, add-on uploads are disabled."), sock);
-							continue;
-						}
-
-						LOG_CS << "sending terms " << network::ip_address(sock) << "\n";
-						network::send_data(construct_message("All add-ons uploaded to this server must be licensed under the terms of the GNU General Public License (GPL). By uploading content to this server, you certify that you have the right to place the content under the conditions of the GPL, and choose to do so."), sock);
-						LOG_CS << " Done\n";
-					}
-					else if (config &upload = data.child("upload"))
-					{
-						LOG_CS << "uploading campaign '" << upload["name"] << "' from " << network::ip_address(sock) << ".\n";
-						config &data = upload.child("data");
-						const std::string& name = upload["name"];
-						std::string lc_name(name.size(), ' ');
-						std::transform(name.begin(), name.end(), lc_name.begin(), tolower);
-						config *campaign = NULL;
-						BOOST_FOREACH(config &c, campaigns().child_range("campaign")) {
-							if (utf8::lowercase(c["name"]) == lc_name) {
-								campaign = &c;
-								break;
-							}
-						}
-
-						if (read_only_) {
-							LOG_CS << "Upload aborted - uploads not permitted in read-only mode.\n";
-							network::send_data(construct_error("Add-on rejected: The server is currently in read-only mode."), sock);
-						} else if (!data) {
-							LOG_CS << "Upload aborted - no add-on data.\n";
-							network::send_data(construct_error("Add-on rejected: No add-on data was supplied."), sock);
-						} else if (!addon_name_legal(upload["name"])) {
-							LOG_CS << "Upload aborted - invalid add-on name.\n";
-							network::send_data(construct_error("Add-on rejected: The name of the add-on is invalid."), sock);
-						} else if (is_text_markup_char(upload["name"].str()[0])) {
-							LOG_CS << "Upload aborted - add-on name starts with an illegal formatting character.\n";
-							network::send_data(construct_error("Add-on rejected: The name of the add-on starts with an illegal formatting character."), sock);
-						} else if (upload["title"].empty()) {
-							LOG_CS << "Upload aborted - no add-on title specified.\n";
-							network::send_data(construct_error("Add-on rejected: You did not specify the title of the add-on in the pbl file!"), sock);
-						} else if (is_text_markup_char(upload["title"].str()[0])) {
-							LOG_CS << "Upload aborted - add-on title starts with an illegal formatting character.\n";
-							network::send_data(construct_error("Add-on rejected: The title of the add-on starts with an illegal formatting character."), sock);
-						} else if (get_addon_type(upload["type"]) == ADDON_UNKNOWN) {
-							LOG_CS << "Upload aborted - unknown add-on type specified.\n";
-							network::send_data(construct_error("Add-on rejected: You did not specify a known type for the add-on in the pbl file! (See PblWML: wiki.wesnoth.org/PblWML)"), sock);
-						} else if (upload["author"].empty()) {
-							LOG_CS << "Upload aborted - no add-on author specified.\n";
-							network::send_data(construct_error("Add-on rejected: You did not specify the author(s) of the add-on in the pbl file!"), sock);
-						} else if (upload["version"].empty()) {
-							LOG_CS << "Upload aborted - no add-on version specified.\n";
-							network::send_data(construct_error("Add-on rejected: You did not specify the version of the add-on in the pbl file!"), sock);
-						} else if (upload["description"].empty()) {
-							LOG_CS << "Upload aborted - no add-on description specified.\n";
-							network::send_data(construct_error("Add-on rejected: You did not specify a description of the add-on in the pbl file!"), sock);
-						} else if (upload["email"].empty()) {
-							LOG_CS << "Upload aborted - no add-on email specified.\n";
-							network::send_data(construct_error("Add-on rejected: You did not specify your email address in the pbl file!"), sock);
-						} else if (!check_names_legal(data)) {
-							LOG_CS << "Upload aborted - invalid file names in add-on data.\n";
-							network::send_data(construct_error("Add-on rejected: The add-on contains an illegal file or directory name."
-									" File or directory names may not contain whitespace or any of the following characters: '/ \\ : ~'"), sock);
-						} else if (campaign && (*campaign)["passphrase"].str() != upload["passphrase"]) {
-							LOG_CS << "Upload aborted - incorrect passphrase.\n";
-							network::send_data(construct_error("Add-on rejected: The add-on already exists, and your passphrase was incorrect."), sock);
-						} else {
-							const time_t upload_ts = time(NULL);
-
-							LOG_CS << "Upload is owner upload.\n";
-							std::string message = "Add-on accepted.";
-
-							if (!version_info(upload["version"]).good()) {
-								message += "\n<255,255,0>Note: The version you specified is invalid. This add-on will be ignored for automatic update checks.";
-							}
-
-							if(campaign == NULL) {
-								campaign = &campaigns().add_child("campaign");
-								(*campaign)["original_timestamp"] = lexical_cast<std::string>(upload_ts);
-							}
-
-							(*campaign)["title"] = upload["title"];
-							(*campaign)["name"] = upload["name"];
-							(*campaign)["filename"] = "data/" + upload["name"].str();
-							(*campaign)["passphrase"] = upload["passphrase"];
-							(*campaign)["author"] = upload["author"];
-							(*campaign)["description"] = upload["description"];
-							(*campaign)["version"] = upload["version"];
-							(*campaign)["icon"] = upload["icon"];
-							(*campaign)["translate"] = upload["translate"];
-							(*campaign)["dependencies"] = upload["dependencies"];
-							(*campaign)["upload_ip"] = network::ip_address(sock);
-							(*campaign)["type"] = upload["type"];
-							(*campaign)["email"] = upload["email"];
-
-							if((*campaign)["highest_review_id"].empty()) {
-								(*campaign)["highest_review_id"] = 0;
-							}
-							if((*campaign)["downloads"].empty()) {
-								(*campaign)["downloads"] = 0;
-							}
-							(*campaign)["timestamp"] = lexical_cast<std::string>(upload_ts);
-
-							int uploads = (*campaign)["uploads"].to_int() + 1;
-							(*campaign)["uploads"] = uploads;
-
-							(*campaign).clear_children("feedback");
-							if(const config& url_params = upload.child("feedback")) {
-								(*campaign).add_child("feedback", url_params);
-							}
-
-							std::string filename = (*campaign)["filename"];
-							data["title"] = (*campaign)["title"];
-							data["name"] = "";
-							data["campaign_name"] = (*campaign)["name"];
-							data["author"] = (*campaign)["author"];
-							data["description"] = (*campaign)["description"];
-							data["version"] = (*campaign)["version"];
-							data["timestamp"] = (*campaign)["timestamp"];
-							data["original_timestamp"] = (*campaign)["original_timestamp"];
-							data["icon"] = (*campaign)["icon"];
-							data["type"] = (*campaign)["type"];
-							(*campaign).clear_children("translation");
-							find_translations(data, *campaign);
-
-							add_license(data);
-
-							{
-								scoped_ostream campaign_file = ostream_file(filename);
-								config_writer writer(*campaign_file, true, compress_level_);
-								writer.write(data);
-							}
-//							write_compressed(*campaign_file, *data);
-
-							(*campaign)["size"] = lexical_cast<std::string>(
-									file_size(filename));
-							scoped_ostream cfgfile = ostream_file(file_);
-							write(*cfgfile, cfg_);
-							network::send_data(construct_message(message), sock);
-
-							fire("hook_post_upload", upload["name"]);
-						}
-					}
-					else if (const config &erase = data.child("delete"))
-					{
-						if(read_only_) {
-							LOG_CS << "in read-only mode, request to delete '" << erase["name"] << "' from " << network::ip_address(sock) << " denied\n";
-							network::send_data(construct_error("Cannot delete add-on: The server is currently in read-only mode."), sock);
-							continue;
-						}
-
-						LOG_CS << "deleting campaign '" << erase["name"] << "' requested from " << network::ip_address(sock) << "\n";
-						const config &campaign = campaigns().find_child("campaign", "name", erase["name"]);
-						if (!campaign) {
-							network::send_data(construct_error("The add-on does not exist."), sock);
-							continue;
-						}
-
-						if (campaign["passphrase"] != erase["passphrase"]
-								&& (campaigns()["master_password"].empty()
-								|| campaigns()["master_password"] != erase["passphrase"]))
-						{
-							network::send_data(construct_error("The passphrase is incorrect."), sock);
-							continue;
-						}
-
-						//erase the campaign
-						write_file(campaign["filename"], std::string());
-						remove(campaign["filename"].str().c_str());
-
-						config::child_itors itors = campaigns().child_range("campaign");
-						for (size_t index = 0; itors.first != itors.second;
-						     ++index, ++itors.first)
-						{
-							if (&campaign == &*itors.first) {
-								campaigns().remove_child("campaign", index);
-								break;
-							}
-						}
-						scoped_ostream cfgfile = ostream_file(file_);
-						write(*cfgfile, cfg_);
-						network::send_data(construct_message("Add-on deleted."), sock);
-
-						fire("hook_post_erase", erase["name"]);
-					}
-					else if (const config &cpass = data.child("change_passphrase"))
-					{
-						if(read_only_) {
-							LOG_CS << "in read-only mode, request to change passphrase denied\n";
-							network::send_data(construct_error("Cannot change passphrase: The server is currently in read-only mode."), sock);
-							continue;
-						}
-
-						config &campaign = campaigns().find_child("campaign", "name", cpass["name"]);
-						if (!campaign) {
-							network::send_data(construct_error("No add-on with that name exists."), sock);
-						} else if (campaign["passphrase"] != cpass["passphrase"]) {
-							network::send_data(construct_error("Your old passphrase was incorrect."), sock);
-						} else if (cpass["new_passphrase"].empty()) {
-							network::send_data(construct_error("No new passphrase was supplied."), sock);
-						} else {
-							campaign["passphrase"] = cpass["new_passphrase"];
-							scoped_ostream cfgfile = ostream_file(file_);
-							write(*cfgfile, cfg_);
-							network::send_data(construct_message("Passphrase changed."), sock);
-						}
-					}
-					else if (const config &req = data.child("rate_addon"))
-					{
-						LOG_CS << "received rating of '" << req["addon_name"] << "' from " << network::ip_address(sock) << std::endl;
-						config &campaign = campaigns().find_child("campaign", "name", req["addon_name"]);
-						if (!campaign) {
-							network::send_data(construct_error("Add-on '" + req["addon_name"].str() + "' not found."), sock);
-						} else {
-							if (!req["rating"].empty()) {
-								config& new_rating = campaign.add_child("rate");
-								new_rating["num"] = req["rating"];
-								new_rating["ip"] = network::ip_address(sock);
-								new_rating["time"] = lexical_cast<std::string>(time(NULL));
-								campaign["user_rating"] = req["rating"];
-							}
-							const config& users_review = req.child_or_empty("user_review");
-							if (!users_review.empty()) {
-								config& new_review = campaign.add_child("review");
-								if (!users_review["gameplay"].empty()) {
-									new_review["gameplay"] = users_review["gameplay"];
-								}
-								if (!users_review["visuals"].empty()) {
-									new_review["visuals"] = users_review["visuals"];
-								}
-								if (!users_review["story"].empty())
-								{
-									new_review["story"] = users_review["story"];
-								}
-								if (!users_review["balance"].empty())
-								{
-									new_review["balance"] = users_review["balance"];
-								}
-								if (!users_review["overall"].empty())
-								{
-									new_review["overall"] = users_review["overall"];
-								}
-								new_review["ip"] = network::ip_address(sock);
-								new_review["time"] = lexical_cast<std::string>(time(NULL));
-								campaign["highest_review_id"] = campaign["highest_review_id"].to_int() + 1;
-								new_review["id"] = campaign["highest_review_id"];
-							}
-							BOOST_FOREACH(const config &liked_review, req.child_range("liked_review"))
-							{
-								config& review = campaign.find_child("review", "id", liked_review["number"]);
-								if (review) {
-									if (!review["likers_ips"].empty()) {
-										review["likers_ips"] = review["likers_ips"] + std::string(",") + network::ip_address(sock);
-									} else {
-										review["likers_ips"] = network::ip_address(sock);
-									}
-								}
-							}
-						}
-					}
-				}
-			} catch(network::error& e) {
-				if(!e.socket) {
-					LOG_CS << "fatal network error: " << e.message << "\n";
-					throw;
+					review["likers_ips"] = review["likers_ips"] + std::string(",") + network::ip_address(req.sock);
 				} else {
-					LOG_CS << "client disconnect: " << e.message << " " << network::ip_address(e.socket) << "\n";
-					e.disconnect();
-				}
-			} catch(const config::error& e) {
-				network::connection err_sock = 0;
-				network::connection const * err_connection = boost::get_error_info<network::connection_info>(e);
-				if(err_connection != NULL) {
-					err_sock = *err_connection;
-				}
-				if(err_sock == 0 && sock > 0)
-					err_sock = sock;
-				if(err_sock) {
-					LOG_CS << "client disconnect due to exception: " << e.what() << " " << network::ip_address(err_sock) << "\n";
-					network::disconnect(err_sock);
->>>>>>> 2a9491e... Made add-ons's list window display ratings instead of download counts, made the
-				} else {
-					review["likers_ips"] = network::ip_address(sock);
+					review["likers_ips"] = network::ip_address(req.sock);
 				}
 			}
 		}
+		recalculate_campaign_ratings(campaign["name"]);
 	}
 
 }

--- a/src/campaign_server/campaign_server.cpp
+++ b/src/campaign_server/campaign_server.cpp
@@ -704,16 +704,194 @@ void server::handle_delete(const server::request& req)
 		}
 	}
 
+<<<<<<< HEAD
 	write_config();
+=======
+		network::connection sock = 0;
+		for(int increment = 0; ; ++increment) {
+			try {
+ 				std::string admin_cmd;
+ 				if (input_ && input_->read_line(admin_cmd))
+ 				{
+ 					// process command
+ 					if (admin_cmd == "shut_down")
+ 					{
+ 						break;
+ 					}
+ 				}
+			//write config to disk every ten minutes
+				if((increment%(60*10*50)) == 0) {
+					BOOST_FOREACH(config &campaign, campaigns().child_range("campaign"))
+					{
+						long int total_votes = 0;
+						long int total_points = 0;
+						std::map< std::string, initialised_int> ips;
+						BOOST_REVERSE_FOREACH(const config &rate, campaign.child_range("rate"))
+						{
+							if (ips[rate["ip"]]() == 0) {
+								total_points += rate["num"];
+								total_votes++;
+							}
+							ips[rate["ip"]] += 1;
+						}
+						for (std::map< std::string, initialised_int>::iterator iter = ips.begin(); iter != ips.end(); iter++) {
+							if (iter->second() >= 10) {
+								std::cerr << "Suspiciously many votes from a single IP address for campaign " << campaign["title"] << " from address " << iter->first << ", please check it out.\n";
+							}
+						}
+						if (total_votes != 0) {
+							campaign["user_rating"] = total_points/total_votes;
+						} else {
+							campaign["user_rating"] = -1;
+						}
+						BOOST_FOREACH(config &review, campaign.child_range("review"))
+						{
+							long int likes = 0;
+							std::map< std::string, initialised_int> likers_ips;
+							likers_ips[review["ip"]] = 1;
+							std::string ips_string = review["likers_ips"];
+							unsigned long int i = 0;
+							while (i < ips_string.size()) {
+								long int start = i;
+								for ( ; i < ips_string.size(); i++) if (ips_string[i] == 44) break;
+								std::string this_ip = ips_string.substr(start,i - start);
+								if (likers_ips[this_ip]() == 0) likes++;
+								likers_ips[this_ip] += 1;
+								i++;
+							}
+							for (std::map< std::string, initialised_int>::iterator iter = ips.begin(); iter != ips.end(); iter++) {
+								if (iter->second() >= 10) {
+									std::cerr << "Suspiciously many votes from a single IP address for review " << review["id"] << " from address " << iter->first << ", please check it out.\n";
+								}
+							}
+							review["likes"] = likes;
+						}
+						long int hours_played = 0;
+						BOOST_FOREACH(config &entry, campaign.child_range("played"))
+						{
+							hours_played += entry["time"].to_int(0) / 10;
+						}
+						campaign["hours_played"] = str_cast(hours_played);
+					}
+
+					scoped_ostream cfgfile = ostream_file(file_);
+					write(*cfgfile, cfg_);
+				}
+>>>>>>> 2a9491e... Made add-ons's list window display ratings instead of download counts, made the
 
 	send_message("Add-on deleted.", req.sock);
 
 	fire("hook_post_erase", erase["name"]);
 }
 
+<<<<<<< HEAD
 void server::handle_change_passphrase(const server::request& req)
 {
 	const config& cpass = req.cfg;
+=======
+				config data;
+				while((sock = network::receive_data(data, 0)) != network::null_connection) {
+					if (const config &req = data.child("request_campaign_list"))
+					{
+						LOG_CS << "sending campaign list to " << network::ip_address(sock) << " using gzip";
+						time_t epoch = time(NULL);
+						config campaign_list;
+						campaign_list["timestamp"] = lexical_cast<std::string>(epoch);
+						if (req["times_relative_to"] != "now") {
+							epoch = 0;
+						}
+
+						bool before_flag = false;
+						time_t before = epoch;
+						try {
+							before = before + lexical_cast<time_t>(req["before"]);
+							before_flag = true;
+						} catch(bad_lexical_cast) {}
+
+						bool after_flag = false;
+						time_t after = epoch;
+						try {
+							after = after + lexical_cast<time_t>(req["after"]);
+							after_flag = true;
+						} catch(bad_lexical_cast) {}
+
+						std::string name = req["name"], lang = req["language"];
+						BOOST_FOREACH(const config &i, campaigns().child_range("campaign"))
+						{
+							if (!name.empty() && name != i["name"]) continue;
+							std::string tm = i["timestamp"];
+							if (before_flag && (tm.empty() || lexical_cast_default<time_t>(tm, 0) >= before)) continue;
+							if (after_flag && (tm.empty() || lexical_cast_default<time_t>(tm, 0) <= after)) continue;
+							if (!lang.empty()) {
+								bool found = false;
+								BOOST_FOREACH(const config &j, i.child_range("translation")) {
+									if (j["language"] == lang) {
+										found = true;
+										break;
+									}
+								}
+								if (!found) continue;
+							}
+							campaign_list.add_child("campaign", i);
+						}
+
+						BOOST_FOREACH(config &j, campaign_list.child_range("campaign")) {
+							j["passphrase"] = t_string();
+							j["upload_ip"] = t_string();
+							j["email"] = t_string();
+							j["feedback_url"] = t_string();
+							j.clear_children("rate");
+
+
+							BOOST_FOREACH(config &review, j.child_range("review")) {
+								review["likers_ips"] = t_string();
+								review["ip"] = t_string();
+							}
+
+							// Build a feedback_url string attribute from the
+							// internal [feedback] data.
+							config url_params = j.child_or_empty("feedback");
+							j.clear_children("feedback");
+
+							if(!url_params.empty() && !feedback_url_format_.empty()) {
+								j["feedback_url"] = format_addon_feedback_url(feedback_url_format_, url_params);
+							}
+						}
+
+						config response;
+						response.add_child("campaigns",campaign_list);
+
+						std::cerr << " size: " << (network::send_data(response, sock)/1024) << "KiB\n";
+					}
+					else if (const config &req = data.child("submit_gameplay_times"))
+					{
+						time_t epoch = time(NULL);
+						BOOST_FOREACH(const config &entry, req.child_range("played_addon"))
+						{
+							if (entry["name"].empty() || entry["time"].empty()) continue;
+							config& campaign = campaigns().find_child("campaign", "name", entry["name"]);
+							if (!campaign) continue;
+							config& gameplay_entry = campaign.find_child("played", "ip", network::ip_address(sock) );
+							if (gameplay_entry) {
+								if (epoch - gameplay_entry["timestamp"].to_int() < entry["time"].to_int() / 30) {
+									gameplay_entry["time"] = (epoch - gameplay_entry["timestamp"].to_int()) / 30;
+									std::cerr << "Somebody tried to upload too many gameplay hours for add-on: " << entry["name"] << std::endl;
+								} else {
+									gameplay_entry["time"] = str_cast(gameplay_entry["time"].to_int() + entry["time"].to_int());
+								}
+								gameplay_entry["timestamp"] = lexical_cast<std::string>(epoch);
+							} else {
+								config& new_entry = campaign.add_child("played");
+								new_entry["ip"] = network::ip_address(sock);
+								if (epoch - campaign["timestamp"].to_int() < entry["time"].to_int() / 100) {
+									std::cerr << "Somebody tried to upload too many gameplay hours for add-on: " << entry["name"] << std::endl;
+								} else {
+									new_entry["time"] = entry["time"];
+								}
+								new_entry["timestamp"] = lexical_cast<std::string>(epoch);
+							}
+						}
+>>>>>>> 2a9491e... Made add-ons's list window display ratings instead of download counts, made the
 
 	if(read_only_) {
 		LOG_CS << "in read-only mode, request to change passphrase denied\n";
@@ -721,6 +899,7 @@ void server::handle_change_passphrase(const server::request& req)
 		return;
 	}
 
+<<<<<<< HEAD
 	config& campaign = campaigns().find_child("campaign", "name", cpass["name"]);
 
 	if(!campaign) {
@@ -784,6 +963,292 @@ void server::handle_rate_addon(const server::request& req)
 			if (review) {
 				if (!review["likers_ips"].empty()) {
 					review["likers_ips"] = review["likers_ips"] + std::string(",") + network::ip_address(sock);
+=======
+					}
+					else if (data.child("request_terms"))
+					{
+						// This usually means the client wants to upload content, so tell it
+						// to give up when we're in read-only mode.
+						if(read_only_) {
+							LOG_CS << "in read-only mode, request for upload terms denied\n";
+							network::send_data(construct_error("The server is currently in read-only mode, add-on uploads are disabled."), sock);
+							continue;
+						}
+
+						LOG_CS << "sending terms " << network::ip_address(sock) << "\n";
+						network::send_data(construct_message("All add-ons uploaded to this server must be licensed under the terms of the GNU General Public License (GPL). By uploading content to this server, you certify that you have the right to place the content under the conditions of the GPL, and choose to do so."), sock);
+						LOG_CS << " Done\n";
+					}
+					else if (config &upload = data.child("upload"))
+					{
+						LOG_CS << "uploading campaign '" << upload["name"] << "' from " << network::ip_address(sock) << ".\n";
+						config &data = upload.child("data");
+						const std::string& name = upload["name"];
+						std::string lc_name(name.size(), ' ');
+						std::transform(name.begin(), name.end(), lc_name.begin(), tolower);
+						config *campaign = NULL;
+						BOOST_FOREACH(config &c, campaigns().child_range("campaign")) {
+							if (utf8::lowercase(c["name"]) == lc_name) {
+								campaign = &c;
+								break;
+							}
+						}
+
+						if (read_only_) {
+							LOG_CS << "Upload aborted - uploads not permitted in read-only mode.\n";
+							network::send_data(construct_error("Add-on rejected: The server is currently in read-only mode."), sock);
+						} else if (!data) {
+							LOG_CS << "Upload aborted - no add-on data.\n";
+							network::send_data(construct_error("Add-on rejected: No add-on data was supplied."), sock);
+						} else if (!addon_name_legal(upload["name"])) {
+							LOG_CS << "Upload aborted - invalid add-on name.\n";
+							network::send_data(construct_error("Add-on rejected: The name of the add-on is invalid."), sock);
+						} else if (is_text_markup_char(upload["name"].str()[0])) {
+							LOG_CS << "Upload aborted - add-on name starts with an illegal formatting character.\n";
+							network::send_data(construct_error("Add-on rejected: The name of the add-on starts with an illegal formatting character."), sock);
+						} else if (upload["title"].empty()) {
+							LOG_CS << "Upload aborted - no add-on title specified.\n";
+							network::send_data(construct_error("Add-on rejected: You did not specify the title of the add-on in the pbl file!"), sock);
+						} else if (is_text_markup_char(upload["title"].str()[0])) {
+							LOG_CS << "Upload aborted - add-on title starts with an illegal formatting character.\n";
+							network::send_data(construct_error("Add-on rejected: The title of the add-on starts with an illegal formatting character."), sock);
+						} else if (get_addon_type(upload["type"]) == ADDON_UNKNOWN) {
+							LOG_CS << "Upload aborted - unknown add-on type specified.\n";
+							network::send_data(construct_error("Add-on rejected: You did not specify a known type for the add-on in the pbl file! (See PblWML: wiki.wesnoth.org/PblWML)"), sock);
+						} else if (upload["author"].empty()) {
+							LOG_CS << "Upload aborted - no add-on author specified.\n";
+							network::send_data(construct_error("Add-on rejected: You did not specify the author(s) of the add-on in the pbl file!"), sock);
+						} else if (upload["version"].empty()) {
+							LOG_CS << "Upload aborted - no add-on version specified.\n";
+							network::send_data(construct_error("Add-on rejected: You did not specify the version of the add-on in the pbl file!"), sock);
+						} else if (upload["description"].empty()) {
+							LOG_CS << "Upload aborted - no add-on description specified.\n";
+							network::send_data(construct_error("Add-on rejected: You did not specify a description of the add-on in the pbl file!"), sock);
+						} else if (upload["email"].empty()) {
+							LOG_CS << "Upload aborted - no add-on email specified.\n";
+							network::send_data(construct_error("Add-on rejected: You did not specify your email address in the pbl file!"), sock);
+						} else if (!check_names_legal(data)) {
+							LOG_CS << "Upload aborted - invalid file names in add-on data.\n";
+							network::send_data(construct_error("Add-on rejected: The add-on contains an illegal file or directory name."
+									" File or directory names may not contain whitespace or any of the following characters: '/ \\ : ~'"), sock);
+						} else if (campaign && (*campaign)["passphrase"].str() != upload["passphrase"]) {
+							LOG_CS << "Upload aborted - incorrect passphrase.\n";
+							network::send_data(construct_error("Add-on rejected: The add-on already exists, and your passphrase was incorrect."), sock);
+						} else {
+							const time_t upload_ts = time(NULL);
+
+							LOG_CS << "Upload is owner upload.\n";
+							std::string message = "Add-on accepted.";
+
+							if (!version_info(upload["version"]).good()) {
+								message += "\n<255,255,0>Note: The version you specified is invalid. This add-on will be ignored for automatic update checks.";
+							}
+
+							if(campaign == NULL) {
+								campaign = &campaigns().add_child("campaign");
+								(*campaign)["original_timestamp"] = lexical_cast<std::string>(upload_ts);
+							}
+
+							(*campaign)["title"] = upload["title"];
+							(*campaign)["name"] = upload["name"];
+							(*campaign)["filename"] = "data/" + upload["name"].str();
+							(*campaign)["passphrase"] = upload["passphrase"];
+							(*campaign)["author"] = upload["author"];
+							(*campaign)["description"] = upload["description"];
+							(*campaign)["version"] = upload["version"];
+							(*campaign)["icon"] = upload["icon"];
+							(*campaign)["translate"] = upload["translate"];
+							(*campaign)["dependencies"] = upload["dependencies"];
+							(*campaign)["upload_ip"] = network::ip_address(sock);
+							(*campaign)["type"] = upload["type"];
+							(*campaign)["email"] = upload["email"];
+
+							if((*campaign)["highest_review_id"].empty()) {
+								(*campaign)["highest_review_id"] = 0;
+							}
+							if((*campaign)["downloads"].empty()) {
+								(*campaign)["downloads"] = 0;
+							}
+							(*campaign)["timestamp"] = lexical_cast<std::string>(upload_ts);
+
+							int uploads = (*campaign)["uploads"].to_int() + 1;
+							(*campaign)["uploads"] = uploads;
+
+							(*campaign).clear_children("feedback");
+							if(const config& url_params = upload.child("feedback")) {
+								(*campaign).add_child("feedback", url_params);
+							}
+
+							std::string filename = (*campaign)["filename"];
+							data["title"] = (*campaign)["title"];
+							data["name"] = "";
+							data["campaign_name"] = (*campaign)["name"];
+							data["author"] = (*campaign)["author"];
+							data["description"] = (*campaign)["description"];
+							data["version"] = (*campaign)["version"];
+							data["timestamp"] = (*campaign)["timestamp"];
+							data["original_timestamp"] = (*campaign)["original_timestamp"];
+							data["icon"] = (*campaign)["icon"];
+							data["type"] = (*campaign)["type"];
+							(*campaign).clear_children("translation");
+							find_translations(data, *campaign);
+
+							add_license(data);
+
+							{
+								scoped_ostream campaign_file = ostream_file(filename);
+								config_writer writer(*campaign_file, true, compress_level_);
+								writer.write(data);
+							}
+//							write_compressed(*campaign_file, *data);
+
+							(*campaign)["size"] = lexical_cast<std::string>(
+									file_size(filename));
+							scoped_ostream cfgfile = ostream_file(file_);
+							write(*cfgfile, cfg_);
+							network::send_data(construct_message(message), sock);
+
+							fire("hook_post_upload", upload["name"]);
+						}
+					}
+					else if (const config &erase = data.child("delete"))
+					{
+						if(read_only_) {
+							LOG_CS << "in read-only mode, request to delete '" << erase["name"] << "' from " << network::ip_address(sock) << " denied\n";
+							network::send_data(construct_error("Cannot delete add-on: The server is currently in read-only mode."), sock);
+							continue;
+						}
+
+						LOG_CS << "deleting campaign '" << erase["name"] << "' requested from " << network::ip_address(sock) << "\n";
+						const config &campaign = campaigns().find_child("campaign", "name", erase["name"]);
+						if (!campaign) {
+							network::send_data(construct_error("The add-on does not exist."), sock);
+							continue;
+						}
+
+						if (campaign["passphrase"] != erase["passphrase"]
+								&& (campaigns()["master_password"].empty()
+								|| campaigns()["master_password"] != erase["passphrase"]))
+						{
+							network::send_data(construct_error("The passphrase is incorrect."), sock);
+							continue;
+						}
+
+						//erase the campaign
+						write_file(campaign["filename"], std::string());
+						remove(campaign["filename"].str().c_str());
+
+						config::child_itors itors = campaigns().child_range("campaign");
+						for (size_t index = 0; itors.first != itors.second;
+						     ++index, ++itors.first)
+						{
+							if (&campaign == &*itors.first) {
+								campaigns().remove_child("campaign", index);
+								break;
+							}
+						}
+						scoped_ostream cfgfile = ostream_file(file_);
+						write(*cfgfile, cfg_);
+						network::send_data(construct_message("Add-on deleted."), sock);
+
+						fire("hook_post_erase", erase["name"]);
+					}
+					else if (const config &cpass = data.child("change_passphrase"))
+					{
+						if(read_only_) {
+							LOG_CS << "in read-only mode, request to change passphrase denied\n";
+							network::send_data(construct_error("Cannot change passphrase: The server is currently in read-only mode."), sock);
+							continue;
+						}
+
+						config &campaign = campaigns().find_child("campaign", "name", cpass["name"]);
+						if (!campaign) {
+							network::send_data(construct_error("No add-on with that name exists."), sock);
+						} else if (campaign["passphrase"] != cpass["passphrase"]) {
+							network::send_data(construct_error("Your old passphrase was incorrect."), sock);
+						} else if (cpass["new_passphrase"].empty()) {
+							network::send_data(construct_error("No new passphrase was supplied."), sock);
+						} else {
+							campaign["passphrase"] = cpass["new_passphrase"];
+							scoped_ostream cfgfile = ostream_file(file_);
+							write(*cfgfile, cfg_);
+							network::send_data(construct_message("Passphrase changed."), sock);
+						}
+					}
+					else if (const config &req = data.child("rate_addon"))
+					{
+						LOG_CS << "received rating of '" << req["addon_name"] << "' from " << network::ip_address(sock) << std::endl;
+						config &campaign = campaigns().find_child("campaign", "name", req["addon_name"]);
+						if (!campaign) {
+							network::send_data(construct_error("Add-on '" + req["addon_name"].str() + "' not found."), sock);
+						} else {
+							if (!req["rating"].empty()) {
+								config& new_rating = campaign.add_child("rate");
+								new_rating["num"] = req["rating"];
+								new_rating["ip"] = network::ip_address(sock);
+								new_rating["time"] = lexical_cast<std::string>(time(NULL));
+								campaign["user_rating"] = req["rating"];
+							}
+							const config& users_review = req.child_or_empty("user_review");
+							if (!users_review.empty()) {
+								config& new_review = campaign.add_child("review");
+								if (!users_review["gameplay"].empty()) {
+									new_review["gameplay"] = users_review["gameplay"];
+								}
+								if (!users_review["visuals"].empty()) {
+									new_review["visuals"] = users_review["visuals"];
+								}
+								if (!users_review["story"].empty())
+								{
+									new_review["story"] = users_review["story"];
+								}
+								if (!users_review["balance"].empty())
+								{
+									new_review["balance"] = users_review["balance"];
+								}
+								if (!users_review["overall"].empty())
+								{
+									new_review["overall"] = users_review["overall"];
+								}
+								new_review["ip"] = network::ip_address(sock);
+								new_review["time"] = lexical_cast<std::string>(time(NULL));
+								campaign["highest_review_id"] = campaign["highest_review_id"].to_int() + 1;
+								new_review["id"] = campaign["highest_review_id"];
+							}
+							BOOST_FOREACH(const config &liked_review, req.child_range("liked_review"))
+							{
+								config& review = campaign.find_child("review", "id", liked_review["number"]);
+								if (review) {
+									if (!review["likers_ips"].empty()) {
+										review["likers_ips"] = review["likers_ips"] + std::string(",") + network::ip_address(sock);
+									} else {
+										review["likers_ips"] = network::ip_address(sock);
+									}
+								}
+							}
+						}
+					}
+				}
+			} catch(network::error& e) {
+				if(!e.socket) {
+					LOG_CS << "fatal network error: " << e.message << "\n";
+					throw;
+				} else {
+					LOG_CS << "client disconnect: " << e.message << " " << network::ip_address(e.socket) << "\n";
+					e.disconnect();
+				}
+			} catch(const config::error& e) {
+				network::connection err_sock = 0;
+				network::connection const * err_connection = boost::get_error_info<network::connection_info>(e);
+				if(err_connection != NULL) {
+					err_sock = *err_connection;
+				}
+				if(err_sock == 0 && sock > 0)
+					err_sock = sock;
+				if(err_sock) {
+					LOG_CS << "client disconnect due to exception: " << e.what() << " " << network::ip_address(err_sock) << "\n";
+					network::disconnect(err_sock);
+>>>>>>> 2a9491e... Made add-ons's list window display ratings instead of download counts, made the
 				} else {
 					review["likers_ips"] = network::ip_address(sock);
 				}

--- a/src/campaign_server/campaign_server.hpp
+++ b/src/campaign_server/campaign_server.hpp
@@ -163,10 +163,12 @@ private:
 
 	void handle_request_campaign_list(const request&);
 	void handle_request_campaign(const request&);
+	void handle_submit_gameplay_times(const request&);
 	void handle_request_terms(const request&);
 	void handle_upload(const request&);
 	void handle_delete(const request&);
 	void handle_change_passphrase(const request&);
+	void handle_rate_addon(const request&);
 
 	//
 	// Generic responses.

--- a/src/campaign_server/campaign_server.hpp
+++ b/src/campaign_server/campaign_server.hpp
@@ -113,6 +113,16 @@ private:
 	void write_config();
 
 	/**
+	 * Recalculates the times players spent playing add-ons and users' rating of all add-ons.
+	 */
+	void recalculate_player_data();
+
+	/**
+	 * Recalculates the users' ratings of add-ons.
+	 */
+	void recalculate_campaign_ratings(std::string campaign_name);
+
+	/**
 	 * Reads the add-ons upload blacklist from WML.
 	 */
 	void load_blacklist();

--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -291,6 +291,7 @@ void game_config_manager::load_addons_cfg()
 		try {
 			config umc_cfg;
 			cache_.get_config(toplevel, umc_cfg);
+			pair_subjects_with_addon(toplevel,umc_cfg);
 			game_config_.append(umc_cfg);
 		} catch(config::error& err) {
 			ERR_CONFIG << "error reading usermade add-on '" << uc << "'" << std::endl;
@@ -414,6 +415,45 @@ void game_config_manager::load_game_config_for_game(
 		load_game_config(NO_FORCE_RELOAD);
 
 		throw;
+	}
+}
+
+void game_config_manager::pair_subjects_with_addon(const std::string& main, const config& umc_cfg) {
+	std::string without_ending;
+	if (main.find("_main.cfg")) {
+		without_ending = main.substr(0,main.find_last_of("/\\"));
+	} else {
+		without_ending = main.substr(0,main.find_last_of(".cfg"));
+	}
+	std::string addon_id(without_ending.substr(without_ending.find_last_of("/\\")+1));
+
+	BOOST_FOREACH(const config &campaign, umc_cfg.child_range("campaign")) {
+		if (!campaign["id"].empty()) {
+			config& this_entry = game_config_.add_child("subject_addon_pair");
+			this_entry["addon_id"] = addon_id;
+			this_entry["subject"] = campaign["id"];
+		}
+	}
+	BOOST_FOREACH(const config &multiplayer, umc_cfg.child_range("multiplayer")) {
+		if (!multiplayer["id"].empty()) {
+			config& this_entry = game_config_.add_child("subject_addon_pair");
+			this_entry["addon_id"] = addon_id;
+			this_entry["subject"] = multiplayer["id"];
+		}
+	}
+	BOOST_FOREACH(const config &era, umc_cfg.child_range("era")) {
+		if (!era["id"].empty()) {
+			config& this_entry = game_config_.add_child("subject_addon_pair");
+			this_entry["addon_id"] = addon_id;
+			this_entry["subject"] = era["id"];
+		}
+	}
+	BOOST_FOREACH(const config &modification, umc_cfg.child_range("modification")) {
+		if (!modification["id"].empty()) {
+			config& this_entry = game_config_.add_child("subject_addon_pair");
+			this_entry["addon_id"] = addon_id;
+			this_entry["subject"] = modification["id"];
+		}
 	}
 }
 

--- a/src/game_config_manager.hpp
+++ b/src/game_config_manager.hpp
@@ -53,6 +53,8 @@ private:
 	void set_color_info();
 	void set_unit_data();
 
+	void pair_subjects_with_addon(const std::string& main, const config& umc_cfg);
+
 	const commandline_options& cmdline_opts_;
 	game_display& disp_;
 	const bool jump_to_editor_;

--- a/src/gui/dialogs/addon/addon_rate.cpp
+++ b/src/gui/dialogs/addon/addon_rate.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright (C) 2008 - 2014 by Jörg Hinrichs <joerg.hinrichs@alice-dsl.de>
+   Copyright (C) 2008 - 2014 by Ján Dugáček
    Part of the Battle for Wesnoth Project http://www.wesnoth.org/
 
    This program is free software; you can redistribute it and/or modify
@@ -55,8 +55,7 @@ taddon_rate::taddon_rate(int& input)
 void taddon_rate::pre_show(CVideo& /*video*/, twindow& window)
 {
 	tslider& slider = find_widget<tslider>(&window, "rating_input", false);
-	slider.set_decimals(1);
-	slider.set_show_maximum(true);
+	slider.set_value(5);
 }
 
 } // namespace gui2

--- a/src/gui/dialogs/addon/addon_rate.cpp
+++ b/src/gui/dialogs/addon/addon_rate.cpp
@@ -1,0 +1,63 @@
+/*
+   Copyright (C) 2008 - 2014 by Jörg Hinrichs <joerg.hinrichs@alice-dsl.de>
+   Part of the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#define GETTEXT_DOMAIN "wesnoth-lib"
+
+#include "gui/dialogs/addon/addon_rate.hpp"
+
+#include "gettext.hpp"
+#include "gui/dialogs/field.hpp"
+#include "gui/widgets/button.hpp"
+#include "gui/widgets/label.hpp"
+#include "gui/widgets/settings.hpp"
+#include "gui/widgets/slider.hpp"
+
+namespace gui2 {
+
+/*WIKI
+ * @page = GUIWindowDefinitionWML
+ * @order = 2_addon_rating
+ *
+ * == Rate an add-on ==
+ *
+ * This shows the dialog to insert user rating.
+ *
+ * @begin{table}{dialog_widgets}
+ *
+ * title & & label & m &
+ *         The title of the window. $
+ *
+ * rating_input & & text_box & m &
+ *         The user's rating. $
+ *
+ * @end{table}
+ */
+
+REGISTER_DIALOG(addon_rate)
+
+taddon_rate::taddon_rate(int& input)
+{
+
+	register_integer("rating_input", true, input );
+}
+
+void taddon_rate::pre_show(CVideo& /*video*/, twindow& window)
+{
+	tslider& slider = find_widget<tslider>(&window, "rating_input", false);
+	slider.set_decimals(1);
+	slider.set_show_maximum(true);
+}
+
+} // namespace gui2
+

--- a/src/gui/dialogs/addon/addon_rate.cpp
+++ b/src/gui/dialogs/addon/addon_rate.cpp
@@ -55,7 +55,6 @@ taddon_rate::taddon_rate(int& input)
 void taddon_rate::pre_show(CVideo& /*video*/, twindow& window)
 {
 	tslider& slider = find_widget<tslider>(&window, "rating_input", false);
-	slider.set_value(5);
 }
 
 } // namespace gui2

--- a/src/gui/dialogs/addon/addon_rate.hpp
+++ b/src/gui/dialogs/addon/addon_rate.hpp
@@ -1,0 +1,49 @@
+/*
+   Copyright (C) 2008 - 2014 by Jörg Hinrichs <joerg.hinrichs@alice-dsl.de>
+   Part of the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#ifndef GUI_DIALOGS_SAVE_GAME_HPP_INCLUDED
+#define GUI_DIALOGS_SAVE_GAME_HPP_INCLUDED
+
+#include "gui/dialogs/dialog.hpp"
+#include "tstring.hpp"
+
+namespace gui2 {
+
+class taddon_rate : public tdialog
+{
+public:
+
+
+	static bool execute(int& input
+			, CVideo& video)
+	{
+		return taddon_rate(input).show(video);
+	}
+
+private:
+
+	taddon_rate(int& rate);
+
+	/** Inherited from tdialog, implemented by REGISTER_DIALOG. */
+	virtual const std::string& window_id() const;
+
+	/** Inherited from tdialog */
+	void pre_show(CVideo& video, twindow& window);
+
+};
+
+}
+
+#endif
+

--- a/src/gui/dialogs/addon/addon_rate.hpp
+++ b/src/gui/dialogs/addon/addon_rate.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright (C) 2008 - 2014 by Jörg Hinrichs <joerg.hinrichs@alice-dsl.de>
+   Copyright (C) 2008 - 2014 by Ján Dugáček
    Part of the Battle for Wesnoth Project http://www.wesnoth.org/
 
    This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/addon/addon_review_write.cpp
+++ b/src/gui/dialogs/addon/addon_review_write.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright (C) 2008 - 2014 by Jörg Hinrichs <joerg.hinrichs@alice-dsl.de>
+   Copyright (C) 2008 - 2014 by Ján Dugáček
    Part of the Battle for Wesnoth Project http://www.wesnoth.org/
 
    This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/addon/addon_review_write.cpp
+++ b/src/gui/dialogs/addon/addon_review_write.cpp
@@ -1,0 +1,70 @@
+/*
+   Copyright (C) 2008 - 2014 by Jörg Hinrichs <joerg.hinrichs@alice-dsl.de>
+   Part of the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#define GETTEXT_DOMAIN "wesnoth-lib"
+
+#include "gui/dialogs/addon/addon_review_write.hpp"
+
+#include "gettext.hpp"
+#include "gui/dialogs/field.hpp"
+#include "gui/widgets/button.hpp"
+#include "gui/widgets/label.hpp"
+#include "gui/widgets/settings.hpp"
+
+namespace gui2 {
+
+/*WIKI
+ * @page = GUIWindowDefinitionWML
+ * @order = 2_addon_rating
+ *
+ * == Rate an add-on ==
+ *
+ * This shows the dialog to insert user rating.
+ *
+ * @begin{table}{dialog_widgets}
+ *
+ * lblTitle & & label & m &
+ *         The title of the window. $
+ *
+ * gameplay_input & & text_box & m &
+ *         The user's comment about the add-on's gameplay. $
+ *
+ * visuals_input & & text_box & m &
+ *         The user's comment about the add-on's visuals. $
+ *
+ * story_input & & text_box & m &
+ *         The user's comment about the add-on's storyline. $
+ *
+ * balance_input & & text_box & m &
+ *         The user's comment about the add-on's balance. $
+ *
+ * overall_input & & text_box & m &
+ *         The user's overall comment about the add-on.. $
+ *
+ * @end{table}
+ */
+
+REGISTER_DIALOG(addon_review_write)
+
+taddon_review_write::taddon_review_write(addon_info::addon_review& review)
+{
+	register_text("gameplay_input", false, review.gameplay, true);
+	register_text("visuals_input", false, review.visuals, true);
+	register_text("story_input", false, review.story, true);
+	register_text("balance_input", false, review.balance, true);
+	register_text("overall_input", false, review.overall, true);
+}
+
+} // namespace gui2
+

--- a/src/gui/dialogs/addon/addon_review_write.hpp
+++ b/src/gui/dialogs/addon/addon_review_write.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright (C) 2008 - 2014 by Jörg Hinrichs <joerg.hinrichs@alice-dsl.de>
+   Copyright (C) 2008 - 2014 by Ján Dugáček
    Part of the Battle for Wesnoth Project http://www.wesnoth.org/
 
    This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/addon/addon_review_write.hpp
+++ b/src/gui/dialogs/addon/addon_review_write.hpp
@@ -1,0 +1,45 @@
+/*
+   Copyright (C) 2008 - 2014 by Jörg Hinrichs <joerg.hinrichs@alice-dsl.de>
+   Part of the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#ifndef GUI_DIALOGS_SAVE_GAME_HPP_INCLUDED
+#define GUI_DIALOGS_SAVE_GAME_HPP_INCLUDED
+
+#include "gui/dialogs/dialog.hpp"
+#include "tstring.hpp"
+#include "addon/info.hpp"
+
+namespace gui2 {
+
+class taddon_review_write : public tdialog
+{
+public:
+
+	static bool execute(addon_info::addon_review& review
+			, CVideo& video)
+	{
+		return taddon_review_write(review).show(video);
+	}
+
+private:
+
+	taddon_review_write(addon_info::addon_review& review);
+
+	/** Inherited from tdialog, implemented by REGISTER_DIALOG. */
+	virtual const std::string& window_id() const;
+};
+
+}
+
+#endif
+

--- a/src/gui/dialogs/addon/description.cpp
+++ b/src/gui/dialogs/addon/description.cpp
@@ -386,9 +386,9 @@ void taddon_description::pre_show(CVideo& /*video*/, twindow& window)
 	ttext_box& url_textbox = find_widget<ttext_box>(&window, "url", false);
 
 	connect_signal_mouse_left_click(
-				find_widget<tbutton>(&window, "vote_button", false)
+				find_widget<tbutton>(&window, "rate_button", false)
 				, boost::bind(
-					&gui2::taddon_description::vote_button_callback
+					&gui2::taddon_description::rate_button_callback
 					, this
 					, boost::ref(window)));
 
@@ -433,7 +433,7 @@ void taddon_description::pre_show(CVideo& /*video*/, twindow& window)
 	}
 }
 
-void taddon_description::vote_button_callback(twindow& window)
+void taddon_description::rate_button_callback(twindow& window)
 {
 	if (current_users_rating_.numerical == -1) {
 		current_users_rating_.numerical = 50;

--- a/src/gui/dialogs/addon/description.cpp
+++ b/src/gui/dialogs/addon/description.cpp
@@ -343,7 +343,12 @@ taddon_description::taddon_description(const std::string& addon_id,
 				true);
 	}
 
-	register_label("players_rating", true, str_cast(addon.user_rating/10) + "." + str_cast(addon.user_rating % 10) + "/10");
+	if (addon.user_rating != -1) {
+		register_label("players_rating", true, str_cast(addon.user_rating/10) + "." + str_cast(addon.user_rating % 10) + "/10");
+	} else {
+		register_label("players_rating", true, "None yet");
+	}
+
 	register_label("hours_spent_playing", true, str_cast(addon.hours_played));
 
 	feedback_url_ = addon.feedback_url;
@@ -436,10 +441,10 @@ void taddon_description::pre_show(CVideo& /*video*/, twindow& window)
 void taddon_description::rate_button_callback(twindow& window)
 {
 	if (current_users_rating_.numerical == -1) {
-		current_users_rating_.numerical = 50;
+		current_users_rating_.numerical = 5;
 	}
 	gui2::taddon_rate::execute(current_users_rating_.numerical,window.video());
-
+		current_users_rating_.numerical *= 10;
 }
 
 void taddon_description::reviews_button_callback(twindow& window)

--- a/src/gui/dialogs/addon/description.hpp
+++ b/src/gui/dialogs/addon/description.hpp
@@ -26,6 +26,7 @@ namespace gui2
 class taddon_description : public tdialog
 {
 public:
+
 	/**
 	 * Constructor.
 	 *
@@ -36,24 +37,30 @@ public:
 	 *                            @a addons_list.
 	 */
 	taddon_description(const std::string& addon_id,
-					   const addons_list& addons_list,
-					   const addons_tracking_list& addon_states);
+					   addons_list& addons_list,
+					   const addons_tracking_list& addon_states,
+					   addon_info::this_users_rating& current_users_rating);
 
 	/**
 	 * The display function.
 	 *
 	 * See @ref tdialog for more information.
 	 */
-	static void display(const std::string& addon_id,
-						const addons_list& addons_list,
-						const addons_tracking_list& addon_states,
-						CVideo& video)
+	static addon_info::this_users_rating display(const std::string& addon_id, addons_list& addons_list, const addons_tracking_list& addon_states, CVideo& video)
 	{
-		taddon_description(addon_id, addons_list, addon_states).show(video);
+		addon_info::this_users_rating users_rating;
+		users_rating.numerical = -1; //Not rated yet.
+		taddon_description addon_description(addon_id, addons_list, addon_states, users_rating);
+		addon_description.show(video);
+		return addon_description.current_users_rating_;
 	}
 
 private:
 	std::string feedback_url_;
+	addons_list& list_of_addons_;
+	const std::string& addon_id_;
+
+	addon_info::this_users_rating current_users_rating_;
 
 	/** Inherited from tdialog, implemented by REGISTER_DIALOG. */
 	virtual const std::string& window_id() const;
@@ -63,6 +70,10 @@ private:
 
 	void browse_url_callback();
 	void copy_url_callback();
+
+	void vote_button_callback(twindow& window);
+	void reviews_button_callback(twindow& window);
+
 };
 }
 

--- a/src/gui/dialogs/addon/description.hpp
+++ b/src/gui/dialogs/addon/description.hpp
@@ -71,7 +71,7 @@ private:
 	void browse_url_callback();
 	void copy_url_callback();
 
-	void vote_button_callback(twindow& window);
+	void rate_button_callback(twindow& window);
 	void reviews_button_callback(twindow& window);
 
 };

--- a/src/gui/dialogs/addon/description.hpp
+++ b/src/gui/dialogs/addon/description.hpp
@@ -46,10 +46,9 @@ public:
 	 *
 	 * See @ref tdialog for more information.
 	 */
-	static addon_info::this_users_rating display(const std::string& addon_id, addons_list& addons_list, const addons_tracking_list& addon_states, CVideo& video)
+	static addon_info::this_users_rating display(const std::string& addon_id, addons_list& addons_list,
+												 const addons_tracking_list& addon_states, CVideo& video, addon_info::this_users_rating& users_rating)
 	{
-		addon_info::this_users_rating users_rating;
-		users_rating.numerical = -1; //Not rated yet.
 		taddon_description addon_description(addon_id, addons_list, addon_states, users_rating);
 		addon_description.show(video);
 		return addon_description.current_users_rating_;
@@ -73,6 +72,8 @@ private:
 
 	void rate_button_callback(twindow& window);
 	void reviews_button_callback(twindow& window);
+
+	void set_rating_label_contents(twindow& window);
 
 };
 }

--- a/src/gui/dialogs/addon/filter_options.cpp
+++ b/src/gui/dialogs/addon/filter_options.cpp
@@ -99,8 +99,8 @@ namespace gui2
  * sort_descending & & toggle_button & m &
  *     Display add-ons in descending order by default. $
  *
- * * sort_by_rating & & toggle_button & m &
- *     Sort add-ons by rating by default. $
+ * * sort_by_score & & toggle_button & m &
+ *     Sort add-ons by score by default. $
  *
  * sort_by_name & & toggle_button & m &
  *     Sort add-ons by name by default. $
@@ -239,7 +239,7 @@ void taddon_filter_options::pre_show(CVideo& /*video*/, twindow& window)
 						boost::ref(window)));
 
 	sort_tgroup_.clear();
-	register_sort_toggle(window, "by_rating", SORT_RATING);
+	register_sort_toggle(window, "by_score", SORT_SCORE);
 	register_sort_toggle(window, "by_name", SORT_NAMES);
 	register_sort_toggle(window, "by_last_updated", SORT_UPDATED);
 	register_sort_toggle(window, "by_first_upload", SORT_CREATED);

--- a/src/gui/dialogs/addon/filter_options.cpp
+++ b/src/gui/dialogs/addon/filter_options.cpp
@@ -99,6 +99,9 @@ namespace gui2
  * sort_descending & & toggle_button & m &
  *     Display add-ons in descending order by default. $
  *
+ * * sort_by_rating & & toggle_button & m &
+ *     Sort add-ons by rating by default. $
+ *
  * sort_by_name & & toggle_button & m &
  *     Sort add-ons by name by default. $
  *
@@ -234,6 +237,7 @@ void taddon_filter_options::pre_show(CVideo& /*video*/, twindow& window)
 						boost::ref(window)));
 
 	sort_tgroup_.clear();
+	register_sort_toggle(window, "by_rating", SORT_RATING);
 	register_sort_toggle(window, "by_name", SORT_NAMES);
 	register_sort_toggle(window, "by_last_updated", SORT_UPDATED);
 	register_sort_toggle(window, "by_first_upload", SORT_CREATED);

--- a/src/gui/dialogs/addon/filter_options.cpp
+++ b/src/gui/dialogs/addon/filter_options.cpp
@@ -144,6 +144,8 @@ taddon_filter_options::taddon_filter_options()
 	// FIXME: (also in WML) should this and Unknown be a single option in the
 	// UI?
 	register_displayed_type_field("show_other", ADDON_OTHER);
+
+	register_bool("upload_statistics", true, upload_gameplay_times_);
 }
 
 void taddon_filter_options::register_displayed_type_field(

--- a/src/gui/dialogs/addon/filter_options.hpp
+++ b/src/gui/dialogs/addon/filter_options.hpp
@@ -73,6 +73,16 @@ public:
 		dir_ = direction;
 	}
 
+	void set_upload_gameplay_times(bool upload_gameplay_times)
+	{
+		upload_gameplay_times_ = upload_gameplay_times;
+	}
+
+	bool get_upload_gameplay_times()
+	{
+		return upload_gameplay_times_;
+	}
+
 private:
 	ADDON_STATUS_FILTER displayed_status_;
 	boost::array<bool, ADDON_TYPES_COUNT> displayed_types_;
@@ -80,6 +90,8 @@ private:
 
 	ADDON_SORT sort_;
 	ADDON_SORT_DIRECTION dir_;
+
+	bool upload_gameplay_times_;
 
 	typedef std::pair<ttoggle_button*, ADDON_SORT> sort_toggle;
 	typedef std::pair<ttoggle_button*, ADDON_SORT_DIRECTION> dir_toggle;

--- a/src/gui/dialogs/addon/reviews_list.cpp
+++ b/src/gui/dialogs/addon/reviews_list.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright (C) 2011 - 2014 by Ignacio Riquelme Morelle <shadowm2006@gmail.com>
+   Copyright (C) 2011 - 2014 by Ján Dugáček
    Part of the Battle for Wesnoth Project http://www.wesnoth.org/
 
    This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/addon/reviews_list.cpp
+++ b/src/gui/dialogs/addon/reviews_list.cpp
@@ -1,0 +1,184 @@
+/*
+   Copyright (C) 2011 - 2014 by Ignacio Riquelme Morelle <shadowm2006@gmail.com>
+   Part of the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#include "gui/dialogs/addon/reviews_list.hpp"
+
+#include "gui/auxiliary/find_widget.tpp"
+#include "gui/widgets/grid.hpp"
+#ifdef GUI2_EXPERIMENTAL_LISTBOX
+#include "gui/widgets/list.hpp"
+#else
+#include "gui/widgets/listbox.hpp"
+#endif
+#include "gui/widgets/settings.hpp"
+#include "gui/widgets/toggle_button.hpp"
+#include "gui/widgets/window.hpp"
+#include "utils/foreach.tpp"
+#include "gettext.hpp"
+#include "addon/info.hpp"
+#include <boost/bind.hpp>
+#include "gui/widgets/button.hpp"
+#include "gui/dialogs/addon/addon_review_write.hpp"
+
+#include <algorithm>
+
+namespace gui2
+{
+
+/*WIKI
+ * @page = GUIWindowDefinitionWML
+ * @order = 7_addon_reviews_list
+ *
+ * == Add-on reviews list ==
+ *
+ * Dialog with a checkbox list for reading reviews of add-ons and voting them up.
+ *
+ * @begin{table}{dialog_widgets}
+ *
+ * reviews_list & & listbox & m &
+ *     A listbox containing reviews. $
+ *
+ * -player_agrees & & toggle_button & m &
+ *     A toggle button allowing the user to mark which review he likes. $
+ *
+ * -review_box & & scroll_label & m &
+ *     A scroll label where the reviews appear. $
+ *
+ * -people_who_agree & & label & o &
+ *     A label that shows the number of people who voted up that review. $
+ *
+ * @end{table}
+ */
+
+std::string& taddon_reviews_list::cut_into_more_lines(std::string& inserted, int max_length) {
+	// This is basically a workaround for the problem that more than one scroll label can't
+	// appear in the same window, that results in no division of long strings into lines.
+	unsigned int i = 0;
+	while (i < inserted.size()) {
+		unsigned int j;
+		for (j = i + max_length; j >= i; j--) {
+			if (j == i) {
+				inserted.insert(i + max_length,"\n");
+				i += max_length;
+				break;
+			}
+			if (j >= inserted.size()) {
+				i = inserted.size();
+				break;
+			}
+			if (inserted[j] == 32) {
+				inserted[j] = 10;
+				i = j;
+				break;
+			}
+		}
+	}
+	return inserted;
+}
+
+REGISTER_DIALOG(addon_reviews_list)
+
+void taddon_reviews_list::pre_show(CVideo& /*video*/, twindow& window)
+{
+	tlistbox& list = find_widget<tlistbox>(&window, "reviews_list", false);
+	FOREACH(AUTO & entry, addon.reviews)
+	{
+		entry.sorted = false;
+	}
+
+	for (unsigned int i = 0; i < addon.reviews.size(); i++) {
+		int most = -1;
+		int best = -1;
+		for (unsigned int j = 0; j < addon.reviews.size(); j++) {
+			if (addon.reviews[j].sorted == false && addon.reviews[j].likes > most) {
+				most = addon.reviews[j].likes;
+				best = j;
+			}
+		}
+		if (best != -1) {
+			std::string review_content;
+			if (addon.reviews[best].gameplay.size() > 0) {
+				std::string this_part(_("Gameplay: ") + addon.reviews[best].gameplay + "\n");
+				review_content += cut_into_more_lines(this_part);
+			}
+			if (addon.reviews[best].visuals.size() > 0) {
+				std::string this_part(_("Visuals: ") + addon.reviews[best].visuals + "\n");
+				review_content += cut_into_more_lines(this_part);
+			}
+			if (addon.reviews[best].story.size() > 0) {
+				std::string this_part(_("Story: ") + addon.reviews[best].story + "\n");
+				review_content += cut_into_more_lines(this_part);
+			}
+			if (addon.reviews[best].balance.size() > 0) {
+				std::string this_part(_("Balance: ") + addon.reviews[best].balance + "\n");
+				review_content += cut_into_more_lines(this_part);
+			}
+			if (addon.reviews[best].overall.size() > 0) {
+				std::string this_part(_("Overall: ") + addon.reviews[best].overall + "\n");
+				review_content += cut_into_more_lines(this_part);
+			}
+
+			std::map<std::string, string_map> data;
+			string_map column;
+
+			column["label"] = review_content;
+			data.insert(std::make_pair("review_box", column));
+
+			std::string agreements(str_cast(addon.reviews[best].likes) + _(" people like this review. Do you like it too?"));
+			column["label"] = agreements;
+			data.insert(std::make_pair("people_who_agree", column));
+
+			list.add_row(data);
+			addon.reviews[best].sorted = true;
+		}
+	}
+
+	connect_signal_mouse_left_click(
+				find_widget<tbutton>(&window, "write_a_review", false)
+				, boost::bind(
+					&gui2::taddon_reviews_list::write_review_button_callback
+					, this
+					, boost::ref(window)));
+
+}
+
+void taddon_reviews_list::post_show(twindow& window)
+{
+	tlistbox& list = find_widget<tlistbox>(&window, "reviews_list", false);
+
+	unsigned int i = 0;
+	FOREACH(AUTO & entry, addon.reviews)
+	{
+		tgrid* row = list.get_row_grid(i);
+		ttoggle_button& checkbox
+				= find_widget<ttoggle_button>(row, "player_agrees", false);
+		if (checkbox.get_value()) {
+			current_users_rating_.liked_reviews.push_back(entry.id);
+		}
+		i++;
+	}
+}
+
+void taddon_reviews_list::write_review_button_callback(twindow& window)
+{
+	current_users_rating_.submitted_review = gui2::taddon_review_write::execute(current_users_rating_.custom_review,window.video());
+	if (current_users_rating_.submitted_review == true && current_users_rating_.custom_review.overall.size() == 0 &&
+			current_users_rating_.custom_review.visuals.size() == 0 && current_users_rating_.custom_review.gameplay.size() == 0 &&
+			current_users_rating_.custom_review.balance.size() == 0 && current_users_rating_.custom_review.story.size() == 0) {
+		current_users_rating_.submitted_review = false;
+	}
+}
+
+
+} // namespace gui2

--- a/src/gui/dialogs/addon/reviews_list.cpp
+++ b/src/gui/dialogs/addon/reviews_list.cpp
@@ -89,6 +89,17 @@ std::string& taddon_reviews_list::cut_into_more_lines(std::string& inserted, int
 
 REGISTER_DIALOG(addon_reviews_list)
 
+taddon_reviews_list::taddon_reviews_list(addon_info& _addon, addon_info::this_users_rating& current_users_rating)
+	: addon(_addon) , current_users_rating_(current_users_rating)
+{
+	if (addon.reviews.empty()) {
+		initial_comment = _("There are no reviews for this add-on yet. If you know this add-on, help fellow players and add your own review!");
+	} else {
+		initial_comment = _("If you know this add-on, vote for the review that reflects your opinion the best or write your own review.");
+	}
+	register_label("initial_comment", true, initial_comment);
+}
+
 void taddon_reviews_list::pre_show(CVideo& /*video*/, twindow& window)
 {
 	tlistbox& list = find_widget<tlistbox>(&window, "reviews_list", false);

--- a/src/gui/dialogs/addon/reviews_list.hpp
+++ b/src/gui/dialogs/addon/reviews_list.hpp
@@ -42,6 +42,8 @@ private:
 
 	std::string initial_comment;
 
+	std::vector<int> order;
+
 	/** Inherited from tdialog, implemented by REGISTER_DIALOG. */
 	virtual const std::string& window_id() const;
 

--- a/src/gui/dialogs/addon/reviews_list.hpp
+++ b/src/gui/dialogs/addon/reviews_list.hpp
@@ -1,0 +1,61 @@
+/*
+   Copyright (C) 2011 - 2014 by Ignacio Riquelme Morelle <shadowm2006@gmail.com>
+   Part of the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#ifndef GUI_DIALOGS_ADDON_UNINSTALL_LIST_HPP_INCLUDED
+#define GUI_DIALOGS_ADDON_UNINSTALL_LIST_HPP_INCLUDED
+
+#include "gui/dialogs/dialog.hpp"
+#include "addon/info.hpp"
+
+#include <map>
+
+namespace gui2
+{
+
+class taddon_reviews_list : public tdialog
+{
+public:
+	/**
+	 * Constructor.
+	 *
+	 * @param addon
+	 *                        Infomation about the add-on
+	 */
+	explicit taddon_reviews_list(addon_info& _addon, addon_info::this_users_rating& current_users_rating)
+		: addon(_addon) , current_users_rating_(current_users_rating)
+	{
+	}
+
+private:
+	std::string& cut_into_more_lines(std::string& inserted, int max_length = 95);
+
+	addon_info& addon;
+	addon_info::this_users_rating& current_users_rating_;
+
+
+	/** Inherited from tdialog, implemented by REGISTER_DIALOG. */
+	virtual const std::string& window_id() const;
+
+	/** Inherited from tdialog. */
+	void pre_show(CVideo& video, twindow& window);
+
+	/** Inherited from tdialog. */
+	void post_show(twindow& window);
+
+	void write_review_button_callback(twindow& window);
+};
+
+} // namespace gui2
+
+#endif

--- a/src/gui/dialogs/addon/reviews_list.hpp
+++ b/src/gui/dialogs/addon/reviews_list.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright (C) 2011 - 2014 by Ignacio Riquelme Morelle <shadowm2006@gmail.com>
+   Copyright (C) 2011 - 2014 by Ján Dugáček
    Part of the Battle for Wesnoth Project http://www.wesnoth.org/
 
    This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/addon/reviews_list.hpp
+++ b/src/gui/dialogs/addon/reviews_list.hpp
@@ -32,10 +32,7 @@ public:
 	 * @param addon
 	 *                        Infomation about the add-on
 	 */
-	explicit taddon_reviews_list(addon_info& _addon, addon_info::this_users_rating& current_users_rating)
-		: addon(_addon) , current_users_rating_(current_users_rating)
-	{
-	}
+	explicit taddon_reviews_list(addon_info& _addon, addon_info::this_users_rating& current_users_rating);
 
 private:
 	std::string& cut_into_more_lines(std::string& inserted, int max_length = 95);
@@ -43,6 +40,7 @@ private:
 	addon_info& addon;
 	addon_info::this_users_rating& current_users_rating_;
 
+	std::string initial_comment;
 
 	/** Inherited from tdialog, implemented by REGISTER_DIALOG. */
 	virtual const std::string& window_id() const;

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -127,7 +127,6 @@ playsingle_controller::~playsingle_controller()
 	config* prefs = preferences::get_prefs();
 	int gameplay_time = (time(NULL) - started_at_) / (6 * 20); // Measuring in tenths of hours
 	BOOST_FOREACH(const std::string& id, addons_active_) {
-		std::cout << id << std::endl;
 		if (prefs->find_child("gameplay_times" , "name" , id)) {
 			prefs->find_child("gameplay_times" , "name" , id)["time"] = str_cast( prefs->find_child("gameplay_times" , "name" , id)["time"].to_int() + gameplay_time);
 		} else {

--- a/src/playsingle_controller.hpp
+++ b/src/playsingle_controller.hpp
@@ -123,6 +123,8 @@ protected:
 	bool do_autosaves_;
 	LEVEL_RESULT level_result_;
 	void linger();
+	time_t started_at_;
+	std::vector<std::string> addons_active_;
 };
 
 

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -959,5 +959,16 @@ void set_disable_auto_moves(bool value)
 	preferences::set("disable_auto_moves", value);
 }
 
+void add_gameplay_time(std::string campaign)
+{
+	config gameplay_times = prefs.child_or_empty("gameplay_times");
+	config& entry = gameplay_times.find_child("entry", "name", campaign);
+	if (!entry["time"].empty()) {
+		entry["time"] = str_cast(entry["time"].to_int() + 1);
+	} else {
+		entry["time"] = str_cast(1);
+	}
+}
+
 } // end namespace preferences
 

--- a/src/preferences.hpp
+++ b/src/preferences.hpp
@@ -250,6 +250,8 @@ namespace preferences {
 	bool disable_auto_moves();
 	void set_disable_auto_moves(bool value);
 
+	void add_gameplay_time(std::string campaign);
+
 } // end namespace preferences
 
 #endif

--- a/src/replay_controller.cpp
+++ b/src/replay_controller.cpp
@@ -23,6 +23,7 @@
 #include "game_end_exceptions.hpp"
 #include "game_errors.hpp" //needed to be thrown
 #include "game_events/handlers.hpp"
+#include "game_events/pump.hpp"
 #include "gettext.hpp"
 #include "log.hpp"
 #include "map_label.hpp"
@@ -586,7 +587,9 @@ possible_end_play_signal replay_controller::play_move_or_side(bool one_move) {
 		//during the orginal game player_number_ would also be gamestate_.board_.teams().size(),
 		player_number_ = gamestate_.board_.teams().size();
 		finish_turn();
-		gamestate_.tod_manager_.next_turn(*resources::gamedata);
+		bool is_time_left = gamestate_.tod_manager_.next_turn(*resources::gamedata);
+		if(!is_time_left)
+			game_events::fire("time over");
 		it_is_a_new_turn_ = true;
 		player_number_ = 1;
 		current_turn_++;

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -20,6 +20,7 @@
 
 #include "save_index.hpp"
 #include "carryover.hpp"
+#include "config_assign.hpp"
 #include "configure_engine.hpp"
 #include "dialogs.hpp" //FIXME: get rid of this as soon as the two remaining dialogs are moved to gui2
 #include "format_time_summary.hpp"
@@ -797,6 +798,20 @@ static void convert_old_saves_1_13_0(config& cfg)
 			cfg.remove_child("carryover_sides_start", 0);
 		}
 	}
+#if 1
+	//This code is needed becasue for example otherwise it won't find the (empty) era 
+	if(!cfg.has_child("multiplayer")) {
+		cfg.add_child("multiplayer", config_of
+			("mp_era", "era_blank")
+			("show_connect", false)
+			("show_configure", false)
+			("mp_use_map_settings", true)
+		);
+	}
+	//the alternative code down below doesnt work replay saves or start of scenario saves 
+	//becasue those don't contain a snaphot. If the code below works with we can enable that code
+	//If it turns out that this code works well we can delete that code.
+#else
 
 	if(!cfg.has_child("multiplayer") && cfg["campaign_type"] == "scenario") {
 		saved_game tmp(cfg);
@@ -805,6 +820,7 @@ static void convert_old_saves_1_13_0(config& cfg)
 		tmp.mp_settings().mp_era = "era_blank";
 		cfg.add_child("multiplayer", tmp.mp_settings().to_config());
 	}
+#endif
 }
 
 void convert_old_saves(config& cfg)


### PR DESCRIPTION
This adds a system to allow players to find add-ons they seek more easily.

It allows the players to review the add-ons or give them numerical rating (0-10). The reviews can be 'liked' and those liked by the most people are shown the first. A numerical rating based on the frequency of downloads, users' ratings and time players spent playing it is shown instead of the downloads count on the list of add-ons and it is sorted by this number.