### PR TITLE
Fix travis gcc build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ before_install:
     - if [ "$ALTERNATE_CONFIGURATION" = true ]; then export STRICT_COMPILATION=false; fi
     - if [ "$ALTERNATE_CONFIGURATION" = true ]; then export EXTRA_FLAGS_RELEASE=""; fi
     - if [ "$ALTERNATE_CONFIGURATION" = true ]; then export WML_TEST_TIME=20; fi
-    - if [ "$CXX" = "g++" ]; then export CPP_TESTS=false; fi
-    - if [ "$CXX" = "g++" ]; then export EXTRA_FLAGS_RELEASE=""; fi
     - if [ "$CXX" = "g++" ]; then export WML_TESTS=false; fi
     - if [ "$CXX" = "g++" ]; then export PLAY_TEST=false; fi
     - if [ "$CXX" = "g++" ]; then export CHECK_UTF8=false; fi


### PR DESCRIPTION
This reverts commit c9c75e9933c2b94cd7a965200eae42970b541867.

the -O2 flag causes gcc to fail with the error:

src/replay.cpp: In function ‘void verify(const unit_map&, const config&)’:
src/replay.cpp:62:13: internal compiler error: Segmentation fault
