### PR TITLE
when zooming in, use scale_surface_sharp for units, terrain (1.12 branch)

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -731,7 +731,12 @@ static surface get_hexed(const locator& i_locator)
 static surface get_scaled_to_hex(const locator& i_locator)
 {
 	surface img = get_image(i_locator, HEXED);
-	return scale_surface(img, zoom, zoom);
+
+	if (zoom < tile_size) {
+		return scale_surface(img, zoom, zoom);
+	} else {
+		return scale_surface_sharp(img, zoom, zoom);
+	}
 }
 
 static surface get_tod_colored(const locator& i_locator)
@@ -748,7 +753,11 @@ static surface get_scaled_to_zoom(const locator& i_locator)
 	surface res(get_image(i_locator, UNSCALED));
 	// For some reason haloes seems to have invalid images, protect against crashing
 	if(!res.null()) {
-		return scale_surface(res, ((res.get()->w * zoom) / tile_size), ((res.get()->h * zoom) / tile_size));
+		if (zoom < tile_size) {
+			return scale_surface(res, ((res.get()->w * zoom) / tile_size), ((res.get()->h * zoom) / tile_size));
+		} else {
+			return scale_surface_sharp(res, ((res.get()->w * zoom) / tile_size), ((res.get()->h * zoom) / tile_size));
+		}
 	} else {
 		return surface(NULL);
 	}


### PR DESCRIPTION
Previously we were using scale surface. The result is that sprites
look blurry, terrain looks blurry, and for fractional zoom values
"hex tearing" artifacts are more visible. It seems that zookeeper
and others also prefer a more traditional, just-give-me-the-pixels
look anyways.

lipk even thought that we had been using scale_surface_sharp on
units "since forever", so here we treat the fact that we weren't
as a bug.

Before and after screenshots from 1.12 (but also note, the differences are more visible in playtesting, especially the hex-tearing artifcats):
http://imgur.com/a/sSlpT#0

Related discussion:
http://forums.wesnoth.org/viewtopic.php?f=12&t=41109#p576979
