### PR TITLE
Fix bug #22745: choose_track function crashes the game in certain cases

### DIFF
--- a/changelog
+++ b/changelog
@@ -325,6 +325,7 @@ Version 1.13.0-dev:
    * Fix bug #22643: Cannot compile with boost 1.56
    * Fix issue where the chatlog for a replayed game could not be opened in single player.
      The chatlog can now always be opened.
+   * Fix bug #22745: choose_track function crashes the game in certain cases
 
 Version 1.11.11:
  * Add-ons server:

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -225,7 +225,7 @@ static const sound::music_track &choose_track()
 {
 	assert(!current_track_list.empty());
 
-	if (current_track_index == current_track_list.size()) {
+	if (current_track_index >= current_track_list.size()) {
 		current_track_index = 0;
 	}
 


### PR DESCRIPTION
This concerns https://gna.org/bugs/index.php?22745

In certain cases, in the function "choose_track" (sound.cpp" member "current_track_index" can be greater than
"current_track_list.size()" thus causing an "index out of range" error.

For more details see the bug report linked above.
