### PR TITLE
fixup server controller tweaks, dont tweak host

### DIFF
--- a/src/server/game.cpp
+++ b/src/server/game.cpp
@@ -201,7 +201,17 @@ void game::perform_controller_tweaks() {
 				user_name = username(user);
 			}
 
-			change_controller(side_index, sides_[side_index], user_name , false, (**s)["controller"].to_string());
+			// Issue change_controller command, transfering this side to its owner with proper name and controller.
+			// Ensures that what the server now thinks is true is effected on all of the clients.
+			//
+			// We use the "player_left" field as follows. Normally change_controller sends one message to the owner,
+			// and one message to everyone else. In case that a player drops, the owner is gone and should not get
+			// a message, instead the host gets a [side_drop] message.
+			//
+			// In the server controller tweaks, we want to avoid sending controller change messages to the host.
+			// Doing this has the negative consequence that all of the AI side names are given the owners name.
+			// Therefore, if the side belongs to the host, we pass player_left = true, otherwise player_left = false.
+			change_controller(side_index, sides_[side_index], user_name , sides_[side_index] == owner_, (**s)["controller"].to_string());
 
 			//next lines change controller types found in level_ to be what is appropriate for an observer at game start.
 			if ((**s)["controller"] == "ai") {


### PR DESCRIPTION
In 1.11.x cycle, we moved all "client-side controller tweaks" to
be effected by the server, so that clients won't on their own
change the data they find in a level config at game start. This
had some benefits:
- Only host and server are ever modifying the level data
- Easier to keep observers and clients synced correctly
- Easier to change client behavior with server side patches

The server-sided tweaks happened at the following point in time:
1. Host clicks start game button, a [start] signal is sent to
server.
2. Server now checks the level config and tries to make sense of
it, making sure every side has an owner and such. Then it issues
controller change commands to all clients, making sure they match
its picture of what is going on.
3. Server passes the [start] signal on to the other clients.

This introduced some bad behaviors, however, because the host
does not wait to recieve [start] and instead goes right into the
game.

- When host gets controller change signals for AIs it controls, it
would overwrite the names of their leaders with the host names.
(bug #23021)
- It would cause some GUI flashing at game start for the host
(bug #21156)

In this commit, we make sure not to send controller tweak messages
to the host about sides that it controls.

We still may send messages to the host about sides it doesn't
control. If there is the possibility that a game may start and
an AI side is assigned to someone other than the host, then this
commit won't fix the resulting renaming problems. (However afaik
that cannot happen at this revision.)

Conflicts:
	src/server/game.cpp