### PR TITLE
fix host reassignes side during choice

### DIFF
--- a/src/playturn.cpp
+++ b/src/playturn.cpp
@@ -360,7 +360,7 @@ turn_info::PROCESS_DATA_RESULT turn_info::process_network_data(const config& cfg
 						if (have_leader) leader->rename("ai" + side_drop);
 						change_controller(side_drop, "ai");
 					}
-					return restart?PROCESS_RESTART_TURN:PROCESS_CONTINUE;
+					return restart ? PROCESS_RESTART_TURN_TEMPORARY_LOCAL : PROCESS_SIDE_TEMPORARY_LOCAL;
 				}
 				break;
 		}

--- a/src/playturn.hpp
+++ b/src/playturn.hpp
@@ -36,6 +36,10 @@ public:
 	{
 		PROCESS_CONTINUE,
 		PROCESS_RESTART_TURN,
+		/** we wanted to reassign the currently active side to a side, and wait for the server to do so.*/
+		PROCESS_RESTART_TURN_TEMPORARY_LOCAL,
+		/** we wanted to reassign a non currently active side to a side, and wait for the server to do so.*/
+		PROCESS_SIDE_TEMPORARY_LOCAL,
 		PROCESS_END_TURN,
 		/** When the host uploaded the next scenario this is returned. */
 		PROCESS_END_LINGER,


### PR DESCRIPTION
we currently get an OOS when one player leaves while ha had to do a choice and the host reassigns it to a third side (note that we dont get OOS when the host assigns theside to himself or to 'idle')

Assume the following situation:
2 Players in the game (A (side 1), B (side 2)), and one Observer (C).
it's A's turn.
A has to do a decision (for example unit advanement), A leaves the game
and B decides to assign side 1 to C.
On Client B: When returning from process_network_data side 1 is now controlled by B,
and then gets then reassigned with the next call of
process_network_data, but that's too late becasue handle_generaic_event
already returned and B does the advancement decision for side 1.
Players C gets the the first [change_controller](A -> B) and then gets
the second change cntroller (B -> C) before getting B's answer to the
user choice. So when C gets the second [change_controller] he does the
decision himself becasue its C's decision an it has not been received
yet. -> the same decision has been made twice -> OOS.
this fixes this problem, by making the host wait for the servers change
controller in this case
