### PR TITLE
Revert "don't reload config when selecing campaigns"

### DIFF
--- a/src/game_initialization/create_engine.cpp
+++ b/src/game_initialization/create_engine.cpp
@@ -418,9 +418,11 @@ create_engine::create_engine(game_display& disp, saved_game& state) :
 	state_.mp_settings().show_configure = configure;
 	state_.mp_settings().show_connect = connect;
 
-	if (type == game_classification::MULTIPLAYER)
+	if (!(type == game_classification::SCENARIO &&
+			game_config_manager::get()->old_defines_map().count("TITLE_SCREEN") != 0))
 	{
-		game_config_manager::get()->load_game_config_for_game(state_.classification());
+		game_config_manager::get()->
+			load_game_config_for_game(state_.classification());
 	}
 
 	//TODO the editor dir is already configurable, is the preferences value


### PR DESCRIPTION
This reverts commit 61a8de3d946487abe3e1826a476666e23fd01053.

This fixes https://gna.org/bugs/?23399 but not in the way i'd like to have it fixed. still this should be merged before 1.13.0 release (onless teh bug is fixed otherwise)