### PR TITLE
Add [event] remove_on_fire

### DIFF
--- a/src/game_events/handlers.cpp
+++ b/src/game_events/handlers.cpp
@@ -78,6 +78,7 @@ handler_ptr handler_list::iterator::operator*()
 
 event_handler::event_handler(const config &cfg, bool imi, handler_vec::size_type index, manager & man)
 	: first_time_only_(cfg["first_time_only"].to_bool(true))
+	, remove_on_fire_(cfg["remove_on_fire"].to_bool(false))
 	, is_menu_item_(imi)
 	, index_(index)
 	, man_(&man)
@@ -120,8 +121,11 @@ void event_handler::handle_event(const queued_event& event_info, handler_ptr& ha
 		DBG_NG << cfg_["name"] << " will now invoke the following command(s):\n" << cfg_;
 	}
 
-	if (first_time_only_)
-	{
+	if (remove_on_fire_) {
+		(*man_->event_handlers_).remove_event_handler(cfg_["id"]);
+	}
+
+	if (first_time_only_) {
 		// Disable this handler.
 		disable();
 		// Also remove our caller's hold on us.

--- a/src/game_events/handlers.hpp
+++ b/src/game_events/handlers.hpp
@@ -70,6 +70,7 @@ namespace game_events
 
 		private:
 			bool first_time_only_;
+			bool remove_on_fire_;
 			bool is_menu_item_;
 			handler_vec::size_type index_;
 			manager * man_;


### PR DESCRIPTION
This (should be) equivalent to a nested event with remove = yes, id = id_of_parent.

Creating a PR as I'm not sure I'm doing this right. Putting the block after the command causes segfaults. This seems to work fine with the desired behavior without crashing, but it could probably be done better.