### PR TITLE
Move team._info.lost update to check_end_level()

### DIFF
--- a/src/play_controller.hpp
+++ b/src/play_controller.hpp
@@ -151,6 +151,11 @@ public:
 	 */
 	void check_victory();
 
+	/**
+	 * Return the currently undefeated sides as set.
+	 */
+	std::set<unsigned> get_undefeated_sides() const;
+
 	size_t turn() const {return tod_manager_.turn();}
 
 	/** Returns the number of the side whose turn it is. Numbering starts at one. */
@@ -256,6 +261,7 @@ protected:
 	bool linger_;
 	bool it_is_a_new_turn_;
 	bool init_side_done_;
+	bool remove_from_carryover_on_leaders_loss_;
 
 	const std::string& select_victory_music() const;
 	const std::string& select_defeat_music()  const;
@@ -282,7 +288,6 @@ private:
 	std::vector<const_item_ptr> wml_commands_;
 
 	bool victory_when_enemies_defeated_;
-	bool remove_from_carryover_on_leaders_loss_;
 	end_level_data end_level_data_;
 	std::vector<std::string> victory_music_;
 	std::vector<std::string> defeat_music_;

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -151,6 +151,25 @@ void playsingle_controller::force_end_turn(){
 
 void playsingle_controller::check_end_level()
 {
+	std::set<unsigned> not_defeated = get_undefeated_sides();
+
+	// Clear villages for teams that have no leader and
+	// mark side as lost if it should be removed from carryover.
+	for (std::vector<team>::iterator tm_beg = teams_.begin(), tm = tm_beg,
+		 tm_end = teams_.end(); tm != tm_end; ++tm)
+	{
+		if (not_defeated.find(tm - tm_beg + 1) == not_defeated.end()) {
+			tm->clear_villages();
+			// invalidate_all() is overkill and expensive but this code is
+			// run rarely so do it the expensive way.
+			gui_->invalidate_all();
+
+			if (!tm->fight_on_without_leader() && remove_from_carryover_on_leaders_loss_) {
+				tm->set_lost();
+			}
+		}
+	}
+
 	if (level_result_ == NONE || linger_)
 	{
 		team &t = teams_[gui_->viewing_team()];


### PR DESCRIPTION
Without this, we can get inconsistent behavior, where if you manage to end the scenario on turn 1 with [endlevel], the unit carryover information may be outdated(units are carried over despite there being no leader).
