### PR TITLE
use pImpl idiom for gamemap in game_board, avoiding map.h include

### DIFF
--- a/src/game_board.cpp
+++ b/src/game_board.cpp
@@ -16,6 +16,7 @@
 #include "game_board.hpp"
 #include "game_preferences.hpp"
 #include "log.hpp"
+#include "map.hpp"
 #include "unit.hpp"
 
 #include "utils/foreach.tpp"
@@ -28,6 +29,24 @@ static lg::log_domain log_engine("enginerefac");
 #define WRN_RG LOG_STREAM(warn, log_engine)
 #define ERR_RG LOG_STREAM(err, log_engine)
 
+game_board::game_board(const config & game_config, const config & level) : teams_(), map_(new gamemap(game_config, level)), units_() {}
+
+game_board::game_board(const game_board & other) : teams_(other.teams_), map_(new gamemap(*(other.map_))), units_(other.units_) {}
+
+//TODO: Fix this so that we swap pointers to maps, and also fix replace_map to use scoped_ptr::reset.
+// However, then anytime gameboard is overwritten, resources::gamemap must be updated. So might want to
+// just get rid of resources::gamemap and replace with resources::gameboard->map() at that point.
+void swap(game_board & one, game_board & other) {
+	std::swap(one.teams_, other.teams_);
+	std::swap(one.units_, other.units_);
+	std::swap(*one.map_, *other.map_);
+}
+
+game_board & game_board::operator= (game_board other)
+{
+	swap(*this, other);
+	return(*this);
+}
 
 void game_board::new_turn(int player_num) {
 	BOOST_FOREACH (unit & i, units_) {
@@ -54,7 +73,7 @@ void game_board::set_all_units_user_end_turn() {
 unit_map::iterator game_board::find_visible_unit(const map_location &loc,
 	const team& current_team, bool see_all)
 {
-	if (!map_.on_board(loc)) return units_.end();
+	if (!map_->on_board(loc)) return units_.end();
 	unit_map::iterator u = units_.find(loc);
 	if (!u.valid() || !u->is_visible_to_team(current_team, see_all))
 		return units_.end();
@@ -115,7 +134,7 @@ boost::optional<std::string> game_board::replace_map(const gamemap & newmap) {
 
 	/* Remember the locations where a village is owned by a side. */
 	std::map<map_location, int> villages;
-	FOREACH(const AUTO& village, map_.villages()) {
+	FOREACH(const AUTO& village, map_->villages()) {
 		const int owner = village_owner(village);
 		if(owner != -1) {
 			villages[village] = owner;
@@ -140,19 +159,28 @@ boost::optional<std::string> game_board::replace_map(const gamemap & newmap) {
 		}
 	}
 
-	map_ = newmap;
+	*map_ = newmap;
 	return ret;
 }
 
 
 
 void game_board::overlay_map(const gamemap & mask_map, const config & cfg, map_location loc, bool border) {
-	map_.overlay(mask_map, cfg, loc.x, loc.y, border);
+	map_->overlay(mask_map, cfg, loc.x, loc.y, border);
 }
 
-bool game_board::change_terrain(const map_location &loc, const t_translation::t_terrain &t,
-                    gamemap::tmerge_mode mode, bool replace_if_failed)
+bool game_board::change_terrain(const map_location &loc, const std::string &t_str,
+                    const std::string & mode_str, bool replace_if_failed)
 {
+	//Code internalized from the implementation in lua.cpp
+	t_translation::t_terrain terrain = t_translation::read_terrain_code(t_str);
+	if (terrain == t_translation::NONE_TERRAIN) return false;
+
+	gamemap::tmerge_mode mode = gamemap::BOTH;
+
+	if (mode_str == "base") mode = gamemap::BASE;
+	else if (mode_str == "overlay") mode = gamemap::OVERLAY;
+
 	/*
 	 * When a hex changes from a village terrain to a non-village terrain, and
 	 * a team owned that village it loses that village. When a hex changes from
@@ -164,20 +192,20 @@ bool game_board::change_terrain(const map_location &loc, const t_translation::t_
 	 */
 
 	t_translation::t_terrain
-		old_t = map_.get_terrain(loc),
-		new_t = map_.merge_terrains(old_t, t, mode, replace_if_failed);
+		old_t = map_->get_terrain(loc),
+		new_t = map_->merge_terrains(old_t, terrain, mode, replace_if_failed);
 	if (new_t == t_translation::NONE_TERRAIN) return false;
 	preferences::encountered_terrains().insert(new_t);
 
-	if (map_.is_village(old_t) && !map_.is_village(new_t)) {
+	if (map_->is_village(old_t) && !map_->is_village(new_t)) {
 		int owner = village_owner(loc);
 		if (owner != -1)
 			teams_[owner].lose_village(loc);
 	}
 
-	map_.set_terrain(loc, new_t);
+	map_->set_terrain(loc, new_t);
 
-	BOOST_FOREACH(const t_translation::t_terrain &ut, map_.underlying_union_terrain(loc)) {
+	BOOST_FOREACH(const t_translation::t_terrain &ut, map_->underlying_union_terrain(loc)) {
 		preferences::encountered_terrains().insert(ut);
 	}
 	return true;
@@ -212,7 +240,7 @@ void game_board::write_config(config & cfg) const {
 	}
 
 	//write the map
-	cfg["map_data"] = map_.write();
+	cfg["map_data"] = map_->write();
 }
 
 temporary_unit_placer::temporary_unit_placer(unit_map& m, const map_location& loc, unit& u)

--- a/src/play_controller.hpp
+++ b/src/play_controller.hpp
@@ -141,7 +141,7 @@ public:
 		return gameboard_.teams_;
 	}
 	const gamemap& get_map_const() const{
-		return gameboard_.map_;
+		return gameboard_.map();
 	}
 	const tod_manager& get_tod_manager_const() const{
 			return tod_manager_;

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -100,9 +100,9 @@ void playsingle_controller::init_gui(){
 	play_controller::init_gui();
 
 	if(first_human_team_ != -1) {
-		gui_->scroll_to_tile(gameboard_.map_.starting_position(first_human_team_ + 1), game_display::WARP);
+		gui_->scroll_to_tile(gameboard_.map().starting_position(first_human_team_ + 1), game_display::WARP);
 	}
-	gui_->scroll_to_tile(gameboard_.map_.starting_position(1), game_display::WARP);
+	gui_->scroll_to_tile(gameboard_.map().starting_position(1), game_display::WARP);
 
 	update_locker lock_display(gui_->video(),recorder.is_skipping());
 	events::raise_draw_event();
@@ -1012,7 +1012,7 @@ bool playsingle_controller::can_execute_command(const hotkey::hotkey_command& cm
 		case hotkey::HOTKEY_CREATE_UNIT:
 		case hotkey::HOTKEY_CHANGE_SIDE:
 		case hotkey::HOTKEY_KILL_UNIT:
-			return !events::commands_disabled && game_config::debug && gameboard_.map_.on_board(mouse_handler_.get_last_hex());
+			return !events::commands_disabled && game_config::debug && gameboard_.map().on_board(mouse_handler_.get_last_hex());
 
 		case hotkey::HOTKEY_CLEAR_LABELS:
 			res = !is_observer();
@@ -1020,7 +1020,7 @@ bool playsingle_controller::can_execute_command(const hotkey::hotkey_command& cm
 		case hotkey::HOTKEY_LABEL_TEAM_TERRAIN:
 		case hotkey::HOTKEY_LABEL_TERRAIN: {
 			const terrain_label *label = resources::screen->labels().get_label(mouse_handler_.get_last_hex());
-			res = !events::commands_disabled && gameboard_.map_.on_board(mouse_handler_.get_last_hex())
+			res = !events::commands_disabled && gameboard_.map().on_board(mouse_handler_.get_last_hex())
 				&& !gui_->shrouded(mouse_handler_.get_last_hex())
 				&& !is_observer()
 				&& (!label || !label->immutable());

--- a/src/scripting/lua.cpp
+++ b/src/scripting/lua.cpp
@@ -1271,16 +1271,13 @@ static int intf_set_terrain(lua_State *L)
 {
 	int x = luaL_checkint(L, 1);
 	int y = luaL_checkint(L, 2);
-	t_translation::t_terrain terrain = t_translation::read_terrain_code(luaL_checkstring(L, 3));
-	if (terrain == t_translation::NONE_TERRAIN) return 0;
+	std::string t_str(luaL_checkstring(L, 3));
 
-	gamemap::tmerge_mode mode = gamemap::BOTH;
+	std::string mode_str = "both";
 	bool replace_if_failed = false;
 	if (!lua_isnone(L, 4)) {
 		if (!lua_isnil(L, 4)) {
-			const char* const layer = luaL_checkstring(L, 4);
-			if (strcmp(layer, "base") == 0) mode = gamemap::BASE;
-			else if (strcmp(layer, "overlay") == 0) mode = gamemap::OVERLAY;
+			mode_str = luaL_checkstring(L, 4);
 		}
 
 		if(!lua_isnoneornil(L, 5)) {
@@ -1288,7 +1285,7 @@ static int intf_set_terrain(lua_State *L)
 		}
 	}
 
-	bool result = resources::gameboard->change_terrain(map_location(x - 1, y - 1), terrain, mode, replace_if_failed);
+	bool result = resources::gameboard->change_terrain(map_location(x - 1, y - 1), t_str, mode_str, replace_if_failed);
 	if (result) {
 		resources::screen->recalculate_minimap();
 		resources::screen->invalidate_all();


### PR DESCRIPTION
**\* WIP, this seems to work in -debug build but not release build... ***

unit_map is modified in many places that don't normally include
map.hpp. If changes must go through game_board, then the 
game_board header is always needed, currently including
gamemap and all its supporting stuff in places where it wasn't
before. 

so to avoid doing harm by adding game_board, I am making
it hold a scoped pointer to the gamemap instead of an actual
gamemap. This results in very few changes.
- The implementation of game_board has to use the pointer.
- game_board must use copy and swap idiom
- lua get terrain function must pass strings to the game_board,
  not enums, and we parse them as std::strings in game_board
  instead of as c strings in lua api (which was a bit gross anyhow)
