### PR TITLE
Update lua_kernel_base.cpp

### DIFF
--- a/src/scripting/lua_kernel_base.cpp
+++ b/src/scripting/lua_kernel_base.cpp
@@ -94,7 +94,7 @@ int lua_kernel_base::intf_print(lua_State* L)
 		if (!str) {
 			str = "";
 		}
-		cmd_log_ << str;
+		cmd_log_ << str << ' ';
 		DBG_LUA << "'" << str << "'\n";
 	}
 


### PR DESCRIPTION
Add spaces in between outputs of the lua print function when used with multiple arguments