### PR TITLE
add wesnoth.advane_unit lua function

### DIFF
--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -1099,9 +1099,7 @@ function wml_actions.transform_unit(cfg)
 			local status = helper.get_child( unit.__cfg, "status" )
 
 			unit.experience = unit.max_experience
-			wml_actions.store_unit { { "filter", { id = unit.id } }, variable = "Lua_store_unit", kill = true }
-			wml_actions.unstore_unit { variable = "Lua_store_unit", find_vacant = false, advance = true, fire_event = false, animate = false }
-			wesnoth.set_variable ( "Lua_store_unit")
+			wml_actions.advance_unit(unit, false, false)
 
 			unit.hitpoints = hitpoints
 			unit.experience = experience

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -3006,6 +3006,27 @@ static int intf_add_modification(lua_State *L)
 }
 
 /**
+ * Advances a unit if the unit has enough xp.
+ * - Arg 1: unit.
+ * - Arg 2: optional boolean whether to animate the advancement.
+ * - Arg 3: optional boolean whether to fire advancement events.
+ */
+static int intf_advance_unit(lua_State *L)
+{
+	unit_ptr u = luaW_checkunit(L, 1, true);
+	advance_unit_params par(u->get_location());
+	if(lua_isboolean(L, 2)) {
+		par.animate(luaW_toboolean(L, 2));
+	}
+	if(lua_isboolean(L, 3)) {
+		par.fire_events(luaW_toboolean(L, 3));
+	}
+	advance_unit_at(par);
+	return 0;
+}
+
+
+/**
  * Adds a new known unit type to the help system.
  * - Arg 1: string.
  */
@@ -3715,6 +3736,7 @@ game_lua_kernel::game_lua_kernel(const config &cfg, CVideo * video, game_state &
 	static luaL_Reg const callbacks[] = {
 		{ "add_known_unit",           &intf_add_known_unit           },
 		{ "add_modification",         &intf_add_modification         },
+		{ "advance_unit",             &intf_advance_unit             },
 		{ "copy_unit",                &intf_copy_unit                },
 		{ "create_unit",              &intf_create_unit              },
 		{ "debug",                    &intf_debug                    },


### PR DESCRIPTION
previously this was only possible by storing the unit and then unstoring
with advance=yes. Unstoring a unit can cause a lot of overhead if the
unit is complicated. so i added a way to do it without [unstore_unit]