### PR TITLE
Bug fix23201: Toggle icons display error in replay.

### DIFF
--- a/changelog
+++ b/changelog
@@ -552,6 +552,7 @@ Version 1.13.0-dev:
      hexes.
    * Fix bug #23243: Segfault while clicking during [delay] in prestart.
    * Remove support for legacy style unit abilities descriptions.
+   * Fixed bug#23201 Toggle icons display error in replay.
 
 Version 1.11.11:
  * Add-ons server:

--- a/src/replay_controller.cpp
+++ b/src/replay_controller.cpp
@@ -159,6 +159,7 @@ void replay_controller::init_gui(){
 	BOOST_FOREACH(const team & t, gamestate_.board_.teams()) {
 		t.reset_objectives_changed();
 	}
+	get_hotkey_command_executor()->set_button_state(*gui_); 
 	update_replay_ui();
 }
 


### PR DESCRIPTION
Enable hotkeys from replay controller so they show the correct status when the replay is loaded.