### PR TITLE
add [resource] tag simlar to mp modifications.

### DIFF
--- a/src/saved_game.hpp
+++ b/src/saved_game.hpp
@@ -102,6 +102,7 @@ public:
 	replay_recorder_base& get_replay() { return replay_data_; }
 	const replay_recorder_base& get_replay() const { return replay_data_; }
 private:
+	void expand_resources();
 	
 	bool has_carryover_expanded_;
 	/** 


### PR DESCRIPTION
[scenario], [multiplayer], [era], [modification] and [campaign] can now
contain [load_resource] tags that will load [resource]s that are
toplevel tags similar to [modification] whose child tags will be copied
into the scenario.

These are mainly intended to load resrouces like new wml tags or similar. This adresses https://gna.org/bugs/?22974 . This is a rather basic implementation and im not sure whether it  would be better to make it part of mp depcheck or similar. Spcially becasue this for example has no features like "require_resource" (whether all clients need the resource) yet which i sthink it still important.