### PR TITLE
Fix compilation with MinGW on Windows

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -520,7 +520,7 @@ for env in [test_env, client_env, env]:
         env[d] = os.path.join(env["prefix"], env[d])
 
     if env["PLATFORM"] == 'win32':
-        env.Append(LIBS = ["wsock32", "z"], CCFLAGS = ["-mthreads"], LINKFLAGS = ["-mthreads"], CPPDEFINES = ["_WIN32_WINNT=0x0500"])
+        env.Append(LIBS = ["wsock32", "iconv", "z"], CCFLAGS = ["-mthreads"], LINKFLAGS = ["-mthreads"], CPPDEFINES = ["_WIN32_WINNT=0x0500"])
     if env["PLATFORM"] == 'darwin':            # Mac OS X
         env.Append(FRAMEWORKS = "Carbon")            # Carbon GUI
 


### PR DESCRIPTION
This removes linking to `gettext` and adds link to `iconv`. I don't know why `iconv` is absent, because I am not an expert, so a better explanation is appreciated. This PR enables me to compile `wesnothd.exe`
