### PR TITLE
Fix Bug 22251 (map labels not appearing in multiplayer)

### DIFF
--- a/src/map_label.cpp
+++ b/src/map_label.cpp
@@ -151,7 +151,7 @@ const terrain_label* map_labels::set_label(const map_location& loc,
 					   const bool visible_in_shroud,
 					   const bool immutable)
 {
-	terrain_label* res = NULL;
+	terrain_label* res = 0;
 
 	// See if there is already a label in this location for this team.
 	// (We do not use get_label_private() here because we might need
@@ -165,13 +165,15 @@ const terrain_label* map_labels::set_label(const map_location& loc,
 		// Found old checking if need to erase it
 		if(text.str().empty())
 		{
-			// Erase the old label.
+			current_label->second->set_text("");
+			res = NULL;
 			delete current_label->second;
-			current_label_map->second.erase(current_label);
+			current_label_map->second.erase(loc);
 
 			// Restore the global label in the same spot, if any.
 			if ( terrain_label* global_label = get_label_private(loc, "") )
 				global_label->recalculate();
+
 		}
 		else
 		{
@@ -185,7 +187,7 @@ const terrain_label* map_labels::set_label(const map_location& loc,
 		terrain_label* global_label = get_label_private(loc, "");
 
 		// Add the new label.
-		terrain_label* res = new terrain_label(text,
+		terrain_label* label = new terrain_label(text,
 				team_name,
 				loc,
 				*this,
@@ -193,11 +195,14 @@ const terrain_label* map_labels::set_label(const map_location& loc,
 				visible_in_fog,
 				visible_in_shroud,
 				immutable);
-		add_label(loc, res);
+		add_label(loc,label);
+
+		res = label;
 
 		// Hide the old label.
 		if ( global_label != NULL )
 			global_label->recalculate();
+
 	}
 	return res;
 }


### PR DESCRIPTION
**\* NOTE: This commit has not been adequately tested yet, and I don't understand _why_ it fixes the bug, only that it appears to. Please don't merge this yet. ***

This reverts commit 90501cf87254d3d87f876beb504f8734535d1dea.

This issue was bisected to this commit. This commit claims to just
be a harmless cleanup commit, but it completely breaks the map
labels, causing MP map labels not to be visible, and also breaking
the coloration. I'm not sure what assumptions in this apparently
inoccuous commit are wrong, but it seems that all of this is fixed
and nothing is lost by just reverting it.
