### PR TITLE
fix bug 21400: unit::absolute_image being used for unit animations

### DIFF
--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -1958,7 +1958,7 @@ void unit::redraw_unit()
 	// and halo_mod on secondary images and all haloes
 	params.image_mod = image_mods();
 	params.halo_mod = TC_image_mods();
-	params.image= absolute_image();
+	params.image = cfg_["image"].empty() ? cfg_["image_icon"].str() : cfg_["image"].str();
 
 
 	if(get_state(STATE_PETRIFIED)) params.image_mod +="~GS()";
@@ -2161,7 +2161,7 @@ bool unit::invalidate(const map_location &loc)
 		params.halo_y -= height_adjust;
 		params.image_mod = image_mods();
 		params.halo_mod = TC_image_mods();
-		params.image= absolute_image();
+		params.image = cfg_["image"].empty() ? cfg_["image_icon"].str() : cfg_["image"].str();
 
 		result |= get_animation()->invalidate(params);
 	}


### PR DESCRIPTION
When an animation frame had no defined image, it was using "absolute_image"
which yields the unit's `image_icon` if available, and `image` otherwise.

This causes undesirable behavior in cases highlighted by doofus1.

We fix it by replacing use of absolute image with an expression given by Coffee,
which prioritizes `image` over `image_icon`.
