### PR TITLE
fix a check in move_unit

### DIFF
--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -697,7 +697,7 @@ function wml_actions.move_unit(cfg)
 			while true do
 				x = tonumber(x) or helper.wml_error(coordinate_error)
 				y = tonumber(y) or helper.wml_error(coordinate_error)
-				if not x == prevX and not y == prevY then x, y = wesnoth.find_vacant_tile(x, y, pass_check) end
+				if not (x == prevX and y == prevY) then x, y = wesnoth.find_vacant_tile(x, y, pass_check) end
 				if not x or not y then helper.wml_error("Could not find a suitable hex near to one of the target hexes in [move_unit].") end
 				move_string_x = string.format("%s,%u", move_string_x, x)
 				move_string_y = string.format("%s,%u", move_string_y, y)


### PR DESCRIPTION
The logic is supposed to be, if (x,y) == (prev_x, prev_y), then
skip the "find_vacant_hex" function call because we don't have to 
move. Instead we effectively had, if (x == prev_x OR y == prev_y), 
then we can skip that call.

This revises a commit
72f138c54414bc0349def0271ec1ccbad984a28b

in the hopes to fix a bug reported here:
http://forums.wesnoth.org/viewtopic.php?f=4&t=41084
