### PR TITLE
sync random_start time the normal way

### DIFF
--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -230,8 +230,11 @@ void play_controller::init(CVideo& video){
 		team_builders.push_back(tb_ptr);
 	}
 	{
-		//sync traits of start units
+		//sync traits of start units and the random start time.
 		random_new::set_random_determinstic deterministic(gamedata_.rng());
+
+		tod_manager_.resolve_random(*random_new::generator);
+
 		BOOST_FOREACH(team_builder_ptr tb_ptr, team_builders)
 		{
 			gamedata_.build_team_stage_two(tb_ptr);

--- a/src/tod_manager.hpp
+++ b/src/tod_manager.hpp
@@ -23,6 +23,11 @@ class game_state;
 class gamemap;
 class unit_map;
 
+namespace random_new
+{
+	class rng;
+}
+
 //time of day and turn functionality
 class tod_manager : public savegame::savegame_config
 {
@@ -32,7 +37,10 @@ class tod_manager : public savegame::savegame_config
 		tod_manager& operator=(const tod_manager& manager);
 
 		config to_config() const;
-
+		/**
+			handles random_start_time, should be called before the game starts.
+		*/
+		void resolve_random(random_new::rng& r);
 		int get_current_time(const map_location& loc = map_location::null_location()) const;
 
 		void set_current_time(int time) { currentTime_ = time; }
@@ -165,7 +173,6 @@ class tod_manager : public savegame::savegame_config
 		 */
 		bool is_time_left();
 	private:
-		int get_start_ToD(const config& level) const;
 
 		/**
 		 * Returns time of day object in the turn "nturn".
@@ -219,5 +226,7 @@ class tod_manager : public savegame::savegame_config
 		int turn_;
 		//turn limit
 		int num_turns_;
+		//
+		config::attribute_value random_tod_;
 };
 #endif


### PR DESCRIPTION
we now use the deterministic rng which we also use for start unit unit
traits.
