### PR TITLE
add "to_chat" parameter to wml_message

### DIFF
--- a/src/game_events/action_wml.cpp
+++ b/src/game_events/action_wml.cpp
@@ -593,9 +593,9 @@ void handle_wml_log_message(const config& cfg)
 {
 	const std::string& logger = cfg["logger"];
 	const std::string& msg = cfg["message"];
-	const std::string& type = cfg["write_to"];
+	bool in_chat = cfg["to_chat"].to_bool(true);
 
-	put_wml_message(logger,msg,type);
+	put_wml_message(logger,msg,in_chat);
 }
 
 

--- a/src/game_events/pump.cpp
+++ b/src/game_events/pump.cpp
@@ -373,13 +373,10 @@ namespace { // Support functions
 		show_wml_messages(wml_messages_stream, caption, false);
 	}
 
-	void put_wml_message(lg::logger& logger, const std::string& prefix, const std::string& message, const std::string& type)
+	void put_wml_message(lg::logger& logger, const std::string& prefix, const std::string& message, bool in_chat)
 	{
-		if (type != "chat")
-		{
-			logger(log_wml) << message << "\n";
-		}
-		if (type != "console")
+		logger(log_wml) << message << "\n";
+		if (in_chat)
 		{
 			wml_messages_stream << prefix << message << "\n";
 		}
@@ -414,16 +411,16 @@ context::scoped::~scoped()
  * Helper function which determines whether a wml_message text can
  * really be pushed into the wml_messages_stream, and does it.
  */
-void put_wml_message(const std::string& logger, const std::string& message, const std::string& type)
+void put_wml_message(const std::string& logger, const std::string& message, bool in_chat)
 {
 	if (logger == "err" || logger == "error") {
-		put_wml_message(lg::err, _("Error: "), message, type );
+		put_wml_message(lg::err, _("Error: "), message, in_chat );
 	} else if (logger == "warn" || logger == "wrn" || logger == "warning") {
-		put_wml_message(lg::warn, _("Warning: "), message, type );
+		put_wml_message(lg::warn, _("Warning: "), message, in_chat );
 	} else if ((logger == "debug" || logger == "dbg") && !lg::debug.dont_log(log_wml)) {
-		put_wml_message(lg::debug, _("Debug: "), message, type );
+		put_wml_message(lg::debug, _("Debug: "), message, in_chat );
 	} else if (!lg::info.dont_log(log_wml)) {
-		put_wml_message(lg::info, _("Info: "), message, type );
+		put_wml_message(lg::info, _("Info: "), message, in_chat );
 	}
 }
 

--- a/src/game_events/pump.hpp
+++ b/src/game_events/pump.hpp
@@ -97,8 +97,7 @@ namespace game_events
 
 	/// Helper function which determines whether a wml_message text can
 	/// really be pushed into the wml_messages_stream, and does it.
-	/// @param type: "console" for logging into console, "chat" for logging into chat, every other value for loggign into both.
-	void put_wml_message(const std::string& logger, const std::string& message, const std::string& type = "both");
+	void put_wml_message(const std::string& logger, const std::string& message, bool in_chat);
 
 	/**
 	 * Directly runs the lua command(s) @a lua_code


### PR DESCRIPTION
"to_chat" lets the wmldev specify to where the message should be
written. Defaults to the previous behaviour.

The intention is for example that one might want to give a summary  as a
chat message and a very detailed information in the stderr file.
