### PR TITLE
Bug Fix #23117: Invert breaks lobby filtering if Apply Filter is off.

### DIFF
--- a/changelog
+++ b/changelog
@@ -527,6 +527,7 @@ Version 1.13.0-dev:
      defeat_condition set to no_units_left or never couldn't capture villages
    * Fixed several Mac OS specific bugs in GUI.pyw
    * Fixed bug 22987 for filtering on era and mods in the Multiplayer lobby.
+   * Fixed bug 23117 Invert breaks lobby filtering if Apply Filter is off.
 
 Version 1.11.11:
  * Add-ons server:

--- a/src/game_initialization/multiplayer_lobby.cpp
+++ b/src/game_initialization/multiplayer_lobby.cpp
@@ -854,9 +854,10 @@ void gamebrowser::set_game_items(const config& cfg, const config& game_config, c
 		games_.push_back(game_item());
 		populate_game_item(games_.back(), game, game_config, installed_addons);
 		// Hack...
-		if(preferences::fi_invert() ? game_matches_filter(games_.back(), cfg) : !game_matches_filter(games_.back(), cfg))
+		if (preferences::filter_lobby())
 		{
-			if (preferences::filter_lobby())
+			if(preferences::fi_invert() ? game_matches_filter(games_.back(), cfg) :
+ 			  !game_matches_filter(games_.back(), cfg))
 			{
 				games_.pop_back();
 			}
@@ -905,10 +906,6 @@ void gamebrowser::select_game(const std::string& id) {
 
 bool gamebrowser::game_matches_filter(const game_item& i, const config& cfg)
 {
-
-	if(!preferences::filter_lobby()) {
-		return true;
-	}
 	if(preferences::fi_vacant_slots() && i.vacant_slots == 0) {
 		return false;
 	}

--- a/src/game_initialization/multiplayer_lobby.cpp
+++ b/src/game_initialization/multiplayer_lobby.cpp
@@ -854,7 +854,13 @@ void gamebrowser::set_game_items(const config& cfg, const config& game_config, c
 		games_.push_back(game_item());
 		populate_game_item(games_.back(), game, game_config, installed_addons);
 		// Hack...
-		if(preferences::fi_invert() ? game_matches_filter(games_.back(), cfg) : !game_matches_filter(games_.back(), cfg)) games_.pop_back();
+		if(preferences::fi_invert() ? game_matches_filter(games_.back(), cfg) : !game_matches_filter(games_.back(), cfg))
+		{
+			if (preferences::filter_lobby())
+			{
+				games_.pop_back();
+			}
+		}
 	}
 	set_full_size(games_.size());
 	set_shown_size(inner_location().h / row_height());


### PR DESCRIPTION
Only pop games off the list if the apply filter box is checked.