### PR TITLE
add recall list manager

### DIFF
--- a/projectfiles/CodeBlocks-SCons/wesnoth.cbp
+++ b/projectfiles/CodeBlocks-SCons/wesnoth.cbp
@@ -862,6 +862,8 @@
 		<Unit filename="../../src/random_new_deterministic.hpp" />
 		<Unit filename="../../src/random_new_synced.cpp" />
 		<Unit filename="../../src/random_new_synced.hpp" />
+		<Unit filename="../../src/recall_list_manager.cpp" />
+		<Unit filename="../../src/recall_list_manager.hpp" />
 		<Unit filename="../../src/reference_counted_object.hpp" />
 		<Unit filename="../../src/replay.cpp" />
 		<Unit filename="../../src/replay.hpp" />

--- a/projectfiles/CodeBlocks/wesnoth.cbp
+++ b/projectfiles/CodeBlocks/wesnoth.cbp
@@ -895,6 +895,8 @@
 		<Unit filename="..\..\src\random_new_deterministic.hpp" />
 		<Unit filename="..\..\src\random_new_synced.cpp" />
 		<Unit filename="..\..\src\random_new_synced.hpp" />
+		<Unit filename="..\..\src\recall_list_manager.cpp" />
+		<Unit filename="..\..\src\recall_list_manager.hpp" />
 		<Unit filename="..\..\src\reference_counted_object.hpp" />
 		<Unit filename="..\..\src\replay.cpp" />
 		<Unit filename="..\..\src\replay.hpp" />

--- a/projectfiles/VC9/wesnoth.vcproj
+++ b/projectfiles/VC9/wesnoth.vcproj
@@ -20773,6 +20773,14 @@
 			>
 		</File>
 		<File
+			RelativePath="..\..\src\recall_list_manager.cpp"
+			>
+		</File>
+		<File
+			RelativePath="..\..\src\recall_list_manager.hpp"
+			>
+		</File>
+		<File
 			RelativePath="..\..\src\replay.cpp"
 			>
 		</File>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -857,6 +857,7 @@ set(wesnoth-main_SRC
 	random_new.cpp
 	random_new_deterministic.cpp
 	random_new_synced.cpp
+	recall_list_manager.cpp
 	replay.cpp
 	replay_helper.cpp
 	replay_controller.cpp

--- a/src/SConscript
+++ b/src/SConscript
@@ -491,6 +491,7 @@ wesnoth_sources = Split("""
     random_new.cpp
     random_new_deterministic.cpp
     random_new_synced.cpp
+    recall_list_manager.cpp
     replay.cpp
     replay_helper.cpp
     replay_controller.cpp

--- a/src/ai/actions.cpp
+++ b/src/ai/actions.cpp
@@ -47,6 +47,7 @@
 #include "../mouse_handler_base.hpp"
 #include "../pathfind/teleport.hpp"
 #include "../play_controller.hpp"
+#include "../recall_list_manager.hpp"
 #include "../replay.hpp"
 #include "../replay_helper.hpp"
 #include "../resources.hpp"
@@ -503,12 +504,11 @@ recall_result::recall_result(side_number side,
 
 UnitConstPtr recall_result::get_recall_unit(const team &my_team)
 {
-	const std::vector<UnitPtr >::const_iterator rec = find_if_matches_id(my_team.recall_list(), unit_id_);
-	if (rec == my_team.recall_list().end()) {
+	UnitConstPtr rec = my_team.recall_list().find_if_matches_id(unit_id_);
+	if (!rec) {
 		set_error(E_NOT_AVAILABLE_FOR_RECALLING);
-		return UnitConstPtr();
 	}
-	return *rec;
+	return rec;
 }
 
 bool recall_result::test_enough_gold(const team &my_team)

--- a/src/ai/contexts.cpp
+++ b/src/ai/contexts.cpp
@@ -37,6 +37,7 @@
 #include "../log.hpp"
 #include "../map.hpp"
 #include "../mouse_handler_base.hpp"
+#include "../recall_list_manager.hpp"
 #include "../resources.hpp"
 #include "../tod_manager.hpp"
 #include "../unit.hpp"
@@ -784,7 +785,7 @@ const std::vector<UnitPtr>& readonly_context_impl::get_recall_list() const
 		return dummy_units;
 	}
 
-	return current_team().recall_list();
+	return current_team().recall_list().recall_list_; //TODO: Refactor ai so that friend of ai context is not required of recall_list_manager at this line
 }
 
 stage_ptr readonly_context_impl::get_recruitment(ai_context &context) const

--- a/src/ai/default/ai.cpp
+++ b/src/ai/default/ai.cpp
@@ -30,6 +30,7 @@
 #include "../../game_classification.hpp"
 #include "../../log.hpp"
 #include "../../mouse_handler_base.hpp"
+#include "../../recall_list_manager.hpp"
 #include "../../resources.hpp"
 #include "../../terrain_filter.hpp"
 #include "../../unit.hpp"
@@ -763,13 +764,12 @@ bool ai_default_recruitment_stage::analyze_recall_list()
 		return false;
 	}
 
-	const std::vector<UnitPtr > &recalls = current_team().recall_list();
-
-	if (recalls.empty()) {
+	if (current_team().recall_list().empty()) {
 		return false;
 	}
 
-	std::transform(recalls.begin(), recalls.end(), std::back_inserter< std::vector <std::pair<std::string,double> > > (recall_list_scores_), unit_combat_score_getter(*this) );
+	std::transform(current_team().recall_list().begin(), current_team().recall_list().end(),
+			std::back_inserter< std::vector <std::pair<std::string,double> > > (recall_list_scores_), unit_combat_score_getter(*this) );
 
 	debug_print_recall_list_scores(recall_list_scores_,"Recall list, after scoring:");
 

--- a/src/dialogs.cpp
+++ b/src/dialogs.cpp
@@ -38,6 +38,7 @@
 #include "menu_events.hpp"
 #include "mouse_handler_base.hpp"
 #include "minimap.hpp"
+#include "recall_list_manager.hpp"
 #include "replay.hpp"
 #include "replay_helper.hpp"
 #include "resources.hpp"
@@ -133,14 +134,11 @@ gui::dialog_button_action::RESULT delete_recall_unit::button_pressed(int menu_se
 		resources::undo_stack->add_dismissal(u_ptr);
 
 		// Find the unit in the recall list.
-		std::vector<UnitPtr >& recall_list = (*resources::teams)[u.side() -1].recall_list();
-		assert(!recall_list.empty());
-		std::vector<UnitPtr >::iterator dismissed_unit =
-				find_if_matches_id(recall_list, u.id());
-		assert(dismissed_unit != recall_list.end());
+		UnitPtr dismissed_unit = (*resources::teams)[u.side() -1].recall_list().find_if_matches_id(u.id());
+		assert(dismissed_unit);
 
 		// Record the dismissal, then delete the unit.
-		synced_context::run_in_synced_context("disband", replay_helper::get_disband((*dismissed_unit)->id()));
+		synced_context::run_in_synced_context("disband", replay_helper::get_disband(dismissed_unit->id()));
 		//recorder.add_disband(dismissed_unit->id());
 		//recall_list.erase(dismissed_unit);
 

--- a/src/game_board.cpp
+++ b/src/game_board.cpp
@@ -17,6 +17,7 @@
 #include "game_preferences.hpp"
 #include "log.hpp"
 #include "map.hpp"
+#include "recall_list_manager.hpp"
 #include "unit.hpp"
 
 #include "utils/foreach.tpp"
@@ -144,7 +145,7 @@ void game_board::side_change_controller(int side_num, team::CONTROLLER ctrl, con
 bool game_board::try_add_unit_to_recall_list(const map_location& loc, const UnitPtr u)
 {
 	if(teams_[u->side()-1].persistent()) {
-		teams_[u->side()-1].recall_list().push_back(u);
+		teams_[u->side()-1].recall_list().add(u);
 		return true;
 	} else {
 		ERR_RG << "unit with id " << u->id() << ": location (" << loc.x << "," << loc.y <<") is not on the map, and player "

--- a/src/game_events/conditional_wml.cpp
+++ b/src/game_events/conditional_wml.cpp
@@ -23,6 +23,7 @@
 #include "../config.hpp"
 #include "../gamestatus.hpp"
 #include "../log.hpp"
+#include "../recall_list_manager.hpp"
 #include "../resources.hpp"
 #include "../serialization/string_utils.hpp"
 #include "../team.hpp"
@@ -89,13 +90,12 @@ namespace { // Support functions
 					if(counts == default_counts && match_count) {
 						break;
 					}
-					const std::vector<UnitPtr>& avail_units = team->recall_list();
-					for(std::vector<UnitPtr>::const_iterator unit = avail_units.begin(); unit!=avail_units.end(); ++unit) {
+					for(size_t t = 0; t < team->recall_list().size(); ++t) {
 						if(counts == default_counts && match_count) {
 							break;
 						}
-						scoped_recall_unit auto_store("this_unit", team->save_id(), unit - avail_units.begin());
-						if ( (*unit)->matches_filter(*u) ) {
+						scoped_recall_unit auto_store("this_unit", team->save_id(), t);
+						if ( team->recall_list()[t]->matches_filter(*u) ) {
 							++match_count;
 						}
 					}

--- a/src/gamestatus.cpp
+++ b/src/gamestatus.cpp
@@ -30,6 +30,7 @@
 #include "gettext.hpp"
 #include "log.hpp"
 #include "map.hpp"
+#include "recall_list_manager.hpp"
 #include "replay.hpp"
 #include "resources.hpp"
 #include "serialization/binary_or_text.hpp"
@@ -255,7 +256,7 @@ protected:
 				//seen before
 				config u_tmp = u;
 				u_tmp["side"] = str_cast(side_);
-				t_->recall_list().push_back(UnitPtr(new unit(u_tmp,true)));
+				t_->recall_list().add(UnitPtr(new unit(u_tmp,true)));
 			} else {
 				//not seen before
 				unit_configs_.push_back(&u);

--- a/src/gui/dialogs/gamestate_inspector.cpp
+++ b/src/gui/dialogs/gamestate_inspector.cpp
@@ -32,6 +32,7 @@
 #include "utils/foreach.tpp"
 
 #include "../../gamestatus.hpp"
+#include "../../recall_list_manager.hpp"
 #include "../../resources.hpp"
 #include "../../team.hpp"
 #include "../../unit.hpp"
@@ -416,40 +417,34 @@ public:
 		}
 
 		if(selected == 3) {
-			const std::vector<UnitPtr> recall_list
-					= resources::teams
-							  ? resources::teams->at(side_ - 1).recall_list()
-							  : std::vector<UnitPtr>();
-
 			std::stringstream s;
-			FOREACH(const AUTO & u, recall_list)
-			{
-				s << "id=\"" << u->id() << "\" (" << u->type_id() << ")\nL"
-				  << u->level() << "; " << u->experience() << "/"
-				  << u->max_experience() << " xp; " << u->hitpoints() << "/"
-				  << u->max_hitpoints() << " hp\n";
-				FOREACH(const AUTO & str, u->get_traits_list())
+			if (resources::teams) {
+				FOREACH(const AUTO & u, resources::teams->at(side_ - 1).recall_list())
 				{
-					s << "\t" << str << std::endl;
+					s << "id=\"" << u->id() << "\" (" << u->type_id() << ")\nL"
+					  << u->level() << "; " << u->experience() << "/"
+					  << u->max_experience() << " xp; " << u->hitpoints() << "/"
+					  << u->max_hitpoints() << " hp\n";
+					FOREACH(const AUTO & str, u->get_traits_list())
+					{
+						s << "\t" << str << std::endl;
+					}
+					s << std::endl;
 				}
-				s << std::endl;
 			}
 			model_.set_inspect_window_text(s.str());
 			return;
 		}
 
 		if(selected == 4) {
-			const std::vector<UnitPtr> recall_list
-					= resources::teams
-							  ? resources::teams->at(side_ - 1).recall_list()
-							  : std::vector<UnitPtr>();
-
 			config c;
-			FOREACH(const AUTO & u, recall_list)
-			{
-				config c_unit;
-				u->write(c_unit);
-				c.add_child("unit", c_unit);
+			if (resources::teams) {
+				FOREACH(const AUTO & u, resources::teams->at(side_ - 1).recall_list())
+				{
+					config c_unit;
+					u->write(c_unit);
+					c.add_child("unit", c_unit);
+				}
 			}
 			model_.set_inspect_window_text(config_to_string(c));
 			return;

--- a/src/recall_list_manager.cpp
+++ b/src/recall_list_manager.cpp
@@ -1,0 +1,149 @@
+/*
+   Copyright (C) 2014 by Chris Beck <render787@gmail.com>
+   Part of the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#include "recall_list_manager.hpp"
+#include "unit.hpp"
+#include "unit_ptr.hpp"
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include <boost/bind.hpp>
+#include <boost/foreach.hpp>
+
+bool find_if_matches_helper(const UnitPtr & ptr, const std::string & unit_id)
+{
+	return ptr->matches_id(unit_id);
+}
+
+/**
+ * Used to find units in vectors by their ID.
+ */
+UnitPtr recall_list_manager::find_if_matches_id(const std::string &unit_id)
+{
+	std::vector<UnitPtr >::iterator it = std::find_if(recall_list_.begin(), recall_list_.end(),
+	                    boost::bind(&find_if_matches_helper, _1, unit_id));
+	if (it != recall_list_.end()) {
+		return *it;
+	} else {
+		return UnitPtr();
+	}
+}
+
+/**
+ * Used to find units in vectors by their ID.
+ */
+UnitConstPtr recall_list_manager::find_if_matches_id(const std::string &unit_id) const
+{
+	std::vector<UnitPtr >::const_iterator it = std::find_if(recall_list_.begin(), recall_list_.end(),
+	                    boost::bind(&find_if_matches_helper, _1, unit_id));
+	if (it != recall_list_.end()) {
+		return *it;
+	} else {
+		return UnitPtr();
+	}
+}
+
+/**
+ * Used to erase units from vectors by their ID.
+ */
+void recall_list_manager::erase_if_matches_id(const std::string &unit_id)
+{
+	recall_list_.erase(std::remove_if(recall_list_.begin(), recall_list_.end(),
+	                                  boost::bind(&find_if_matches_helper, _1, unit_id)),
+	                       recall_list_.end());
+}
+
+void recall_list_manager::add (const UnitPtr & ptr)
+{
+	recall_list_.push_back(ptr);
+}
+
+size_t recall_list_manager::find_index(const std::string & unit_id) const
+{
+	std::vector<UnitPtr >::const_iterator it = std::find_if(recall_list_.begin(), recall_list_.end(),
+	                    boost::bind(&find_if_matches_helper, _1, unit_id));
+
+	return it - recall_list_.begin();
+}
+
+UnitPtr recall_list_manager::extract_if_matches_id(const std::string &unit_id)
+{
+	std::vector<UnitPtr >::iterator it = std::find_if(recall_list_.begin(), recall_list_.end(),
+	                    boost::bind(&find_if_matches_helper, _1, unit_id));
+	if (it != recall_list_.end()) {
+		UnitPtr ret = *it;
+		recall_list_.erase(it);
+		return ret;
+	} else {
+		return UnitPtr();
+	}
+}
+
+bool find_if_matches_uid_helper(const UnitPtr & ptr, size_t uid)
+{
+	return ptr->underlying_id() == uid;
+}
+
+UnitPtr recall_list_manager::find_if_matches_underlying_id(size_t uid)
+{
+	std::vector<UnitPtr >::iterator it = std::find_if(recall_list_.begin(), recall_list_.end(),
+	                    boost::bind(&find_if_matches_uid_helper, _1, uid));
+	if (it != recall_list_.end()) {
+		return *it;
+	} else {
+		return UnitPtr();
+	}
+}
+
+UnitConstPtr recall_list_manager::find_if_matches_underlying_id(size_t uid) const
+{
+	std::vector<UnitPtr >::const_iterator it = std::find_if(recall_list_.begin(), recall_list_.end(),
+	                    boost::bind(&find_if_matches_uid_helper, _1, uid));
+	if (it != recall_list_.end()) {
+		return *it;
+	} else {
+		return UnitPtr();
+	}
+}
+
+void recall_list_manager::erase_by_underlying_id(size_t uid)
+{
+	recall_list_.erase(std::remove_if(recall_list_.begin(), recall_list_.end(),
+	                                  boost::bind(&find_if_matches_uid_helper, _1, uid)),
+	                       recall_list_.end());
+}
+
+UnitPtr recall_list_manager::extract_if_matches_underlying_id(size_t uid)
+{
+	std::vector<UnitPtr >::iterator it = std::find_if(recall_list_.begin(), recall_list_.end(),
+	                    boost::bind(&find_if_matches_uid_helper, _1, uid));
+	if (it != recall_list_.end()) {
+		UnitPtr ret = *it;
+		recall_list_.erase(it);
+		return ret;
+	} else {
+		return UnitPtr();
+	}
+}
+
+std::vector<UnitPtr>::iterator recall_list_manager::erase_index(size_t idx) {
+	assert(idx < recall_list_.size());
+	return recall_list_.erase(recall_list_.begin()+idx);
+}
+
+std::vector<UnitPtr>::iterator recall_list_manager::erase(std::vector<UnitPtr>::iterator it) {
+	return recall_list_.erase(it);
+}

--- a/src/recall_list_manager.hpp
+++ b/src/recall_list_manager.hpp
@@ -1,0 +1,68 @@
+/*
+   Copyright (C) 2014 by Chris Beck <render787@gmail.com>
+   Part of the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+// This class encapsulates the recall list of a team
+
+#ifndef RECALL_LIST_MGR_HPP
+#define RECALL_LIST_MGR_HPP
+
+#include "unit_ptr.hpp"
+
+#include <string>
+#include <vector>
+
+namespace ai {
+	class readonly_context_impl;
+}
+
+class recall_list_manager {
+public:
+	typedef std::vector<UnitPtr >::iterator iterator;
+	typedef std::vector<UnitPtr >::const_iterator const_iterator;
+
+	iterator begin() { return recall_list_.begin();}
+	iterator end() { return recall_list_.end(); }
+
+	const_iterator begin() const { return recall_list_.begin();}
+	const_iterator end() const { return recall_list_.end(); }
+
+	UnitPtr operator[](size_t index) { return recall_list_[index]; }
+	UnitConstPtr operator[](size_t index) const { return recall_list_[index]; }
+
+	UnitPtr find_if_matches_id(const std::string & unit_id);
+	UnitPtr extract_if_matches_id(const std::string & unit_id);
+	UnitConstPtr find_if_matches_id(const std::string & unit_id) const;
+	void erase_if_matches_id(const std::string & unit_id);
+
+	UnitPtr find_if_matches_underlying_id(size_t uid);
+	UnitPtr extract_if_matches_underlying_id(size_t uid);
+	UnitConstPtr find_if_matches_underlying_id(size_t uid) const;
+	void erase_by_underlying_id(size_t uid);
+
+	iterator erase_index(size_t index);
+	iterator erase(iterator it);
+
+	size_t find_index(const std::string & unit_id) const;
+	size_t size() const { return recall_list_.size(); }
+	bool empty() const { return recall_list_.empty(); }
+
+	void add(const UnitPtr & ptr);
+
+private:
+	std::vector<UnitPtr > recall_list_;
+
+	friend class ai::readonly_context_impl;
+};
+
+#endif

--- a/src/side_filter.cpp
+++ b/src/side_filter.cpp
@@ -18,6 +18,7 @@
 
 #include "config.hpp"
 #include "log.hpp"
+#include "recall_list_manager.hpp"
 #include "resources.hpp"
 #include "side_filter.hpp"
 #include "variable.hpp"
@@ -139,10 +140,8 @@ bool side_filter::match_internal(const team &t) const
 			}
 		}
 		if(!found && unit_filter["search_recall_list"].to_bool(false)) {
-			const std::vector<UnitPtr>& recall_list = t.recall_list();
-			BOOST_FOREACH(const UnitConstPtr & u, recall_list) {
-				std::vector<UnitPtr>::const_iterator it = find_if_matches_id(recall_list, u->id());
-				scoped_recall_unit this_unit("this_unit", t.save_id(), it - recall_list.begin());
+			BOOST_FOREACH(const UnitConstPtr & u, t.recall_list()) {
+				scoped_recall_unit this_unit("this_unit", t.save_id(),t.recall_list().find_index(u->id()));
 				if(u->matches_filter(unit_filter, u->get_location(), flat_)) {
 					found = true;
 					break;

--- a/src/synced_commands.cpp
+++ b/src/synced_commands.cpp
@@ -29,6 +29,7 @@
 #include "game_events/pump.hpp"
 #include "dialogs.hpp"
 #include "unit_helper.hpp"
+#include "recall_list_manager.hpp"
 #include "replay.hpp" //user choice
 #include "resources.hpp"
 #include <boost/foreach.hpp>
@@ -222,12 +223,10 @@ SYNCED_COMMAND_HANDLER_FUNCTION(disband, child, /*use_undo*/, /*show*/, error_ha
 	team &current_team = (*resources::teams)[current_team_num - 1];
 
 	const std::string& unit_id = child["value"];
-	std::vector<UnitPtr>::iterator disband_unit =
-		find_if_matches_id(current_team.recall_list(), unit_id);
+	size_t old_size = current_team.recall_list().size();
+	current_team.recall_list().erase_if_matches_id(unit_id);
 
-	if(disband_unit != current_team.recall_list().end()) {
-		current_team.recall_list().erase(disband_unit);
-	} else {
+	if (old_size == current_team.recall_list().size()) {
 		error_handler("illegal disband\n", true);
 		return false;
 	}

--- a/src/team.hpp
+++ b/src/team.hpp
@@ -18,6 +18,7 @@
 #include "game_config.hpp"
 #include "make_enum.hpp"
 #include "map_location.hpp"
+#include "recall_list_manager.hpp"
 #include "savegame_config.hpp"
 #include "unit_ptr.hpp"
 #include "util.hpp"
@@ -185,8 +186,8 @@ public:
 		{ countdown_time_ = amount; }
 	int action_bonus_count() const { return action_bonus_count_; }
 	void set_action_bonus_count(const int count) { action_bonus_count_ = count; }
-	std::vector<UnitPtr >& recall_list() {return recall_list_;}
-	const std::vector<UnitPtr >& recall_list() const {return recall_list_;}
+	recall_list_manager& recall_list() {return recall_list_;}
+	const recall_list_manager & recall_list() const {return recall_list_;}
 	void set_current_player(const std::string& player)
 		{ info_.current_player = player; }
 
@@ -349,7 +350,7 @@ private:
 	mutable int countdown_time_;
 	int action_bonus_count_;
 
-	std::vector<UnitPtr > recall_list_;
+	recall_list_manager recall_list_;
 	std::string last_recruit_;
 
 	bool calculate_enemies(size_t index) const;

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -2466,48 +2466,6 @@ bool unit::matches_id(const std::string& unit_id) const
         return id_ == unit_id;
 }
 
-bool find_if_matches_helper(const UnitPtr & ptr, const std::string & unit_id) 
-{
-	return ptr->matches_id(unit_id);
-}
-
-/**
- * Used to find units in vectors by their ID. (Convenience wrapper)
- * @returns what std::find_if() returns.
- */
-std::vector<UnitPtr >::iterator find_if_matches_id(
-		std::vector<UnitPtr > &unit_list, // Not const so we can get a non-const iterator to return.
-		const std::string &unit_id)
-{
-	return std::find_if(unit_list.begin(), unit_list.end(),
-	                    boost::bind(&find_if_matches_helper, _1, unit_id));
-}
-
-/**
- * Used to find units in vectors by their ID. (Convenience wrapper; const version)
- * @returns what std::find_if() returns.
- */
-std::vector<UnitPtr >::const_iterator find_if_matches_id(
-		const std::vector<UnitPtr > &unit_list,
-		const std::string &unit_id)
-{
-	return std::find_if(unit_list.begin(), unit_list.end(),
-	                    boost::bind(&find_if_matches_helper, _1, unit_id));
-}
-
-/**
- * Used to erase units from vectors by their ID. (Convenience wrapper)
- * @returns what std::vector<>::erase() returns.
- */
-std::vector<UnitPtr >::iterator erase_if_matches_id(
-		std::vector<UnitPtr > &unit_list,
-		const std::string &unit_id)
-{
-	return unit_list.erase(std::remove_if(unit_list.begin(), unit_list.end(),
-	                                      boost::bind(&find_if_matches_helper, _1, unit_id)),
-	                       unit_list.end());
-}
-
 int side_units(int side)
 {
 	int res = 0;


### PR DESCRIPTION
This commit adds a dedicated recall list manager class.

The purpose of this is to
- Simplify the code that interacts with the recall list. Prior to
  the commit most such code was based on iteration with explicit
  iterators, and called global helper functions implemented in
  unit.cpp to wrap the code that finds a unit in a vector. It turns
  out that interacting with the recall list was the _only_ use of
  that code, so we make it a member function of the recall list
  manager and take it out of unit.cpp.

Most of the code that touches the recall list was previously
7 or 8 lines with a for loop, now it tends to be 1 or 2 lines,
although further refactor may be possible.
- Improve encapsulation. This makes it possible to track how
  other classes are interacting with the recall list, and may
  make it easier to debug recall list problems by adding debugging
  output to the class.
