### PR TITLE
Fixed bug #22324: team name in turn dialog untranslateable.

### DIFF
--- a/changelog
+++ b/changelog
@@ -315,6 +315,7 @@ Version 1.13.0-dev:
    * Fix bug #22306: move_unit moves a unit even when it shouldn't
    * Fix minor bug where toggling accelerated speed caused two lines of print messages to display
      on top of one another. Reported here: http://forums.wesnoth.org/viewtopic.php?f=5&t=40745
+   * Fix bug #22324: team name in turn dialog untranslateable since save id is used
 
 Version 1.11.11:
  * Add-ons server:

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -849,7 +849,7 @@ void playsingle_controller::show_turn_dialog(){
 		resources::screen->recalculate_minimap();
 		std::string message = _("It is now $name|’s turn");
 		utils::string_map symbols;
-		symbols["name"] = gamestate_.board_.teams()[player_number_ - 1].current_player();
+		symbols["name"] = gamestate_.board_.teams()[player_number_ - 1].current_player(true);
 		message = utils::interpolate_variables_into_string(message, &symbols);
 		gui2::show_transient_message(gui_->video(), "", message);
 	}

--- a/src/team.cpp
+++ b/src/team.cpp
@@ -420,8 +420,9 @@ const std::string& team::current_player(bool is_override_current_player) const
 		if (u != resources::units->end())
 			return u->name();
 		else {
-			outStr = std::string(_("scenario settings^Side")) + " " + std::to_string(info_.side);
-			return outStr;
+			std::stringstream currPlyStr;
+			currPlyStr  << _("scenario settings^Side") << " " << info_.side;
+			return outStr = currPlyStr.str();
 		}
 	}
 	else

--- a/src/team.cpp
+++ b/src/team.cpp
@@ -29,6 +29,8 @@
 #include "sdl/utils.hpp" // Only needed for int_to_color (!)
 #include "unit_types.hpp"
 #include "whiteboard/side_actions.hpp"
+#include "unit.hpp"
+#include "unit_map.hpp"
 
 #include <boost/foreach.hpp>
 #include <boost/assign/list_of.hpp>
@@ -167,9 +169,6 @@ void team::team_info::read(const config &cfg)
 
 	if(save_id.empty()) {
 		save_id = description;
-	}
-	if (current_player.empty()) {
-		current_player = save_id;
 	}
 
 	income_per_village = cfg["village_gold"].to_int(game_config::village_income);
@@ -409,6 +408,24 @@ int team::minimum_recruit_price() const
 		info_.minimum_recruit_price = min;
 	}
 	return info_.minimum_recruit_price;
+}
+
+const std::string& team::current_player(bool is_override_current_player) const
+{
+
+	static std::string outStr;
+
+	if (info_.current_player.empty() || is_override_current_player) {
+		unit_map::iterator u = resources::units->find_first_leader(info_.side);
+		if (u != resources::units->end())
+			return u->name();
+		else {
+			outStr = std::string(_("scenario settings^Side")) + " " + std::to_string(info_.side);
+			return outStr;
+		}
+	}
+	else
+		return info_.current_player;
 }
 
 bool team::calculate_enemies(size_t index) const

--- a/src/team.hpp
+++ b/src/team.hpp
@@ -217,7 +217,7 @@ public:
 	void set_name(const std::string& name) { info_.name = name; }
 	const std::string& save_id() const { return info_.save_id; }
 	void set_save_id(const std::string& save_id) { info_.save_id = save_id; }
-	const std::string& current_player() const { return info_.current_player; }
+	const std::string& current_player(bool is_override_current_player = false) const;
 
 	void set_objectives(const t_string& new_objectives, bool silently=false);
 	void set_objectives_changed(bool c = true) const { info_.objectives_changed = c; }

--- a/src/teambuilder.hpp
+++ b/src/teambuilder.hpp
@@ -322,11 +322,6 @@ protected:
 			uc.add_unit(*u);
 		}
 
-		// Find the first leader and use its name as the player name.
-		unit_map::iterator u = resources::units->find_first_leader(t_->side());
-		if ((u != resources::units->end()) && t_->current_player().empty())
-			t_->set_current_player(u->name());
-
 	}
 
 };


### PR DESCRIPTION
This concerns https://gna.org/bugs/index.php?22324

In the turn dialog, instead of using the "current_player" attribute of the side tag, we use the name of the current side leader (the same string used in the status table). This string is translateable.