### PR TITLE
fix issue where wml unit tests run in the presence of addon WML

### DIFF
--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -138,7 +138,12 @@ void game_config_manager::load_game_config(FORCE_RELOAD_CONFIG force_reload,
 		config core_terrain_rules;
 		core_terrain_rules.splice_children(game_config_, "terrain_graphics");
 
-		load_addons_cfg();
+		//TODO: it would be better actually if this were not the default behavior for tests,
+		// and instead is specified by a command-line argument "--no-addons" or some such,
+		// to permit umc defined unit tests to run
+		if (!(classification && classification->campaign_type == game_classification::TEST)) {
+			load_addons_cfg();
+		}
 
 		// If multiplayer campaign is being loaded, [scenario] tags should
 		// become [multiplayer] tags and campaign's id should be added to them


### PR DESCRIPTION
Any scenario of type "test", indeed the generation of the  entire
"TEST" game-config mode, skips all add-ons.

When tests are run, we want them to run in a clean place where
errors and warnings from add-ons don't cause test failures. This
seems to be the simplest way to achieve this right now.

A possible drawback is that if a user defines their own wml unit
tests, they need to move them to their data/test/ folder and
cannot put them in their add-on or they won't be found.

See irc discussion:
http://www.wesnoth.org/irclogs/2014/11/%23wesnoth-dev.2014-11-06.log
