### PR TITLE
add "disallow_shuffle" attribute to [side]

### DIFF
--- a/src/game_initialization/connect_engine.cpp
+++ b/src/game_initialization/connect_engine.cpp
@@ -417,7 +417,7 @@ void connect_engine::start_game(LOAD_USERS load_users)
 		// Only playable sides should be shuffled.
 		std::vector<int> playable_sides;
 		BOOST_FOREACH(side_engine_ptr side, side_engines_) {
-			if (side->allow_player()) {
+			if (side->allow_player() && side->allow_shuffle()) {
 				playable_sides.push_back(side->index());
 			}
 		}
@@ -853,6 +853,7 @@ side_engine::side_engine(const config& cfg, connect_engine& parent_engine,
 	ai_algorithm_(),
 	waiting_to_choose_faction_(allow_changes_),
 	chose_random_(cfg["chose_random"].to_bool(false)),
+	disallow_shuffle_(cfg["disallow_shuffle"].to_bool(false)),
 	flg_(parent_.era_factions_, cfg_, parent_.force_lock_settings_,
 		parent_.params_.use_map_settings, parent_.params_.saved_game, color_)
 {

--- a/src/game_initialization/connect_engine.hpp
+++ b/src/game_initialization/connect_engine.hpp
@@ -212,6 +212,7 @@ public:
 	bool waiting_to_choose_faction() const { return waiting_to_choose_faction_; }
 	void set_waiting_to_choose_status(bool status) { waiting_to_choose_faction_ = status;}
 	bool chose_random() const { return chose_random_;}
+	bool allow_shuffle() const { return !disallow_shuffle_;}
 	const std::vector<std::string>& player_teams() const
 		{ return parent_.player_teams_; }
 	flg_manager& flg() { return flg_; }
@@ -250,6 +251,7 @@ private:
 
 	bool waiting_to_choose_faction_;
 	bool chose_random_;
+	bool disallow_shuffle_;
 	flg_manager flg_;
 };
 

--- a/src/team.cpp
+++ b/src/team.cpp
@@ -70,7 +70,7 @@ const boost::container::flat_set<std::string> team::attributes = boost::assign::
 	("faction_from_recruit")("faction_name")("gold_lock")("income_lock")
 	("leader")("random_leader")("team_lock")("terrain_liked")
 	("user_description")("default_recruit")("controller_lock")("chose_random")
-	("description").convert_to_container<boost::container::flat_set<std::string> >();
+	("disallow_shuffle")("description").convert_to_container<boost::container::flat_set<std::string> >();
 
 team::team_info::team_info() :
 	name(),


### PR DESCRIPTION
which causes them to be ignored by the "shuffle_sides" phase,
regardless of the heuristic used by the connect engine