### PR TITLE
revert PR 98

### DIFF
--- a/src/game_end_exceptions.cpp
+++ b/src/game_end_exceptions.cpp
@@ -33,8 +33,6 @@ end_level_data::end_level_data()
 	, carryover_percentage(game_config::gold_carryover_percentage)
 	, carryover_add(false)
 	, transient()
-	, next_scenario_settings()
-	, next_scenario_append()
 {
 }
 
@@ -45,13 +43,6 @@ void end_level_data::write(config& cfg) const
 	cfg["bonus"] = gold_bonus;
 	cfg["carryover_percentage"] = carryover_percentage;
 	cfg["carryover_add"] = carryover_add;
-	if (!next_scenario_settings.empty()) {
-		cfg.add_child("next_scenario_settings", next_scenario_settings);
-	}
-	if (!next_scenario_append.empty()) {
-		cfg.add_child("next_scenario_append", next_scenario_append);
-	}
-
 }
 
 void end_level_data::read(const config& cfg)
@@ -61,13 +52,4 @@ void end_level_data::read(const config& cfg)
 	gold_bonus = cfg["bonus"].to_bool(true);
 	carryover_percentage = cfg["carryover_percentage"].to_int(game_config::gold_carryover_percentage);
 	carryover_add = cfg["carryover_add"].to_bool(false);
-	const config & next_scenario_settings_cfg = cfg.child_or_empty("next_scenario_settings");
-	if (!next_scenario_settings_cfg.empty()) {
-		next_scenario_settings = next_scenario_settings_cfg;
-	}
-	const config & next_scenario_append_cfg = cfg.child_or_empty("next_scenario_append");
-	if (!next_scenario_append_cfg.empty()) {
-		next_scenario_append = next_scenario_append_cfg;
-	}
-
 }

--- a/src/game_end_exceptions.hpp
+++ b/src/game_end_exceptions.hpp
@@ -26,7 +26,7 @@
 
 #include <string>
 
-#include "config.hpp"
+class config;
 
 enum LEVEL_RESULT {
 	NONE,
@@ -107,9 +107,6 @@ struct end_level_data
 	int carryover_percentage;          /**< How much gold is carried over to next scenario. */
 	bool carryover_add;                /**< Add or replace next scenario's minimum starting gold. */
 	transient_end_level transient;
-
-	config next_scenario_settings;
-	config next_scenario_append;
 
 	void write(config& cfg) const;
 

--- a/src/game_events/action_wml.cpp
+++ b/src/game_events/action_wml.cpp
@@ -727,15 +727,6 @@ WML_HANDLER_FUNCTION(endlevel, /*event_info*/, cfg)
 	std::string next_scenario = cfg["next_scenario"];
 	if (!next_scenario.empty()) {
 		resources::gamedata->set_next_scenario(next_scenario);
-
-		const config next_scenario_settings_cfg = cfg.get_parsed_config().child_or_empty("next_scenario_settings");
-		if (!next_scenario_settings_cfg.empty()) {
-			data.next_scenario_settings = next_scenario_settings_cfg;
-		}
-		const config next_scenario_append_cfg = cfg.get_parsed_config().child_or_empty("next_scenario_append");
-		if (!next_scenario_append_cfg.empty()) {
-			data.next_scenario_append = next_scenario_append_cfg;
-		}
 	}
 
 	std::string end_of_campaign_text = cfg["end_text"];


### PR DESCRIPTION
This commit removes the "carryover_wml" feature which was added
just before 1.12 was branched off.

I added this feature at a time when I didn't have as good an
understanding as I do now of the networked mp code, I now believe
that it was poorly concieved and should not be implemented this
way if at all. There are better ways to achieve what was meant to
be achieved here, we are better off to remove it as it currently
exists.
