### PR TITLE
Fix the linking error found in the last commit.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -852,6 +852,7 @@ set(wesnoth-main_SRC
 	scripting/lua_types.cpp
 	settings.cpp
 	sha1.cpp
+	spritesheet.cpp
 	side_filter.cpp
 	statistics.cpp
 	statistics_dialog.cpp

--- a/src/spritesheet.cpp
+++ b/src/spritesheet.cpp
@@ -15,8 +15,8 @@ static lg::log_domain log_config("config");
 sprite_data::sprite_data(const config& cfg) :
 	image(cfg["spritesheet_image"]),
 	id(cfg["id"].to_int()),
-	x_coor(cfg["x_coor"].to_int()),
-	y_coor(cfg["y_coor"].to_int()),
+	x_coordinate(cfg["x_coor"].to_int()),
+	y_coordinate(cfg["y_coor"].to_int()),
 	height(cfg["height"].to_int()),
 	width(cfg["width"].to_int())
 {

--- a/src/spritesheet.hpp
+++ b/src/spritesheet.hpp
@@ -17,7 +17,7 @@ struct sprite_data {
 
 	//enum location { X_COOR, Y_COOR, WIDTH, HEIGHT };  replace with array?
 
-	std::string spritesheet;
+	std::string image;
 	
 	// if moved to array place these 5 values into it?
 	int id;

--- a/src/unit_types.cpp
+++ b/src/unit_types.cpp
@@ -545,8 +545,6 @@ void unit_type::build_full(const movement_type_map &mv_types,
 	// parse the spritesheet tags if found.
 	BOOST_FOREACH(const config &spritesheet, cfg_.child_range("spritesheet"))
 	{
-		// mordante I'm getting an undefined reference at this point and
-		// I can't see the reason.
 		spritesheet_sprites_.push_back(sprite_data(spritesheet));
 	}
 


### PR DESCRIPTION
The error was caused by forgetting to add the new file to the
CMakeList.txt file.  It was then found that the new file did not
compile because of non matching variable names, those were changed
so they match.  Lastly a comment asking for reveiw/help finding the
issue was removed from unit_types.cpp as it is no longer an issue.
