### PR TITLE
disable activation of the whiteboard

### DIFF
--- a/data/core/hotkeys.cfg
+++ b/data/core/hotkeys.cfg
@@ -274,35 +274,35 @@
 #    key=d
 #    shift=yes
 #[/hotkey]
-[hotkey]
-    command=wbtoggle
-    key=p
-[/hotkey]
-[hotkey]
-    command=wbexecuteaction
-    key=y
-[/hotkey]
-[hotkey]
-    command=wbexecuteallactions
-    key=y
-    ctrl=yes
-[/hotkey]
-[hotkey]
-    command=wbdeleteaction
-    key=h
-[/hotkey]
-[hotkey]
-    command=wbbumpupaction
-    key="page up"
-[/hotkey]
-[hotkey]
-    command=wbbumpdownaction
-    key="page down"
-[/hotkey]
-[hotkey]
-    command=wbsupposedead
-    key=i
-[/hotkey]
+#[hotkey]
+#    command=wbtoggle
+#    key=p
+#[/hotkey]
+#[hotkey]
+#    command=wbexecuteaction
+#    key=y
+#[/hotkey]
+#[hotkey]
+#    command=wbexecuteallactions
+#    key=y
+#    ctrl=yes
+#[/hotkey]
+#[hotkey]
+#    command=wbdeleteaction
+#    key=h
+#[/hotkey]
+#[hotkey]
+#    command=wbbumpupaction
+#    key="page up"
+#[/hotkey]
+#[hotkey]
+#    command=wbbumpdownaction
+#    key="page down"
+#[/hotkey]
+#[hotkey]
+#    command=wbsupposedead
+#    key=i
+#[/hotkey]
 
 [hotkey]
     command=title_screen__reload_wml

--- a/data/themes/default.cfg
+++ b/data/themes/default.cfg
@@ -99,7 +99,7 @@
             id=actions-menu
             title= _ "Actions"
             image=button_menu/menu_button_copper_H20
-            items=undo,redo,wbexecuteallactions,wbexecuteaction,wbdeleteaction,cycle,speak,recruit,recall,showenemymoves,bestenemymoves,wbtoggle,delayshroud,updateshroud,endturn
+            items=undo,redo,cycle,speak,recruit,recall,showenemymoves,bestenemymoves,delayshroud,updateshroud,endturn
             rect="+2,=,+100,="
             xanchor=fixed
             yanchor=fixed
@@ -113,7 +113,7 @@
         {COUNTDOWN_THEME}
         [menu]
             is_context_menu=true
-            items=wml,undo,redo,wbexecuteaction,wbdeleteaction,wbbumpupaction,wbbumpdownaction,wbsupposedead,describeterrain,describeunit,renameunit,createunit,changeside,killunit,labelteamterrain,labelterrain,clearlabels,speak,continue,recruit,recall,wbtoggle,delayshroud,updateshroud,cycle,endturn
+            items=wml,undo,redo,describeterrain,describeunit,renameunit,createunit,changeside,killunit,labelteamterrain,labelterrain,clearlabels,speak,continue,recruit,recall,delayshroud,updateshroud,cycle,endturn
         [/menu]
         [action]
             id=button-endturn

--- a/data/themes/pandora.cfg
+++ b/data/themes/pandora.cfg
@@ -113,7 +113,7 @@
             id=menu-main
             title= _ "Menu"
             image=button_square/button_square_60
-            items=objectives,statistics,unitlist,statustable,save,savereplay,load,preferences,chatlog,AUTOSAVES,help,stopnetwork,startnetwork,quit,undo,redo,wbexecuteallactions,wbexecuteaction,wbdeleteaction,speak,recruit,recall,showenemymoves,bestenemymoves,wbtoggle,delayshroud,updateshroud
+            items=objectives,statistics,unitlist,statustable,save,savereplay,load,preferences,chatlog,AUTOSAVES,help,stopnetwork,startnetwork,quit,undo,redo,speak,recruit,recall,showenemymoves,bestenemymoves,delayshroud,updateshroud
             #,endturn
             ref=sidebar-panel
             font_size=30
@@ -163,7 +163,7 @@ Turn"
         #    id=actions-menu
         #    title= _ "Actions"
         #    image=button_menu/menu_button_copper_H20
-        #    items=undo,redo,wbexecuteallactions,wbexecuteaction,wbdeleteaction,cycle,speak,recruit,recall,showenemymoves,bestenemymoves,wbtoggle,delayshroud,updateshroud,endturn
+        #    items=undo,redo,cycle,speak,recruit,recall,showenemymoves,bestenemymoves,delayshroud,updateshroud,endturn
         #    rect="+2,=,+100,="
         #    xanchor=fixed
         #    yanchor=fixed
@@ -172,7 +172,7 @@ Turn"
         #{COUNTDOWN_THEME}
         [menu]
             is_context_menu=true
-            items=wml,undo,redo,wbexecuteaction,wbdeleteaction,wbbumpupaction,wbbumpdownaction,wbsupposedead,describeunit,renameunit,createunit,changeside,killunit,describeterrain,labelteamterrain,labelterrain,clearlabels,speak,continue,recruit,recall,wbtoggle,delayshroud,updateshroud,cycle,endturn
+            items=wml,undo,redo,describeunit,renameunit,createunit,changeside,killunit,describeterrain,labelteamterrain,labelterrain,clearlabels,speak,continue,recruit,recall,delayshroud,updateshroud,cycle,endturn
         [/menu]
 
         [label]

--- a/src/game_preferences_display.cpp
+++ b/src/game_preferences_display.cpp
@@ -124,8 +124,7 @@ private:
 			friends_list_button_, friends_back_button_,
 			friends_add_friend_button_, friends_add_ignore_button_,
 			friends_remove_button_, show_floating_labels_button_,
-			turn_dialog_button_, whiteboard_on_start_button_,
-			hide_whiteboard_button_, turn_bell_button_, show_team_colors_button_,
+			turn_dialog_button_, turn_bell_button_, show_team_colors_button_,
 			show_haloing_button_, video_mode_button_,
 			theme_button_, hotkeys_button_,
 			paths_button_,
@@ -195,8 +194,6 @@ preferences_dialog::preferences_dialog(display& disp, const config& game_cfg)
 	  friends_remove_button_(disp.video(), _("Remove")),
 	  show_floating_labels_button_(disp.video(), _("Show floating labels"), gui::button::TYPE_CHECK),
 	  turn_dialog_button_(disp.video(), _("Turn dialog"), gui::button::TYPE_CHECK),
-	  whiteboard_on_start_button_(disp.video(), _("Enable planning mode on start"), gui::button::TYPE_CHECK),
-	  hide_whiteboard_button_(disp.video(), _("Hide allies’ plans by default"), gui::button::TYPE_CHECK),
 	  turn_bell_button_(disp.video(), _("Turn bell"), gui::button::TYPE_CHECK),
 	  show_team_colors_button_(disp.video(), _("Show team colors"), gui::button::TYPE_CHECK),
 	  show_haloing_button_(disp.video(), _("Show haloing effects"), gui::button::TYPE_CHECK),
@@ -414,12 +411,6 @@ preferences_dialog::preferences_dialog(display& disp, const config& game_cfg)
 	turn_dialog_button_.set_check(turn_dialog());
 	turn_dialog_button_.set_help_string(_("Display a dialog at the beginning of your turn"));
 
-	whiteboard_on_start_button_.set_check(enable_whiteboard_mode_on_start());
-	whiteboard_on_start_button_.set_help_string(_("Activates Planning Mode on game start"));
-
-	hide_whiteboard_button_.set_check(hide_whiteboard());
-	hide_whiteboard_button_.set_help_string(_("Hides allies’ Planning Mode plans in multiplayer games"));
-
 	turn_bell_button_.set_check(turn_bell());
 	turn_bell_button_.set_help_string(_("Play a bell sound at the beginning of your turn"));
 
@@ -477,8 +468,6 @@ handler_vector preferences_dialog::handler_members()
 	h.push_back(&advanced_combo_);
 	h.push_back(&show_floating_labels_button_);
 	h.push_back(&turn_dialog_button_);
-	h.push_back(&whiteboard_on_start_button_);
-	h.push_back(&hide_whiteboard_button_);
 	h.push_back(&turn_bell_button_);
 	h.push_back(&UI_sound_button_);
 	h.push_back(&show_team_colors_button_);
@@ -549,8 +538,6 @@ void preferences_dialog::update_location(SDL_Rect const &rect)
 	turbo_slider_.set_location(turbo_rect);
 	ypos += item_interline; show_ai_moves_button_.set_location(rect.x, ypos);
 	ypos += short_interline; turn_dialog_button_.set_location(rect.x, ypos);
-	ypos += short_interline; whiteboard_on_start_button_.set_location(rect.x, ypos);
-	ypos += short_interline; hide_whiteboard_button_.set_location(rect.x, ypos);
 	ypos += short_interline; interrupt_when_ally_sighted_button_.set_location(rect.x, ypos);
 	ypos += item_interline; save_replays_button_.set_location(rect.x, ypos);
 	ypos += short_interline; delete_saves_button_.set_location(rect.x, ypos);
@@ -743,10 +730,6 @@ void preferences_dialog::process_event()
 			set_delete_saves(delete_saves_button_.checked());
 		if (turn_dialog_button_.pressed())
 			set_turn_dialog(turn_dialog_button_.checked());
-		if (whiteboard_on_start_button_.pressed())
-			set_enable_whiteboard_mode_on_start(whiteboard_on_start_button_.checked());
-		if (hide_whiteboard_button_.pressed())
-			set_hide_whiteboard(hide_whiteboard_button_.checked());
 		if (hotkeys_button_.pressed()) {
 			show_hotkeys_preferences_dialog(disp_);
 			parent->clear_buttons();
@@ -1300,8 +1283,6 @@ void preferences_dialog::set_selection(int index)
 	turbo_slider_.enable(turbo());
 	show_ai_moves_button_.hide(hide_general);
 	turn_dialog_button_.hide(hide_general);
-	whiteboard_on_start_button_.hide(hide_general);
-	hide_whiteboard_button_.hide(hide_general);
 	interrupt_when_ally_sighted_button_.hide(hide_general);
 	hotkeys_button_.hide(hide_general);
 	paths_button_.hide(hide_general);

--- a/src/hotkey/hotkey_command.cpp
+++ b/src/hotkey/hotkey_command.cpp
@@ -102,6 +102,7 @@ hotkey::hotkey_command_temp hotkey_list_[] = {
 	{ hotkey::HOTKEY_REPLAY_SKIP_ANIMATION, "replayskipanimation", N_("Skip Animation"), false, hotkey::SCOPE_GAME, "" },
 	// Whiteboard commands
 	// TRANSLATORS: whiteboard menu entry: toggle planning mode
+	/*
 	{ hotkey::HOTKEY_WB_TOGGLE, "wbtoggle", N_("whiteboard^Planning Mode"), false, hotkey::SCOPE_GAME, "" },
 	// TRANSLATORS: whiteboard menu entry: execute planned action
 	{ hotkey::HOTKEY_WB_EXECUTE_ACTION, "wbexecuteaction", N_("whiteboard^Execute Action"), false, hotkey::SCOPE_GAME, "" },
@@ -115,6 +116,7 @@ hotkey::hotkey_command_temp hotkey_list_[] = {
 	{ hotkey::HOTKEY_WB_BUMP_DOWN_ACTION, "wbbumpdownaction", N_("whiteboard^Move Action Down"), false, hotkey::SCOPE_GAME, "" },
 	// TRANSLATORS: whiteboard menu entry: plan as though the chosen unit were dead
 	{ hotkey::HOTKEY_WB_SUPPOSE_DEAD, "wbsupposedead", N_("whiteboard^Suppose Dead"), false, hotkey::SCOPE_GAME, "" },
+	*/
 
 	{ hotkey::HOTKEY_EDITOR_QUIT_TO_DESKTOP, "editor-quit-to-desktop", N_("Quit to Desktop"), false, hotkey::SCOPE_EDITOR, "" },
 	{ hotkey::HOTKEY_EDITOR_MAP_CLOSE, "editor-close-map", N_("Close Map"), false, hotkey::SCOPE_EDITOR, "" },

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -2017,8 +2017,8 @@ class console_handler : public map_command_handler<console_handler>, private cha
 		void do_event();
 		void do_toggle_draw_coordinates();
 		void do_toggle_draw_terrain_codes();
-		void do_toggle_whiteboard();
-		void do_whiteboard_options();
+		//void do_toggle_whiteboard();
+		//void do_whiteboard_options();
 
 		std::string get_flags_description() const {
 			return _("(D) — debug only, (N) — network only, (A) — admin only");
@@ -2148,12 +2148,12 @@ class console_handler : public map_command_handler<console_handler>, private cha
 			register_command("show_terrain_codes", &console_handler::do_toggle_draw_terrain_codes,
 				_("Toggle overlaying of terrain codes on hexes."));
 			register_alias("show_terrain_codes", "tc");
-			register_command("whiteboard", &console_handler::do_toggle_whiteboard,
+/*			register_command("whiteboard", &console_handler::do_toggle_whiteboard,
 				_("Toggle planning mode."));
 			register_alias("whiteboard", "wb");
 			register_command("whiteboard_options", &console_handler::do_whiteboard_options,
 				_("Access whiteboard options dialog."));
-			register_alias("whiteboard_options", "wbo");
+			register_alias("whiteboard_options", "wbo");*/
 
 			if (const config &alias_list = preferences::get_alias())
 			{
@@ -3250,7 +3250,7 @@ void console_handler::do_toggle_draw_terrain_codes() {
 	menu_handler_.gui_->set_draw_terrain_codes(!menu_handler_.gui_->get_draw_terrain_codes());
 	menu_handler_.gui_->invalidate_all();
 }
-
+#if 0
 void console_handler::do_toggle_whiteboard() {
 	resources::whiteboard->set_active(!resources::whiteboard->is_active());
 	if (resources::whiteboard->is_active()) {
@@ -3260,11 +3260,14 @@ void console_handler::do_toggle_whiteboard() {
 		print(get_cmd(), _("Planning mode deactivated!"));
 	}
 }
+#endif
 
-void console_handler::do_whiteboard_options()
+#if 0
+console_handler::do_whiteboard_options()
 {
 	resources::whiteboard->options_dlg();
 }
+#endif
 
 void menu_handler::do_ai_formula(const std::string& str,
 	int side_num, mouse_handler& /*mousehandler*/)

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -1126,9 +1126,11 @@ void play_controller::process_focus_keydown_event(const SDL_Event& event)
 }
 
 void play_controller::process_keydown_event(const SDL_Event& event) {
+#if 0
 	if (event.key.keysym.sym == SDLK_TAB) {
 		whiteboard_manager_->set_invert_behavior(true);
 	}
+#endif
 }
 
 void play_controller::process_keyup_event(const SDL_Event& event) {
@@ -1157,11 +1159,13 @@ void play_controller::process_keyup_event(const SDL_Event& event) {
 			}
 
 		}
+#if 0
 	} else if (event.key.keysym.sym == SDLK_TAB) {
 		static CKey keys;
 		if (!keys[SDLK_TAB]) {
 			whiteboard_manager_->set_invert_behavior(false);
 		}
+#endif
 	}
 }
 

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -219,6 +219,7 @@ void playsingle_controller::clear_messages(){
 }
 
 void playsingle_controller::whiteboard_toggle() {
+#if 0
 	resources::whiteboard->set_active(!resources::whiteboard->is_active());
 
 	if (resources::whiteboard->is_active()) {
@@ -233,6 +234,7 @@ void playsingle_controller::whiteboard_toggle() {
 	}
 	//@todo Stop printing whiteboard help in the chat once we have better documentation/help
 	resources::whiteboard->print_help_once();
+#endif
 }
 
 void playsingle_controller::whiteboard_execute_action(){

--- a/src/whiteboard/manager.cpp
+++ b/src/whiteboard/manager.cpp
@@ -163,6 +163,7 @@ bool manager::can_activate() const
 
 void manager::set_active(bool active)
 {
+#if 0
 	if(!can_activate())
 	{
 		active_ = false;
@@ -184,10 +185,12 @@ void manager::set_active(bool active)
 			LOG_WB << "Whiteboard deactivated!\n";
 		}
 	}
+#endif
 }
 
 void manager::set_invert_behavior(bool invert)
 {
+#if 0
 	//any more than one reference means a lock on whiteboard state was requested
 	if(!activation_state_lock_.unique())
 		return;
@@ -234,6 +237,7 @@ void manager::set_invert_behavior(bool invert)
 			}
 		}
 	}
+#endif
 }
 
 bool manager::can_enable_execution_hotkeys() const


### PR DESCRIPTION
I'm proposing this is because of
- bug reports about assertion failures
- performance problems -- I tested both master and 1.12 branch and 1.11 series dating back to January 2014, and whiteboard moves no longer work fully, which was the most important part of the feature. It seems that the "future_map" which is supposed to control alternations of the gamestate from with planned moves / without planned moves is no longer working, so units with planned moves cannot be selected or moved properly. 
- graphical glitches -- the "ghosted" unit standing animations are corrupted and twitch continuously while units with such animations have planned moves

https://gna.org/bugs/index.php?22231
https://gna.org/bugs/?func=detailitem&item_id=21302

I suggest that we might look towards restoring the whiteboard in version 1.14, if we can reimplement it in a more robust / maintainable manner, and with sufficient unit tests to help prevent it from breaking in the future
