### PR TITLE
add error reporting when [if] is evaluated with no actions

### DIFF
--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -335,11 +335,21 @@ wml_actions.command = handle_event_commands
 
 wml_actions["if"] = function( cfg )
 	if wesnoth.eval_conditional( cfg ) then -- evalutate [if] tag
+		local found_something = 0
 		for then_child in helper.child_range ( cfg, "then" ) do
 			handle_event_commands( then_child )
+			found_something = 1
+		end
+		if found_something == 0 then
+			if not helper.get_child( cfg, "else", nil ) then
+				if not helper.get_child( cfg, "elseif", nil ) then
+					wesnoth.message("WML warning","[if] didn't find any [then], [elseif], or [else] children. Check your {IF_VAR}!")
+				end
+			end
 		end
 		return -- stop after executing [then] tags
 	else
+		local found_something = 0
 		for elseif_child in helper.child_range ( cfg, "elseif" ) do
 			if wesnoth.eval_conditional( elseif_child ) then -- we'll evalutate the [elseif] tags one by one
 				for then_tag in helper.child_range( elseif_child, "then" ) do
@@ -347,10 +357,17 @@ wml_actions["if"] = function( cfg )
 				end
 				return -- stop on first matched condition
 			end
+			found_something = 1
 		end
 		-- no matched condition, try the [else] tags
 		for else_child in helper.child_range ( cfg, "else" ) do
 			handle_event_commands( else_child )
+			found_something = 1
+		end
+		if found_something == 0 then
+			if not helper.get_child( cfg, "then", nil ) then
+				wesnoth.message("WML warning","[if] didn't find any [then], [elseif], or [else] children. Check your {IF_VAR}!")
+			end
 		end
 	end
 end


### PR DESCRIPTION
I frequently make the mistake of using {IF_VAR} but forgetting to
use [then] with it. One solution is to use my own macro, but the
better solution is to add proper error reporting to if. If the
engine parses an [if] tag with no [then], [else], or [elseif], it
should flag an error... otherwise these mistakes are generally
silent and very difficult to find.

One possible criticism is that this will slow things down slightly, since we would have to keep a local variable when evaluting ifs.

Possible resolutions:
1. Who cares.
2. Drop support for having multiple [then], or multiple [else], children of [if], since this makes no syntactic sense anyways... This would speed up the current implementation by requesting only one child instead of a list of children, and require no local variables to detect the miss.
3. Patch the preprocessor to automatically merge any multiple [then] and multiple [else] subchildren of [if]. If someone is using insert tag syntax... too bad, they can just insert into the previous [then] or [else] instead.
