### PR TITLE
*DO NOT MERGE* Added 'faction_lock' and 'leader_lock' for MultiplayerWML.

### DIFF
--- a/src/flg_manager.cpp
+++ b/src/flg_manager.cpp
@@ -38,11 +38,11 @@ std::string get_RC_suffix(const std::string& unit_color, const int color)
 
 
 flg_manager::flg_manager(const std::vector<const config*>& era_factions,
-	const config& side, const bool lock_settings, const bool saved_game,
-	const int color) :
+	const config& side, const bool lock_settings, const bool use_map_settings,
+	const bool saved_game, const int color) :
 	era_factions_(era_factions),
 	side_(side),
-	lock_settings_(lock_settings),
+	use_map_settings_(use_map_settings),
 	saved_game_(saved_game),
 	has_no_recruits_(
 		((side_.has_attribute("default_recruit") ?
@@ -50,6 +50,8 @@ flg_manager::flg_manager(const std::vector<const config*>& era_factions,
 			side_["recruit"].empty()) ||
 		side_["no_recruit"].to_bool()) &&
 		side_["previous_recruits"].empty() && side_["extra_recruit"].empty()),
+	faction_lock_(side_["faction_lock"].to_bool(lock_settings) && use_map_settings),
+	leader_lock_(side_["leader_lock"].to_bool(lock_settings) && use_map_settings),
 	color_(color),
 	available_factions_(),
 	available_leaders_(),
@@ -333,7 +335,7 @@ void flg_manager::update_available_leaders()
 {
 	available_leaders_.clear();
 
-	if (!side_["no_leader"].to_bool() || !lock_settings_) {
+	if (!side_["no_leader"].to_bool() || !leader_lock_) {
 		// Add a default leader if there is one.
 		if (!default_leader_type_.empty()) {
 			available_leaders_.push_back(default_leader_type_);
@@ -436,7 +438,7 @@ void flg_manager::update_choosable_factions()
 {
 	choosable_factions_ = available_factions_;
 
-	if ((!side_["faction"].empty() || !has_no_recruits_) && lock_settings_) {
+	if ((!side_["faction"].empty() || !has_no_recruits_) && faction_lock_) {
 		std::string faction_id;
 		if (!has_no_recruits_) {
 			faction_id = "Custom";
@@ -454,7 +456,7 @@ void flg_manager::update_choosable_leaders()
 {
 	choosable_leaders_ = available_leaders_;
 
-	if (!default_leader_type_.empty() && lock_settings_) {
+	if (!default_leader_type_.empty() && leader_lock_) {
 		if (std::find(available_leaders_.begin(), available_leaders_.end(),
 			default_leader_type_) != available_leaders_.end()) {
 
@@ -468,7 +470,7 @@ void flg_manager::update_choosable_genders()
 {
 	choosable_genders_ = available_genders_;
 
-	if (lock_settings_) {
+	if (leader_lock_) {
 		std::string default_gender = default_leader_gender_;
 		if (default_gender.empty()) {
 			default_gender = choosable_genders_.front();

--- a/src/flg_manager.hpp
+++ b/src/flg_manager.hpp
@@ -31,8 +31,8 @@ class flg_manager
 {
 public:
 	flg_manager(const std::vector<const config*>& era_factions,
-		const config& side, const bool lock_settings, const bool saved_game,
-		const int color);
+		const config& side, const bool faction_lock, const bool leader_lock,
+		const bool saved_game, const int color);
 	~flg_manager();
 
 	void set_current_faction(const unsigned index);
@@ -106,9 +106,12 @@ private:
 
 	const config& side_;
 
-	const bool lock_settings_;
+	const bool use_map_settings_;
 	const bool saved_game_;
 	const bool has_no_recruits_;
+
+	const bool faction_lock_;
+	const bool leader_lock_;
 
 	const int color_;
 

--- a/src/multiplayer_connect_engine.cpp
+++ b/src/multiplayer_connect_engine.cpp
@@ -857,7 +857,7 @@ side_engine::side_engine(const config& cfg, connect_engine& parent_engine,
 	waiting_to_choose_faction_(allow_changes_),
 	chose_random_(cfg["chose_random"].to_bool(false)),
 	flg_(parent_.era_factions_, cfg_, parent_.force_lock_settings_,
-		parent_.params_.saved_game, color_)
+		parent_.params_.use_map_settings, parent_.params_.saved_game, color_)
 {
 	// Check if this side should give its control to some other side.
 	const int side_cntr = cfg_["controller"].to_int(-1);

--- a/src/multiplayer_wait.cpp
+++ b/src/multiplayer_wait.cpp
@@ -312,10 +312,12 @@ void wait::join_game(bool observe)
 
 			const bool lock_settings =
 				level_["force_lock_settings"].to_bool();
+			const bool use_map_settings =
+				level_.child("multiplayer")["mp_use_map_settings"].to_bool();
 			const bool saved_game =
 				level_.child("multiplayer")["savegame"].to_bool();
 
-			flg_manager flg(era_factions, *side_choice, lock_settings,
+			flg_manager flg(era_factions, *side_choice, lock_settings, use_map_settings,
 				saved_game, color);
 
 			std::vector<std::string> choices;


### PR DESCRIPTION
These attributes work similarly as all other lock attributes such as
'gold_lock': 'faction_lock' locks faction selection, while 'leader_lock' locks
both leader and its gender selections.

These attributes were added to fix #21978.
