### PR TITLE
*DONT MERGE* Factor out the unit_pod from unit_map

### DIFF
--- a/src/game_board.cpp
+++ b/src/game_board.cpp
@@ -30,19 +30,26 @@ static lg::log_domain log_engine("enginerefac");
 #define WRN_RG LOG_STREAM(warn, log_engine)
 #define ERR_RG LOG_STREAM(err, log_engine)
 
-game_board::game_board(const config & game_config, const config & level) : teams_(), map_(new gamemap(game_config, level)), units_() {}
+game_board::game_board(const config & game_config, const config & level) : teams_(), map_(new gamemap(game_config, level)), units_() {
+	DBG_RG << "game_board constructed" << std::endl;
+}
 
-game_board::game_board(const game_board & other) : teams_(other.teams_), map_(new gamemap(*(other.map_))), units_(other.units_) {}
+game_board::game_board(const game_board & other) : teams_(other.teams_), map_(new gamemap(*(other.map_))), units_(other.units_) {
+	DBG_RG << "game_board constructed" << std::endl;
+}
 
-game_board::~game_board() {}
+game_board::~game_board() {
+	DBG_RG << "game_board destructed" << std::endl;
+}
 
 
 //TODO: Fix this so that we swap pointers to maps, and also fix replace_map to use scoped_ptr::reset.
 // However, then anytime gameboard is overwritten, resources::gamemap must be updated. So might want to
 // just get rid of resources::gamemap and replace with resources::gameboard->map() at that point.
 void swap(game_board & one, game_board & other) {
+	DBG_RG << "game_board swap" << std::endl;
 	std::swap(one.teams_, other.teams_);
-	std::swap(one.units_, other.units_);
+	one.units_.swap(other.units_);
 	one.map_.swap(other.map_);
 }
 

--- a/src/tests/test_unit_map.cpp
+++ b/src/tests/test_unit_map.cpp
@@ -242,7 +242,7 @@ BOOST_AUTO_TEST_CASE( track_real_unit_by_iterator ) {
 
 	UnitPtr extracted_unit = unit_map.extract(hex);
 
-	BOOST_CHECK_MESSAGE(unit_iterator.valid() == false, "Iterator should be invalid after extraction.");
+	//BOOST_CHECK_MESSAGE(unit_iterator.valid() == false, "Iterator should be invalid after extraction.");
 
 	unit_map.insert(extracted_unit);
 
@@ -279,7 +279,7 @@ BOOST_AUTO_TEST_CASE( track_fake_unit_by_iterator ) {
 
 	UnitPtr extracted_unit = unit_map.extract(hex);
 
-	BOOST_CHECK_MESSAGE(unit_iterator.valid() == false, "Iterator should be invalid after extraction.");
+	//BOOST_CHECK_MESSAGE(unit_iterator.valid() == false, "Iterator should be invalid after extraction.");
 
 	unit_map.insert(extracted_unit);
 

--- a/src/whiteboard/mapbuilder.cpp
+++ b/src/whiteboard/mapbuilder.cpp
@@ -62,7 +62,10 @@ void mapbuilder::pre_build()
 	}
 
 	int current_side = resources::controller->current_side();
-	BOOST_FOREACH(unit& u, *resources::units) {
+	for(unit_map::iterator it = resources::units->begin(); it != resources::units->end(); ) {
+		unit & u = *it;
+		it++;
+
 		bool on_current_side = (u.side() == current_side);
 
 		//Remove any unit the current side cannot see to avoid their detection by planning


### PR DESCRIPTION
This commit attempts to cleanup and simplify the unit_map
further. After this commit, unit_pods are removed and 
instead the unit_map is based on the "universal" reference
counted pointer (UnitPtr).

However this also changes the guarantee of iterators and
when they are invalidated. Formerly, iterators *never*
invalidate. After this commit, they never invalidate for
*dereference* but they may invalidate for increment
if the unit they refer to is extracted from the map. Thus
code along the following lines:

BOOST_FOREACH( unit & u , *resources::units ) {
    if (...) {
        resources::units->extract(u.get_location());
        ...
    }
}

will likely segfault, because it does not "preincrement" the iterator before deleting the object.

The unit_pod system effectively prevented any deletions from occurring in the unit_map
internal data structures until there are no iterators pointing at the relevant node. Some kind
of reference counting is probably necessary for this behavior, so the approach here should
perhaps be reconsidered.