### PR TITLE
allow putting units on recall list for nonpersistent sides

### DIFF
--- a/src/actions/undo.cpp
+++ b/src/actions/undo.cpp
@@ -678,12 +678,6 @@ bool undo_list::dismiss_action::undo(int side, undo_list & /*undos*/)
 {
 	team &current_team = (*resources::teams)[side-1];
 
-	if ( !current_team.persistent() ) {
-		ERR_NG << "Trying to undo a dismissal for side " << side
-			<< ", which has no recall list!\n";
-		return false;
-	}
-
 	current_team.recall_list().add(dismissed_unit);
 	return true;
 }
@@ -697,12 +691,6 @@ bool undo_list::recall_action::undo(int side, undo_list & /*undos*/)
 	game_display & gui = *resources::screen;
 	unit_map &   units = *resources::units;
 	team &current_team = (*resources::teams)[side-1];
-
-	if ( !current_team.persistent() ) {
-		ERR_NG << "Trying to undo a recall for side " << side
-			<< ", which has no recall list!\n";
-		return false;
-	}
 
 	const map_location & recall_loc = route.front();
 	unit_map::iterator un_it = units.find(recall_loc);
@@ -893,11 +881,6 @@ bool undo_list::dismiss_action::redo(int side)
 {
 	team &current_team = (*resources::teams)[side-1];
 
-	if ( !current_team.persistent() ) {
-		ERR_NG << "Trying to redo a dismissal for side " << side
-			<< ", which has no recall list!\n";
-		return false;
-	}
 	resources::recorder->redo(replay_data);
 	replay_data.clear();
 	current_team.recall_list().erase_if_matches_id(dismissed_unit->id());
@@ -912,12 +895,6 @@ bool undo_list::recall_action::redo(int side)
 {
 	game_display & gui = *resources::screen;
 	team &current_team = (*resources::teams)[side-1];
-
-	if ( !current_team.persistent() ) {
-		ERR_NG << "Trying to redo a recall for side " << side
-			<< ", which has no recall list!\n";
-		return false;
-	}
 
 	map_location loc = route.front();
 	map_location from = recall_from;

--- a/src/ai/contexts.cpp
+++ b/src/ai/contexts.cpp
@@ -802,12 +802,7 @@ const moves_map& readonly_context_impl::get_possible_moves() const
 
 const std::vector<unit_ptr>& readonly_context_impl::get_recall_list() const
 {
-	static std::vector<unit_ptr> dummy_units;
 	///@todo 1.9: check for (level_["disallow_recall"]))
-	if(!current_team().persistent()) {
-		return dummy_units;
-	}
-
 	return current_team().recall_list().recall_list_; //TODO: Refactor ai so that friend of ai context is not required of recall_list_manager at this line
 }
 

--- a/src/game_board.cpp
+++ b/src/game_board.cpp
@@ -239,16 +239,10 @@ bool game_board::team_is_defeated(const team& t) const
 	}
 }
 
-bool game_board::try_add_unit_to_recall_list(const map_location& loc, const unit_ptr u)
+bool game_board::try_add_unit_to_recall_list(const map_location&, const unit_ptr u)
 {
-	if(teams_[u->side()-1].persistent()) {
-		teams_[u->side()-1].recall_list().add(u);
-		return true;
-	} else {
-		ERR_RG << "unit with id " << u->id() << ": location (" << loc.x << "," << loc.y <<") is not on the map, and player "
-			<< u->side() << " has no recall list.\n";
-		return false;
-	}
+	teams_[u->side()-1].recall_list().add(u);
+	return true;
 }
 
 

--- a/src/game_events/action_wml.cpp
+++ b/src/game_events/action_wml.cpp
@@ -1829,8 +1829,6 @@ WML_HANDLER_FUNCTION(unstore_unit, /*event_info*/, cfg)
 
 			team& t = (*resources::teams)[u->side()-1];
 
-			if(t.persistent()) {
-
 				// Test whether the recall list has duplicates if so warn.
 				// This might be removed at some point but the uniqueness of
 				// the description is needed to avoid the recall duplication
@@ -1866,10 +1864,6 @@ WML_HANDLER_FUNCTION(unstore_unit, /*event_info*/, cfg)
 						<< u->underlying_id() << "' on the recall list\n";
 				}
 				t.recall_list().add(u);
-			} else {
-				ERR_NG << "Cannot unstore unit: recall list is empty for player " << u->side()
-					<< " and the map location is invalid.\n";
-			}
 		}
 
 		// If we unstore a leader make sure the team gets a leader if not the loading

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -677,11 +677,6 @@ void menu_handler::recall(int side_num, const map_location &last_hex)
 	}
 
 	team &current_team = teams()[side_num - 1];
-	if(!current_team.persistent()) {
-		ERR_NG << "cannot recall a unit for side " << side_num
-			<< ", which has no recall list!\n";
-		return;
-	}
 
 	boost::shared_ptr<std::vector<unit_const_ptr > > recall_list_team = boost::make_shared<std::vector<unit_const_ptr> >();
 	{ wb::future_map future; // ensures recall list has planned recalls removed

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -2174,9 +2174,6 @@ int game_lua_kernel::intf_put_recall_unit(lua_State *L)
 
 	if (!side) side = u->side();
 	team &t = teams()[side - 1];
-	if (!t.persistent())
-		return luaL_argerror(L, 2, "nonpersistent side");
-
 	// Avoid duplicates in the recall list.
 	size_t uid = u->underlying_id();
 	t.recall_list().erase_by_underlying_id(uid);


### PR DESCRIPTION
persistent=no does not imply that the side does not have a recall list:
1) persisent=no did prevent units from this scenario to be carried over
to a next scenario but it did not prevent units from a previous scenario
to be carried over to this scenario.
2) [unit] in [side] and [unit] in action wml can give recall units to
nonpersistent sides.
3) The wiki does not mention that a side with persistent=no cannot have
recall units.

So i removed checks for [side]persistent= so that [unstore_unit] and
wesnoth.put_recall_unit can put units to the recall list and also tidied
up some other code that assumed sides with persistent=no to not have a
recall list.