### PR TITLE
revert PR 98

### DIFF
--- a/src/carryover.cpp
+++ b/src/carryover.cpp
@@ -270,15 +270,6 @@ void carryover_info::transfer_to(config& level){
 		level["next_underlying_unit_id"] = next_underlying_unit_id_;
 	}
 
-	if(!end_level_.next_scenario_settings.empty()) {
-		level.merge_with(end_level_.next_scenario_settings);
-	}
-	if(!end_level_.next_scenario_append.empty())
-	{
-		level.append_children(end_level_.next_scenario_append);
-	}
-	end_level_.next_scenario_append = config();
-	end_level_.next_scenario_settings = config();
 	//if the game has been loaded from a snapshot, the existing variables will be the current ones
 	if(!level.has_child("variables")) {
 		level.add_child("variables", variables_);

--- a/src/carryover.hpp
+++ b/src/carryover.hpp
@@ -9,6 +9,7 @@ class game_data;
 #include <string>
 #include <set>
 
+#include "config.hpp"
 #include "game_end_exceptions.hpp"
 #include "simple_rng.hpp"
 #include "game_events/wmi_container.hpp"
@@ -112,4 +113,3 @@ private:
 
 
 #endif
-

--- a/src/game_end_exceptions.cpp
+++ b/src/game_end_exceptions.cpp
@@ -34,8 +34,6 @@ end_level_data::end_level_data()
 	, carryover_add(false)
 	, proceed_to_next_level(false)
 	, transient()
-	, next_scenario_settings()
-	, next_scenario_append()
 {
 }
 
@@ -47,13 +45,6 @@ void end_level_data::write(config& cfg) const
 	cfg["carryover_percentage"] = carryover_percentage;
 	cfg["carryover_add"] = carryover_add;
 	cfg["proceed_to_next_level"] = proceed_to_next_level;
-	if (!next_scenario_settings.empty()) {
-		cfg.add_child("next_scenario_settings", next_scenario_settings);
-	}
-	if (!next_scenario_append.empty()) {
-		cfg.add_child("next_scenario_append", next_scenario_append);
-	}
-
 }
 
 void end_level_data::read(const config& cfg)
@@ -64,13 +55,4 @@ void end_level_data::read(const config& cfg)
 	carryover_percentage = cfg["carryover_percentage"].to_int(game_config::gold_carryover_percentage);
 	carryover_add = cfg["carryover_add"].to_bool(false);
 	proceed_to_next_level = cfg["proceed_to_next_level"].to_bool(true);
-	const config & next_scenario_settings_cfg = cfg.child_or_empty("next_scenario_settings");
-	if (!next_scenario_settings_cfg.empty()) {
-		next_scenario_settings = next_scenario_settings_cfg;
-	}
-	const config & next_scenario_append_cfg = cfg.child_or_empty("next_scenario_append");
-	if (!next_scenario_append_cfg.empty()) {
-		next_scenario_append = next_scenario_append_cfg;
-	}
-
 }

--- a/src/game_end_exceptions.hpp
+++ b/src/game_end_exceptions.hpp
@@ -24,11 +24,12 @@
 
 #include "lua_jailbreak_exception.hpp"
 
+#include "config.hpp"
+
 #include <string>
 
 #include <boost/optional.hpp>
-
-#include "config.hpp"
+#include <boost/variant/variant.hpp>
 
 enum LEVEL_RESULT {
 	NONE,
@@ -221,9 +222,6 @@ struct end_level_data
 	bool carryover_add;                /**< Add or replace next scenario's minimum starting gold. */
 	bool proceed_to_next_level;        /**< whether to proceed to the next scenario, equals (res == VICTORY) in sp. We need to save this in saves during linger mode. > */
 	transient_end_level transient;
-
-	config next_scenario_settings;
-	config next_scenario_append;
 
 	void write(config& cfg) const;
 

--- a/src/game_events/action_wml.cpp
+++ b/src/game_events/action_wml.cpp
@@ -698,15 +698,6 @@ WML_HANDLER_FUNCTION(endlevel, /*event_info*/, cfg)
 	std::string next_scenario = cfg["next_scenario"];
 	if (!next_scenario.empty()) {
 		resources::gamedata->set_next_scenario(next_scenario);
-
-		const config next_scenario_settings_cfg = cfg.get_parsed_config().child_or_empty("next_scenario_settings");
-		if (!next_scenario_settings_cfg.empty()) {
-			data.next_scenario_settings = next_scenario_settings_cfg;
-		}
-		const config next_scenario_append_cfg = cfg.get_parsed_config().child_or_empty("next_scenario_append");
-		if (!next_scenario_append_cfg.empty()) {
-			data.next_scenario_append = next_scenario_append_cfg;
-		}
 	}
 
 	std::string end_of_campaign_text = cfg["end_text"];

--- a/src/playcampaign.cpp
+++ b/src/playcampaign.cpp
@@ -374,14 +374,6 @@ LEVEL_RESULT play_game(game_display& disp, saved_game& gamestate,
 				//note that although starting_pos is const it might be changed by gamestate.some_non_const_operation()  .
 				const config& starting_pos = gamestate.get_starting_pos();
 
-				//We don't merge WML until start of next scenario, but if we want to allow user to disable MP ui in transition,
-				//then we have to move "allow_new_game" attribute over now.
-				bool allow_new_game_flag = starting_pos["allow_new_game"].to_bool(gamestate.mp_settings().show_connect);
-
-				if (gamestate.carryover().child_or_empty("end_level_data").child_or_empty("next_scenario_settings").has_attribute("allow_new_game")) {
-					allow_new_game_flag = gamestate.carryover().child_or_empty("end_level_data").child("next_scenario_settings")["allow_new_game"].to_bool();
-				}
-
 				gamestate.mp_settings().num_turns = starting_pos["turns"].to_int(-1);
 				gamestate.mp_settings().saved_game = false;
 				gamestate.mp_settings().use_map_settings
@@ -391,7 +383,7 @@ LEVEL_RESULT play_game(game_display& disp, saved_game& gamestate,
 					connect_engine(new ng::connect_engine(gamestate,
 						!network_game, false));
 
-				if (allow_new_game_flag || (game_config::debug && network::nconnections() == 0)) {
+				if (starting_pos["allow_new_game"].to_bool(true) || (game_config::debug && network::nconnections() == 0)) {
 					// Opens mp::connect dialog to allow users to
 					// make an adjustments for scenario.
 					// TODO: Fix this so that it works when network::nconnections() > 0 as well.


### PR DESCRIPTION
This is a parallel commit to PR 243, on master instead of 1.12
branch.

The commit is significantly different because this feature got
swept up in a different refactor of playcampaign / carryover. I
didn't test the feature extensively on this branch, this might not
be necessary at all. I'm simply making the sister commit anyways
so that we have something concrete to discuss when deciding
whether to merge either or both of these pull requests.

I do think the feature is of questionable value and adds
complexity to an already confusing part of the engine, and should
therefore be considered for removal.
