### PR TITLE
fixup end of scenario saves

### DIFF
--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -749,7 +749,7 @@ config play_controller::to_config() const
 		side["no_leader"] = true;
 		side["side"] = str_cast(side_num);
 
-		if (!linger_){
+		{
 			//current visible units
 			for(unit_map::const_iterator i = units_.begin(); i != units_.end(); ++i) {
 				if (i->side() == side_num) {


### PR DESCRIPTION
<iceiceice_> does anyone know why we have this line?
<iceiceice_> https://github.com/wesnoth/wesnoth/blob/master/src/play_controller.cpp#L752
<iceiceice_> it causes end of scenario saves to be stripped of all units
<iceiceice_> my theory is that it was some kind of hack for some point in time before carryover was implemented properly
<iceiceice_> i propose to remove it in 1.12 and master
