### PR TITLE
allow chat_log to be opened even when not in networked games

### DIFF
--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -935,7 +935,7 @@ bool play_controller::can_execute_command(const hotkey::hotkey_command& cmd, int
 		return network::nconnections() == 0; // Can only load games if not in a network game
 
 	case hotkey::HOTKEY_CHAT_LOG:
-		return network::nconnections() > 0;
+		return true;
 
 	case hotkey::HOTKEY_REDO:
 		return !linger_ && undo_stack_->can_redo() && !events::commands_disabled && !browse_;


### PR DESCRIPTION
I would like to merge this to address issue #5 reported by Bob_the_mighty here:
http://forums.wesnoth.org/viewtopic.php?f=5&t=40745#p575541

Please voice any objections to this.
