### PR TITLE
Fix bug #22628: status orbs wrong in replay if not side 1

### DIFF
--- a/changelog
+++ b/changelog
@@ -352,6 +352,7 @@ Version 1.13.0-dev:
      for UI sounds, and moving the "Ready to start" sound to the turn bell channel.
    * Bug fix: another instance of "overlapping messages", this time with
      the planning mode activiation hotkey
+   * Fix bug #22628: status orbs wrong in replay if not side 1
 
 Version 1.11.11:
  * Add-ons server:

--- a/src/hotkey/hotkey_command.cpp
+++ b/src/hotkey/hotkey_command.cpp
@@ -103,7 +103,7 @@ hotkey::hotkey_command_temp hotkey_list_[] = {
 	{ hotkey::HOTKEY_REPLAY_NEXT_MOVE, "replaynextmove", N_("Next Move"), false, scope_game, "" },
 	{ hotkey::HOTKEY_REPLAY_SHOW_EVERYTHING, "replayshoweverything", N_("Full Map"), false, scope_game, "" },
 	{ hotkey::HOTKEY_REPLAY_SHOW_EACH, "replayshoweach", N_("Each Team"), false, scope_game, "" },
-	{ hotkey::HOTKEY_REPLAY_SHOW_TEAM1, "replayshowteam1", N_("Team 1"), false, scope_game, "" },
+	{ hotkey::HOTKEY_REPLAY_SHOW_TEAM1, "replayshowteam1", N_("Human Team"), false, scope_game, "" },
 	{ hotkey::HOTKEY_REPLAY_SKIP_ANIMATION, "replayskipanimation", N_("Skip Animation"), false, scope_game, "" },
 	// Whiteboard commands
 	// TRANSLATORS: whiteboard menu entry: toggle planning mode

--- a/src/replay_controller.cpp
+++ b/src/replay_controller.cpp
@@ -118,12 +118,14 @@ replay_controller::replay_controller(const config& level,
 	current_turn_(1),
 	is_playing_(false),
 	show_everything_(false),
-	show_team_(state_of_game.classification().campaign_type == game_classification::MULTIPLAYER ? 0 : 1)
+	is_multiplayer_(state_of_game.classification().campaign_type == game_classification::MULTIPLAYER)
 {
 	// Our parent class correctly detects that we are loading a game. However,
 	// we are not loading mid-game, so from here on, treat this as not loading
 	// a game. (Allows turn_1 et al. events to fire at the correct time.)
 	loading_game_ = false;
+
+	viewing_team_ = gamestate_.first_human_team_;
 
 	init();
 	reset_replay();
@@ -151,10 +153,12 @@ void replay_controller::init_gui(){
 	DBG_NG << "Initializing GUI... " << (SDL_GetTicks() - ticks_) << "\n";
 	play_controller::init_gui();
 
-	if (show_team_)
-		gui_->set_team(show_team_ - 1, show_everything_);
-	else
+	if (is_multiplayer_) {
 		gui_->set_team(0, show_everything_);
+	}
+	else {
+		gui_->set_team(viewing_team_, show_everything_);
+	}
 
 	gui_->scroll_to_leader(player_number_, display::WARP);
 	update_locker lock_display((*gui_).video(),false);
@@ -436,21 +440,21 @@ void replay_controller::process_oos(const std::string& msg) const
 
 void replay_controller::replay_show_everything(){
 	show_everything_ = true;
-	show_team_ = 0;
+	is_multiplayer_ = true;
 	update_teams();
 	update_gui();
 }
 
 void replay_controller::replay_show_each(){
 	show_everything_ = false;
-	show_team_ = 0;
+	is_multiplayer_ = true;
 	update_teams();
 	update_gui();
 }
 
 void replay_controller::replay_show_team1(){
 	show_everything_ = false;
-	show_team_ = 1;
+	is_multiplayer_ = false;
 	update_teams();
 	update_gui();
 }
@@ -609,10 +613,10 @@ void replay_controller::update_teams(){
 		next_team = 1;
 	}
 
-	if ( show_team_ == 0 ) {
+	if (is_multiplayer_) {
 		gui_->set_team(next_team - 1, show_everything_);
 	} else {
-		gui_->set_team(show_team_ - 1, show_everything_);
+		gui_->set_team(viewing_team_, show_everything_);
 	}
 
 	gui_->set_playing_team(next_team - 1);

--- a/src/replay_controller.cpp
+++ b/src/replay_controller.cpp
@@ -125,8 +125,6 @@ replay_controller::replay_controller(const config& level,
 	// a game. (Allows turn_1 et al. events to fire at the correct time.)
 	loading_game_ = false;
 
-	viewing_team_ = gamestate_.first_human_team_;
-
 	init();
 	reset_replay();
 }
@@ -157,7 +155,7 @@ void replay_controller::init_gui(){
 		gui_->set_team(0, show_everything_);
 	}
 	else {
-		gui_->set_team(viewing_team_, show_everything_);
+		gui_->set_team(gamestate_.first_human_team_, show_everything_);
 	}
 
 	gui_->scroll_to_leader(player_number_, display::WARP);
@@ -616,7 +614,7 @@ void replay_controller::update_teams(){
 	if (is_multiplayer_) {
 		gui_->set_team(next_team - 1, show_everything_);
 	} else {
-		gui_->set_team(viewing_team_, show_everything_);
+		gui_->set_team(gamestate_.first_human_team_, show_everything_);
 	}
 
 	gui_->set_playing_team(next_team - 1);

--- a/src/replay_controller.hpp
+++ b/src/replay_controller.hpp
@@ -100,7 +100,8 @@ private:
 	bool is_playing_;
 
 	bool show_everything_;
-	unsigned int show_team_;
+	bool is_multiplayer_;
+	size_t viewing_team_;
 };
 
 

--- a/src/replay_controller.hpp
+++ b/src/replay_controller.hpp
@@ -101,7 +101,6 @@ private:
 
 	bool show_everything_;
 	bool is_multiplayer_;
-	size_t viewing_team_;
 };
 
 


### PR DESCRIPTION
This concerns https://gna.org/bugs/index.php?22628

In the replay code, the viewing side was always set to 0 if it was a single player game.

Also, "show_team_" was replaced with the boolean "is_multiplayer_" as there was no reason to use an int in
this case.