### PR TITLE
[filter_vision] tag should return true if *any* viewer matches

### DIFF
--- a/src/terrain_filter.cpp
+++ b/src/terrain_filter.cpp
@@ -166,13 +166,16 @@ bool terrain_filter::match_internal(const map_location& loc, const bool ignore_x
 			side_filter ssf(*i);
 			std::vector<int> sides = ssf.get_teams();
 
+			bool found = false;
 			BOOST_FOREACH(const int side, sides) {
 				const team &viewing_team = resources::teams->at(side - 1);
 				bool viewer_sees = respect_fog ? !viewing_team.fogged(loc) : !viewing_team.shrouded(loc);
-				if (visible != viewer_sees) {
-					return false;
+				if (visible == viewer_sees) {
+					found = true;
+					break;
 				}
 			}
+			if (!found) return false;
 		}
 	}
 

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -1562,16 +1562,18 @@ bool unit::internal_matches_filter(const vconfig& cfg, const map_location& loc, 
 			side_filter ssf(*i);
 			std::vector<int> sides = ssf.get_teams();
 			viewers.insert(sides.begin(), sides.end());
-			if (viewers.empty()) {
-				return false;
-			}
-			std::set<int>::const_iterator viewer, viewer_end = viewers.end();
-			for (viewer = viewers.begin(); viewer != viewer_end; ++viewer) {
-				bool fogged = teams_manager::get_teams()[*viewer - 1].fogged(loc);
+
+			bool found = false;
+			BOOST_FOREACH(const int viewer, viewers) {
+				bool fogged = teams_manager::get_teams()[viewer - 1].fogged(loc);
 				bool hiding = this->invisible(loc/*, false(?) */);
 				bool unit_hidden = fogged || hiding;
-				if (visible == unit_hidden) return false;
+				if (visible != unit_hidden) {
+					found = true;
+					break;
+				}
 			}
+			if (!found) return false;
 		}
 	}
 


### PR DESCRIPTION
I wrote an email about this to the dev-list, please don't merge unless that is resolved.

This is intended as a bug fix for the [filter_vision] tags in standard unit and standard location filters.

See forum post for background: http://forums.wesnoth.org/viewtopic.php?f=21&t=40702
