### PR TITLE
remove replay viewer text label

### DIFF
--- a/data/themes/macros.cfg
+++ b/data/themes/macros.cfg
@@ -375,12 +375,12 @@
             ref=top-panel
             rect="=,+41,+842,768"
         [/change]
-        [add]
+        [add] # Note, when I try to remove this, even updating the refs and the rect offsets in the logical way causes the buttons to be placed way to the right, so I'm just leaving this as a blank item. If someone can figure out the right way to get rid of this please do so.
             [label]
                 id=replay-label
-                text= _ "Replay"
+                text= ""
                 ref=replay-panel
-                rect="=+3,=+10,+60,=-4"
+                rect="=+3,=+10,0,=-4"
                 #font_size={FONT_NORMAL_SIZE}
                 font_rgb=160,160,160
                 xanchor=fixed


### PR DESCRIPTION
This label didn't seem to contribute much of anything, and it
caused big problems for translators because we don't have
dynamically resizing text labels, and that would have provoked
intractable layout problems anyways, so we decide just to remove
it and rely on the tooltips / media controller icons on the buttons
to tell the user what is going on.

See also discussion here:
http://forums.wesnoth.org/viewtopic.php?f=9&t=24598&start=120#p575851
