### PR TITLE
Added [portrait] info to hakim.cfg

### DIFF
--- a/data/core/units/khalifate/Hakim.cfg
+++ b/data/core/units/khalifate/Hakim.cfg
@@ -21,6 +21,18 @@
     description= _ "Hakim are learned individuals who have given up their urban life in order to assist the Khalifate armies in their travels. Their motivations are many; some look to it as an adventure or as a steady source of pay, while others feel it to be a requirement of their faith. Regardless, Hakims are highly respected by all. They are trained with the advanced medical techniques and possess a potent clutch of medicines and herbs, which allows them to quickly heal even the most gravely wounded allies."+{SPECIAL_NOTES}+{SPECIAL_NOTES_EXTRA_HEAL}
     die_sound={SOUND_LIST:HUMAN_DIE}
     {DEFENSE_ANIM "units/khalifate/hakim.png" "units/khalifate/hakim.png" {SOUND_LIST:HUMAN_HIT} }
+    [portrait]
+        size=400
+        side="left"
+        mirror="false"
+        image="portraits/khalifate/transparent/hakim.png"
+    [/portrait]
+    [portrait]
+        size=400
+        side="right"
+        mirror="true"
+        image="portraits/khalifate/transparent/hakim.png"
+    [/portrait]
     [attack]
         name=mace
         description= _ "mace"
@@ -29,7 +41,6 @@
         damage=7
         number=2
     [/attack]
-
     [attack_anim]
         [filter_attack]
             name=mace


### PR DESCRIPTION
Hakim has a portrait, but his config file is missing it.
(This is useful in game, to see unit portraits.)
