### PR TITLE
Lua: Fix uses of `tostring` calls as LHSs to `or`

### DIFF
--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -60,9 +60,10 @@ end
 
 function wml_actions.chat(cfg)
 	local side_list = wesnoth.get_sides(cfg)
-	local speaker = tostring(cfg.speaker) or "WML"
-	local message = tostring(cfg.message) or
+	local speaker = tostring(cfg.speaker or "WML")
+	local message = tostring(cfg.message or
 		helper.wml_error "[chat] missing required message= attribute."
+	)
 
 	for index, side in ipairs(side_list) do
 		if side.controller == "human" then
@@ -710,8 +711,8 @@ end
 
 function wml_actions.move_unit(cfg)
 	local coordinate_error = "invalid coordinate in [move_unit]"
-	local to_x = tostring(cfg.to_x) or helper.wml_error(coordinate_error)
-	local to_y = tostring(cfg.to_y) or helper.wml_error(coordinate_error)
+	local to_x = tostring(cfg.to_x or helper.wml_error(coordinate_error))
+	local to_y = tostring(cfg.to_y or helper.wml_error(coordinate_error))
 	local fire_event = cfg.fire_event
 	local muf_force_scroll = cfg.force_scroll
 	local check_passability = cfg.check_passability; if check_passability == nil then check_passability = true end

--- a/data/lua/wml/items.lua
+++ b/data/lua/wml/items.lua
@@ -81,7 +81,7 @@ end
 
 function wml_actions.store_items(cfg)
 	local variable = cfg.variable or "items"
-	variable = tostring(variable) or helper.wml_error("invalid variable= in [store_items]")
+	variable = tostring(variable or helper.wml_error("invalid variable= in [store_items]"))
 	wesnoth.set_variable(variable)
 	local index = 0
 	for i, loc in ipairs(wesnoth.get_locations(cfg)) do


### PR DESCRIPTION
This commit changes occurrences of the pattern `tostring(x) or y` to
`tostring(x or y)` in the following Lua scripts:
- `data/lua/wml-tags.lua`
- `data/lua/wml/items.lua`

`tostring(x) or y` is unlikely to do what the author intended (and is
pointless unless `x` is an object of a custom type with unusual
behavior), because `tostring` returns a string (`"false"` or `"nil"`)
if `x` is a falsy value (`false` or `nil`), and all strings are truthy
in Lua — thus, `tostring(x) or y` will (unless `x` is of a custom
type) _always_ evaluate to `tostring(x)`, never to `y`.

`tostring(x or y)` should, I expect, give the intended behavior.
