### PR TITLE
Add defense caps for mushroom terrain type, tweak some fluff

### DIFF
--- a/data/core/terrain.cfg
+++ b/data/core/terrain.cfg
@@ -2228,10 +2228,10 @@ For those who go by land or sea, a bridge is the best of both worlds — for gam
     editor_name= _ "Fungus"
     string=Uft
     hidden=yes
-    help_topic_text= _ "<italic>text='Mushroom groves'</italic> are vast underground forests of giant mushrooms,
-which thrive in the damp darkness. Most units have trouble negotiating the spongy floor of smaller fungi, but they have plenty of cover behind the larger stalks. Mounted units, however, become completely mired and lack proper freedom of movement in combat. Undead units have a natural affinity for decay and function quite well in mushroom forests.
+    help_topic_text= _ "<italic>text='Mushroom groves'</italic> are vast forests of giant mushrooms.
+Wild mushrooms thrive underground in the damp darkness, but may also grow on the surface in an abundance of decaying plant material. Most units have trouble negotiating the spongy floor of smaller fungi, but they have plenty of cover behind the larger stalks. Mounted units, however, become completely mired and lack proper freedom of movement in combat. Undead units have a natural affinity for decay and function quite well in mushroom forests. Wild mushrooms are known to have a potent intoxicating effect on dwarves, and the spore clouds which emanate from mature giant mushroom stalks will render a dwarf sluggish and slow to react.
 
-Most units receive 50% to 60% defense in mushroom groves, whereas cavalry receive only 20%."
+Most units receive 50% to 60% defense in mushroom groves, whereas cavalry receive only 20%, and dwarves recieve only 40%."
 [/terrain_type]
 
 [terrain_type]

--- a/data/core/units.cfg
+++ b/data/core/units.cfg
@@ -611,7 +611,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             castle=60
             cave=80
             frozen=70
-            fungus=80
+            fungus=-80
         [/defense]
 
         [resistance]
@@ -1038,7 +1038,7 @@ The life span of the wose is unknown, although the most ancient members of this 
         castle=40
         cave=50
         frozen=70
-        fungus=60
+        fungus=-60
     [/defense]
 #enddef
     [movetype]
@@ -1646,7 +1646,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             castle=60
             cave=80
             frozen=70
-            fungus=80
+            fungus=-80
         [/defense]
         [resistance]
             blade=90
@@ -1686,7 +1686,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             castle=50
             cave=80
             frozen=70
-            fungus=80
+            fungus=-80
         [/defense]
         [resistance]
             blade=70

--- a/data/core/units/gryphons/Gryphon_Master.cfg
+++ b/data/core/units/gryphons/Gryphon_Master.cfg
@@ -34,6 +34,9 @@
     [defense]
         mountains=40
     [/defense]
+    [defense]
+        fungus=-70
+    [/defense]
     [resistance]
         arcane=90
     [/resistance]

--- a/data/core/units/gryphons/Gryphon_Rider.cfg
+++ b/data/core/units/gryphons/Gryphon_Rider.cfg
@@ -33,6 +33,9 @@
     [defense]
         mountains=40
     [/defense]
+    [defense]
+        fungus=-70
+    [/defense]
     [resistance]
         arcane=90
     [/resistance]


### PR DESCRIPTION
*\* Note: Please don't merge this, this is being actively discussed on the forums. This is not even my favored way to resolve the issue, its just a way to see hands on what the new settings / help descriptions might look like with such a change. **

This Pull request adds negative defense modifiers to fungus, (thus establishing
a defense cap for mushroom mixed terrain types) for Dwarves,
Gryphon Riders, and Loyalist and Khalifate cavalry.

Pretty much it works along the lines I suggested here:
http://forums.wesnoth.org/viewtopic.php?f=15&t=40753&sid=5f6460f6567081ae62d5c9d0cf80357f#p573355

It also updates the "fluff" associated to fungus terrains to explain
in a different manner why dwarves and gryphon riders are weakened
here.

Feedback is very much welcome.

One extension of this which appeals to me is to also add negative modifiers
for the "swimmer" type, thus giving all mermen poor defense on mushrooms.
This might make swamp+mushroom a more interesting terrain type, as most
land units and mermen would be very weak and slow there but saurians 
would be fast and strong. However this change isn't strictly important for
balancing out the (Flat / Hill / Cave) + Mushroom so it isn't included here.
