### PR TITLE
cache minimap images in mp create screen

### DIFF
--- a/src/game_initialization/create_engine.hpp
+++ b/src/game_initialization/create_engine.hpp
@@ -37,7 +37,7 @@ public:
 
 	virtual bool can_launch_game() const = 0;
 
-	virtual surface* create_image_surface(const SDL_Rect& image_rect) = 0;
+	virtual surface create_image_surface(const SDL_Rect& image_rect) = 0;
 
 	virtual void set_metadata() = 0;
 
@@ -67,7 +67,7 @@ public:
 
 	bool can_launch_game() const;
 
-	surface* create_image_surface(const SDL_Rect& image_rect);
+	surface create_image_surface(const SDL_Rect& image_rect);
 
 	void set_metadata();
 
@@ -78,6 +78,9 @@ protected:
 	void set_sides();
 
 	boost::scoped_ptr<gamemap> map_;
+
+	surface minimap_img_;
+	std::basic_string<unsigned char> map_hash_;
 
 private:
 	scenario(const scenario&);
@@ -140,7 +143,7 @@ public:
 
 	bool can_launch_game() const;
 
-	surface* create_image_surface(const SDL_Rect& image_rect);
+	surface create_image_surface(const SDL_Rect& image_rect);
 
 	void set_metadata();
 

--- a/src/game_initialization/multiplayer_create.cpp
+++ b/src/game_initialization/multiplayer_create.cpp
@@ -493,19 +493,18 @@ void create::synchronize_selections()
 
 void create::draw_level_image()
 {
-	boost::scoped_ptr<surface> image(
+	surface image(
 		engine_.current_level().create_image_surface(image_rect_));
 
-	if (image.get() != NULL) {
+	if (!image.null()) {
 		SDL_Color back_color = {0,0,0,255};
-		draw_centered_on_background(*image, image_rect_, back_color,
+		draw_centered_on_background(image, image_rect_, back_color,
 			video().getSurface());
 	} else {
 		surface display(disp_.get_screen_surface());
 		sdl::fill_rect(display, &image_rect_,
 			SDL_MapRGB(display->format, 0, 0, 0));
 		update_rect(image_rect_);
-
 	}
 }
 


### PR DESCRIPTION
When we are actually in the game, the image.cpp file uses an
elaborate collection of caches to make sure that all images are
cached and reloaded rather than redoing work (even scaling). It's
questionable whether the amount of caching going on there is
appropriate, it seems it might even be faster if we did less. But
one place that we don't do any caching and performance is bad is
in the mp create screen. There was a bug report in 1.12:

https://gna.org/bugs/?func=detailitem&item_id=21801

In this commit, I implement quick and dirty caching for scenario
minimap images. Each scenario record holds a surface (an SDL
reference counted pointer to image data), and when a minimap is
rendered this gets saved, along with the md5 hash of the map that
got rendered. Whenever a minimap is requested, we hash it first
and check if the cache is dirty. If so we recalculate, otherwise
we return the cached image.

The code is also cleaner and a bit less convoluted than the
previous code -- the previous author seemed to think that surfaces
are "object" types and not "pointer" types, that require an
additional layer of memory management with boost scoped pointer
etc. This was in fact redundant.

I don't know if this commit will actually help report 21801,
the profiling seemed to suggest that it's the minimap rendering
code that is actually slow. But it seems that this can't hurt,
and may at least mitigate the slowness, since except for random
maps it means the minimap calculation won't be repeated.
