### PR TITLE
add FreeBSD packager to about.cfg

### DIFF
--- a/data/core/about.cfg
+++ b/data/core/about.cfg
@@ -916,6 +916,11 @@
         name = "Vlad Glagolev (Stealth)"
         comment = "OpenBSD packager"
     [/entry]
+    [entry]
+        name = "Torsten Zühlsdorff"
+        comment = "FreeBSD Packager"
+        email = "ports_AT_toco-domains.de"
+    [/entry]
 [/about]
 
 [about]


### PR DESCRIPTION
Hello, i'm Torsten Zühlsdorff. I'm taking care about the Wesnoth package at FreeBSD. Therefore i've added my contacts to the about.cfg file, so that FreeBSD user which wishes/problems/etc could contact me.