### PR TITLE
Don't generate mp data for start-of-scenario saves.

### DIFF
--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -798,7 +798,10 @@ static void convert_old_saves_1_13_0(config& cfg)
 		}
 	}
 
-	if(!cfg.has_child("multiplayer") && cfg["campaign_type"] == "scenario") {
+	if(!cfg.has_child("multiplayer")
+			&& cfg["campaign_type"] == "scenario"
+			&& !cfg.child("carryover_sides_start"))
+	{
 		saved_game tmp(cfg);
 		ng::configure_engine eng(tmp);
 		eng.set_default_values();


### PR DESCRIPTION
https://gna.org/bugs/?22546
