### PR TITLE
disable most mp_configure settings when force_lock_settings=yes

### DIFF
--- a/src/game_initialization/configure_engine.cpp
+++ b/src/game_initialization/configure_engine.cpp
@@ -3,6 +3,7 @@
 #include "game_config_manager.hpp"
 #include "mp_game_settings.hpp"
 #include "settings.hpp"
+#include "tod_manager.hpp"
 
 #include <boost/foreach.hpp>
 #include <cassert>
@@ -199,6 +200,33 @@ const mp_game_settings& configure_engine::get_parameters() const {
 
 const std::vector<std::string>& configure_engine::entry_point_titles() const {
 	return entry_point_titles_;
+}
+
+void configure_engine::write_parameters()
+{
+	config& scenario = this->state_.get_starting_pos();
+	const mp_game_settings& params = this->state_.mp_settings();
+
+	if (params.random_start_time) {
+		if (!tod_manager::is_start_ToD(scenario["random_start_time"])) {
+			scenario["random_start_time"] = true;
+		}
+	}
+	else {
+		scenario["random_start_time"] = false;
+	}
+	scenario["experience_modifier"] = params.xp_modifier;
+	scenario["turns"] = params.num_turns;
+
+	BOOST_FOREACH(config& side, scenario.child_range("side"))
+	{
+		side["fog"] = params.fog_game;
+		side["shroud"] = params.shroud_game;
+		if (!params.use_map_settings) {
+			side["village_gold"] = params.village_gold;
+			side["village_support"] = params.village_support;
+		}
+	}
 }
 
 } //end namespace ng

--- a/src/game_initialization/configure_engine.hpp
+++ b/src/game_initialization/configure_engine.hpp
@@ -107,7 +107,7 @@ public:
 	const mp_game_settings& get_parameters() const;
 
 	const std::vector<std::string>& entry_point_titles() const;
-
+	void write_parameters();
 private:
 	saved_game& state_;
 	mp_game_settings& parameters_;

--- a/src/game_initialization/connect_engine.cpp
+++ b/src/game_initialization/connect_engine.cpp
@@ -1069,23 +1069,9 @@ config side_engine::new_config() const
 		res["gold"] = gold_;
 		res["income"] = income_;
 
-		if (!parent_.params_.use_map_settings) {
-			res["fog"] = parent_.params_.fog_game;
-			res["shroud"] = parent_.params_.shroud_game;
-		}
 
 		//share view default to true here to restore the previous behavior.
 		res["share_view"] =  res["share_view"].to_bool(true);
-
-		if (!parent_.params_.use_map_settings || res["village_gold"].empty()) {
-			res["village_gold"] = parent_.params_.village_gold;
-		}
-
-		if (!parent_.params_.use_map_settings ||
-			res["village_support"].empty()) {
-			res["village_support"] =
-				lexical_cast<std::string>(parent_.params_.village_support);
-		}
 
 	}
 

--- a/src/game_initialization/mp_game_utils.cpp
+++ b/src/game_initialization/mp_game_utils.cpp
@@ -23,7 +23,6 @@
 #include "log.hpp"
 #include "mp_options.hpp"
 #include "savegame.hpp"
-#include "tod_manager.hpp"
 #include "unit_id.hpp"
 
 #include <boost/foreach.hpp>
@@ -65,22 +64,8 @@ config initial_level_config(saved_game& state)
 	config& scenario = state.get_starting_pos();
 	if(!state.mp_settings().saved_game)
 	{
-		state.set_random_seed();
-		
 		scenario["turns"] = params.num_turns;
-		if (params.random_start_time)
-		{
-			if (!tod_manager::is_start_ToD(scenario["random_start_time"]))
-			{
-				scenario["random_start_time"] = true;
-			}
-		}
-		else
-		{
-			scenario["random_start_time"] = false;
-		}
-
-		scenario["experience_modifier"] = params.xp_modifier;
+		state.set_random_seed();
 	}
 
 	if (scenario["objectives"].empty()) {

--- a/src/game_initialization/multiplayer_configure.hpp
+++ b/src/game_initialization/multiplayer_configure.hpp
@@ -24,6 +24,7 @@
 #include "tooltips.hpp"
 #include "mp_options.hpp"
 #include "configure_engine.hpp"
+#include <boost/scoped_ptr.hpp>
 
 class saved_game;
 namespace mp {
@@ -36,7 +37,7 @@ public:
 	configure(game_display& dist, const config& game_config, chat& c, config& gamelist, saved_game& game, bool local_players_only);
 	~configure();
 
-	const mp_game_settings& get_parameters();
+	void get_parameters();
 
 protected:
 	virtual void layout_children(const SDL_Rect& rect);
@@ -44,14 +45,31 @@ protected:
 	virtual void hide_children(bool hide=true);
 
 private:
+	//Settings that can be changed unledd wml forbids it
+	struct nolock_settings
+	{
+		nolock_settings(game_display& disp);
+
+		gui::slider turns_slider_;
+		gui::label turns_label_;
+		gui::slider village_gold_slider_;
+		gui::label village_gold_label_;
+		gui::slider village_support_slider_;
+		gui::label village_support_label_;
+		gui::slider xp_modifier_slider_;
+		gui::label xp_modifier_label_;
+		gui::label generic_label_;
+		gui::button use_map_settings_;
+		gui::button random_start_time_;
+		gui::button fog_game_;
+		gui::button shroud_game_;
+	};
 	bool local_players_only_;
 
 	tooltips::manager tooltip_manager_;
 	int mp_countdown_init_time_;
 	int mp_countdown_reservoir_time_;
 
-	gui::slider turns_slider_;
-	gui::label turns_label_;
 	gui::button countdown_game_;
 	gui::slider countdown_init_time_slider_;
 	gui::label countdown_init_time_label_;
@@ -61,21 +79,8 @@ private:
 	gui::slider countdown_turn_bonus_slider_;
 	gui::label countdown_action_bonus_label_;
 	gui::slider countdown_action_bonus_slider_;
-	gui::slider village_gold_slider_;
-	gui::label village_gold_label_;
-	gui::slider village_support_slider_;
-	gui::label village_support_label_;
-	gui::slider xp_modifier_slider_;
-	gui::label xp_modifier_label_;
 
-	gui::label generic_label_;
 	gui::label name_entry_label_;
-	gui::label num_players_label_;
-	gui::label map_size_label_;
-	gui::button use_map_settings_;
-	gui::button random_start_time_;
-	gui::button fog_game_;
-	gui::button shroud_game_;
 	gui::button observers_game_;
 	gui::button oos_debug_;
 	gui::button shuffle_sides_;
@@ -103,6 +108,7 @@ private:
 	ng::configure_engine engine_;
 	options::manager options_manager_;
 
+	boost::scoped_ptr<nolock_settings> nolock_settings_;
 	struct process_event_data {
 		bool launch, quit;
 


### PR DESCRIPTION
When using force_lock_settings=yes that game now not only forces
use_map_settings to on, instead if doest show these options and doesn't
thouch those attributes in the scenario.
This implements http://gna.org/bugs/?23037
and might also fix some bugs related to spmp patch ( specially
https://gna.org/bugs/?23509) since force_lock_settings default to yes
for campaigns.