### PR TITLE
Enable tree_view gui2 widget for lua

### DIFF
--- a/src/gui/widgets/tree_view.hpp
+++ b/src/gui/widgets/tree_view.hpp
@@ -76,7 +76,7 @@ public:
 		return selected_item_;
 	}
 
-	void set_selection_change_callback(boost::function<void()> callback)
+	void set_selection_change_callback(boost::function<void(twidget&)> callback)
 	{
 		selection_change_callback_ = callback;
 	}
@@ -113,7 +113,7 @@ private:
 
 	ttree_view_node* selected_item_;
 
-	boost::function<void()> selection_change_callback_;
+	boost::function<void(twidget&)> selection_change_callback_;
 
 	/**
 	 * Resizes the content.

--- a/src/gui/widgets/tree_view_node.cpp
+++ b/src/gui/widgets/tree_view_node.cpp
@@ -336,9 +336,9 @@ bool ttree_view_node::disable_click_dismiss() const
 	return true;
 }
 
-tpoint ttree_view_node::get_current_size() const
+tpoint ttree_view_node::get_current_size(bool assume_visible) const
 {
-	if(parent_node_ && parent_node_->is_folded()) {
+	if(parent_node_ && parent_node_->is_folded() && !assume_visible) {
 		return tpoint(0, 0);
 	}
 
@@ -396,7 +396,7 @@ tpoint ttree_view_node::get_unfolded_size() const
 			continue;
 		}
 
-		tpoint node_size = node.get_unfolded_size();
+		tpoint node_size = node.get_current_size(true);
 
 		size.y += node_size.y;
 		size.x = std::max(size.x, node_size.x);

--- a/src/gui/widgets/tree_view_node.cpp
+++ b/src/gui/widgets/tree_view_node.cpp
@@ -478,6 +478,7 @@ unsigned ttree_view_node::place(const unsigned indention_step_size,
 
 	if(!is_root_node()) {
 		origin.x += indention_step_size;
+		assert(width >= indention_step_size);
 		width -= indention_step_size;
 	}
 	origin.y += best_size.y;
@@ -615,7 +616,7 @@ void ttree_view_node::signal_handler_label_left_button_click(
 		tree_view().selected_item_ = this;
 
 		if(tree_view().selection_change_callback_) {
-			tree_view().selection_change_callback_();
+			tree_view().selection_change_callback_(tree_view());
 		}
 	}
 }
@@ -666,4 +667,28 @@ const std::string& ttree_view_node::get_control_type() const
 	return type;
 }
 
+ttree_view_node& ttree_view_node::get_child_at(int index)
+{
+	assert(static_cast<size_t>(index) < children_.size());
+	return children_[index];
+}
+
+std::vector<int> ttree_view_node::describe_path()
+{
+	if(is_root_node()) {
+		return std::vector<int>();
+	}
+	else {
+		std::vector<int> res = parent_node_->describe_path();
+		const boost::ptr_vector<ttree_view_node>& parents_childs = parent_node_->children_;
+		for(int i = 0, size = parents_childs.size(); i < size; ++i) {
+			if(&parents_childs[i] == this) {
+				res.push_back(i);
+				return res;
+			}
+		}
+		assert(!"tree_view_node was not found in parent nodes children");
+		throw "assertion ignored"; //To silence 'no return value in this codepath' warning.
+	}
+}
 } // namespace gui2

--- a/src/gui/widgets/tree_view_node.hpp
+++ b/src/gui/widgets/tree_view_node.hpp
@@ -184,6 +184,11 @@ public:
 
 	const ttree_view& tree_view() const;
 
+	ttree_view_node& get_child_at(int index);
+	/**
+		calculates the node indicies that we need to get from the root node to this node.
+	*/
+	std::vector<int> describe_path();
 private:
 	/** See @ref twidget::request_reduce_width. */
 	virtual void request_reduce_width(const unsigned maximum_width) OVERRIDE;

--- a/src/gui/widgets/tree_view_node.hpp
+++ b/src/gui/widgets/tree_view_node.hpp
@@ -245,8 +245,8 @@ private:
 
 	tpoint calculate_best_size(const int indention_level,
 							   const unsigned indention_step_size) const;
-
-	tpoint get_current_size() const;
+	/** @param assume_visible: if false (default) it will return 0 if the parent node is folded*/
+	tpoint get_current_size(bool assume_visible = false) const;
 	tpoint get_folded_size() const;
 	tpoint get_unfolded_size() const;
 

--- a/src/scripting/lua_gui2.hpp
+++ b/src/scripting/lua_gui2.hpp
@@ -28,6 +28,7 @@ int intf_set_dialog_callback(lua_State *L);
 int intf_set_dialog_markup(lua_State *L);
 int intf_set_dialog_canvas(lua_State *L);
 int intf_set_dialog_active(lua_State *L);
+int intf_add_dialog_tree_node(lua_State *L);
 int show_dialog(lua_State *L, CVideo & video);
 int show_lua_console(lua_State*L, CVideo & video, lua_kernel_base * lk);
 int show_gamestate_inspector(CVideo & video, const vconfig & cfg);

--- a/src/scripting/lua_kernel_base.cpp
+++ b/src/scripting/lua_kernel_base.cpp
@@ -234,6 +234,7 @@ lua_kernel_base::lua_kernel_base(CVideo * video)
 		{ "tovconfig",                &lua_common::intf_tovconfig		},
 		{ "get_dialog_value",         &lua_gui2::intf_get_dialog_value		},
 		{ "set_dialog_active",        &lua_gui2::intf_set_dialog_active		},
+		{ "add_dialog_tree_node",     &lua_gui2::intf_add_dialog_tree_node	},
 		{ "set_dialog_callback",      &lua_gui2::intf_set_dialog_callback	},
 		{ "set_dialog_canvas",        &lua_gui2::intf_set_dialog_canvas		},
 		{ "set_dialog_markup",        &lua_gui2::intf_set_dialog_markup		},


### PR DESCRIPTION
wesnoth.add_dialog_tree_value to add nodes to a tree_value
wesnoth.set_dialog_callback support for tree_views (triggers when the
selected node was changed)
wesnoth.get_dialog_value support for tree_views returns an array of
integers that describe the path to the currebntly selected node.