### PR TITLE
scons: remove boostfilesystem build option, replace with "libintl"

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -73,7 +73,7 @@ opts.AddVariables(
     BoolVariable('lowmem', 'Set to reduce memory usage by removing extra functionality', False),
     BoolVariable('notifications', 'Enable support for desktop notifications', True),
     BoolVariable('nls','enable compile/install of gettext message catalogs',True),
-    BoolVariable('boostfilesystem', 'Use boost filesystem', True),
+    BoolVariable('libintl', 'Use lib intl for translations, instead of boost locale', False),
     BoolVariable('png', 'Clear to disable writing png files for screenshots, images', True),
     PathVariable('prefix', 'autotools-style installation prefix', "/usr/local", PathVariable.PathAccept),
     PathVariable('prefsdir', 'user preferences directory', "", PathVariable.PathAccept),
@@ -299,8 +299,8 @@ configure_args = dict(
 env.MergeFlags(env["extra_flags_config"])
 
 # Some tests need to load parts of boost
-if env["boostfilesystem"]:
-    env.PrependENVPath('LD_LIBRARY_PATH', env["boostlibdir"])
+env.PrependENVPath('LD_LIBRARY_PATH', env["boostlibdir"])
+
 if env["prereqs"]:
     conf = env.Configure(**configure_args)
 
@@ -373,16 +373,15 @@ if env["prereqs"]:
     have_server_prereqs = (\
         conf.CheckCPlusPlus(gcc_version = "3.3") & \
         have_sdl_net() & \
-        ((env["boostfilesystem"]) or (conf.CheckGettextLibintl())) & \
         conf.CheckBoost("iostreams", require_version = "1.34.1") & \
         conf.CheckBoostIostreamsGZip() & \
         conf.CheckBoostIostreamsBZip2() & \
         conf.CheckBoost("random",require_version = "1.40.0") & \
         conf.CheckBoost("smart_ptr", header_only = True) & \
         conf.CheckBoost("system") & \
-        ((not env["boostfilesystem"]) or 
-            (conf.CheckBoost("filesystem", require_version = "1.44.0") & \
-            conf.CheckBoost("locale"))) \
+        conf.CheckBoost("filesystem", require_version = "1.44.0") & \
+        ((not env["libintl"]) or conf.CheckGettextLibintl()) & \
+        (env["libintl"] or conf.CheckBoost("locale")) \
             and Info("GOOD: Base prerequisites are met")) \
             or Warning("WARN: Base prerequisites are not met")
 
@@ -404,6 +403,10 @@ if env["prereqs"]:
     if have_client_prereqs:
         if env["PLATFORM"] != "win32":
             have_X = conf.CheckLib('X11')
+        else:
+            if env["libintl"]:
+                Warning("ERROR: You cannot use the libintl option when building for windows")
+                have_client_prereqs = False
 
         env["notifications"] = env["notifications"] and conf.CheckPKG("dbus-1")
         if env["notifications"]:
@@ -521,6 +524,7 @@ for env in [test_env, client_env, env]:
 
     if env["PLATFORM"] == 'win32':
         env.Append(LIBS = ["wsock32", "iconv", "z"], CCFLAGS = ["-mthreads"], LINKFLAGS = ["-mthreads"], CPPDEFINES = ["_WIN32_WINNT=0x0500"])
+
     if env["PLATFORM"] == 'darwin':            # Mac OS X
         env.Append(FRAMEWORKS = "Carbon")            # Carbon GUI
 

--- a/SConstruct
+++ b/SConstruct
@@ -520,7 +520,7 @@ for env in [test_env, client_env, env]:
         env[d] = os.path.join(env["prefix"], env[d])
 
     if env["PLATFORM"] == 'win32':
-        env.Append(LIBS = ["wsock32", "z"], CCFLAGS = ["-mthreads"], LINKFLAGS = ["-mthreads"], CPPDEFINES = ["_WIN32_WINNT=0x0500"])
+        env.Append(LIBS = ["wsock32", "iconv", "z"], CCFLAGS = ["-mthreads"], LINKFLAGS = ["-mthreads"], CPPDEFINES = ["_WIN32_WINNT=0x0500"])
     if env["PLATFORM"] == 'darwin':            # Mac OS X
         env.Append(FRAMEWORKS = "Carbon")            # Carbon GUI
 

--- a/SConstruct
+++ b/SConstruct
@@ -370,6 +370,13 @@ if env["prereqs"]:
                 conf.CheckSDL("SDL_mixer", require_version = '1.2.12') & \
                 conf.CheckSDL("SDL_image", require_version = '1.2.0')
 
+    if env["libintl"]:
+        def have_i18n_prereqs():
+            return conf.CheckGettextLibintl()
+    else:
+        def have_i18n_prereqs():
+            return conf.CheckBoost("locale")
+
     have_server_prereqs = (\
         conf.CheckCPlusPlus(gcc_version = "3.3") & \
         have_sdl_net() & \
@@ -380,8 +387,7 @@ if env["prereqs"]:
         conf.CheckBoost("smart_ptr", header_only = True) & \
         conf.CheckBoost("system") & \
         conf.CheckBoost("filesystem", require_version = "1.44.0") & \
-        ((not env["libintl"]) or conf.CheckGettextLibintl()) & \
-        (env["libintl"] or conf.CheckBoost("locale")) \
+        have_i18n_prereqs() \
             and Info("GOOD: Base prerequisites are met")) \
             or Warning("WARN: Base prerequisites are not met")
 

--- a/SConstruct
+++ b/SConstruct
@@ -520,7 +520,7 @@ for env in [test_env, client_env, env]:
         env[d] = os.path.join(env["prefix"], env[d])
 
     if env["PLATFORM"] == 'win32':
-        env.Append(LIBS = ["wsock32", "intl", "z"], CCFLAGS = ["-mthreads"], LINKFLAGS = ["-mthreads"], CPPDEFINES = ["_WIN32_WINNT=0x0500"])
+        env.Append(LIBS = ["wsock32", "z"], CCFLAGS = ["-mthreads"], LINKFLAGS = ["-mthreads"], CPPDEFINES = ["_WIN32_WINNT=0x0500"])
     if env["PLATFORM"] == 'darwin':            # Mac OS X
         env.Append(FRAMEWORKS = "Carbon")            # Carbon GUI
 

--- a/src/SConscript
+++ b/src/SConscript
@@ -66,8 +66,8 @@ if env['default_prefs_file']:
 libwesnoth_core_sources.extend([
     game_config_env.Object("game_config.cpp"),
     filesystem_env.Object("filesystem_common.cpp"),
-    filesystem_env.Object("filesystem_boost.cpp") if env["boostfilesystem"] else filesystem_env.Object("filesystem.cpp"),
-    filesystem_env.Object("gettext_boost.cpp") if env["boostfilesystem"] else filesystem_env.Object("gettext.cpp")
+    filesystem_env.Object("filesystem_boost.cpp"),
+    filesystem_env.Object("gettext.cpp") if env["libintl"] else filesystem_env.Object("gettext_boost.cpp")
     ])
 
 libwesnoth_core = [env.Library("wesnoth_core", libwesnoth_core_sources)]


### PR DESCRIPTION
This option cleans up some of the compatibility path code from the
1.12 release. After this commit:

- boost::filesystem becomes a hard dependency, for scons
- boost::locale is a soft dependency, a build flag "libintl" allows to swap boost::locale out for libintl.
- The libintl option cannot be used when building for windows

This decision is made based on gfgtdf's comments in this forum thread:
http://forums.wesnoth.org/viewtopic.php?f=10&t=41196

and the fact that the boost filesystem code currently assumes the presence of boost locale, for windows.

It also incorporates techtonik's patch:
#347

It is left to backport the same patch for cmake, but the libintl code there
seems messed up already...