### PR TITLE
revert movement of unit alignment init to initializer list

### DIFF
--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -273,7 +273,7 @@ unit::unit(const config &cfg, bool use_traits, const vconfig* vcfg) :
 	recall_cost_(-1),
 	canrecruit_(cfg["canrecruit"].to_bool()),
 	recruit_list_(),
-	alignment_(lexical_cast_default<unit_type::ALIGNMENT> (cfg["alignment"].str(), unit_type::NEUTRAL)),
+	alignment_(),
 	flag_rgb_(),
 	image_mods_(),
 	unrenamable_(false),
@@ -503,6 +503,8 @@ unit::unit(const config &cfg, bool use_traits, const vconfig* vcfg) :
 	if(!cfg["recall_cost"].blank()) {
 		recall_cost_ = cfg["recall_cost"].to_int(recall_cost_);
 	}
+
+	alignment_ = lexical_cast_default<unit_type::ALIGNMENT> (cfg["alignment"].str(), unit_type::NEUTRAL);
 
 	generate_name();
 


### PR DESCRIPTION
**\* Please don't merge! This appears to break something. ***

This change was suggested by gfgtdf, it partially reverts

https://github.com/wesnoth/wesnoth/commit/30c179b92da29bb03541e8e0c7dfaf1c3c401b35#diff-af3fd7e884f8ab9f39f9088ca4010d0dR1738

It fails unit tests on my machine and so I don't think it should
be committed.
