### PR TITLE
OOS debug

### DIFF
--- a/src/game_classification.cpp
+++ b/src/game_classification.cpp
@@ -44,7 +44,8 @@ game_classification::game_classification():
 	end_text(),
 	end_text_duration(),
 	difficulty(DEFAULT_DIFFICULTY),
-	random_mode("")
+	random_mode(""),
+	oos_debug(false)
 	{}
 
 game_classification::game_classification(const config& cfg):
@@ -64,7 +65,8 @@ game_classification::game_classification(const config& cfg):
 	end_text(cfg["end_text"]),
 	end_text_duration(cfg["end_text_duration"]),
 	difficulty(cfg["difficulty"].empty() ? DEFAULT_DIFFICULTY : cfg["difficulty"].str()),
-	random_mode(cfg["random_mode"])
+	random_mode(cfg["random_mode"]),
+	oos_debug(cfg["oos_debug"].to_bool(false))
 	{}
 
 game_classification::game_classification(const game_classification& gc):
@@ -84,7 +86,8 @@ game_classification::game_classification(const game_classification& gc):
 	end_text(gc.end_text),
 	end_text_duration(gc.end_text_duration),
 	difficulty(gc.difficulty),
-	random_mode(gc.random_mode)
+	random_mode(gc.random_mode),
+	oos_debug(gc.oos_debug)
 {
 }
 
@@ -108,6 +111,6 @@ config game_classification::to_config() const
 	cfg["end_text_duration"] = str_cast<unsigned int>(end_text_duration);
 	cfg["difficulty"] = difficulty;
 	cfg["random_mode"] = random_mode;
-
+	cfg["oos_debug"] = oos_debug;
 	return cfg;
 }

--- a/src/game_classification.hpp
+++ b/src/game_classification.hpp
@@ -57,6 +57,7 @@ public:
 	unsigned int end_text_duration;                  /**< for how long the end-of-campaign text is shown */
 	std::string difficulty; /**< The difficulty level the game is being played on. */
 	std::string random_mode;
+	bool oos_debug;
 };
 MAKE_ENUM_STREAM_OPS2(game_classification, CAMPAIGN_TYPE)
 

--- a/src/game_initialization/configure_engine.cpp
+++ b/src/game_initialization/configure_engine.cpp
@@ -97,6 +97,7 @@ void configure_engine::set_random_start_time(bool val) { parameters_.random_star
 void configure_engine::set_fog_game(bool val) { parameters_.fog_game = val; }
 void configure_engine::set_shroud_game(bool val) { parameters_.shroud_game = val; }
 void configure_engine::set_allow_observers(bool val) { parameters_.allow_observers = val; }
+void configure_engine::set_oos_debug(bool val) { state_.classification().oos_debug = val; }
 void configure_engine::set_shuffle_sides(bool val) { parameters_.shuffle_sides = val; }
 void configure_engine::set_options(const config& cfg) { parameters_.options = cfg; }
 

--- a/src/game_initialization/configure_engine.hpp
+++ b/src/game_initialization/configure_engine.hpp
@@ -73,6 +73,7 @@ public:
 	void set_fog_game(bool val);
 	void set_shroud_game(bool val);
 	void set_allow_observers(bool val);
+	void set_oos_debug(bool val);
 	void set_shuffle_sides(bool val);
 	void set_options(const config& cfg);
 

--- a/src/game_initialization/connect_engine.cpp
+++ b/src/game_initialization/connect_engine.cpp
@@ -247,7 +247,7 @@ void connect_engine::import_user(const config& data, const bool observer,
 
 	// Check if user has a side(s) reserved for him.
 	BOOST_FOREACH(side_engine_ptr side, side_engines_) {
-		if (side->reserved_for() == username && side->player_id().empty()) {
+		if (side->reserved_for() == username && side->player_id().empty() && side->controller() != CNTR_COMPUTER) {
 			side->place_user(data);
 
 			side_assigned = true;
@@ -793,7 +793,7 @@ void connect_engine::load_previous_sides_users(LOAD_USERS load_users)
 		if (side_users.find(save_id) != side_users.end()) {
 			side->set_reserved_for(side_users[save_id]);
 
-			if (load_users == RESERVE_USERS) {
+			if (load_users == RESERVE_USERS && side->controller() != CNTR_COMPUTER) {
 				side->update_controller_options();
 				side->set_controller(CNTR_RESERVED);
 			} else if (load_users == FORCE_IMPORT_USERS) {

--- a/src/game_initialization/multiplayer_configure.cpp
+++ b/src/game_initialization/multiplayer_configure.cpp
@@ -80,6 +80,7 @@ configure::configure(game_display& disp, const config &cfg, chat& c, config& gam
 	fog_game_(disp.video(), _("Fog of war"), gui::button::TYPE_CHECK),
 	shroud_game_(disp.video(), _("Shroud"), gui::button::TYPE_CHECK),
 	observers_game_(disp.video(), _("Observers"), gui::button::TYPE_CHECK),
+	oos_debug_(disp.video(), _("Debug OOS"), gui::button::TYPE_CHECK),
 	shuffle_sides_(disp.video(), _("Shuffle sides"), gui::button::TYPE_CHECK),
 	cancel_game_(disp.video(), _("Back")),
 	launch_game_(disp.video(), _("OK")),
@@ -174,6 +175,10 @@ configure::configure(game_display& disp, const config &cfg, chat& c, config& gam
 	observers_game_.set_check(engine_.allow_observers_default());
 	observers_game_.set_help_string(_("Allow users who are not playing to watch the game"));
 	observers_game_.enable(state_.classification().campaign_type != game_classification::SCENARIO);
+
+	oos_debug_.set_check(false);
+	oos_debug_.set_help_string(_("More checks for OOS errors but also more network traffic"));
+	oos_debug_.enable(true);
 
 	shuffle_sides_.set_check(engine_.shuffle_sides_default());
 	shuffle_sides_.set_help_string(_("Assign sides to players at random"));
@@ -285,6 +290,7 @@ const mp_game_settings& configure::get_parameters()
 	engine_.set_fog_game(fog_game_.checked());
 	engine_.set_shroud_game(shroud_game_.checked());
 	engine_.set_allow_observers(observers_game_.checked());
+	engine_.set_oos_debug(oos_debug_.checked());
 	engine_.set_shuffle_sides(shuffle_sides_.checked());
 
 	engine_.set_options(options_manager_.get_values());
@@ -475,6 +481,7 @@ void configure::hide_children(bool hide)
 	fog_game_.hide(hide);
 	shroud_game_.hide(hide);
 	observers_game_.hide(hide);
+	oos_debug_.hide(hide);
 	shuffle_sides_.hide(hide);
 	cancel_game_.hide(hide);
 	launch_game_.hide(hide);
@@ -569,6 +576,9 @@ void configure::layout_children(const SDL_Rect& rect)
 	countdown_action_bonus_slider_.set_width(slider_width);
 	options_pane_left_.add_widget(&countdown_action_bonus_slider_, xpos_left, ypos_left);
 	ypos_left += countdown_action_bonus_slider_.height() + border_size;
+
+	options_pane_left_.add_widget(&oos_debug_, xpos_left, ypos_left	);
+	ypos_left += oos_debug_.height() + border_size;
 
 	if (show_entry_points_) {
 		int x = ca.x;

--- a/src/game_initialization/multiplayer_configure.hpp
+++ b/src/game_initialization/multiplayer_configure.hpp
@@ -77,6 +77,7 @@ private:
 	gui::button fog_game_;
 	gui::button shroud_game_;
 	gui::button observers_game_;
+	gui::button oos_debug_;
 	gui::button shuffle_sides_;
 	gui::button cancel_game_;
 	gui::button launch_game_;

--- a/src/synced_checkup.hpp
+++ b/src/synced_checkup.hpp
@@ -34,36 +34,23 @@ public:
 		returns whether the two config objects are equal.
 	*/
 	virtual bool local_checkup(const config& expected_data, config& real_data) = 0;
-	/**
-		compares data on all clients in a networked game, the disadvantage is,
-		that the clients have to communicate more which  might be not wanted if some persons have laggy inet.
-		returns whether the two config objects are equal.
-
-		This is currently not used.
-		This is currently not implemented.
-
-		TODO: we might want to change the design to have a 'local_checkup' subclass (the normal case)
-		and a 'networked_checkup' subclass (for network OOS debugging) of the checkup class that then replace
-		the synced_checkup class. Instead of having 2 different methods local_checkup,networked_checkup.
-	*/
-	virtual bool networked_checkup(const config& expected_data, config& real_data) = 0;
 };
 
+/**
+	This checkup compares whether the results calculated during the original game match the ones calculated during replay.
+	Whether this checkup also compares the calculated results of different clients in a a mp game depends on whether
+	there was already data sended about the current synced command.
+*/
 class synced_checkup : public checkup
 {
 public:
 	synced_checkup(config& buffer);
 	virtual ~synced_checkup();
 	virtual bool local_checkup(const config& expected_data, config& real_data);
-	virtual bool networked_checkup(const config& expected_data, config& real_data);
 private:
 	config& buffer_;
 	unsigned int  pos_;
 };
-
-/*
-	the only purpose of these function isto thro OOS erros, because they should never be called.
-*/
 
 class ignored_checkup : public checkup
 {
@@ -74,10 +61,16 @@ public:
 		always returns true
 	*/
 	virtual bool local_checkup(const config& expected_data, config& real_data);
-	/**
-		always returns true
-	*/
-	virtual bool networked_checkup(const config& expected_data, config& real_data);
+};
+/**
+	This checkup always compares the results in from different clients in a mp game but it also causes more network overhead.
+*/
+class mp_debug_checkup : public checkup
+{
+public:
+	mp_debug_checkup();
+	virtual ~mp_debug_checkup();
+	virtual bool local_checkup(const config& expected_data, config& real_data);
 };
 
 /*

--- a/src/synced_context.hpp
+++ b/src/synced_context.hpp
@@ -23,6 +23,7 @@
 #include "generic_event.hpp"
 #include "mouse_handler_base.hpp"
 #include <boost/shared_ptr.hpp>
+#include <boost/scoped_ptr.hpp>
 class config;
 
 //only static methods.
@@ -145,10 +146,11 @@ public:
 private:
 	//only called by contructors.
 	void init();
+	static checkup* generate_checkup(const std::string& tagname);
 	random_new::rng* old_rng_;
 	boost::shared_ptr<random_new::rng> new_rng_;
 	checkup* old_checkup_;
-	synced_checkup new_checkup_;
+	boost::scoped_ptr<checkup> new_checkup_;
 	events::command_disabler disabler_;
 };
 


### PR DESCRIPTION
the game sometimes does some checkup to test whether the calculated results in a replay match the ones calculated during the original game.
This data was stored in the replay inside the [command] for that action. The problem is that this doesn't work in networked mp because we often send the [command] before calculating the results.
I added an alternative mode that used get_user_choice to compare the results, this also works in networked mp but it causes a little more network traffic.