### PR TITLE
fixup lines with two closers on a line in wml test directory

### DIFF
--- a/data/test/scenarios/break_replay_with_lua_random.cfg
+++ b/data/test/scenarios/break_replay_with_lua_random.cfg
@@ -71,7 +71,8 @@
             code =<<
                 wesnoth.set_variable("rnd_num", math.random(200))
             >>
-        [/lua])}
+        [/lua]
+)}
 
 {TEST_BREAK_REPLAY "fixed_lua_random_replay_with_sync_choice"
        ([lua]
@@ -82,4 +83,5 @@
                   end)
                 wesnoth.set_variable("rnd_num", result.value)
             >>
-        [/lua])}
+        [/lua]
+)}

--- a/data/test/scenarios/event_handlers_in_events.cfg
+++ b/data/test/scenarios/event_handlers_in_events.cfg
@@ -189,7 +189,8 @@
                                             name=post_advance
                                             {VARIABLE pass_test 1}
                                         [/my_event]
-                                    [/variables])}
+                                    [/variables]
+)}
         [store_unit]
             [filter]
                 x=1

--- a/data/test/scenarios/move_skip_sighted.cfg
+++ b/data/test/scenarios/move_skip_sighted.cfg
@@ -61,7 +61,8 @@
                 id=bob
                 x={STOP_X}
                 y={STOP_Y}
-            [/have_unit])}
+            [/have_unit]
+)}
     [/event]
 [/test]
 #enddef

--- a/data/test/scenarios/test_unit_map.cfg
+++ b/data/test/scenarios/test_unit_map.cfg
@@ -9,14 +9,16 @@
         [have_unit] 
             x,y=9,5 
         [/have_unit]
-    [/not])}
+    [/not]
+)}
 #enddef
 
 #define ASSERT_YES_9_5
 {ASSERT (
     [have_unit] 
         x,y=9,5 
-    [/have_unit])}
+    [/have_unit]
+)}
 #enddef
 
 

--- a/data/test/scenarios/units_offmap_goto_recall.cfg
+++ b/data/test/scenarios/units_offmap_goto_recall.cfg
@@ -20,13 +20,15 @@
                     side = 1
                     search_recall_list = no
                 [/have_unit]
-            [/not])}
+            [/not]
+)}
         {RETURN (
             [have_unit]
                 id = Charlie
                 canrecruit = no
                 side = 1
                 search_recall_list = yes
-            [/have_unit])}
+            [/have_unit]
+)}
     [/event]
 )}


### PR DESCRIPTION
Note: Please don't pull unless some of the other bugs in wmlindent have been fixed and
will give good output

wmlindent chokes on these

commit made with the following command:

find data/test/scenarios/ -type f -print0 | xargs -0 sed -i
"s|^([[:space:]]_[\/._])[[:space:]]_)}[[:space:]]_$|\1\n)}|"
