### PR TITLE
Allow [message] image= to have 'none' as a value

### DIFF
--- a/src/game_events/action_wml.cpp
+++ b/src/game_events/action_wml.cpp
@@ -311,6 +311,11 @@ namespace { // Support functions
 	std::string get_image(const vconfig& cfg, unit_map::iterator speaker)
 	{
 		std::string image = cfg["image"];
+
+		if (image == "none") {
+			return "";
+		}
+
 		if (image.empty() && speaker != resources::units->end())
 		{
 			image = speaker->big_profile();


### PR DESCRIPTION
This eliminates the need for image=misc/blank-hex.png

NOTE: Currently, you CAN just leave out the image= key when you use [message], and this
produces the same behavior, but wmllint complains about that, so there must have been some
reason to always use an image= key.

Shadowm suggested this method was a better solution than having it directly in gui2::twml_message.
