### PR TITLE
New ImagePathWML functions: ~SEPIA() and ~NEG()

### DIFF
--- a/src/image_modifications.cpp
+++ b/src/image_modifications.cpp
@@ -205,6 +205,11 @@ surface sepia_modification::operator()(const surface &src) const
 	return sepia_image(src);
 }
 
+surface negative_modification::operator()(const surface &src) const
+{
+	return negative_image(src);
+}
+
 surface plot_alpha_modification::operator()(const surface& src) const
 {
 	return alpha_to_greyscale(src);
@@ -753,6 +758,12 @@ REGISTER_MOD_PARSER(GS, )
 REGISTER_MOD_PARSER(SEPIA, )
 {
 	return new sepia_modification;
+}
+
+// Negative
+REGISTER_MOD_PARSER(NEG, )
+{
+	return new negative_modification;
 }
 
 // Plot Alpha

--- a/src/image_modifications.cpp
+++ b/src/image_modifications.cpp
@@ -200,6 +200,11 @@ surface gs_modification::operator()(const surface& src) const
 	return greyscale_image(src);
 }
 
+surface sepia_modification::operator()(const surface &src) const
+{
+	return sepia_image(src);
+}
+
 surface plot_alpha_modification::operator()(const surface& src) const
 {
 	return alpha_to_greyscale(src);
@@ -742,6 +747,12 @@ REGISTER_MOD_PARSER(ROTATE, args)
 REGISTER_MOD_PARSER(GS, )
 {
 	return new gs_modification;
+}
+
+// Sepia
+REGISTER_MOD_PARSER(SEPIA, )
+{
+	return new sepia_modification;
 }
 
 // Plot Alpha

--- a/src/image_modifications.hpp
+++ b/src/image_modifications.hpp
@@ -230,6 +230,14 @@ struct sepia_modification : modification
 };
 
 /**
+ * Make an image negative (NEG)
+ */
+struct negative_modification : modification
+{
+	virtual surface operator()(const surface &src) const;
+};
+
+/**
  * Plot Alpha (Alpha) modification
  */
 class plot_alpha_modification : public modification

--- a/src/image_modifications.hpp
+++ b/src/image_modifications.hpp
@@ -222,6 +222,14 @@ public:
 };
 
 /**
+ * Give to the image a sepia tint (SEPIA)
+ */
+struct sepia_modification : modification
+{
+	virtual surface operator()(const surface &src) const;
+};
+
+/**
  * Plot Alpha (Alpha) modification
  */
 class plot_alpha_modification : public modification

--- a/src/sdl/utils.cpp
+++ b/src/sdl/utils.cpp
@@ -1031,6 +1031,43 @@ surface sepia_image(const surface &surf, bool optimize)
 	return optimize ? create_optimized_surface(nsurf) : nsurf;
 }
 
+surface negative_image(const surface &surf, bool optimize)
+{
+	if(surf == NULL)
+		return NULL;
+
+	surface nsurf(make_neutral_surface(surf));
+	if(nsurf == NULL) {
+		std::cerr << "failed to make neutral surface\n";
+		return NULL;
+	}
+
+	{
+		surface_lock lock(nsurf);
+		Uint32* beg = lock.pixels();
+		Uint32* end = beg + nsurf->w*surf->h;
+
+		while(beg != end) {
+			Uint8 alpha = (*beg) >> 24;
+
+			if(alpha) {
+				Uint8 r, g, b;
+				r = (*beg) >> 16;
+				g = (*beg) >> 8;
+				b = (*beg);
+
+				// basically, to get a channel's negative it's enough
+				// to subtract its value from 255
+				*beg = (alpha << 24) | ((255 - r) << 16) | ((255 - g) << 8) | (255 - b);
+			}
+
+			++beg;
+		}
+	}
+
+	return optimize ? create_optimized_surface(nsurf) : nsurf;
+}
+
 surface alpha_to_greyscale(const surface &surf, bool optimize)
 {
 	if(surf == NULL)

--- a/src/sdl/utils.hpp
+++ b/src/sdl/utils.hpp
@@ -247,6 +247,7 @@ surface tile_surface(const surface &surf, int w, int h, bool optimize=true);
 surface adjust_surface_color(const surface &surf, int r, int g, int b, bool optimize=true);
 surface greyscale_image(const surface &surf, bool optimize=true);
 surface sepia_image(const surface &surf, bool optimize=true);
+surface negative_image(const surface &surf, bool optimize=true);
 surface alpha_to_greyscale(const surface & surf, bool optimize=true);
 surface wipe_alpha(const surface & surf, bool optimize=true);
 /** create an heavy shadow of the image, by blurring, increasing alpha and darkening */

--- a/src/sdl/utils.hpp
+++ b/src/sdl/utils.hpp
@@ -246,6 +246,7 @@ surface tile_surface(const surface &surf, int w, int h, bool optimize=true);
 
 surface adjust_surface_color(const surface &surf, int r, int g, int b, bool optimize=true);
 surface greyscale_image(const surface &surf, bool optimize=true);
+surface sepia_image(const surface &surf, bool optimize=true);
 surface alpha_to_greyscale(const surface & surf, bool optimize=true);
 surface wipe_alpha(const surface & surf, bool optimize=true);
 /** create an heavy shadow of the image, by blurring, increasing alpha and darkening */


### PR DESCRIPTION
This PR adds two new ImagePath functions.
The first one is called **~SEPIA**, and adds a sepia tone to the image. When applied to the portrait of an Elvish Captain, for example, this is the result:
![screenshot sepia](https://cloud.githubusercontent.com/assets/4049668/6598684/9cf936b6-c805-11e4-9767-19f1fd73dc0b.jpg)
The second one is called **~NEG** (short for *negative*), and makes an image negative. When applied to the same portrait, this is the result:
![screenshot negative](https://cloud.githubusercontent.com/assets/4049668/6598719/dc540462-c805-11e4-93c5-48fec3b834a8.jpg)
None of these two functions accepts additional arguments.
