### PR TITLE
partly revert e454252f2

### DIFF
--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -1388,6 +1388,9 @@ void play_controller::check_victory()
 	{
 		return;
 	}
+
+	check_end_level();
+
 	std::set<unsigned> not_defeated;
 
 	for (unit_map::const_iterator i = units_.begin(),
@@ -1429,8 +1432,6 @@ void play_controller::check_victory()
 			there_is_a_local_human = true;
 		}
 	}
-
-	check_end_level();
 
 	bool found_player = false;
 	bool found_network_player = false;


### PR DESCRIPTION
there are multiple reasons why i think this should be reverted:
1) this wasn't tested enough, especialy we don't even know, whether all mainline campaigns are compatible
(this can be easily fixed, but only if one know which campaigns are effected which requires testing)
2) after renaming remove_from_carryover_on_leaders_loss to remove_from_carryover_on_defeat it sounds wrong that this can result in removing units on victory.
3) this seemed to break many UMC addons.

Note that this only removes one check for defeat_condition before [endlevel].
Especialy if for example side 1 gets defeated by defeat_condition in turn 1 but the game still goes on due to multiple other non defeated sides, but then the game ends with [endlevel] result=victory in turn 2, the units will be removed from carryover (unless specified otherwise)
This was also the pre 1.11.13 behaviour.
Also note that we cannot remove the 'defeated' side in case of [endlevel]result=victory, becasue [endlevel] doesn't sepcify which sides have victory/defeat.
