### PR TITLE
fix bug #22984: sliders not adjustable with arrow keys

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -840,7 +840,7 @@ gui::button* display::find_menu_button(const std::string& id)
 	return NULL;
 }
 
-gui::slider* display::find_slider(const std::string& id)
+gui::zoom_slider* display::find_slider(const std::string& id)
 {
 	for (size_t i = 0; i < sliders_.size(); ++i) {
 		if(sliders_[i].id() == id) {
@@ -854,12 +854,12 @@ void display::create_buttons()
 {
 	std::vector<gui::button> menu_work;
 	std::vector<gui::button> action_work;
-	std::vector<gui::slider> slider_work;
+	std::vector<gui::zoom_slider> slider_work;
 
 	DBG_DP << "creating sliders...\n";
 	const std::vector<theme::slider>& sliders = theme_.sliders();
 	for(std::vector<theme::slider>::const_iterator i = sliders.begin(); i != sliders.end(); ++i) {
-		gui::slider s(screen_, i->image(), i->black_line());
+		gui::zoom_slider s(screen_, i->image(), i->black_line());
 		DBG_DP << "drawing button " << i->get_id() << "\n";
 		s.set_id(i->get_id());
 		const SDL_Rect& loc = i->location(screen_area());
@@ -875,7 +875,7 @@ void display::create_buttons()
 			s.set_volatile(true);
 		}
 
-		gui::slider* s_prev = find_slider(s.id());
+		gui::zoom_slider* s_prev = find_slider(s.id());
 		if(s_prev) {
 			s.set_max(s_prev->max_value());
 			s.set_min(s_prev->min_value());

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -399,7 +399,7 @@ public:
 	 */
 	gui::button* find_action_button(const std::string& id);
 	gui::button* find_menu_button(const std::string& id);
-	gui::slider* find_slider(const std::string& id);
+	gui::zoom_slider* find_slider(const std::string& id);
 
 	gui::button::TYPE string_to_button_type(std::string type);
 	void create_buttons();
@@ -807,7 +807,7 @@ protected:
 #endif
 	std::map<std::string, config> reports_;
 	std::vector<gui::button> menu_buttons_, action_buttons_;
-	std::vector<gui::slider> sliders_;
+	std::vector<gui::zoom_slider> sliders_;
 	std::set<map_location> invalidated_;
 	std::set<map_location> previous_invalidated_;
 #ifdef SDL_GPU

--- a/src/widgets/slider.cpp
+++ b/src/widgets/slider.cpp
@@ -242,11 +242,11 @@ void slider::mouse_down(const SDL_MouseButtonEvent& event)
 		return;
 
 	state_ = CLICKED;
+	set_focus(true);
 	if (sdl::point_in_rect(event.x, event.y, slider_area())) {
 		sound::play_UI_sound(game_config::sounds::button_press);
 	} else {
 		value_change_ = false;
-		set_focus(true);
 		set_slider_position(event.x);
 		if(value_change_) {
 			sound::play_UI_sound(game_config::sounds::slider_adjust);
@@ -335,19 +335,19 @@ void slider::handle_event(const SDL_Event& event)
 			mouse_motion(event.motion);
 		break;
 		//TODO enable if you know how to fix the zoom slider bug
-//	case SDL_KEYDOWN:
-//		if(focus(&event)) {
-//			const SDL_keysym& key = reinterpret_cast<const SDL_KeyboardEvent&>(event).keysym;
-//			const int c = key.sym;
-//			if(c == SDLK_LEFT) {
-//				sound::play_UI_sound(game_config::sounds::slider_adjust);
-//				set_value(value_ - increment_);
-//			} else if(c == SDLK_RIGHT) {
-//				sound::play_UI_sound(game_config::sounds::slider_adjust);
-//				set_value(value_ + increment_);
-//			}
-//		}
-//		break;
+	case SDL_KEYDOWN:
+		if(focus(&event)) {
+			const SDL_keysym& key = reinterpret_cast<const SDL_KeyboardEvent&>(event).keysym;
+			const int c = key.sym;
+			if(c == SDLK_LEFT) {
+				sound::play_UI_sound(game_config::sounds::slider_adjust);
+				set_value(value_ - increment_);
+			} else if(c == SDLK_RIGHT) {
+				sound::play_UI_sound(game_config::sounds::slider_adjust);
+				set_value(value_ + increment_);
+			}
+		}
+		break;
 #if SDL_VERSION_ATLEAST(2,0,0)
 	case SDL_MOUSEWHEEL:
 		if (!mouse_locked())

--- a/src/widgets/slider.cpp
+++ b/src/widgets/slider.cpp
@@ -334,9 +334,8 @@ void slider::handle_event(const SDL_Event& event)
 		if (!mouse_locked())
 			mouse_motion(event.motion);
 		break;
-		//TODO enable if you know how to fix the zoom slider bug
 	case SDL_KEYDOWN:
-		if(focus(&event)) {
+		if(focus(&event) && allow_key_events()) { //allow_key_events is used by zoom_sliders to disable left-right key press, which is buggy for them
 			const SDL_keysym& key = reinterpret_cast<const SDL_KeyboardEvent&>(event).keysym;
 			const int c = key.sym;
 			if(c == SDLK_LEFT) {
@@ -419,5 +418,16 @@ void list_slider<T>::set_items(const std::vector<T> &items)
 template class list_slider< double >;
 template class list_slider< int >;
 template class list_slider< std::string >;
+
+/***
+*
+* Zoom Slider
+*
+***/
+
+zoom_slider::zoom_slider(CVideo &video, const std::string& image, bool black)
+	: slider(video, image, black)
+{
+}
 
 } //end namespace gui

--- a/src/widgets/slider.hpp
+++ b/src/widgets/slider.hpp
@@ -51,6 +51,7 @@ protected:
 	bool requires_event_focus(const SDL_Event *event=NULL) const;
 	virtual void handle_event(const SDL_Event& event);
 	virtual void draw_contents();
+	virtual bool allow_key_events() { return true; }
 
 private:
 	void mouse_motion(const SDL_MouseMotionEvent& event);
@@ -86,6 +87,14 @@ class list_slider : public slider
 		const T& item_selected() const; //use item_selected() instead of value()
 	private:
 		std::vector<T> items_;
+};
+
+// This is a different style of slider, which doesn't implement key left/right responses
+class zoom_slider : public slider
+{
+public:
+	zoom_slider(CVideo &video, const std::string& image = "buttons/sliders/slider", bool black = false);
+	virtual bool allow_key_events() { return false; }
 };
 
 }


### PR DESCRIPTION
This commit causes sliders to attract focus properly when their
grips are clicked on, and to respond to left and right arrow
presses again. It partly reverts two earlier commits that
affected this functionality.

cf84e1d8aae84b76e7e9adc15847089bdc940632
49614599fa5211e0bc3fdba43c6255509da66022

It causes the zoom slider to behave slightly badly, because it
does not lose focus when the user clicks elsewhere on the map.
But this bug should be fixed at the source and not by disabling
wanted functionality for all sliders.