### PR TITLE
Fix bug #22306: move_unit moves a unit even when it shouldn't

### DIFF
--- a/changelog
+++ b/changelog
@@ -294,6 +294,7 @@ Version 1.13.0-dev:
    * Added automatic help entries for all eras, fulfilling Feature Request #22107
    * Fixed in-game help descriptions of default factions, using content from wiki
    * Added automatically generated lists of races and alignments to the descriptions of factions
+   * Fix bug #22306: move_unit moves a unit even when it shouldn't
 
 Version 1.11.11:
  * Add-ons server:

--- a/data/core/about.cfg
+++ b/data/core/about.cfg
@@ -1138,6 +1138,9 @@
         name = "Laurent Birtz"
     [/entry]
     [entry]
+        name = "Lovens Weche (LovCAPONE)"
+    [/entry]
+    [entry]
         name = "Luiz Fernando de Faria Pereira (lfernando)"
     [/entry]
     [entry]

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -731,15 +731,17 @@ function wml_actions.move_unit(cfg)
 			if check_passability then pass_check = current_unit end
 
 			local x, y = xs(), ys()
+			local prevX, prevY = tonumber(current_unit.x), tonumber(current_unit.y)
 			while true do
 				x = tonumber(x) or helper.wml_error(coordinate_error)
-				y = tonumber(y) or helper.wml_error(coordinate_error)
-				x, y = wesnoth.find_vacant_tile(x, y, pass_check)
+				y = tonumber(y) or helper.wml_error(coordinate_error)			
+				if not x == prevX and not y == prevY then x, y = wesnoth.find_vacant_tile(x, y, pass_check) end
 				if not x or not y then helper.wml_error("Could not find a suitable hex near to one of the target hexes in [move_unit].") end
 				move_string_x = string.format("%s,%u", move_string_x, x)
 				move_string_y = string.format("%s,%u", move_string_y, y)
 				local next_x, next_y = xs(), ys()
 				if not next_x and not next_y then break end
+				prevX, prevY = x, y
 				x, y = next_x, next_y
 			end
 


### PR DESCRIPTION
This concerns https://gna.org/bugs/index.php?22306

Modified the lua script for wml_action.move_unit. In the loop to check for vacant tile, if the current location
is equal to the previous location we don't look for a vacant tile since our location is free (where we are).
