### PR TITLE
Revert "call maybe_do_init_side when the engine starts a sides turn"

### DIFF
--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -674,8 +674,6 @@ void playsingle_controller::play_side()
 	//check for team-specific items in the scenario
 	gui_->parse_team_overlays();
 
-	maybe_do_init_side(do_autosaves_);
-
 	//flag used when we fallback from ai and give temporarily control to human
 	bool temporary_human = false;
 	do {


### PR DESCRIPTION
This reverts commit 77ead906927bec69d9136d349d637458f7a553f0.

After the refactor which removed unnecessary arguments of functions,
and clarified that the value "save" is actually "do_autosaves_"...
this addition looks more obviously like an error. For one thing,
it is passing the do_autosaves_ bool parameter to maybe_do_init_sides,
which expects that the first parameter indicated whether we are
coming from the replay code path or not (!). So if this was working,
it was probably lucky.

Conflicts:
    src/playsingle_controller.cpp
