### PR TITLE
Config converters

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -685,6 +685,7 @@ test_sources = Split("""
     tests/test_addons.cpp
     tests/test_commandline_options.cpp
     tests/test_config.cpp
+    tests/test_config_convert.cpp
     tests/test_formula_ai.cpp
     tests/test_formula_function.cpp
     tests/test_image_modifications.cpp

--- a/src/tests/test_config_convert.cpp
+++ b/src/tests/test_config_convert.cpp
@@ -29,17 +29,23 @@
 #include "utils/convert_lexical.hpp"
 
 CONFIG_CLASS( test_info,
-	( int,		i,	convert::to_int(3))
-	( int,		i2,	convert::to_int())
-	( bool, 	b,	convert::to_bool(true))
-	( bool, 	b2,	convert::to_bool(false))
-	( std::string,	s,	convert::str())
+	CONFIG_VAL( int,		i,	convert::to_int(3))
+	CONFIG_VAL( int,		i2,	convert::to_int())
+	CONFIG_VAL( bool, 		b,	convert::to_bool(true))
+	CONFIG_VAL( bool, 		b2,	convert::to_bool(false))
+	CONFIG_VAL( std::string,	s,	convert::str())
 )
 
 CONFIG_CLASS( test_comma_list_struct,
-	( std::vector<std::string>, 	vec, convert::comma_list<std::vector<std::string> >() )
-	( std::set<std::string>, 	set, convert::comma_list<std::set<std::string> >() )
+	CONFIG_VAL( std::vector<std::string>, 	vec, convert::comma_list<std::vector<std::string> >() )
+	CONFIG_VAL( std::set<std::string>, 	set, convert::comma_list<std::set<std::string> >() )
 )
+
+CONFIG_CLASS( test_comma_list_struct_templ,
+	CONFIG_VAL_T( std::vector<std::string>, vec, convert::comma_list)
+	CONFIG_VAL_T( std::set<std::string>, 	set, convert::comma_list)
+)
+
 
 namespace foo {
 	MAKE_ENUM( ey,
@@ -54,11 +60,9 @@ namespace foo {
 }
 
 CONFIG_CLASS( test_lexical_struct,
-	( foo::ey,	widget,		convert::lexical<foo::ey>())
-	( foo::ey,	gadget,		convert::lexical<foo::ey>(foo::BAZ))
+	CONFIG_VAL( foo::ey,	widget,		convert::lexical<foo::ey>())
+	CONFIG_VAL( foo::ey,	gadget,		convert::lexical<foo::ey>(foo::BAZ))
 )
-
-convert::lexical<foo::ey> blah;
 
 BOOST_AUTO_TEST_SUITE ( test_config_convert )
 
@@ -87,6 +91,20 @@ BOOST_AUTO_TEST_CASE( test_comma_list )
 	test_comma_list_struct t = from_config<test_comma_list_struct>(cfg);
 
 	const config cfg2 = to_config<test_comma_list_struct> (t);
+
+	BOOST_CHECK_EQUAL(cfg2["vec"].str(), "1,1,2,3,5");
+	BOOST_CHECK_EQUAL(cfg2["set"].str(), "2,4,6,8");
+}
+
+BOOST_AUTO_TEST_CASE( test_comma_list_templ )
+{
+	const config cfg = config_of
+		("vec", "1,1,2,3,5")
+		("set", "2,4,6,8");
+
+	test_comma_list_struct_templ t = from_config<test_comma_list_struct_templ>(cfg);
+
+	const config cfg2 = to_config<test_comma_list_struct_templ> (t);
 
 	BOOST_CHECK_EQUAL(cfg2["vec"].str(), "1,1,2,3,5");
 	BOOST_CHECK_EQUAL(cfg2["set"].str(), "2,4,6,8");

--- a/src/tests/test_config_convert.cpp
+++ b/src/tests/test_config_convert.cpp
@@ -1,0 +1,106 @@
+/*
+   Copyright (C) 2014 by Chris Beck <render787@gmail.com>
+   Part of the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#define GETTEXT_DOMAIN "wesnoth-test"
+
+#include <boost/test/unit_test.hpp>
+#include <boost/foreach.hpp>
+#include <cmath>
+#include <set>
+#include <vector>
+
+#include "config.hpp"
+#include "config_assign.hpp"
+#include "make_enum.hpp"
+#include "utils/config_class.tpp"
+#include "utils/convert.hpp"
+#include "utils/convert_comma_list.hpp"
+#include "utils/convert_lexical.hpp"
+
+CONFIG_CLASS( test_info,
+	( int,		i,	convert::to_int(3))
+	( int,		i2,	convert::to_int())
+	( bool, 	b,	convert::to_bool(true))
+	( bool, 	b2,	convert::to_bool(false))
+	( std::string,	s,	convert::str())
+)
+
+CONFIG_CLASS( test_comma_list_struct,
+	( std::vector<std::string>, 	vec, convert::comma_list<std::vector<std::string> >() )
+	( std::set<std::string>, 	set, convert::comma_list<std::set<std::string> >() )
+)
+
+namespace foo {
+	MAKE_ENUM( ey,
+		(FOO, "foo")
+		(BAR, "bar")
+		(BAZ, "baz")
+	)
+
+	MAKE_ENUM_STREAM_OPS1(ey)
+
+	ey warning_suppressor = string_to_ey_default("asdf", FOO);
+}
+
+CONFIG_CLASS( test_lexical_struct,
+	( foo::ey,	widget,		convert::lexical<foo::ey>())
+	( foo::ey,	gadget,		convert::lexical<foo::ey>(foo::BAZ))
+)
+
+convert::lexical<foo::ey> blah;
+
+BOOST_AUTO_TEST_SUITE ( test_config_convert )
+
+BOOST_AUTO_TEST_CASE( test_info_1 )
+{
+	const config cfg = config_of
+		("i2", 2)
+		("b", "no")
+		("s", "huzzah");
+
+	test_info t = from_config<test_info>(cfg);
+
+	BOOST_CHECK_EQUAL(t.i_, 3);
+	BOOST_CHECK_EQUAL(t.i2_,2);
+	BOOST_CHECK_EQUAL(t.b_, false);
+	BOOST_CHECK_EQUAL(t.b2_,false);
+	BOOST_CHECK_EQUAL(t.s_, "huzzah");
+}
+
+BOOST_AUTO_TEST_CASE( test_comma_list )
+{
+	const config cfg = config_of
+		("vec", "1,1,2,3,5")
+		("set", "2,4,6,8");
+
+	test_comma_list_struct t = from_config<test_comma_list_struct>(cfg);
+
+	const config cfg2 = to_config<test_comma_list_struct> (t);
+
+	BOOST_CHECK_EQUAL(cfg2["vec"].str(), "1,1,2,3,5");
+	BOOST_CHECK_EQUAL(cfg2["set"].str(), "2,4,6,8");
+}
+
+BOOST_AUTO_TEST_CASE( test_lexical )
+{
+	const config cfg = config_of
+		("widget", "bar");
+
+	test_lexical_struct t = from_config<test_lexical_struct>(cfg);
+
+	BOOST_CHECK_EQUAL(t.widget_, foo::BAR);
+	BOOST_CHECK_EQUAL(t.gadget_, foo::BAZ);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/utils/config_class.tpp
+++ b/src/utils/config_class.tpp
@@ -1,0 +1,167 @@
+/*
+   Copyright (C) 2014 by Chris Beck <render787@gmail.com>
+   Part of the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#ifndef CONFIG_CLASS_HPP_
+#define CONFIG_CLASS_HPP_
+
+#include "config.hpp"
+#include "global.hpp"
+#include "wml_exception.hpp"
+
+#include <boost/preprocessor/cat.hpp>
+#include <boost/preprocessor/seq/for_each.hpp>
+#include <cassert>
+#include <cstddef>
+#include <string>
+
+/**
+ * These template functions act as an interface to the functions defined by
+ * the CONFIG_CLASS macro, if you don't want to read the macros below.
+ *
+ * CONFIG_CLASS defines an all public class (not technically a struct though) from 
+ * a list of member variables, identifiers, and attribute_value_converter objects.
+ * Converter objects are function objects which might be constructed with default 
+ * values or special policies, and convert between some type and config::attribute_value
+ * and back. The variable name is enforced to be the corresponding config attribute 
+ * value, plus an underscore. 
+ *
+ * TODO: A fallback attribute value to read from may be specified in case the intended
+ * attribute is missing.
+ *
+ * TODO: Extend this to include config converter objects to parse children.
+ */
+template <class T>
+config to_config(const T & t)
+{
+	config c;
+	t.write(c);
+	return c;
+}
+
+template <class T>
+T from_config(const config & c)
+{
+	T ret;
+	ret.read(c);
+	return ret;
+}
+
+template <class T>
+T from_config_warn(const config & c)
+{
+	T ret = from_config<T>(c);
+	config check = to_config<T>(ret);
+	config diff = check.get_diff(c);
+	VALIDATE_WITH_DEV_MESSAGE( !diff.child("delete") , std::string("Lost some information when parsing a config to class ") + T::name() , diff.child("delete").debug());
+	return ret;
+}
+
+
+/**
+ * This abstract base class defines an conversion pair for attribute value
+ * and some other type. There may be many of these for any type, and the
+ * converter may take arguments when it is constructed. Objects derived from
+ * this type are expected to be used as building blocks to define a config
+ * class.
+ */
+template <typename T>
+class attribute_value_converter {
+public:
+	virtual T operator()(const config::attribute_value &) = 0;
+	virtual config::attribute_value operator()(const T &) = 0;
+
+	virtual ~attribute_value_converter() {}
+};
+
+// Wrappers for primitive token pasting ops and quote ops
+#define CAT2( A, B ) A ## B
+#define CAT3( A, B, C ) A ## B ## C
+#define QQ( A ) #A
+
+// Gets a variable name by appending _
+#define GET_VAR_NAME( b ) CAT2( b, _ )
+
+// Generate code from a ( type, identifier, convertor) triple
+// Gets a variable defn corresponding to a triple
+#define GET_VAR_DEFN3( a, b, c ) a GET_VAR_NAME( b ) ;
+#define EXPAND_VAR_DEFS3( r, data, elem ) GET_VAR_DEFN3 elem
+
+// Gets a read statement corresponding to a triple
+#define GET_READ3( a, b, c ) GET_VAR_NAME( b ) = c ( cfg[ QQ( b ) ] ) ;
+#define EXPAND_READS3( r, data, elem ) GET_READ3 elem
+
+// Gets a write statement corresponding to a triple
+#define GET_WRITE3( a, b, c ) cfg[ QQ( b ) ] = c ( GET_VAR_NAME( b ) ) ;
+#define EXPAND_WRITES3( r, data, elem ) GET_WRITE3 elem
+
+// Formats args as triples so that we can use BOOST_PP_SEQ_FOREACH
+#define ADD_PARENS_1( A, B, C ) ((A, B, C)) ADD_PARENS_2
+#define ADD_PARENS_2( A, B, C ) ((A, B, C)) ADD_PARENS_1
+#define ADD_PARENS_1_END
+#define ADD_PARENS_2_END
+#define MAKE_TRIPLES( INPUT ) BOOST_PP_CAT(ADD_PARENS_1 INPUT,_END)
+
+// Generate code from a ( type, identifier, convertor, fallback config attribute ) quad
+// Get a variable definition from a quad the same as from a triple
+#define GET_VAR_DEFN4( a, b, c, d ) GET_VAR_DEFN3( a, b, c )
+#define EXPAND_VAR_DEFS4( r, data, elem ) GET_VAR_DEFN4 elem
+
+// Get a write statement from a quad the same as from a triple
+#define GET_WRITE4( a, b, c, d ) GET_WRITE3( a, b, c )
+#define EXPAND_WRITES4( r, data, elem ) GET_WRITE4 elem
+
+// Get a read statement corresponding to a quad
+#define GET_READ4( a, b, c, d ) GET_VAR_NAME( b ) = c ( cfg.has_attribute( QQ( b ) ) ? cfg[ QQ( b ) ] : cfg[ d ] )
+
+// Format args as quads so that we can use BOOST_PP_SEQ_FOREACH
+#define ADD_PARENS_3( A, B, C, D ) ((A, B, C, D)) ADD_PARENS_4
+#define ADD_PARENS_4( A, B, C, D ) ((A, B, C, D)) ADD_PARENS_3
+#define ADD_PARENS_3_END
+#define ADD_PARENS_4_END
+#define MAKE_QUADS( INPUT ) BOOST_PP_CAT(ADD_PARENS_3 INPUT,_END)
+
+// Define the config struct, with variable defns, read and write functions, and a name.
+// This can now be used with the templates defined above.
+#define CONFIG_CLASS( NAME, CONTENTS3 ) \
+class NAME { \
+public: \
+	BOOST_PP_SEQ_FOR_EACH( EXPAND_VAR_DEFS3 , , MAKE_TRIPLES( CONTENTS3 ) ) \
+	void read(const config & cfg) { \
+		BOOST_PP_SEQ_FOR_EACH( EXPAND_READS3, , MAKE_TRIPLES( CONTENTS3 ) ) \
+	} \
+	void write(config & cfg) const { \
+		BOOST_PP_SEQ_FOR_EACH( EXPAND_WRITES3, , MAKE_TRIPLES( CONTENTS3 ) ) \
+	} \
+	static const std::string name() { return QQ(NAME) ; } \
+};
+
+/*
+#define CONFIG_CLASS( NAME, CONTENTS3, CONTENTS4 ) \
+class NAME { \
+public: \
+	BOOST_PP_SEQ_FOREACH( EXPAND_VAR_DEFS3 , , MAKE_TRIPLES( CONTENTS3 ) ) \
+	BOOST_PP_SEQ_FOREACH( EXPAND_VAR_DEFS4 , , MAKE_QUADS( CONTENTS4 ) ) \
+	void read(const config & cfg) { \
+		BOOST_PP_SEQ_FOREACH( EXPAND_READS3, , MAKE_TRIPLES( CONTENTS3 ) ) \
+		BOOST_PP_SEQ_FOREACH( EXPAND_READS4, , MAKE_QUADS( CONTENTS4 ) ) \
+	} \
+	void write(config & cfg) { \
+		BOOST_PP_SEQ_FOREACH( EXPAND_WRITES3, , MAKE_TRIPLES( CONTENTS3 ) ) \
+		BOOST_PP_SEQ_FOREACH( EXPAND_WRITES4, , MAKE_QUADS( CONTENTS4 ) ) \
+	} \
+	static const std::string name( QQ(NAME) ); \
+};
+*/
+
+#endif

--- a/src/utils/convert.hpp
+++ b/src/utils/convert.hpp
@@ -17,6 +17,7 @@
 
 #include "config.hpp"
 #include "config_class.tpp"
+#include "utils/boost_function_guarded.hpp"
 
 #include <boost/optional.hpp>
 
@@ -67,6 +68,20 @@ public:
 
 	std::string operator()(const aval & a) { return a.str(); }
 	aval operator()(const std::string & s) { aval a; a = s; return a; }
+};
+
+/// Define an adhoc config attribute_value_converter from a pair of functions.
+template<typename T>
+class pair : public attribute_value_converter<T> {
+public:
+	pair(boost::function1<T, const aval &> from, boost::function1<aval,const T &> to) : from_(from), to_(to) {}
+	~pair() {}
+
+	T operator()(const aval & a) { return from_(a); }
+	aval operator()(const T & t) { return to_(t); }
+private:
+	boost::function1<T, const aval &> from_;
+	boost::function1<aval, const T &> to_;
 };
 
 } // end namespace convert

--- a/src/utils/convert.hpp
+++ b/src/utils/convert.hpp
@@ -1,0 +1,74 @@
+/*
+   Copyright (C) 2014 by Chris Beck <render787@gmail.com>
+   Part of the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#ifndef CONVERT_HPP_
+#define CONVERT_HPP_
+
+#include "config.hpp"
+#include "config_class.tpp"
+
+#include <boost/optional.hpp>
+
+namespace convert {
+
+typedef config::attribute_value aval;
+
+class to_int : public attribute_value_converter<int> {
+public:
+	to_int() : def_() {}
+	to_int(int def) : def_(def) {}
+	~to_int() {}
+
+	int operator()(const aval & a) { return (def_ ? a.to_int(*def_) : a.to_int()); }
+	aval operator()(const int & t) { aval a; a = t; return a; }
+private:
+	boost::optional<int> def_;
+};
+
+class to_unsigned : public attribute_value_converter<unsigned int> {
+public:
+	to_unsigned() : def_() {}
+	to_unsigned(unsigned int def) : def_(def) {}
+	~to_unsigned() {}
+
+	unsigned int operator()(const aval & a) { return (def_ ? a.to_unsigned(*def_) : a.to_unsigned()); }
+	aval operator()(const unsigned int & t) { aval a; a = t; return a; }
+private:
+	boost::optional<unsigned int> def_;
+};
+
+class to_bool : public attribute_value_converter<bool> {
+public:
+	to_bool() : def_() {}
+	to_bool(bool def) : def_(def) {}
+	~to_bool() {}
+
+	bool operator()(const aval & a) { return (def_ ? a.to_bool(*def_) : a.to_bool()); }
+	aval operator()(const bool & t) { aval a; a = t; return a; }
+private:
+	boost::optional<bool> def_;
+};
+
+class str : public attribute_value_converter<std::string> {
+public:
+	str() {}
+	~str() {}
+
+	std::string operator()(const aval & a) { return a.str(); }
+	aval operator()(const std::string & s) { aval a; a = s; return a; }
+};
+
+} // end namespace convert
+
+#endif

--- a/src/utils/convert_comma_list.hpp
+++ b/src/utils/convert_comma_list.hpp
@@ -1,0 +1,46 @@
+/*
+   Copyright (C) 2014 by Chris Beck <render787@gmail.com>
+   Part of the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#ifndef CONVERT_COMMA_LIST_HPP_
+#define CONVERT_COMMA_LIST_HPP_
+
+#include "global.hpp"
+
+#include "config.hpp"
+#include "config_class.tpp"
+#include "serialization/string_utils.hpp"
+
+namespace convert {
+
+template<class T>
+class comma_list : public attribute_value_converter<T> {
+public:
+	comma_list() {}
+	~comma_list() {}
+
+	T operator()(const aval & a) {
+		std::vector<std::string> v = utils::split(a.str());
+		return T(v.begin(), v.end());
+	}
+
+	aval operator()(const T & t) {
+		aval a;
+		a = utils::join<T>(t);
+		return a;
+	}
+};
+
+} // end namespace convert
+
+#endif

--- a/src/utils/convert_lexical.hpp
+++ b/src/utils/convert_lexical.hpp
@@ -1,0 +1,50 @@
+/*
+   Copyright (C) 2014 by Chris Beck <render787@gmail.com>
+   Part of the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#ifndef CONVERT_LEXICAL_HPP_
+#define CONVERT_LEXICAL_HPP_
+
+#include "config.hpp"
+#include "config_class.tpp"
+#include "global.hpp"
+#include "util.hpp"
+
+#include <boost/optional.hpp>
+
+namespace convert {
+
+template<typename T>
+class lexical : public attribute_value_converter<T> {
+public:
+	lexical() {}
+	lexical(T def) : def_(def) {}
+	~lexical() {}
+
+	T operator()(const aval & a) {
+		if (def_) return lexical_cast_default<T>(a.str(), *def_);
+		else return lexical_cast<T>(a.str());
+	}
+
+	aval operator()(const T & t) {
+		aval a;
+		a = lexical_cast<std::string>(t);
+		return a;
+	}
+private:
+	boost::optional<T> def_;
+};
+
+} // end namespace convert
+
+#endif


### PR DESCRIPTION
** Please don't merge, this is still a draft. **

This commit adds a macro "CONFIG_CLASS", the idea is to create a syntax to define a struct which can be converted to and from a config, and where each member's declaration specifies how it is converted to and from a config attribute. It enforces that attributes should correspond to a member variable of the same name with an underscore appended. 

This macro might be useful to ease the creation of classes / structs like team::team_info. This is a good thing because, while configs are convenient to use and easy to extend, they are much bigger and slower than structs, and errors resulting from misnamed identifiers / typos become runtime errors instead of compile time errors. 