### PR TITLE
Bug 23108: expected damage for aborted attacks

### DIFF
--- a/changelog
+++ b/changelog
@@ -372,7 +372,7 @@ Version 1.13.0-dev:
    * Added 'faction_lock' and 'leader_lock' to SideWML to be used in MP Connect
      screen. Fixes bug #21978.
    * Fix bug #22231: partial moves now able to be continued in whiteboard
-   * Fix bug #23108: exclucde aborted attacks from statistics
+   * Fix bug #23108: exclude aborted attacks from statistics
    * Added wmi_pager object to control how wml menu items are displayed in context menus, and allow
      to display more than seven.
    * Fix an inefficient implementation of unit::invisible, in an effort to address slow performance problems:

--- a/changelog
+++ b/changelog
@@ -91,6 +91,7 @@ Version 1.13.0-dev:
      * Hide unit variations that should not be listed in the help browser.
  * C++ Engine:
    * Purge "human_ai" controller type. This is a fixup of bugfix #18829 below.
+   * Move expected damage calculation into each strike (bug #23108 below).
  * Editor:
    * Added an entry for the terrain description help to the context menu.
    * Default hotkey bindings for brushes (1-5)
@@ -371,6 +372,7 @@ Version 1.13.0-dev:
    * Added 'faction_lock' and 'leader_lock' to SideWML to be used in MP Connect
      screen. Fixes bug #21978.
    * Fix bug #22231: partial moves now able to be continued in whiteboard
+   * Fix bug #23108: exclucde aborted attacks from statistics
    * Added wmi_pager object to control how wml menu items are displayed in context menus, and allow
      to display more than seven.
    * Fix an inefficient implementation of unit::invisible, in an effort to address slow performance problems:

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -918,6 +918,14 @@ namespace {
 
 		// can do no more damage than the defender has hitpoints
 		int damage_done = std::min<int>(defender.get_unit().hitpoints(), attacker.damage_);
+		// expected damage = damage potential * chance to hit (as a percentage)
+		double expected_damage = damage_done*attacker.cth_*0.01;
+		if (attacker_turn) {
+			stats.attack_expected_damage(expected_damage, 0);
+		} else {
+			stats.attack_expected_damage(0, expected_damage);
+		}
+
 		int drains_damage = 0;
 		if (hits && attacker_stats->drains) {
 			drains_damage = damage_done * attacker_stats->drain_percent / 100 + attacker_stats->drain_constant;
@@ -1203,17 +1211,6 @@ namespace {
 
 		DBG_NG << "getting attack statistics\n";
 		statistics::attack_context attack_stats(a_.get_unit(), d_.get_unit(), a_stats_->chance_to_hit, d_stats_->chance_to_hit);
-
-		{
-			// Calculate stats for battle
-			combatant attacker(bc_->get_attacker_stats());
-			combatant defender(bc_->get_defender_stats());
-			attacker.fight(defender,false);
-			const double attacker_inflict = static_cast<double>(d_.get_unit().hitpoints()) - defender.average_hp();
-			const double defender_inflict = static_cast<double>(a_.get_unit().hitpoints()) - attacker.average_hp();
-
-			attack_stats.attack_expected_damage(attacker_inflict,defender_inflict);
-		}
 
 		a_.orig_attacks_ = a_stats_->num_blows;
 		d_.orig_attacks_ = d_stats_->num_blows;


### PR DESCRIPTION
[ref](https://gna.org/bugs/index.php?reload=1&func=detailitem&item_id=23108)

This commit moves the expected damage calculation from before the attack loop to during the perform_hit phase, since it's possible to abort from the attack loop prematurely via WML actions like teleporting a unit or changing its side. Now each strike adds its expected damage to the total expected.

I also refactored the replay validation into its own function to cut down on the complexity of perform_hit (still almost 200 lines).