### PR TITLE
Show on which difficulty levels a campaign was completed

### DIFF
--- a/changelog
+++ b/changelog
@@ -3,6 +3,8 @@ Version 1.13.0+dev:
    * New generic portrait for the Walking Corpse and Soulless
  * Language and i18n:
    * Updated translations:
+ * User interface:
+   * Started showing on which difficulty levels a campaign was completed.
 
 Version 1.13.0:
  * Security fixes:

--- a/data/gui/default/window/campaign_difficulty.cfg
+++ b/data/gui/default/window/campaign_difficulty.cfg
@@ -114,11 +114,42 @@
 													horizontal_alignment = "left"
 													border = "all"
 													border_size = 5
-													[image]
-														id = "icon"
+													[stacked_widget]
+														id = ""
 														definition = "default"
 														linked_group = "icon"
-													[/image]
+														[stack]
+															[layer]
+																[row]
+																	[column]
+																		grow_factor = 1
+																		horizontal_grow = "true"
+																		border = "left"
+																		border_size = 3
+																		[image]
+																			id = "victory"
+																			definition = "default"
+																			label = "misc/laurel.png"
+																		[/image]
+																	[/column]
+																[/row]
+															[/layer]
+															[layer]
+																[row]
+																	[column]
+																		grow_factor = 1
+																		horizontal_grow = "true"
+																		border = "left"
+																		border_size = 3
+																		[image]
+																			id = "icon"
+																			definition = "default"
+																		[/image]
+																	[/column]
+																[/row]
+															[/layer]
+														[/stack]
+													[/stacked_widget]
 												[/column]
 												[column]
 													grow_factor = 1

--- a/players_changelog
+++ b/players_changelog
@@ -9,6 +9,9 @@ Version 1.13.0+dev:
  * Language and i18n:
    * Updated translations:
 
+ * User interface:
+   * Started showing on which difficulty levels a campaign was completed.
+
 
 Version 1.13.0:
  * Security fixes:

--- a/src/game_initialization/create_engine.cpp
+++ b/src/game_initialization/create_engine.cpp
@@ -585,10 +585,6 @@ void create_engine::prepare_for_campaign(const std::string& difficulty)
  */
 std::string create_engine::select_campaign_difficulty(int set_value)
 {
-	const std::string difficulty_descriptions =
-		current_level().data()["difficulty_descriptions"];
-	std::vector<std::string> difficulty_options =
-		utils::split(difficulty_descriptions, ';');
 	const std::vector<std::string> difficulties =
 		utils::split(current_level().data()["difficulties"]);
 
@@ -619,9 +615,16 @@ std::string create_engine::select_campaign_difficulty(int set_value)
 	}
 	else
 	{
-		if(difficulty_options.size() != difficulties.size())
+		std::string campaign_id = current_level().data()["id"];
+		std::vector<std::string> difficulty_opts =
+			utils::split(current_level().data()["difficulty_descriptions"], ';');
+		if(difficulty_opts.size() != difficulties.size())
 		{
-			difficulty_options = difficulties;
+			difficulty_opts = difficulties;
+		}
+		std::vector<std::pair<std::string, bool> > difficulty_options;
+		for (size_t i = 0; i < difficulties.size(); i++) {
+			difficulty_options.push_back(make_pair(difficulty_opts[i], preferences::is_campaign_completed(campaign_id, difficulties[i])));
 		}
 
 		// show gui

--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -1081,7 +1081,7 @@ void game_launcher::launch_game(RELOAD_GAME_DATA reload)
 		// don't show The End for multiplayer scenario
 		// change this if MP campaigns are implemented
 		if(result == VICTORY && state_.classification().campaign_type != game_classification::MULTIPLAYER) {
-			preferences::add_completed_campaign(state_.classification().campaign);
+			preferences::add_completed_campaign(state_.classification().campaign, state_.classification().difficulty);
 			the_end(disp(), state_.classification().end_text, state_.classification().end_text_duration);
 			if(state_.classification().end_credits) {
 				about::show_about(disp(),state_.classification().campaign);

--- a/src/game_preferences.cpp
+++ b/src/game_preferences.cpp
@@ -56,6 +56,7 @@ bool message_private_on = false;
 
 bool haloes = true;
 
+std::map<std::string, std::set<std::string> > completed_campaigns;
 std::set<std::string> encountered_units_set;
 std::set<t_translation::t_terrain> encountered_terrains_set;
 
@@ -120,6 +121,26 @@ manager::manager() :
 		preferences::erase("mp_countdown_action_bonus");
 	}
 
+	/*
+	completed_campaigns = "A,B,C"
+	[completed_campaigns]
+		[campaign]
+			name = "A"
+			difficulty_levels = "EASY,MEDIUM"
+		[/campaign]
+	[/completed_campaigns]
+	*/
+	BOOST_FOREACH(const std::string &c, utils::split(preferences::get("completed_campaigns"))) {
+		completed_campaigns[c]; // create the elements
+	}
+	if (const config &ccc = preferences::get_child("completed_campaigns")) {
+		BOOST_FOREACH(const config &cc, ccc.child_range("campaign")) {
+			std::set<std::string> &d = completed_campaigns[cc["name"]];
+			std::vector<std::string> nd = utils::split(cc["difficulty_levels"]);
+			std::copy(nd.begin(), nd.end(), std::inserter(d, d.begin()));
+		}
+	}
+
 	const std::vector<std::string> v (utils::split(preferences::get("encountered_units")));
 	encountered_units_set.insert(v.begin(), v.end());
 
@@ -148,6 +169,15 @@ manager::manager() :
 
 manager::~manager()
 {
+	config campaigns;
+	typedef const std::pair<std::string, std::set<std::string> > cc_elem;
+	BOOST_FOREACH(cc_elem &elem, completed_campaigns) {
+		config cmp;
+		cmp["name"] = elem.first;
+		cmp["difficulty_levels"] = utils::join(elem.second);
+		campaigns.add_child("campaign", cmp);
+	}
+	preferences::set_child("completed_campaigns", campaigns);
 	std::vector<std::string> v (encountered_units_set.begin(), encountered_units_set.end());
 	preferences::set("encountered_units", utils::join(v));
 	t_translation::t_list terrain (encountered_terrains_set.begin(), encountered_terrains_set.end());
@@ -295,20 +325,17 @@ bool is_ignored(const std::string& nick)
 	}
 }
 
-void add_completed_campaign(const std::string& campaign_id) {
-	std::vector<std::string> completed = utils::split(preferences::get("completed_campaigns"));
-
-	if(std::find(completed.begin(), completed.end(), campaign_id) != completed.end())
-		return;
-
-	completed.push_back(campaign_id);
-	preferences::set("completed_campaigns", utils::join(completed));
+void add_completed_campaign(const std::string &campaign_id, const std::string &difficulty_level) {
+	completed_campaigns[campaign_id].insert(difficulty_level);
 }
 
 bool is_campaign_completed(const std::string& campaign_id) {
-	std::vector<std::string> completed = utils::split(preferences::get("completed_campaigns"));
+	return completed_campaigns.count(campaign_id) != 0;
+}
 
-	return std::find(completed.begin(), completed.end(), campaign_id) != completed.end();
+bool is_campaign_completed(const std::string& campaign_id, const std::string &difficulty_level) {
+	std::map<std::string, std::set<std::string> >::iterator it = completed_campaigns.find(campaign_id);
+	return it == completed_campaigns.end() ? false : it->second.count(difficulty_level) != 0;
 }
 
 bool parse_should_show_lobby_join(const std::string &sender, const std::string &message)

--- a/src/game_preferences.hpp
+++ b/src/game_preferences.hpp
@@ -53,11 +53,12 @@ class acquaintance;
 	std::map<std::string, std::string> get_acquaintances_nice(const std::string& filter);
 	bool add_friend(const std::string& nick, const std::string& notes);
 	bool add_ignore(const std::string& nick, const std::string& reason);
-	void add_completed_campaign(const std::string& campaign_id);
+	void add_completed_campaign(const std::string &campaign_id, const std::string &difficulty_level);
 	void remove_acquaintance(const std::string& nick);
 	bool is_friend(const std::string& nick);
 	bool is_ignored(const std::string& nick);
 	bool is_campaign_completed(const std::string& campaign_id);
+	bool is_campaign_completed(const std::string& campaign_id, const std::string &difficulty_level);
 
 	const std::vector<game_config::server_info>& server_list();
 

--- a/src/gui/dialogs/campaign_difficulty.cpp
+++ b/src/gui/dialogs/campaign_difficulty.cpp
@@ -65,12 +65,12 @@ namespace gui2
 REGISTER_DIALOG(campaign_difficulty)
 
 tcampaign_difficulty::tcampaign_difficulty(
-		const std::vector<std::string>& items)
+		const std::vector<std::pair<std::string, bool> >& items)
 	: index_(-1), items_()
 {
-	FOREACH(const AUTO & it, items)
+	FOREACH(const AUTO & p, items)
 	{
-		items_.push_back(tlegacy_menu_item(it));
+		items_.push_back(std::make_pair(tlegacy_menu_item(p.first), p.second));
 	}
 }
 
@@ -83,17 +83,25 @@ void tcampaign_difficulty::pre_show(CVideo& /*video*/, twindow& window)
 
 	FOREACH(const AUTO & item, items_)
 	{
-		if(item.is_default()) {
+		if(item.first.is_default()) {
 			index_ = list.get_item_count();
 		}
 
-		data["icon"]["label"] = item.icon();
-		data["label"]["label"] = item.label();
+		data["icon"]["label"] = item.first.icon();
+		data["label"]["label"] = item.first.label();
 		data["label"]["use_markup"] = "true";
-		data["description"]["label"] = item.description();
+		data["description"]["label"] = item.first.description();
 		data["description"]["use_markup"] = "true";
 
 		list.add_row(data);
+
+		tgrid* grid = list.get_row_grid(list.get_item_count() - 1);
+		assert(grid);
+
+		twidget *widget = grid->find("victory", false);
+		if (widget && !item.second) {
+			widget->set_visible(twidget::tvisible::hidden);
+		}
 	}
 
 	if(index_ != -1) {

--- a/src/gui/dialogs/campaign_difficulty.hpp
+++ b/src/gui/dialogs/campaign_difficulty.hpp
@@ -26,7 +26,10 @@ namespace gui2
 class tcampaign_difficulty : public tdialog
 {
 public:
-	explicit tcampaign_difficulty(const std::vector<std::string>& items);
+	/**
+	 * @param items vector of (difficulty description, already completed) pairs
+	 */
+	explicit tcampaign_difficulty(const std::vector<std::pair<std::string, bool> >& items);
 
 	/**
 	 * Returns the selected item index after displaying.
@@ -39,7 +42,7 @@ public:
 
 private:
 	int index_;
-	std::vector<tlegacy_menu_item> items_;
+	std::vector<std::pair<tlegacy_menu_item, bool> > items_;
 
 	/** Inherited from tdialog, implemented by REGISTER_DIALOG. */
 	virtual const std::string& window_id() const;

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -131,20 +131,26 @@ void loadgame::show_difficulty_dialog()
 		|| (!cfg_summary["turn"].empty()) )
 		return;
 
+	std::string campaign_id = cfg_summary["campaign"];
 	const config::const_child_itors &campaigns = game_config_.child_range("campaign");
-	std::vector<std::string> difficulty_descriptions;
 	std::vector<std::string> difficulties;
+	std::vector<std::pair<std::string, bool> > difficulty_options;
 	BOOST_FOREACH(const config &campaign, campaigns)
 	{
-		if (campaign["id"] == cfg_summary["campaign"]) {
-			difficulty_descriptions = utils::split(campaign["difficulty_descriptions"], ';');
+		if (campaign["id"] == campaign_id) {
 			difficulties = utils::split(campaign["difficulties"], ',');
-
+			std::vector<std::string> difficulty_opts = utils::split(campaign["difficulty_descriptions"], ';');
+			if (difficulty_opts.size() != difficulties.size()) {
+				difficulty_opts = difficulties;
+			}
+			for (size_t i = 0; i < difficulties.size(); i++) {
+				difficulty_options.push_back(make_pair(difficulty_opts[i], preferences::is_campaign_completed(campaign_id, difficulties[i])));
+			}
 			break;
 		}
 	}
 
-	if (difficulty_descriptions.empty())
+	if (difficulty_options.empty())
 		return;
 
 #if 0
@@ -157,7 +163,7 @@ void loadgame::show_difficulty_dialog()
 	}
 #endif
 
-	gui2::tcampaign_difficulty difficulty_dlg(difficulty_descriptions);
+	gui2::tcampaign_difficulty difficulty_dlg(difficulty_options);
 	difficulty_dlg.show(gui_.video());
 
 	if (difficulty_dlg.get_retval() != gui2::twindow::OK) {

--- a/src/tests/gui/test_gui2.cpp
+++ b/src/tests/gui/test_gui2.cpp
@@ -517,7 +517,7 @@ struct twrapper<gui2::tcampaign_difficulty>
 {
 	static gui2::tcampaign_difficulty* create()
 	{
-		static std::vector<std::string> items;
+		static std::vector<std::pair<std::string, bool> > items;
 
 		return new gui2::tcampaign_difficulty(items);
 	}


### PR DESCRIPTION
Currently, users can see which campaigns they completed, but they don't see on which difficulty levels they were completed. This feature was [requested](http://forums.wesnoth.org/viewtopic.php?f=12&t=19757) [multiple](http://forums.wesnoth.org/viewtopic.php?f=12&t=29387) [times](http://forums.wesnoth.org/viewtopic.php?f=12&t=36061) on the forums.