### PR TITLE
Fix bug #22465: Minimap not redrawn after turn dialog.

### DIFF
--- a/changelog
+++ b/changelog
@@ -311,6 +311,7 @@ Version 1.13.0-dev:
    * Align unit overlays to the sprite rather than the occupied hex.
    * Remove carryover WML (this may make a reappearance in 1.13.0 but it is
      considered premature now, please see github PR discussion for more info)
+   * Fix bug #22465: Minimap not redrawn after turn dialog.
 
 Version 1.11.11:
  * Add-ons server:

--- a/data/core/about.cfg
+++ b/data/core/about.cfg
@@ -1138,6 +1138,9 @@
         name = "Laurent Birtz"
     [/entry]
     [entry]
+        name = "Lovens Weche (LovCAPONE)"
+    [/entry]
+    [entry]
         name = "Luiz Fernando de Faria Pereira (lfernando)"
     [/entry]
     [entry]

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -846,6 +846,7 @@ void playsingle_controller::show_turn_dialog(){
 	if(preferences::turn_dialog() && (level_result_ == NONE) ) {
 		blindfold b(*resources::screen, true); //apply a blindfold for the duration of this dialog
 		resources::screen->redraw_everything();
+		resources::screen->recalculate_minimap();
 		std::string message = _("It is now $name|’s turn");
 		utils::string_map symbols;
 		symbols["name"] = gamestate_.board_.teams()[player_number_ - 1].current_player();


### PR DESCRIPTION
This concerns https://gna.org/bugs/index.php?22465

In playsingle_controller::show_turn_dialog added a call to redraw the minimap in addition to the call to redraw
everything.
