### PR TITLE
check properly if a config attribute value is not a boolean

### DIFF
--- a/src/multiplayer_connect_engine.cpp
+++ b/src/multiplayer_connect_engine.cpp
@@ -1059,12 +1059,12 @@ config side_engine::new_config() const
 		res["income"] = income_;
 
 		if (!parent_.params_.use_map_settings || res["fog"].empty() ||
-			(res["fog"] != "yes" && res["fog"] != "no")) {
+			(res["fog"].to_bool(true) == true && res["fog"].to_bool(false) == false)) {
 			res["fog"] = parent_.params_.fog_game;
 		}
 
 		if (!parent_.params_.use_map_settings || res["shroud"].empty() ||
-			(res["shroud"] != "yes" && res["shroud"] != "no")) {
+			(res["shroud"].to_bool(true) == true && res["shroud"].to_bool(false) == false)) {
 			res["shroud"] = parent_.params_.shroud_game;
 		}
 


### PR DESCRIPTION
I don't know if this commit is related to or fixes any bugs, but
there are many bugs reported about fog / shroud / mp campaigns it
seems, and these lines always looked a bit squirrely to me. Since
boolean config values can be indicated by "yes", "no", "true" or
"false", testing for the presence of "yes" / "no" only seems like
it won't work in general, even if it works oftentimes. This commit
replaces it with a test for whether the to_bool function is
selecting the default boolean value.
