### PR TITLE
ImagePathWML: added ~SWAP() function

### DIFF
--- a/src/image_modifications.cpp
+++ b/src/image_modifications.cpp
@@ -551,6 +551,11 @@ const SDL_Color& background_modification::get_color() const
 	return color_;
 }
 
+surface swap_modification::operator()(const surface &src) const
+{
+	return swap_channels_image(src, red_, green_, blue_, alpha_);
+}
+
 namespace {
 
 struct parse_mod_registration
@@ -1190,6 +1195,82 @@ REGISTER_MOD_PARSER(BG, args)
 	}
 
 	return new background_modification(create_color(c[0], c[1], c[2], c[3]));
+}
+
+// Channel swap
+REGISTER_MOD_PARSER(SWAP, args)
+{
+	std::vector<std::string> params = utils::split(args, ',', utils::STRIP_SPACES);
+
+	// accept 3 arguments (rgb) or 4 (rgba)
+	if (params.size() != 3 && params.size() != 4) {
+		ERR_DP << "incorrect number of arguments in ~SWAP() function, they must be 3 or 4" << std::endl;
+		return NULL;
+	}
+
+	channel redValue, greenValue, blueValue, alphaValue;
+	// compare the parameter's value with the constants defined in the channels enum
+	if (params[0] == "red") {
+		redValue = RED;
+	} else if (params[0] == "green") {
+		redValue = GREEN;
+	} else if (params[0] == "blue") {
+		redValue = BLUE;
+	} else if (params[0] == "alpha") {
+		redValue = ALPHA;
+	} else {
+		ERR_DP << "unsupported argument value in ~SWAP() function: " << params[0] << std::endl;
+		return NULL;
+	}
+
+	// wash, rinse and repeat for the other three channels
+	if (params[1] == "red") {
+		greenValue = RED;
+	} else if (params[1] == "green") {
+		greenValue = GREEN;
+	} else if (params[1] == "blue") {
+		greenValue = BLUE;
+	} else if (params[1] == "alpha") {
+		greenValue = ALPHA;
+	} else {
+		ERR_DP << "unsupported argument value in ~SWAP() function: " << params[0] << std::endl;
+		return NULL;
+	}
+
+	if (params[2] == "red") {
+		blueValue = RED;
+	} else if (params[2] == "green") {
+		blueValue = GREEN;
+	} else if (params[2] == "blue") {
+		blueValue = BLUE;
+	} else if (params[2] == "alpha") {
+		blueValue = ALPHA;
+	} else {
+		ERR_DP << "unsupported argument value in ~SWAP() function: " << params[0] << std::endl;
+		return NULL;
+	}
+
+	// additional check: the params vector may not have a fourth elementh
+	// if so, default to the same channel
+	if (params.size() == 3) {
+		alphaValue = ALPHA;
+	}
+	else {
+		if (params[3] == "red") {
+			alphaValue = RED;
+		} else if (params[3] == "green") {
+			alphaValue = GREEN;
+		} else if (params[3] == "blue") {
+			alphaValue = BLUE;
+		} else if (params[3] == "alpha") {
+			alphaValue = ALPHA;
+		} else {
+			ERR_DP << "unsupported argument value in ~SWAP() function: " << params[3] << std::endl;
+			return NULL;
+		}
+	}
+
+	return new swap_modification(redValue, greenValue, blueValue, alphaValue);
 }
 
 } // end anon namespace

--- a/src/image_modifications.hpp
+++ b/src/image_modifications.hpp
@@ -516,6 +516,21 @@ private:
 	SDL_Color color_;
 };
 
+/**
+ * Channel swap (SWAP).
+ */
+class swap_modification : public modification
+{
+public:
+	swap_modification(channel r, channel g, channel b, channel a): red_(r), green_(g), blue_(b), alpha_(a) {}
+	virtual surface operator()(const surface& src) const;
+private:
+	channel red_;
+	channel green_;
+	channel blue_;
+	channel alpha_;
+};
+
 } /* end namespace image */
 
 #endif /* !defined(IMAGE_MODIFICATIONS_HPP_INCLUDED) */

--- a/src/sdl/utils.cpp
+++ b/src/sdl/utils.cpp
@@ -1207,6 +1207,107 @@ surface shadow_image(const surface &surf, bool optimize)
 	return optimize ? create_optimized_surface(nsurf) : nsurf;
 }
 
+surface swap_channels_image(const surface& surf, channel r, channel g, channel b, channel a, bool optimize) {
+	if(surf == NULL)
+		return NULL;
+
+	surface nsurf(make_neutral_surface(surf));
+	if(nsurf == NULL) {
+		std::cerr << "failed to make neutral surface\n";
+		return NULL;
+	}
+
+	{
+		surface_lock lock(nsurf);
+		Uint32* beg = lock.pixels();
+		Uint32* end = beg + nsurf->w*surf->h;
+
+		while(beg != end) {
+			Uint8 alpha = (*beg) >> 24;
+
+			if(alpha) {
+				Uint8 red, green, blue, newRed, newGreen, newBlue, newAlpha;
+				red = (*beg) >> 16;
+				green = (*beg) >> 8;
+				blue = (*beg);
+
+				switch (r) {
+					case RED:
+						newRed = red;
+						break;
+					case GREEN:
+						newRed = green;
+						break;
+					case BLUE:
+						newRed = blue;
+						break;
+					case ALPHA:
+						newRed = alpha;
+						break;
+					default:
+						return NULL;
+				}
+
+				switch (g) {
+					case RED:
+						newGreen = red;
+						break;
+					case GREEN:
+						newGreen = green;
+						break;
+					case BLUE:
+						newGreen = blue;
+						break;
+					case ALPHA:
+						newGreen = alpha;
+						break;
+					default:
+						return NULL;
+				}
+
+				switch (b) {
+					case RED:
+						newBlue = red;
+						break;
+					case GREEN:
+						newBlue = green;
+						break;
+					case BLUE:
+						newBlue = blue;
+						break;
+					case ALPHA:
+						newBlue = alpha;
+						break;
+					default:
+						return NULL;
+				}
+
+				switch (a) {
+					case RED:
+						newAlpha = red;
+						break;
+					case GREEN:
+						newAlpha = green;
+						break;
+					case BLUE:
+						newAlpha = blue;
+						break;
+					case ALPHA:
+						newAlpha = alpha;
+						break;
+					default:
+						return NULL;
+				}
+
+				*beg = (newAlpha << 24) | (newRed << 16) | (newGreen << 8) | newBlue;
+			}
+
+			++beg;
+		}
+	}
+
+	return optimize ? create_optimized_surface(nsurf) : nsurf;
+}
 
 surface recolor_image(surface surf, const std::map<Uint32, Uint32>& map_rgb, bool optimize){
 	if(surf == NULL)

--- a/src/sdl/utils.hpp
+++ b/src/sdl/utils.hpp
@@ -254,6 +254,9 @@ surface wipe_alpha(const surface & surf, bool optimize=true);
 /** create an heavy shadow of the image, by blurring, increasing alpha and darkening */
 surface shadow_image(const surface &surf, bool optimize=true);
 
+enum channel { RED, GREEN, BLUE, ALPHA };
+surface swap_channels_image(const surface& surf, channel r, channel g, channel b, channel a, bool optimize=true);
+
 /**
  * Recolors a surface using a map with source and converted palette values.
  * This is most often used for team-coloring.


### PR DESCRIPTION
This PR adds a new ImagePath function, called **~SWAP()**.
This functions performs the channel swap operations that can be found in several image manipulation programs. It accepts three or four arguments (one for each RGBA channel of the image), and each of them can be one of _"red"_, _"green"_, _"blue"_ and _"alpha"_.
The attached image is an example of the effects that can be achieved by using this function.
* Top-left corner: original image `(portraits/elves/captain.png)`
* Top-middle: `~SWAP(red,blue,green)`
* Top-right: `~SWAP(blue,green,red)`
* Bottom-left: `~SWAP(blue,red,green)`
* Bottom-middle: `~SWAP(green,red,blue)`
* Bottom-right: `~SWAP(green,blue,red)`

![swap channels](https://cloud.githubusercontent.com/assets/4049668/8009039/2b43952c-0ba6-11e5-83ef-4e40b6419476.jpg)
