### PR TITLE
NR S5a: Minor textual edits

### DIFF
--- a/data/campaigns/Northern_Rebirth/scenarios/05a_The_Pursuit.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/05a_The_Pursuit.cfg
@@ -456,7 +456,7 @@
 
         [message]
             speaker=Tallin
-            message= _ "We won’t leave them in Malifor's chains!"
+            message= _ "We won’t leave them in Malifor’s chains!"
         [/message]
 
         [allow_undo][/allow_undo]
@@ -1984,12 +1984,12 @@
 
         [message]
             speaker=Tallin
-            message= _ "Can you tell us where he is? And, if I may ask, who are - or rather, were - you?"
+            message= _ "Can you tell us where he is? And, if I may ask, who are — or rather, were — you?"
         [/message]
 
         [message]
             speaker=Abhai
-            message= _ "My name is Lord Abhai and I am... or was... the ruler of a great kingdom far to the west. In time, as all men do, I grew old and passed to the land of the dead. I know not how long I dwelt there, before I was wrenched from my peace and drawn into this rhelm by a terrible power."
+            message= _ "I am Lord Abhai, the ruler... once... of a great kingdom far to the west. In time, as all men do, I grew old and passed to the Land of the Dead. I know not how long I dwelt there, before I was wrenched from my peace and drawn into this realm by a terrible power."
         [/message]
 
         [message]
@@ -1999,12 +1999,12 @@
 
         [message]
             speaker=Abhai
-            message= _ "Indeed. He was once a great sorcerer, but he coveted wealth and power. TO gain his ends, he allied himself with the Lich Lords, and from them he learned their craft. When the orcish menace first appeared on the continent and the Wesfolk fled to the east, Malifor left their service and followed. No word surfaced of his fate from then on, but it seems he turned himself into a lich himself. I am not surprised he took up residence in these mines, all these years later; he always had a love of gold, and a special hatred of me. He tried to break me into mindless slavery, but I resisted his power and fled. I have been hiding in these flooded tunnels ever since. Some monster that Malifor’s minions greatly fear lives in these waters; they do not molest me here."
+            message= _ "Indeed. He was once a great sorcerer, but he coveted wealth and power. To gain his ends, he allied himself with the Lich-Lords, and from them he learned their craft. When the orcish menace first appeared on the continent and the Wesfolk fled to the east, Malifor left their service and followed the Wesfolk. No word surfaced of his fate from then on, but it seems he became a lich himself. I am not surprised he took up residence in these mines, all these years later — he always had a love of gold, and a special hatred of me. He tried to break me into mindless slavery, but I resisted his power and fled. I have been hiding in these flooded tunnels ever since. Some monster that Malifor’s minions greatly fear lives in these waters; they do not molest me here."
         [/message]
 
         [message]
             speaker=Tallin
-            message= _ "I am afraid times have changed much. Our first king, Haldric the First, fled from the Green Isle with the Wesfolk and the ocs in pursuit. He came ashore on this land that we now call the Great Continent and destroyed the Lich Lord Jevyan before founding the kingdom of Wesnoth. That was centuries ago."
+            message= _ "I am afraid times have changed much. Our first king, Haldric I, fled from the Green Isle with the Wesfolk and the orcs in pursuit. He came ashore on this land that we now call the Great Continent and destroyed the Lich-Lord Jevyan before founding the Kingdom of Wesnoth. That was centuries ago."
         [/message]
 
         [message]
@@ -2045,7 +2045,7 @@
 
         [message]
             speaker=unit
-            message= _ "Ugh, a corpse. And it - (<i>gags</i>) - reeks!"
+            message= _ "Ugh, a corpse. And it — (<i>gags</i>) — reeks!"
         [/message]
     [/event]
 
@@ -2162,7 +2162,7 @@
                     [message]
                         speaker=narrator
                         image=none
-                        message= _ "With a grating sound, the false wall slides away to reveal Malifor's study."
+                        message= _ "With a grating sound, the false wall slides away to reveal Malifor’s study."
                     [/message]
 
                     [terrain]


### PR DESCRIPTION
This commit makes some minor (non-semantic) textual edits in the
mainline campaign "Northern Rebirth"’s scenario 5a, "The
Pursuit", mostly miscellaneous edits for correctness or clarity.

As far as edits that might need explanation:

  - The change of “Lich Lord(s)” to “Lich-Lord(s)” matches
    usage in the mainline campaign "The Rise of Wesnoth".

  - The change of “the land of the dead” to “the Land of the
    Dead” matches usage in the mainline campaign "Delfador’s
    Memoirs".

  - The “I am Lord Abhai” change is because “Lord Abhai” isn’t a
    *name* exactly.

r? @Vultraz