### PR TITLE
disable "alpha thresholding" in our bilinear interpolation algo

### DIFF
--- a/src/sdl_utils.cpp
+++ b/src/sdl_utils.cpp
@@ -523,19 +523,6 @@ surface scale_surface(const surface &surf, int w, int h, bool optimize)
 				// Some of the input images are hex tiles,
 				// created using a hexagon shaped alpha channel
 				// that is either set to full-on or full-off.
-				//
-				// If intermediate alpha values are introduced
-				// along a hex edge, it produces a gametime artifact.
-				// Moving the mouse around will leave behind
-				// "hexagon halos" from the temporary highlighting.
-				// In other words, the Wesnoth rendering engine
-				// freaks out.
-				//
-				// The alpha thresholding step attempts
-				// to accommodates this limitation.
-				// There is a small loss of quality.
-				// For example, skeleton bowstrings
-				// are not as good as they could be.
 
 				rr = gg = bb = aa = 0;
 				for (loc=0; loc<4; loc++) {
@@ -557,7 +544,6 @@ surface scale_surface(const surface &surf, int w, int h, bool optimize)
 				g = gg >> 16;
 				b = bb >> 16;
 				a = aa >> 16;
-				a = (a < avg_a/2) ? 0 : avg_a;
 				*dst_word = (a << 24) + (r << 16) + (g << 8) + b;
 			}
 		}


### PR DESCRIPTION
In this commit from late 2005, boucman added a bilinear interpolation
routine for scaling images which we use everywhere.

https://github.com/wesnoth/wesnoth/commit/2df60619

It is a modified bilinear interpolation -- one of the tweaks is that
at the very end an "alpha thresholding" step occurs. If the alpha
of a pixel is less than half of the average alpha of its neighbors,
it is discarded and set to fully transparent. Boucman writes that
this was done to combat a gametime artifact that would occur when
moving the hexagonal selector around with the mouse -- however, it
creates a small loss in image quality. Boucman writes that skeleton
archer bowstrings don't look as good -- I notice also that the edges
of the wings of drakes seem a bit sharper / more pixelated somehow.

In this commit I tried disabling the alpha thresholding, since the
way that the hex selector works has been changed since 2005, so this
might no longer be an issue. Sure enough the "hexagonal haloes" are
gone now, so it seems that we can safely get rid of the alpha
thresholding.
