### PR TITLE
Bug fix23060: unit status tooltips do not show.

### DIFF
--- a/changelog
+++ b/changelog
@@ -574,6 +574,7 @@ Version 1.13.0-dev:
      that the game is not unoptimized
    * Increased minimum version of FriBiDi to 0.10.9 in cmake to match scons
    * Changed how FriBiDi is found in cmake to using pkgconfig
+   * Fixed bug 23060: unit stat tooltips do not show.
 
 Version 1.11.11:
  * Add-ons server:

--- a/data/themes/default.cfg
+++ b/data/themes/default.cfg
@@ -269,7 +269,7 @@
                 id=unit-status
                 font_size={DEFAULT_FONT_SMALL}
                 ref=label-hp
-                rect="+10,=-2,1022,+16"
+                rect="+10,=-4,1022,+16"
                 xanchor=right
                 yanchor=fixed
             [/unit_status]


### PR DESCRIPTION
The rectangle for the unit_stats in default.cfg (not a problem in classic.cfg) was overlapping other rectangles, making it not function properly.  Just resized it to fit. Tested with single poison effect, both poison and slow, and no effects, all worked.