### PR TITLE
commit a patch to our fribidi cmake, from downstream (macports)

### DIFF
--- a/cmake/FindFriBiDi.cmake
+++ b/cmake/FindFriBiDi.cmake
@@ -19,15 +19,14 @@ SET(FRIBIDI_FOUND "NO")
 # Set variable in temp var, otherwise FIND_PATH might fail
 # unset isn't present in the required version of cmake.
 FIND_PATH(xFRIBIDI_INCLUDE_DIR fribidi.h
-  /usr/local/include/fribidi
-  /usr/include/fribidi
+  @PREFIX@/include/fribidi
   )
 set(FRIBIDI_INCLUDE_DIR ${xFRIBIDI_INCLUDE_DIR})
 
 SET(FRIBIDI_NAMES ${FRIBIDI_NAMES} fribidi libfribidi)
 FIND_LIBRARY(FRIBIDI_LIBRARY
   NAMES ${FRIBIDI_NAMES}
-  PATHS /usr/lib /usr/local/lib
+  PATHS @PREFIX@/lib
   )
 
 IF (FRIBIDI_LIBRARY AND FRIBIDI_INCLUDE_DIR)


### PR DESCRIPTION
see here:
https://trac.macports.org/browser/trunk/dports/games/wesnoth/files/patch-cmake-FindFriBiDi.cmake.diff

i tested that cmake still works and finds fribidi for me (linux)

edit: actually for some reason its failing on linking but it seems unrelated
