### PR TITLE
automatically download needed addons in mp lobby

### DIFF
--- a/src/addon/manager_ui.cpp
+++ b/src/addon/manager_ui.cpp
@@ -1208,7 +1208,7 @@ bool manage_addons(display& disp)
 	}
 }
 
-bool ad_hoc_addon_fetch_session(display & disp, const std::string & addon_id)
+bool ad_hoc_addon_fetch_session(display & disp, const std::vector<std::string> & addon_ids)
 {
 	std::string remote_address = preferences::campaign_server();
 
@@ -1225,10 +1225,15 @@ bool ad_hoc_addon_fetch_session(display & disp, const std::string & addon_id)
 			return false;
 		}
 
-		const addon_info& addon = addon_at(addon_id, addons);
+		bool return_value = true;
+		BOOST_FOREACH(const std::string & addon_id, addon_ids) {
+			const addon_info& addon = addon_at(addon_id, addons);
 
-		ADDON_OP_RESULT res = try_fetch_addon_with_checks(disp, client, addons, addon);
-		return res.outcome_ == SUCCESS;
+			ADDON_OP_RESULT res = try_fetch_addon_with_checks(disp, client, addons, addon);
+			return_value = return_value && (res.outcome_ == SUCCESS);
+		}
+
+		return return_value;
 
 	} catch(const config::error& e) {
 		ERR_CFG << "config::error thrown during transaction with add-on server; \""<< e.message << "\"" << std::endl;

--- a/src/addon/manager_ui.hpp
+++ b/src/addon/manager_ui.hpp
@@ -17,6 +17,7 @@
 #define ADDON_MANAGER_UI_HPP_INCLUDED
 
 #include <string>
+#include <vector>
 
 class display;
 
@@ -39,6 +40,6 @@ bool manage_addons(display& disp);
  *
  * @return @a true when we successfully installed the target (possibly the user chose to ignore failures)
  */
-bool ad_hoc_addon_fetch_session(display & disp, const std::string & addon_id);
+bool ad_hoc_addon_fetch_session(display & disp, const std::vector<std::string> & addon_ids);
 
 #endif

--- a/src/addon/manager_ui.hpp
+++ b/src/addon/manager_ui.hpp
@@ -30,4 +30,15 @@ class display;
  */
 bool manage_addons(display& disp);
 
+/**
+ * Conducts an ad-hoc add-ons server connection to download an add-on with a particular id and all
+ * it's dependencies. Launches gui dialogs when issues arise.
+ *
+ * @param disp Display object on which to render UI elements.
+ * @param id The id of the target add-on.
+ *
+ * @return @a true when we successfully installed the target (possibly the user chose to ignore failures)
+ */
+bool ad_hoc_addon_fetch_session(display & disp, const std::string & addon_id);
+
 #endif

--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -335,39 +335,15 @@ void game_config_manager::load_addons_cfg()
 		const std::string file = uc;
 		const int size_minus_extension = file.size() - 4;
 		if(file.substr(size_minus_extension, file.size()) == ".cfg") {
-			bool ok = true;
-			// Allowing it if the dir doesn't exist,
-			// for the single-file add-on.
-			if(filesystem::file_exists(file.substr(0, size_minus_extension))) {
-				// Unfortunately, we create the dir plus
-				// _info.cfg ourselves on download.
-				std::vector<std::string> dirs, files;
-				filesystem::get_files_in_dir(file.substr(0, size_minus_extension),
-					&files, &dirs);
-				if(dirs.size() > 0) {
-					ok = false;
-				}
-				if(files.size() > 1) {
-					ok = false;
-				}
-				if(files.size() == 1 && files[0] != "_info.cfg") {
-					ok = false;
-				}
-			}
-			if(!ok) {
 				const int userdata_loc = file.find("data/add-ons") + 5;
 				ERR_CONFIG << "error reading usermade add-on '"
 					<< file << "'\n";
 				error_addons.push_back(file);
 				error_log.push_back("The format '~" + file.substr(userdata_loc)
-					+ "' is only for single-file add-ons, use '~"
+					+ "' (for single-file add-ons) is not supported anymore, use '~"
 					+ file.substr(userdata_loc,
 						size_minus_extension - userdata_loc)
 					+ "/_main.cfg' instead.");
-			}
-			else {
-				addons_to_load.push_back(file);
-			}
 		}
 	}
 

--- a/src/game_initialization/lobby_reload_request_exception.hpp
+++ b/src/game_initialization/lobby_reload_request_exception.hpp
@@ -1,0 +1,28 @@
+/*
+   Copyright (C) 2015 by Chris Beck <render787@gmail.com>
+   Part of the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+#ifndef LOBBY_RELOAD_REQUEST_EXCEPTION_HPP_INCLUDED
+#define LOBBY_RELOAD_REQUEST_EXCEPTION_HPP_INCLUDED
+
+#include <exception>
+#include <string>
+
+namespace mp {
+
+struct lobby_reload_request_exception : game::error {
+	lobby_reload_request_exception() : game::error("Lobby requested to reload the game config and launch again") {}
+};
+
+}
+
+#endif

--- a/src/game_initialization/multiplayer_lobby.cpp
+++ b/src/game_initialization/multiplayer_lobby.cpp
@@ -47,6 +47,12 @@
 static lg::log_domain log_config("config");
 #define ERR_CF LOG_STREAM(err, log_config)
 
+static lg::log_domain log_lobby("mp/lobby");
+#define ERR_MP LOG_STREAM(err, log_lobby)
+#define WRN_MP LOG_STREAM(warn, log_lobby)
+#define LOG_MP LOG_STREAM(info, log_lobby)
+#define DBG_MP LOG_STREAM(debug, log_lobby)
+
 namespace {
 std::vector<std::string> empty_string_vector;
 }
@@ -176,6 +182,16 @@ void gamebrowser::draw_row(const size_t index, const SDL_Rect& item_rect, ROW_TY
 	if(!game.have_all_mods && font_color != font::BAD_COLOR) {
 		font_color = font::DISABLED_COLOR;
 	}
+	if(game.addons_outcome != SATISFIED) {
+		font_color = font::DISABLED_COLOR;
+		if (game.addons_outcome == NEED_DOWNLOAD) {
+			no_era_string += _(" (Need to download addons)");
+		} else {
+			no_era_string += _(" (Outdated addons)");
+		}
+	} /*else {
+		no_era_string += _(" (You have this addon)");
+	}*/
 
 	const surface status_text(font::get_rendered_text(game.status,
 	    font::SIZE_NORMAL, font_color, TTF_STYLE_BOLD));
@@ -418,7 +434,7 @@ void gamebrowser::handle_event(const SDL_Event& event)
 			if(event.type == DOUBLE_CLICK_EVENT) {
 				if (ignore_next_doubleclick_) {
 					ignore_next_doubleclick_ = false;
-				} else if(selection_is_joinable_with_addons() || selection_is_observable_with_addons()) {
+				} else if(selection_is_joinable() || selection_is_observable()) {
 					double_clicked_ = true;
 					last_was_doubleclick_ = true;
 				}
@@ -439,6 +455,104 @@ void gamebrowser::handle_event(const SDL_Event& event)
 	}
 }
 
+// Determine if this is a campaign or scenario and add info string to this game item.
+void gamebrowser::populate_game_item_campaign_or_scenario_info(gamebrowser::game_item & item, const config & game, const config & game_config, bool & verified)
+{
+	if (game["mp_campaign"].empty()) {
+		if (!game["mp_scenario"].empty()) {
+			// Check if it's a multiplayer scenario.
+			const config* level_cfg = &game_config.find_child("multiplayer",
+				"id", game["mp_scenario"]);
+			if (!*level_cfg) {
+				// Check if it's a user map.
+				level_cfg = &game_config.find_child("generic_multiplayer",
+					"id", game["mp_scenario"]);
+			}
+			if (*level_cfg) {
+				item.map_info = _("Scenario:");
+				item.map_info += " ";
+				item.map_info += (*level_cfg)["name"].str();
+				// Reloaded games do not match the original scenario hash,
+				// so it makes no sense to test them,
+				// they always would appear as remote scenarios.
+				if (map_hashes_ && !item.reloaded) {
+					std::string hash = game["hash"];
+					bool hash_found = false;
+					BOOST_FOREACH(const config::attribute& i,
+						map_hashes_.attribute_range()) {
+
+						if (i.first == game["mp_scenario"] &&
+							i.second == hash) {
+
+							hash_found = true;
+							break;
+						}
+					}
+					if (!hash_found) {
+						item.map_info += " — ";
+						item.map_info += _("Remote scenario");
+						verified = false;
+					}
+				}
+			} else {
+				utils::string_map symbols;
+				symbols["scenario_id"] = game["mp_scenario"];
+				item.map_info =
+					vgettext("Unknown scenario: $scenario_id", symbols);
+				verified = false;
+			}
+		} else {
+			item.map_info = _("Unknown scenario");
+			verified = false;
+		}
+	} else { // Is a campaign
+		const config* level_cfg = &game_config.find_child("campaign", "id",
+			game["mp_campaign"]);
+		if (*level_cfg) {
+			item.map_info = _("Campaign:");
+			item.map_info += " ";
+			item.map_info += (*level_cfg)["name"].str();
+			item.map_info += " — ";
+			item.map_info += game["mp_scenario_name"].str();
+
+			// Difficulty.
+			const std::vector<std::string> difficulties =
+				utils::split((*level_cfg)["difficulties"]);
+			const std::string difficulty_descriptions =
+				(*level_cfg)["difficulty_descriptions"];
+			std::vector<std::string> difficulty_options =
+				utils::split(difficulty_descriptions, ';');
+			int index = 0;
+			//TODO: use difficulties instead of difficulty_descriptions if
+			//difficulty_descriptions is not available
+			assert(difficulties.size() == difficulty_options.size());
+			BOOST_FOREACH(const std::string& difficulty, difficulties) {
+				if (difficulty == game["difficulty_define"]) {
+					gui2::tlegacy_menu_item menu_item(difficulty_options[index]);
+					item.map_info += " — ";
+					item.map_info += menu_item.label();
+					item.map_info += " ";
+					item.map_info += menu_item.description();
+
+					break;
+				}
+				index++;
+			}
+
+		} else {
+			utils::string_map symbols;
+			symbols["campaign_id"] = game["mp_campaign"];
+			item.map_info =
+				vgettext("Unknown campaign: $campaign_id", symbols);
+			verified = false;
+
+			if (game["require_scenario"].to_bool(false)) {
+				item.have_scenario = false;
+			}
+		}
+	}
+}
+
 struct minimap_cache_item {
 
 	minimap_cache_item() :
@@ -453,14 +567,9 @@ struct minimap_cache_item {
 	std::string map_info_size;
 };
 
-void gamebrowser::set_game_items(const config& cfg, const config& game_config)
+// Handle the minimap data. Some caching is taking place to avoid repeatedly rendering the minimaps.
+void gamebrowser::populate_game_item_map_info(gamebrowser::game_item & item, const config & game, const config & game_config, bool & verified)
 {
-	const bool scrolled_to_max = (has_scrollbar() && get_position() == get_max_position());
-	const bool selection_visible = (selected_ >= visible_range_.first && selected_ <= visible_range_.second);
-	const std::string selected_game = (selected_ < games_.size()) ? games_[selected_].id : "";
-
-	item_height_ = 100;
-
 	// Don't throw the rendered minimaps away
 	std::vector<minimap_cache_item> minimap_cache;
 	for(std::vector<game_item>::iterator oldgame = games_.begin(); oldgame != games_.end(); ++oldgame) {
@@ -471,253 +580,272 @@ void gamebrowser::set_game_items(const config& cfg, const config& game_config)
 		minimap_cache.push_back(item);
 	}
 
+	item.map_data = game["map_data"].str();
+	if(item.map_data.empty()) {
+		item.map_data = filesystem::read_map(game["map"]);
+	}
+	if(! item.map_data.empty()) {
+		try {
+			std::vector<minimap_cache_item>::iterator i;
+			bool found = false;
+			for(i = minimap_cache.begin(); i != minimap_cache.end() && !found; ++i) {
+				if (i->map_data == item.map_data) {
+					found = true;
+					item.map_info_size = i->map_info_size;
+					item.mini_map = i->mini_map;
+				}
+			}
+			if (!found) {
+				// Parsing the map and generating the minimap are both cpu expensive
+				gamemap map(boost::make_shared<terrain_type_data>(game_config), item.map_data);
+				item.mini_map = image::getMinimap(minimap_size_, minimap_size_, map, 0);
+				item.map_info_size = str_cast(map.w()) + utils::unicode_multiplication_sign
+					+ str_cast(map.h());
+			}
+		} catch (incorrect_map_format_error &e) {
+			ERR_CF << "illegal map: " << e.message << '\n';
+			verified = false;
+		} catch(twml_exception& e) {
+			ERR_CF <<  "map could not be loaded: " << e.dev_message << '\n';
+			verified = false;
+		}
+	}
+}
+
+// local_item is either an [era] or [modification] tag, something with addon_version and addon_id.
+// (These are currently added at add-on loading time in the game_config_manager.)
+// It is checked whether the local item's add-on version is required for this game, and if the
+// versions are compatible. If it's not, a record is made in the req_list passed as argument.
+static mp::ADDON_REQ check_addon_version_compatibility (const config & local_item, const config & game, std::vector<required_addon> & req_list)
+{
+	if (local_item.has_attribute("addon_id") && local_item.has_attribute("addon_version")) {
+		if (const config & game_req = game.find_child("addon", "id", local_item["addon_id"])) {
+			// Record object which we will potentially store for this check
+			required_addon r;
+			r.addon_id = local_item["addon_id"].str();
+
+			const version_info local_ver(local_item["addon_version"].str());
+			version_info local_min_ver(local_item.has_attribute("addon_min_version") ? local_item["addon_min_version"] : local_item["addon_version"]);
+			// If UMC didn't specify last compatible version, assume no backwards compatibility.
+			if (local_min_ver > local_ver) {
+				// Some sanity checking regarding min version. If the min ver doens't make sense, ignore it.
+				local_min_ver = local_ver;
+			}
+
+			const version_info remote_ver(game_req["version"].str());
+			version_info remote_min_ver(game_req.has_attribute("min_version") ? game_req["min_version"] : game_req["version"]);
+			if (remote_min_ver > remote_ver) {
+				remote_min_ver = remote_ver;
+			}
+
+			// Check if the host is too out of date to play.
+			if (local_min_ver > remote_ver) {
+				r.outcome = CANNOT_SATISFY;
+
+				utils::string_map symbols;
+				symbols["addon"] = r.addon_id; // TODO: Figure out how to ask the add-on manager for the user-friendly name of this add-on.
+				symbols["host_ver"] = remote_ver.str();
+				symbols["local_ver"] = local_ver.str();
+				r.message = vgettext("Host's version of $addon is too old: host's version $host_ver < your version $local_ver.", symbols);
+				req_list.push_back(r);
+				return r.outcome;
+			}
+
+			// Check if our version is too out of date to play.
+			if (remote_min_ver > local_ver) {
+				r.outcome = NEED_DOWNLOAD;
+
+				utils::string_map symbols;
+				symbols["addon"] = r.addon_id; // TODO: Figure out how to ask the add-on manager for the user-friendly name of this add-on.
+				symbols["host_ver"] = remote_ver.str();
+				symbols["local_ver"] = local_ver.str();
+				r.message = vgettext("Your version of $addon is out of date: host's version $host_ver > your version $local_ver.", symbols);
+				req_list.push_back(r);
+				return r.outcome;
+			}
+		}
+	}
+	return SATISFIED;
+}
+
+// Check the era of the game, whether it is available, and compatible with installed content, and add info strings to this game_item.
+void gamebrowser::populate_game_item_era_info(gamebrowser::game_item & item, const config & game, const config & game_config, bool & verified) {
+	if (!game["mp_era"].empty())
+	{
+		const config &era_cfg = game_config.find_child("era", "id", game["mp_era"]);
+		utils::string_map symbols;
+		symbols["era_id"] = game["mp_era"];
+		if (era_cfg) {
+			item.era_and_mod_info = _("Era:");
+			item.era_and_mod_info += " ";
+			item.era_and_mod_info += era_cfg["name"].str();
+
+			mp::ADDON_REQ result = check_addon_version_compatibility(era_cfg, game, item.addons);
+			item.addons_outcome = std::max(item.addons_outcome, result); //elevate to most severe error level encountered so far
+		} else {
+			if (!game["require_era"].to_bool(true)) {
+				item.have_era = true;
+			} else {
+				item.have_era = false;
+			}
+			item.era_and_mod_info = vgettext("Unknown era: $era_id", symbols);
+			verified = false;
+		}
+	} else {
+		item.era_and_mod_info = _("Unknown era");
+		verified = false;
+	}
+}
+
+// Check the mods applied to the game, whether they are available / required, and compatible with installed content, and add info strings to this game_item.
+void gamebrowser::populate_game_item_mod_info(gamebrowser::game_item & item, const config & game, const config & game_config, bool & verified) {
+	(void) verified;
+	if (!game.child_or_empty("modification").empty()) {
+		item.have_all_mods = true;
+		item.era_and_mod_info += " — ";
+		item.era_and_mod_info += _("Modifications:");
+		item.era_and_mod_info += " ";
+
+		BOOST_FOREACH (const config& m, game.child_range("modification")) {
+			const config& mod_cfg = game_config.find_child("modification", "id", m["id"]);
+			if (mod_cfg) {
+				item.era_and_mod_info += mod_cfg["name"].str();
+				item.era_and_mod_info += ", ";
+
+				mp::ADDON_REQ result = check_addon_version_compatibility(mod_cfg, game, item.addons);
+				item.addons_outcome = std::max(item.addons_outcome, result); //elevate to most severe error level encountered so far
+			} else {
+				item.era_and_mod_info += m["id"].str();
+				if (m["require_modification"].to_bool(false)) {
+					item.have_all_mods = false;
+					item.era_and_mod_info += _(" (missing)");
+				}
+				item.era_and_mod_info += ", ";
+			}
+		}
+		item.era_and_mod_info.erase(item.era_and_mod_info.size()-2, 2);
+	} else {
+		item.have_all_mods = true;
+	}
+}
+
+// Do this before populating eras and mods, to get reports of missing add-ons in the most sensible order.
+void gamebrowser::populate_game_item_addons_installed(gamebrowser::game_item & item, const config & game, const std::vector<std::string> & installed_addons)
+{
+	BOOST_FOREACH(const config & addon, game.child_range("addon")) {
+		if (addon.has_attribute("id")) {
+			if (std::find(installed_addons.begin(), installed_addons.end(), addon["id"].str()) == installed_addons.end()) {
+				required_addon r;
+				r.addon_id = addon["id"].str();
+				r.outcome = NEED_DOWNLOAD;
+
+				utils::string_map symbols;
+				symbols["id"] = addon["id"].str();
+				r.message = vgettext("Missing addon: $id", symbols);
+				item.addons.push_back(r);
+				if (item.addons_outcome == SATISFIED) {
+					item.addons_outcome = NEED_DOWNLOAD;
+				}
+			}
+		}
+	}
+}
+
+// Build an appropriate game_item corresponding to this game (config) which we retrieved from [gamelist] from the server.
+void gamebrowser::populate_game_item(gamebrowser::game_item & item, const config & game, const config & game_config, const std::vector<std::string> & installed_addons)
+{
+	bool verified = true;
+	item.password_required = game["password"].to_bool();
+	item.reloaded = game["savegame"].to_bool();
+	item.have_era = true;
+	item.have_scenario = true;
+
+	populate_game_item_addons_installed(item, game, installed_addons);
+	populate_game_item_campaign_or_scenario_info(item, game, game_config, verified);
+	populate_game_item_map_info(item, game, game_config, verified);
+	populate_game_item_era_info(item, game, game_config, verified);
+	populate_game_item_mod_info(item, game, game_config, verified);
+
+	if (item.reloaded) {
+		item.map_info += " — ";
+		item.map_info += _("Reloaded game");
+		verified = false;
+	}
+	item.id = game["id"].str();
+	item.name = game["name"].str();
+	std::string turn = game["turn"];
+	std::string slots = game["slots"];
+	item.vacant_slots = lexical_cast_default<size_t>(slots, 0);
+	item.current_turn = 0;
+	if (!turn.empty()) {
+		item.started = true;
+		int index = turn.find_first_of('/');
+		if (index > -1){
+			const std::string current_turn = turn.substr(0, index);
+			item.current_turn = lexical_cast<unsigned int>(current_turn);
+		}
+		item.status = _("Turn ") + turn;
+	} else {
+		item.started = false;
+		if (item.vacant_slots > 0) {
+			item.status = std::string(_n("Vacant Slot:", "Vacant Slots:",
+					item.vacant_slots)) + " " + slots;
+			if (item.password_required) {
+				item.status += std::string(" (") + std::string(_("Password Required")) + ")";
+			}
+		}
+	}
+
+	item.use_map_settings = game["mp_use_map_settings"].to_bool();
+	item.gold = game["mp_village_gold"].str();
+	if (game["mp_fog"].to_bool()) {
+		item.vision = _("Fog");
+		item.fog = true;
+		if (game["mp_shroud"].to_bool()) {
+			item.vision += "/";
+			item.vision += _("Shroud");
+			item.shroud = true;
+		} else {
+			item.shroud = false;
+		}
+	} else if (game["mp_shroud"].to_bool()) {
+		item.vision = _("Shroud");
+		item.fog = false;
+		item.shroud = true;
+	} else {
+		item.vision = _("none");
+		item.fog = false;
+		item.shroud = false;
+	}
+	if (game["mp_countdown"].to_bool()) {
+		item.time_limit = game["mp_countdown_init_time"].str() + " / +"
+			+ game["mp_countdown_turn_bonus"].str() + " "
+			+ game["mp_countdown_action_bonus"].str();
+	} else {
+		item.time_limit = "";
+	}
+	item.xp = game["experience_modifier"].str() + "%";
+	item.observers = game["observer"].to_bool(true);
+	item.shuffle_sides = game["shuffle_sides"].to_bool(true);
+	item.verified = verified;
+}
+
+void gamebrowser::set_game_items(const config& cfg, const config& game_config, const std::vector<std::string> & installed_addons)
+{
+	//DBG_MP << "** gamelist **\n" << cfg.debug() << "****\n";
+
+	const bool scrolled_to_max = (has_scrollbar() && get_position() == get_max_position());
+	const bool selection_visible = (selected_ >= visible_range_.first && selected_ <= visible_range_.second);
+	const std::string selected_game = (selected_ < games_.size()) ? games_[selected_].id : "";
+
+	item_height_ = 100;
+
 	games_.clear();
 
 	BOOST_FOREACH(const config &game, cfg.child("gamelist").child_range("game"))
 	{
-		bool verified = true;
 		games_.push_back(game_item());
-		games_.back().password_required = game["password"].to_bool();
-		games_.back().reloaded = game["savegame"].to_bool();
-		games_.back().addon_ids = game["addon_ids"].str();
-		games_.back().have_era = true;
-		games_.back().have_scenario = true;
-		if (game["mp_campaign"].empty()) {
-			if (!game["mp_scenario"].empty()) {
-				// Check if it's a multiplayer scenario.
-				const config* level_cfg = &game_config.find_child("multiplayer",
-					"id", game["mp_scenario"]);
-				if (!*level_cfg) {
-					// Check if it's a user map.
-					level_cfg = &game_config.find_child("generic_multiplayer",
-						"id", game["mp_scenario"]);
-				}
-				if (*level_cfg) {
-					games_.back().map_info = _("Scenario:");
-					games_.back().map_info += " ";
-					games_.back().map_info += (*level_cfg)["name"].str();
-					// Reloaded games do not match the original scenario hash,
-					// so it makes no sense to test them,
-					// they always would appear as remote scenarios.
-					if (map_hashes_ && !games_.back().reloaded) {
-						std::string hash = game["hash"];
-						bool hash_found = false;
-						BOOST_FOREACH(const config::attribute& i,
-							map_hashes_.attribute_range()) {
-
-							if (i.first == game["mp_scenario"] &&
-								i.second == hash) {
-
-								hash_found = true;
-								break;
-							}
-						}
-						if (!hash_found) {
-							games_.back().map_info += " — ";
-							games_.back().map_info += _("Remote scenario");
-							verified = false;
-						}
-					}
-				} else {
-					utils::string_map symbols;
-					symbols["scenario_id"] = game["mp_scenario"];
-					games_.back().map_info =
-						vgettext("Unknown scenario: $scenario_id", symbols);
-					verified = false;
-				}
-			} else {
-				games_.back().map_info = _("Unknown scenario");
-				verified = false;
-			}
-		} else { // Is a campaign
-			const config* level_cfg = &game_config.find_child("campaign", "id",
-				game["mp_campaign"]);
-			if (*level_cfg) {
-				games_.back().map_info = _("Campaign:");
-				games_.back().map_info += " ";
-				games_.back().map_info += (*level_cfg)["name"].str();
-				games_.back().map_info += " — ";
-				games_.back().map_info += game["mp_scenario_name"].str();
-
-				// Difficulty.
-				const std::vector<std::string> difficulties =
-					utils::split((*level_cfg)["difficulties"]);
-				const std::string difficulty_descriptions =
-					(*level_cfg)["difficulty_descriptions"];
-				std::vector<std::string> difficulty_options =
-					utils::split(difficulty_descriptions, ';');
-				int index = 0;
-				//TODO: use difficulties instead of difficulty_descriptions if
-				//difficulty_descriptions is not available
-				assert(difficulties.size() == difficulty_options.size());
-				BOOST_FOREACH(const std::string& difficulty, difficulties) {
-					if (difficulty == game["difficulty_define"]) {
-						gui2::tlegacy_menu_item menu_item(difficulty_options[index]);
-						games_.back().map_info += " — ";
-						games_.back().map_info += menu_item.label();
-						games_.back().map_info += " ";
-						games_.back().map_info += menu_item.description();
-
-						break;
-					}
-					index++;
-				}
-
-			} else {
-				utils::string_map symbols;
-				symbols["campaign_id"] = game["mp_campaign"];
-				games_.back().map_info =
-					vgettext("Unknown campaign: $campaign_id", symbols);
-				verified = false;
-
-				if (game["require_scenario"].to_bool(false)) {
-					games_.back().have_scenario = false;
-				}
-			}
-		}
-		games_.back().map_data = game["map_data"].str();
-		if(games_.back().map_data.empty()) {
-			games_.back().map_data = filesystem::read_map(game["map"]);
-		}
-		if(! games_.back().map_data.empty()) {
-			try {
-				std::vector<minimap_cache_item>::iterator i;
-				bool found = false;
-				for(i = minimap_cache.begin(); i != minimap_cache.end() && !found; ++i) {
-					if (i->map_data == games_.back().map_data) {
-						found = true;
-						games_.back().map_info_size = i->map_info_size;
-						games_.back().mini_map = i->mini_map;
-					}
-				}
-				if (!found) {
-					// Parsing the map and generating the minimap are both cpu expensive
-					gamemap map(boost::make_shared<terrain_type_data>(game_config), games_.back().map_data);
-					games_.back().mini_map = image::getMinimap(minimap_size_, minimap_size_, map, 0);
-					games_.back().map_info_size = str_cast(map.w()) + utils::unicode_multiplication_sign
-						+ str_cast(map.h());
-				}
-			} catch (incorrect_map_format_error &e) {
-				ERR_CF << "illegal map: " << e.message << '\n';
-				verified = false;
-			} catch(twml_exception& e) {
-				ERR_CF <<  "map could not be loaded: " << e.dev_message << '\n';
-				verified = false;
-			}
-		}
-
-		if (!game["mp_era"].empty())
-		{
-			const config &era_cfg = game_config.find_child("era", "id", game["mp_era"]);
-			utils::string_map symbols;
-			symbols["era_id"] = game["mp_era"];
-			if (era_cfg) {
-				games_.back().era_and_mod_info = _("Era:");
-				games_.back().era_and_mod_info += " ";
-				games_.back().era_and_mod_info += era_cfg["name"].str();
-			} else {
-				if (!game["require_era"].to_bool(true)) {
-					games_.back().have_era = true;
-				} else {
-					games_.back().have_era = false;
-				}
-				games_.back().era_and_mod_info = vgettext("Unknown era: $era_id", symbols);
-				verified = false;
-			}
-		} else {
-			games_.back().era_and_mod_info = _("Unknown era");
-			verified = false;
-		}
-
-		if (!game.child_or_empty("modification").empty()) {
-			games_.back().have_all_mods = true;
-			games_.back().era_and_mod_info += " — ";
-			games_.back().era_and_mod_info += _("Modifications:");
-			games_.back().era_and_mod_info += " ";
-
-			BOOST_FOREACH (const config& m, game.child_range("modification")) {
-				const config& mod_cfg = game_config.find_child("modification", "id", m["id"]);
-				if (mod_cfg) {
-					games_.back().era_and_mod_info += mod_cfg["name"].str();
-					games_.back().era_and_mod_info += ", ";
-				} else {
-					games_.back().era_and_mod_info += m["id"].str();
-					if (m["require_modification"].to_bool(false)) {
-						games_.back().have_all_mods = false;
-						games_.back().era_and_mod_info += _(" (missing)");
-					}
-					games_.back().era_and_mod_info += ", ";
-				}
-			}
-			games_.back().era_and_mod_info.erase(games_.back().era_and_mod_info.size()-2, 2);
-		} else {
-			games_.back().have_all_mods = true;
-		}
-
-
-		if (games_.back().reloaded) {
-			games_.back().map_info += " — ";
-			games_.back().map_info += _("Reloaded game");
-			verified = false;
-		}
-		games_.back().id = game["id"].str();
-		games_.back().name = game["name"].str();
-		std::string turn = game["turn"];
-		std::string slots = game["slots"];
-		games_.back().vacant_slots = lexical_cast_default<size_t>(slots, 0);
-		games_.back().current_turn = 0;
-		if (!turn.empty()) {
-			games_.back().started = true;
-			int index = turn.find_first_of('/');
-			if (index > -1){
-				const std::string current_turn = turn.substr(0, index);
-				games_.back().current_turn = lexical_cast<unsigned int>(current_turn);
-			}
-			games_.back().status = _("Turn ") + turn;
-		} else {
-			games_.back().started = false;
-			if (games_.back().vacant_slots > 0) {
-				games_.back().status = std::string(_n("Vacant Slot:", "Vacant Slots:",
-						games_.back().vacant_slots)) + " " + slots;
-				if (games_.back().password_required) {
-					games_.back().status += std::string(" (") + std::string(_("Password Required")) + ")";
-				}
-			}
-		}
-
-		games_.back().use_map_settings = game["mp_use_map_settings"].to_bool();
-		games_.back().gold = game["mp_village_gold"].str();
-		if (game["mp_fog"].to_bool()) {
-			games_.back().vision = _("Fog");
-			games_.back().fog = true;
-			if (game["mp_shroud"].to_bool()) {
-				games_.back().vision += "/";
-				games_.back().vision += _("Shroud");
-				games_.back().shroud = true;
-			} else {
-				games_.back().shroud = false;
-			}
-		} else if (game["mp_shroud"].to_bool()) {
-			games_.back().vision = _("Shroud");
-			games_.back().fog = false;
-			games_.back().shroud = true;
-		} else {
-			games_.back().vision = _("none");
-			games_.back().fog = false;
-			games_.back().shroud = false;
-		}
-		if (game["mp_countdown"].to_bool()) {
-			games_.back().time_limit = game["mp_countdown_init_time"].str() + " / +"
-				+ game["mp_countdown_turn_bonus"].str() + " "
-				+ game["mp_countdown_action_bonus"].str();
-		} else {
-			games_.back().time_limit = "";
-		}
-		games_.back().xp = game["experience_modifier"].str() + "%";
-		games_.back().observers = game["observer"].to_bool(true);
-		games_.back().shuffle_sides = game["shuffle_sides"].to_bool(true);
-		games_.back().verified = verified;
-
+		populate_game_item(games_.back(), game, game_config, installed_addons);
 		// Hack...
 		if(preferences::fi_invert() ? game_matches_filter(games_.back(), cfg) : !game_matches_filter(games_.back(), cfg)) games_.pop_back();
 	}
@@ -862,7 +990,7 @@ bool lobby::lobby_sorter::less(int column, const gui::menu::item& row1, const gu
 	return basic_sorter::less(column,row1,row2);
 }
 
-lobby::lobby(game_display& disp, const config& cfg, chat& c, config& gamelist) :
+lobby::lobby(game_display& disp, const config& cfg, chat& c, config& gamelist, const std::vector<std::string> & installed_addons) :
 	mp::ui(disp, _("Game Lobby"), cfg, c, gamelist),
 
 	game_vacant_slots_(),
@@ -883,7 +1011,8 @@ lobby::lobby(game_display& disp, const config& cfg, chat& c, config& gamelist) :
 	last_selected_game_(-1), sorter_(gamelist),
 	games_menu_(disp.video(),cfg.child("multiplayer_hashes")),
 	minimaps_(),
-	search_string_(preferences::fi_text())
+	search_string_(preferences::fi_text()),
+	installed_addons_(installed_addons)
 {
 	std::vector<std::string> replay_options_strings_;
 	replay_options_strings_.push_back(_("Normal Replays"));
@@ -1009,9 +1138,9 @@ void lobby::gamelist_updated(bool silent)
 		// No gamelist yet. Do not update anything.
 		return;
 	}
-	games_menu_.set_game_items(gamelist(), game_config());
-	join_game_.enable(games_menu_.selection_is_joinable_with_addons());
-	observe_game_.enable(games_menu_.selection_is_observable_with_addons());
+	games_menu_.set_game_items(gamelist(), game_config(), installed_addons_);
+	join_game_.enable(games_menu_.selection_is_joinable());
+	observe_game_.enable(games_menu_.selection_is_observable());
 }
 
 void lobby::process_event()
@@ -1028,19 +1157,62 @@ void lobby::process_event()
 // The return value should be true if the gui result was not chnaged
 void lobby::process_event_impl(const process_event_data & data)
 {
-	join_game_.enable(games_menu_.selection_is_joinable_with_addons());
-	observe_game_.enable(games_menu_.selection_is_observable_with_addons());
+	join_game_.enable(games_menu_.selection_is_joinable());
+	observe_game_.enable(games_menu_.selection_is_observable());
 
 	// check whehter to try to download addons
 	if ((games_menu_.selected() || data.observe || data.join) && games_menu_.selection_needs_addons())
 	{
-		if (gui2::show_message(video(), _("Missing user-made content."), _("This game requires one or more user-made addons to join. Do you want to try to install them?"), gui2::tmessage::yes_no_buttons) == gui2::twindow::OK) {
-			std::vector<std::string> addon_ids = games_menu_.selection_addon_ids();
-			BOOST_FOREACH(const std::string & id, addon_ids) {
-				ad_hoc_addon_fetch_session(disp(), id);
+		if (const std::vector<required_addon> * reqs = games_menu_.selection_addon_requirements()) {
+			if (games_menu_.selection_addon_outcome() == CANNOT_SATISFY) {
+				std::string e_title = _("Incompatible user-made content.");
+				std::string err_msg = _("This game cannot be joined because the host has out-of-date add-ons which are incompatible with your version. You might suggest to them that they update their add-ons.");
+
+				err_msg +="\n\n";
+				err_msg += _("Details:");
+				err_msg += "\n";
+
+				BOOST_FOREACH(const required_addon & a, *reqs) {
+					if (a.outcome == CANNOT_SATISFY) {
+						err_msg += a.message;
+						err_msg += "\n";
+					}
+				}
+				gui2::show_message(video(), e_title, err_msg, gui2::tmessage::auto_close);
+			} else if (games_menu_.selection_addon_outcome() == NEED_DOWNLOAD) {
+				std::string e_title = _("Missing user-made content.");
+				std::string err_msg = _("This game requires one or more user-made addons to be installed or updated in order to join. Do you want to try to install them?");
+
+				err_msg +="\n\n";
+				err_msg += _("Details:");
+				err_msg += "\n";
+
+				std::vector<std::string> needs_download;
+
+				BOOST_FOREACH(const required_addon & a, *reqs) {
+					if (a.outcome == NEED_DOWNLOAD) {
+						err_msg += a.message;
+						err_msg += "\n";
+
+						needs_download.push_back(a.addon_id);
+					} else if (a.outcome == CANNOT_SATISFY) {
+						assert(false);
+					}
+				}
+				assert(needs_download.size() > 0);
+
+				if (gui2::show_message(video(), e_title, err_msg, gui2::tmessage::yes_no_buttons) == gui2::twindow::OK) {
+					BOOST_FOREACH(const std::string & addon_id, needs_download) {
+						ad_hoc_addon_fetch_session(disp(), addon_id);
+					}
+					throw lobby_reload_request_exception();
+				}
 			}
-			throw lobby_reload_request_exception();
+		} else {
+			gui2::show_error_message(video(), _("Something is wrong with the addon version check database supporting the multiplayer lobby, please report this at bugs.wesnoth.org."));
 		}
+		games_menu_.reset_selection();
+		return ;
 	}
 
 	const bool observe = (data.observe || (games_menu_.selected() && !games_menu_.selection_is_joinable())) && games_menu_.selection_is_observable();

--- a/src/game_initialization/multiplayer_lobby.cpp
+++ b/src/game_initialization/multiplayer_lobby.cpp
@@ -417,7 +417,7 @@ void gamebrowser::handle_event(const SDL_Event& event)
 			if(event.type == DOUBLE_CLICK_EVENT) {
 				if (ignore_next_doubleclick_) {
 					ignore_next_doubleclick_ = false;
-				} else if(selection_is_joinable() || selection_is_observable()) {
+				} else if(selection_is_joinable_with_addons() || selection_is_observable_with_addons()) {
 					double_clicked_ = true;
 					last_was_doubleclick_ = true;
 				}

--- a/src/game_initialization/multiplayer_lobby.cpp
+++ b/src/game_initialization/multiplayer_lobby.cpp
@@ -1202,9 +1202,7 @@ void lobby::process_event_impl(const process_event_data & data)
 				assert(needs_download.size() > 0);
 
 				if (gui2::show_message(video(), e_title, err_msg, gui2::tmessage::yes_no_buttons) == gui2::twindow::OK) {
-					BOOST_FOREACH(const std::string & addon_id, needs_download) {
-						ad_hoc_addon_fetch_session(disp(), addon_id);
-					}
+					ad_hoc_addon_fetch_session(disp(), needs_download);
 					throw lobby_reload_request_exception();
 				}
 			}

--- a/src/game_initialization/multiplayer_lobby.hpp
+++ b/src/game_initialization/multiplayer_lobby.hpp
@@ -20,6 +20,7 @@
 #include "multiplayer_ui.hpp"
 #include "game_preferences.hpp"
 #include "image.hpp"
+#include "serialization/string_utils.hpp"
 
 class config;
 class video;
@@ -62,7 +63,8 @@ public:
 			password_required(false),
 			have_scenario(false),
 			have_era(false),
-			have_all_mods(false)
+			have_all_mods(false),
+			addon_ids()
 		{
 		}
 
@@ -92,6 +94,7 @@ public:
 		bool have_scenario;
 		bool have_era;
 		bool have_all_mods;
+		std::string addon_ids;
 	};
 	gamebrowser(CVideo& video, const config &map_hashes);
 	void scroll(unsigned int pos);
@@ -117,6 +120,11 @@ public:
 		games_[selected_].have_era &&
 		games_[selected_].have_all_mods) ||
 		preferences::is_authenticated(); }
+	bool selection_needs_addons() const // TODO: Add support have downloading addons that require the scenario
+	{ return empty() ? false : !games_[selected_].have_era ||
+		!games_[selected_].have_all_mods; }
+	std::vector<std::string> selection_addon_ids() const
+	{ return empty() ? std::vector<std::string>() : utils::split(games_[selected_].addon_ids, ','); }
 	bool selected() const { return double_clicked_ && !empty(); }
 	void reset_selection() { double_clicked_ = false; }
 	int selection() const { return selected_; }

--- a/src/game_initialization/multiplayer_lobby.hpp
+++ b/src/game_initialization/multiplayer_lobby.hpp
@@ -108,21 +108,20 @@ public:
 	SDL_Rect get_item_rect(size_t index) const;
 	bool empty() const { return games_.empty(); }
 	bool selection_is_joinable() const
-	{ return empty() ? false : (games_[selected_].vacant_slots > 0 &&
-		!games_[selected_].started &&
-		games_[selected_].have_scenario &&
-		games_[selected_].have_era &&
-		games_[selected_].have_all_mods); }
-	// Moderators may observe any game.
+	{ return selection_is_joinable_with_addons() && !selection_needs_addons(); }
 	bool selection_is_observable() const
-	{ return empty() ? false : (games_[selected_].observers &&
-		games_[selected_].have_scenario &&
-		games_[selected_].have_era &&
-		games_[selected_].have_all_mods) ||
-		preferences::is_authenticated(); }
-	bool selection_needs_addons() const // TODO: Add support have downloading addons that require the scenario
+	{ return selection_is_observable_with_addons() && !selection_needs_addons(); }
+	bool selection_needs_addons() const
 	{ return empty() ? false : !games_[selected_].have_era ||
-		!games_[selected_].have_all_mods; }
+		!games_[selected_].have_all_mods ||
+		!games_[selected_].have_scenario; }
+	bool selection_is_joinable_with_addons() const
+	{ return empty() ? false : (games_[selected_].vacant_slots > 0 &&
+		!games_[selected_].started); }
+	// Moderators may observe any game.
+	bool selection_is_observable_with_addons() const
+	{ return empty() ? false : (games_[selected_].observers || preferences::is_authenticated()); }
+
 	std::vector<std::string> selection_addon_ids() const
 	{ return empty() ? std::vector<std::string>() : utils::split(games_[selected_].addon_ids, ','); }
 	bool selected() const { return double_clicked_ && !empty(); }

--- a/src/game_initialization/multiplayer_lobby.hpp
+++ b/src/game_initialization/multiplayer_lobby.hpp
@@ -33,6 +33,15 @@ class game_display;
  * games.
  */
 namespace mp {
+
+enum ADDON_REQ { SATISFIED, NEED_DOWNLOAD, CANNOT_SATISFY };
+
+struct required_addon {
+	std::string addon_id;
+	ADDON_REQ outcome;
+	std::string message;
+};
+
 class gamebrowser : public gui::menu {
 public:
 	struct game_item {
@@ -64,7 +73,8 @@ public:
 			have_scenario(false),
 			have_era(false),
 			have_all_mods(false),
-			addon_ids()
+			addons(),
+			addons_outcome(SATISFIED)
 		{
 		}
 
@@ -94,36 +104,48 @@ public:
 		bool have_scenario;
 		bool have_era;
 		bool have_all_mods;
-		std::string addon_ids;
+		std::vector<required_addon> addons;
+		ADDON_REQ addons_outcome;
 	};
 	gamebrowser(CVideo& video, const config &map_hashes);
 	void scroll(unsigned int pos);
 	void handle_event(const SDL_Event& event);
 	void set_inner_location(const SDL_Rect& rect);
 	void set_item_height(unsigned int height);
-	void set_game_items(const config& cfg, const config& game_config);
+
+	void populate_game_item(game_item &, const config &, const config &, const std::vector<std::string> &);
+	void populate_game_item_campaign_or_scenario_info(game_item &, const config &, const config &, bool &);
+	void populate_game_item_map_info(game_item &, const config &, const config &, bool &);
+	void populate_game_item_era_info(game_item &, const config &, const config &, bool &);
+	void populate_game_item_mod_info(game_item &, const config &, const config &, bool &);
+	void populate_game_item_addons_installed(game_item &, const config &, const std::vector<std::string> &);
+
+	void set_game_items(const config& cfg, const config& game_config, const std::vector<std::string> & installed_addons);
 	void draw();
 	void draw_contents();
 	void draw_row(const size_t row_index, const SDL_Rect& rect, ROW_TYPE type);
 	SDL_Rect get_item_rect(size_t index) const;
 	bool empty() const { return games_.empty(); }
 	bool selection_is_joinable() const
-	{ return selection_is_joinable_with_addons() && !selection_needs_addons(); }
+	{ return selection_in_joinable_state() && (!selection_needs_content() || selection_needs_addons()); }
 	bool selection_is_observable() const
-	{ return selection_is_observable_with_addons() && !selection_needs_addons(); }
-	bool selection_needs_addons() const
+	{ return selection_in_observable_state() && (!selection_needs_content() || selection_needs_addons()); }
+	bool selection_needs_content() const
 	{ return empty() ? false : !games_[selected_].have_era ||
 		!games_[selected_].have_all_mods ||
 		!games_[selected_].have_scenario; }
-	bool selection_is_joinable_with_addons() const
-	{ return empty() ? false : (games_[selected_].vacant_slots > 0 &&
-		!games_[selected_].started); }
+	bool selection_needs_addons() const
+	{ return empty() ? false : (games_[selected_].addons_outcome != SATISFIED); }
+	bool selection_in_joinable_state() const
+	{ return empty() ? false : (games_[selected_].vacant_slots > 0 && !games_[selected_].started); }
 	// Moderators may observe any game.
-	bool selection_is_observable_with_addons() const
+	bool selection_in_observable_state() const
 	{ return empty() ? false : (games_[selected_].observers || preferences::is_authenticated()); }
 
-	std::vector<std::string> selection_addon_ids() const
-	{ return empty() ? std::vector<std::string>() : utils::split(games_[selected_].addon_ids, ','); }
+	ADDON_REQ selection_addon_outcome() const
+	{ return empty() ? SATISFIED : games_[selected_].addons_outcome; }
+	const std::vector<required_addon> * selection_addon_requirements() const
+	{ return empty() ? NULL : &games_[selected_].addons; }
 	bool selected() const { return double_clicked_ && !empty(); }
 	void reset_selection() { double_clicked_ = false; }
 	int selection() const { return selected_; }
@@ -163,7 +185,7 @@ private:
 class lobby : public ui
 {
 public:
-	lobby(game_display& d, const config& cfg, chat& c, config& gamelist);
+	lobby(game_display& d, const config& cfg, chat& c, config& gamelist, const std::vector<std::string> & installed_addons);
 
 	virtual void process_event();
 
@@ -212,6 +234,8 @@ private:
 	std::map<std::string,std::string> minimaps_;
 
 	std::string search_string_;
+
+	const std::vector<std::string> & installed_addons_;
 
 	struct process_event_data {
 		bool join;

--- a/src/mp_game_settings.cpp
+++ b/src/mp_game_settings.cpp
@@ -32,6 +32,7 @@ mp_game_settings::mp_game_settings() :
 	mp_campaign(),
 	difficulty_define(),
 	active_mods(),
+	addon_ids(),
 	side_users(),
 	show_configure(true),
 	show_connect(true),
@@ -66,6 +67,7 @@ mp_game_settings::mp_game_settings(const config& cfg)
 	, mp_campaign(cfg["mp_campaign"].str())
 	, difficulty_define(cfg["difficulty_define"].str())
 	, active_mods(utils::split(cfg["active_mods"], ','))
+	, addon_ids(utils::split(cfg["addon_ids"], ','))
 	, side_users(utils::map_split(cfg["side_users"]))
 	, show_configure(cfg["show_configure"].to_bool(true))
 	, show_connect(cfg["show_connect"].to_bool(true))
@@ -102,6 +104,7 @@ config mp_game_settings::to_config() const
 	cfg["mp_campaign"] = mp_campaign;
 	cfg["difficulty_define"] = difficulty_define;
 	cfg["active_mods"] = utils::join(active_mods, ",");
+	cfg["addon_ids"] = utils::join(addon_ids, ",");
 	cfg["side_users"] = utils::join_map(side_users);
 	cfg["show_configure"] = show_configure;
 	cfg["show_connect"] = show_connect;

--- a/src/mp_game_settings.hpp
+++ b/src/mp_game_settings.hpp
@@ -21,6 +21,9 @@
 #include "gettext.hpp"
 #include "make_enum.hpp"
 #include "savegame_config.hpp"
+#include "version.hpp"
+
+#include <boost/optional.hpp>
 
 struct mp_game_settings : public savegame::savegame_config
 {
@@ -40,7 +43,6 @@ struct mp_game_settings : public savegame::savegame_config
 	std::string mp_campaign;
 	std::string difficulty_define;
 	std::vector<std::string> active_mods;
-	std::vector<std::string> addon_ids;
 	std::map<std::string, std::string> side_users;
 
 	bool show_configure;
@@ -73,6 +75,17 @@ struct mp_game_settings : public savegame::savegame_config
 	RANDOM_FACTION_MODE random_faction_mode;
 
 	config options;
+
+	struct addon_version_info {
+		std::string id;
+		boost::optional<version_info> version;
+		boost::optional<version_info> min_version;
+
+		explicit addon_version_info(const config &);
+		void write(config &) const;
+	};
+
+	std::vector<addon_version_info> addons;
 };
 
 MAKE_ENUM_STREAM_OPS2(mp_game_settings, RANDOM_FACTION_MODE)

--- a/src/mp_game_settings.hpp
+++ b/src/mp_game_settings.hpp
@@ -40,6 +40,7 @@ struct mp_game_settings : public savegame::savegame_config
 	std::string mp_campaign;
 	std::string difficulty_define;
 	std::vector<std::string> active_mods;
+	std::vector<std::string> addon_ids;
 	std::map<std::string, std::string> side_users;
 
 	bool show_configure;

--- a/src/saved_game.cpp
+++ b/src/saved_game.cpp
@@ -36,6 +36,7 @@
 
 #include "saved_game.hpp"
 #include "carryover.hpp"
+#include "config_assign.hpp"
 #include "cursor.hpp"
 #include "log.hpp"
 #include "game_config_manager.hpp"
@@ -229,7 +230,6 @@ void saved_game::expand_mp_events()
 	if(this->starting_pos_type_ == STARTINGPOS_SCENARIO && !this->starting_pos_["has_mod_events"].to_bool(false))
 	{
 		std::vector<modevents_entry> mods;
-		std::vector<std::string> addon_ids;
 
 		boost::copy( mp_settings_.active_mods
 			| boost::adaptors::transformed(modevents_entry_for("modification"))
@@ -244,7 +244,8 @@ void saved_game::expand_mp_events()
 			{
 				// Note the addon_id
 				if (cfg.has_attribute("addon_id") && !cfg["addon_id"].empty()) {
-					addon_ids.push_back(cfg["addon_id"].str());
+					config addon_data = config_of("id",cfg["addon_id"])("version", cfg["addon_version"])("min_version", cfg["addon_min_version"]);
+					mp_settings_.addons.push_back(mp_game_settings::addon_version_info(addon_data));
 				}
 
 				// Copy events
@@ -265,7 +266,6 @@ void saved_game::expand_mp_events()
 			}
 		}
 
-		mp_settings_.addon_ids = addon_ids;
 		this->starting_pos_["has_mod_events"] = true;
 	}
 }

--- a/src/saved_game.cpp
+++ b/src/saved_game.cpp
@@ -242,8 +242,9 @@ void saved_game::expand_mp_events()
 			if(const config& cfg = game_config_manager::get()->
 				game_config().find_child(mod.type, "id", mod.id))
 			{
-				// Note the addon_id
-				if (cfg.has_attribute("addon_id") && !cfg["addon_id"].empty()) {
+				// Note the addon_id if this mod is required to play the game in mp
+				std::string require_attr = "require_" + mod.type;
+				if (cfg.has_attribute("addon_id") && !cfg["addon_id"].empty() && cfg[require_attr].to_bool(true)) {
 					config addon_data = config_of("id",cfg["addon_id"])("version", cfg["addon_version"])("min_version", cfg["addon_min_version"]);
 					mp_game_settings::addon_version_info new_data(addon_data);
 

--- a/src/tests/gui/test_gui2.cpp
+++ b/src/tests/gui/test_gui2.cpp
@@ -455,6 +455,14 @@ BOOST_AUTO_TEST_CASE(test_gui2)
 			std::remove(list.begin(), list.end(), "lua_interpreter")
 			, list.end());
 
+	//Window 'addon_description' registered but not tested.
+	//Window 'addon_filter_options' registered but not tested.
+	//Window 'addon_uninstall_list' registered but not tested.
+	//Window 'network_transmission' registered but not tested.
+	list.erase(std::remove(list.begin(), list.end(), "addon_description"), list.end());	
+	list.erase(std::remove(list.begin(), list.end(), "addon_filter_options"), list.end());	
+	list.erase(std::remove(list.begin(), list.end(), "addon_uninstall_list"), list.end());	
+	list.erase(std::remove(list.begin(), list.end(), "network_transmission"), list.end());	
 
 	// Test size() instead of empty() to get the number of offenders
 	BOOST_CHECK_EQUAL(list.size(), 0);


### PR DESCRIPTION
** Experimental **

A new feature: If one cannot join a game in the mp lobby because of missing addons, prompt the user to try to download those addons and whatever dependencies they have.

Four parts:
1.) Refactor some of the addon client code so that there is a simple "try to fetch and install this addon" function.
2.) In the game config manager, annotate certain top-level tags "era" and "modification" with "addon_id" attributes (generally, the addon folder name).
3.) In saved_game::expand_mp_events, when iterating over the mods and eras, also take note of their addon_id, and add these to a comma separated list in mp_game_settings, "addon_ids". Indirectly, this results that [multiplayer] tags now have an "addon_ids" attribute which becomes part of the server-side [game] children of [gamelist] and are sent to clients in the lobby.
4.) In the mp lobby, add methods to check if we are missing addons for the currently selected game, and if we try to join or observe it, then prompt the user whether to try to download these, using the "ad hoc" addon download session function from step 1.

Issues:
- I don't know if I think that step 2 should be done differently, it might be nicer to do this earlier in the process, because it could get confusing if someone works at an earlier part and expects to find these addon_ids. It was much easier to add this in at game config manager than in the preprocessor somehow though. 
  
  It also means that, what is represented in the cache is not *exactly* faithful to what configs are ultimately generated...

- When I started working on this, I didn't know about "require_scenario = yes", I thought that only mods and eras could require a download generally. But the code in step 4 in the mp lobby makes this clear, so probably should go back and fetch the addon ids for that as well.

- Get addon versions as well as ids? I didn't do this in part yet...