### PR TITLE
fixup check_victory

### DIFF
--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -1421,6 +1421,7 @@ void play_controller::check_victory()
 	check_end_level();
 
 	bool found_player = false;
+	bool found_human_or_network = false;
 
 	for (std::set<unsigned>::iterator n = not_defeated.begin(); n != not_defeated.end(); ++n) {
 		size_t side = *n - 1;
@@ -1435,6 +1436,10 @@ void play_controller::check_victory()
 		if (teams_[side].is_human()) {
 			found_player = true;
 		}
+
+		if (teams_[side].is_human() || teams_[side].is_network()){
+			found_human_or_network = true;
+		}
 	}
 
 	if (found_player) {
@@ -1444,9 +1449,9 @@ void play_controller::check_victory()
 
 	DBG_NG << "victory_when_enemies_defeated: " << victory_when_enemies_defeated_ << std::endl;
 	DBG_NG << "found_player: " << found_player << std::endl;
-	DBG_NG << "is_observer: " << is_observer() << std::endl;
+	DBG_NG << "found_human_or_network: " << found_human_or_network << std::endl;
 
-	if (!victory_when_enemies_defeated_ && (found_player || is_observer())) {
+	if (!victory_when_enemies_defeated_ && found_human_or_network) {
 		// This level has asked not to be ended by this condition.
 		return;
 	}


### PR DESCRIPTION
**\* Experimental branch ***

It seems like common sense that the check victory function should be basically symmetric with regards to host and client, as far as _when_ the level is ended, and the current implementation definitely isn't, because it checks is_observer when making this decision. This change is a "common sense fix", but not necessitated by any known bugs, afaik. I believe this version would in all common cases be essentially the same.

However I don't have much appetite to test this change right now, nor do I think it would be a good idea to merge it to 1.12 without a good reason. So I'm just putting it up as a PR so that it may perhaps be revisited later.

Edit: A scenario where things could possibly go awry in the current version, where they wouldn't with this commit, is if one player in an mp game only has control over AI sides, victory_when_enemies_defeated = true, and no existing sides are enemies of one another (so presumably this is a cutscene in an mp campaign.) I believe such a player would be defeated immediately, while the others would continue. But like I said I haven't tested any of this.
