### PR TITLE
add [sync_variable] tag

### DIFF
--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -78,6 +78,41 @@ end
 
 local engine_message = wml_actions.message
 
+function wml_actions.sync_variable(cfg)
+	local names = cfg.name or helper.wml_error "[sync_variable] missing required name= attribute."
+	local result = wesnoth.synchronize_choice(
+		function()
+			local res = {}
+			for name_raw in split(names) do
+				local name = trim(name_raw)
+				local content = wesnoth.get_variable(name)
+				if type(content) == "table" then
+					table.insert(res, { "variable",  {
+						name = trim(name),
+						{ "value",  {content }}
+					}})
+				else
+					table.insert(res, { "variable", {
+						name = trim(name),
+						value = content
+					}})
+				end
+			end
+			return res
+		end
+	)
+	for index, variable in ipairs(result) do
+		local name = variable[2].name
+		if variable[2][1] ~= nil then
+			-- a table variable
+			wesnoth.set_variable(name, variable[2][1][2])
+		else
+			-- a scalar variable
+			wesnoth.set_variable(name, variable[2].value)
+		end
+	end
+end
+
 function wml_actions.message(cfg)
 	local show_if = helper.get_child(cfg, "show_if")
 	if not show_if or wesnoth.eval_conditional(show_if) then


### PR DESCRIPTION
used as 
```
[sync_variable]
	name=my_variable
[/sync_variable]
```
it sets my_variable to the same value as on all clients, it uses the value from the currently active side.

The main intention is to replace needs_select=yes for wml menu items somewhen because needs_select is slightly bugged: needs_select=yes causes the event to be fired again when the wml menu item is triggered so the select event it fired 2 times in total on the currently active client.
The most common usecase of needs_select are wml menus like this:

```
[event]
	name=start
	[set_menu_item]
		id=move_unit
		description= _ "Move!"
		image=buttons/WML-custom.png
		needs_select=yes
		[command]
			{MOVE_UNIT x,y=$moving_unit_x,$moving_unit_y $x1 $y1}
			{VARIABLE moving_unit_x $x1}
			{VARIABLE moving_unit_y $y1}
		[/command]
	[/set_menu_item]
[/event]
 
[event]
	name=select
	first_time_only=no
	{VARIABLE moving_unit_x $unit.x}
	{VARIABLE moving_unit_y $unit.y}
[/event]
```
With the new tags it now not much harder to do it woithout needs_select:
```

[event]
	name=start
	[set_menu_item]
		id=move_unit
		description= _ "Move!"
		image=buttons/WML-custom.png
		[command]
			[sync_variable]
				name=moving_unit_x,moving_unit_y
			[sync_variable]
			{MOVE_UNIT x,y=$moving_unit_x,$moving_unit_y $x1 $y1}
			{VARIABLE moving_unit_x $x1}
			{VARIABLE moving_unit_y $y1}
		[/command]
	[/set_menu_item]
[/event]
 
[event]
	name=select
	first_time_only=no
	{VARIABLE moving_unit_x $unit.x}
	{VARIABLE moving_unit_y $unit.y}
[/event]
```

Unrelated to this specific usecase, Ravana suggested to add this tag to core.
Also note that it's currently possible to archieve similar behaviour with wml by using set_global_variable and get_global_variable in the same event.