### PR TITLE
Updated default window size for Macs

### DIFF
--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -333,7 +333,15 @@ std::pair<int,int> resolution()
 		//res.second &= ~3;
 		return res;
 	} else {
+	#ifdef __APPLE__
+		// When windowsize is larger than the screen,  Wesnoth scales the video
+		// which causes distortion with mouse tracking. 768 is simply too large
+		// vertically to safely fit. We need a smaller default resolution here for Macs.
+		// See bug #20332.
+		return std::pair<int,int>(800,600);
+	#else
 		return std::pair<int,int>(1024,768);
+	#endif
 	}
 }
 


### PR DESCRIPTION
Make the default window size 800 x 600 for Macs. This is a workaround for bug #20332.
