### PR TITLE
main catches and handles "std::exception" and "...", returning 1

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -784,6 +784,12 @@ int main(int argc, char** argv)
 	} catch(std::exception & e) { //Added this in case the others fall through.
 		std::cerr << "Caught general exception: " << e.what() << std::endl;
 		return 1;
+	} catch(std::string & e) {
+		std::cerr << "Caught a string thrown as an exception: " << e << std::endl;
+		return 1;
+	} catch(const char * e) {
+		std::cerr << "Caught a string thrown as an exception: " << e << std::endl;
+		return 1;
 	} catch(...) { //Added this to ensure that even when we terminate with `throw 42`, the exception is caught and all destructors are actually called.
 		std::cerr << "Caught unspecified general exception. Terminating." << std::endl; //Apparently, some compilers will simply terminate without
 		return 1;									//calling destructors if there is no one to catch it at all.


### PR DESCRIPTION
Note: I added this after reading a blog post:

http://akrzemi1.wordpress.com/2011/10/05/using-stdterminate/

"C++ allows compilers or runtimes not to call destructors in such cases in order for them to be able to provide more efficient implementations of exception handling mechanism. Therefore, programmers are often encouraged to wrap function main with exception handlers that catch every possible exception:

int main() 
try {
    // do what you want
}
catch( std::exception & exc ) {
    // use exc.what()
}
catch( ... ) {
    // ensure destuctors of auto objects are called
}
Not to (or, not only to) prevent calling std::terminate, but to make sure all destructors of automatic objects have been called."

I'm not sure if this is accurate info, but after reading it this commit
seemed like a good idea, and I don't see that it could be harmful.
Seemed like a good idea to make a PR anyways though.

The purpose of this is so that even when we request the program
to be terminated with "throw 42", the exception will be guaranteed
to propogate back to main and all destructors will be called along
the way. This way, if the program requested a socket for example,
the socket will still be released when we terminate unexpectedly,
and not need to be timed out by the OS, so it would be more 
convenient after a crash or after testing, for example.
