### PR TITLE
allow chat_log to be opened even when not in networked games

### DIFF
--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -815,7 +815,7 @@ bool play_controller::can_execute_command(const hotkey::hotkey_command& cmd, int
 		return network::nconnections() == 0; // Can only load games if not in a network game
 
 	case hotkey::HOTKEY_CHAT_LOG:
-		return network::nconnections() > 0;
+		return true;
 
 	case hotkey::HOTKEY_REDO:
 		return !linger_ && undo_stack_->can_redo() && !events::commands_disabled && !browse_;


### PR DESCRIPTION
This is the master branch version of PR #282. (not merged yet in case of objections)
