### PR TITLE
make force_lock_settings default to true for [scenario]

### DIFF
--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -262,6 +262,8 @@ void game_config_manager::load_game_config(FORCE_RELOAD_CONFIG force_reload,
 				BOOST_FOREACH(config& cfg, scenarios) {
 					cfg["campaign_id"] = campaign_id;
 					cfg["require_scenario"] = require_campaign;
+					// make force_lock_settings default to true for [scenario]
+					cfg["force_lock_settings"] = cfg["force_lock_settings"].to_bool(true);
 					game_config_.add_child(lexical_cast<std::string>(game_classification::MULTIPLAYER), cfg);
 				}
 			}


### PR DESCRIPTION
In most cases the campaigns designer don't want the use to be able to
overwrite scenario properites like "turn limit" or "use fog".

It is easiert to do this here in the code that loads the config than in
the code that reads that value becasue there are multiple codes that
read it and it's not clear that all of then know whether teh scenario
was a [multiplayer] or a [scenario].

Partly implements http://gna.org/bugs/?23037 which suggests to remove
the ability to overwite those settings in capaigns completely.
