### PR TITLE
fix minor bug in get_healing_phase 

### DIFF
--- a/data/core/about.cfg
+++ b/data/core/about.cfg
@@ -1037,6 +1037,10 @@
         comment = "wmllint enhancements"
     [/entry]
     [entry]
+        name = "Guorui Xi (Kevin_Xi)"
+        email = "kevin_DOT_xgr_AT_gmail_DOT_com"
+    [/entry]
+    [entry]
         name = "Hans-Joachim Gurt (HaJo)"
     [/entry]
     [entry]

--- a/src/ai/testing/ca.cpp
+++ b/src/ai/testing/ca.cpp
@@ -1741,7 +1741,7 @@ double get_healing_phase::evaluate()
 			while(it.first != it.second) {
 				const map_location& dst = it.first->second;
 				if (resources::game_map->gives_healing(dst) && (units_.find(dst) == units_.end() || dst == u_it->get_location())) {
-					const double vuln = power_projection(it.first->first, get_enemy_dstsrc());
+					const double vuln = power_projection(dst, get_enemy_dstsrc());
 					DBG_AI_TESTING_AI_DEFAULT << "found village with vulnerability: " << vuln << "\n";
 					if(vuln < best_vulnerability) {
 						best_vulnerability = vuln;


### PR DESCRIPTION
We want to calculate the power_projection of the village, so the first argument should be the location of the village, that is, 'it.first->second', or 'dst'
