### PR TITLE
maybe fix 23115

### DIFF
--- a/src/game_events/manager.cpp
+++ b/src/game_events/manager.cpp
@@ -245,4 +245,9 @@ game_events::t_pump & manager::pump()
 	return *pump_;
 }
 
+const boost::shared_ptr<manager * const> & manager::get_shared()
+{
+	return me_;
+}
+
 } //end namespace game_events

--- a/src/game_events/manager.hpp
+++ b/src/game_events/manager.hpp
@@ -136,6 +136,8 @@ namespace game_events {
 		                const std::string& type = std::string());
 		void write_events(config& cfg);
 
+		const boost::shared_ptr<manager * const> & get_shared();
+
 		game_events::t_pump & pump();
 	};
 }

--- a/src/game_events/menu_item.cpp
+++ b/src/game_events/menu_item.cpp
@@ -244,6 +244,7 @@ void wml_menu_item::init_handler(const boost::shared_ptr<manager * const> & man)
 	if ( !command_.empty() ) {
 		assert(man);
 		my_manager_ = man;
+		LOG_NG << "Setting command for " << event_name_ << " to:\n" << command_;
 		(**man).add_event_handler(command_, true);
 	}
 
@@ -251,6 +252,11 @@ void wml_menu_item::init_handler(const boost::shared_ptr<manager * const> & man)
 	if ( use_hotkey_ ) {
 		hotkey::add_wml_hotkey(hotkey_id_, description_, default_hotkey_);
 	}
+}
+
+void wml_menu_item::init_handler(manager & man) const
+{
+	init_handler(man.get_shared());
 }
 
 /**
@@ -355,7 +361,7 @@ void wml_menu_item::update(const vconfig & vcfg)
  */
 void wml_menu_item::update_command(const config & new_command)
 {
-	if (boost::shared_ptr<manager * const> man = my_manager_.lock()) {
+/*	if (boost::shared_ptr<manager * const> man = my_manager_.lock()) {
 		// If there is an old command, remove it from the event handlers.
 		if ( !command_.empty() ) {
 			manager::iteration iter(event_name_, **man);
@@ -367,7 +373,7 @@ void wml_menu_item::update_command(const config & new_command)
 				++iter;
 			}
 		}
-
+*/
 		// Update our stored command.
 		if ( new_command.empty() )
 			command_.clear();
@@ -382,13 +388,15 @@ void wml_menu_item::update_command(const config & new_command)
 			command_["name"] = event_name_;
 			command_["first_time_only"] = false;
 
+/*
 			// Register the event.
 			LOG_NG << "Setting command for " << event_name_ << " to:\n" << command_;
 			(**man).add_event_handler(command_, true);
-		}
-	} else {
+*/		}
+/*	} else {
 		ERR_NG << "Tried to set a command for a menu item, but the manager could not be found\n";
 	}
+*/
 }
 
 } // end namespace game_events

--- a/src/game_events/menu_item.hpp
+++ b/src/game_events/menu_item.hpp
@@ -62,6 +62,7 @@ public:
 	void finish_handler() const;
 	/// Initializes the implicit event handler for an inlined [command].
 	void init_handler(const boost::shared_ptr<manager * const> &) const;
+	void init_handler(manager &) const;
 	/// The text to put in a menu for this item.
 	/// This will be either translated text or a hotkey identifier.
 	std::string menu_text() const

--- a/src/game_events/wmi_container.cpp
+++ b/src/game_events/wmi_container.cpp
@@ -155,9 +155,7 @@ void wmi_container::init_handlers(const boost::shared_ptr<manager * const> & man
 	}
 
 	// Diagnostic:
-	if ( wmi_count > 0 ) {
-		LOG_NG << wmi_count << " WML menu items found, loaded." << std::endl;
-	}
+	LOG_NG << wmi_count << " WML menu items found, loaded." << std::endl;
 }
 
 void wmi_container::to_config(config& cfg) const
@@ -171,19 +169,24 @@ void wmi_container::to_config(config& cfg) const
 /**
  * Updates or creates (as appropriate) the menu item with the given @a id.
  */
-void wmi_container::set_item(const std::string& id, const vconfig& menu_item)
+void wmi_container::set_item(const std::string& id, const vconfig& menu_item, manager * man)
 {
 	// Try to insert a dummy value. This combines looking for an existing
 	// entry with insertion.
 	map_t::iterator add_it = wml_menu_items_.insert(map_t::value_type(id, item_ptr())).first;
 
-	if ( add_it->second )
+	if ( add_it->second ) {
 		// Create a new menu item based on the old. This leaves the old item
 		// alone in case someone else is holding on to (and processing) it.
 		add_it->second.reset(new wml_menu_item(id, menu_item, *add_it->second));
-	else
+	} else {
 		// This is a new menu item.
 		add_it->second.reset(new wml_menu_item(id, menu_item));
+	}
+
+	if (man) {
+		add_it->second->init_handler(*man);
+	}
 }
 
 /**

--- a/src/game_events/wmi_container.hpp
+++ b/src/game_events/wmi_container.hpp
@@ -88,7 +88,7 @@ public:
 	void init_handlers(const boost::shared_ptr<manager * const> &) const;
 	void to_config(config& cfg) const;
 	/// Updates or creates (as appropriate) the menu item with the given @a id.
-	void set_item(const std::string& id, const vconfig& menu_item);
+	void set_item(const std::string& id, const vconfig& menu_item, manager *);
 	/// Sets the current menu items to the "menu_item" children of @a cfg.
 	void set_menu_items(const config& cfg);
 

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -757,7 +757,8 @@ int game_lua_kernel::intf_set_variable(lua_State *L)
 
 int game_lua_kernel::intf_set_menu_item(lua_State *L)
 {
-	gamedata().get_wml_menu_items().set_item(luaL_checkstring(L, 1), luaW_checkvconfig(L,2));
+	gamedata().get_wml_menu_items().set_item(luaL_checkstring(L, 1), luaW_checkvconfig(L,2), game_state_.events_manager_.get());
+
 	return 0;
 }
 


### PR DESCRIPTION
Don't merge yet, needs more testing...

this commit causes wml menu items to have their events registered
not during construction but only when "init_handler" is called.
it refactors the wmi_container object to do this when it
constructs new items via the [set_menu_item] path.

this is necessary because the items might be constructed before
the event queue even exists, and we want them to be able to
persist and be reactivated when a new campaign scenario starts.

more testing is necessary to determine if all code paths, including
carryover and reloading, are still working after this commit, and
the earlier commit 6fc1ac1bb224cddec5ccbb7f7865b69b1b093a01

See also discussion of bug #23115.