### PR TITLE
Fix: Era carryover in Tutorial doesn't work

### DIFF
--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -778,6 +778,8 @@ void game_launcher::set_tutorial()
 	state_ = saved_game();
 	state_.classification().campaign_type = game_classification::TUTORIAL;
 	state_.classification().campaign_define = "TUTORIAL";
+	state_.mp_settings().mp_era = "era_blank";
+	state_.mp_settings().show_connect = false;
 	state_.set_carryover_sides_start(
 		config_of("next_scenario", "tutorial")
 	);

--- a/src/saved_game.cpp
+++ b/src/saved_game.cpp
@@ -455,10 +455,7 @@ config saved_game::to_config() const
 		r.add_child("scenario", starting_pos_);
 	}
 	r.add_child(has_carryover_expanded_ ? "carryover_sides" : "carryover_sides_start" , carryover_);
-	if (classification_.campaign_type == game_classification::MULTIPLAYER
-		|| classification_.campaign_type == game_classification::SCENARIO) {
-		r.add_child("multiplayer", mp_settings_.to_config());
-	}
+	r.add_child("multiplayer", mp_settings_.to_config());
 	return r;
 }
 


### PR DESCRIPTION
Resolves the era carryover bug in the tutorial. Set the default era for the tutorial and hides the multiplayer connect screen.

See https://gna.org/bugs/index.php?23126
