### PR TITLE
Re-enabled the passive OpenMP mode under OS X

### DIFF
--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -920,7 +920,7 @@ int main(int argc, char** argv)
 	// To avoid that problem, we need to set the OMP_WAIT_POLICY env var
 	// but that var is read by OMP at library loading time (before main)
 	// thus the relaunching of ourselves after setting the variable.
-#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(_WIN32)
 	if (!getenv("OMP_WAIT_POLICY")) {
 		setenv("OMP_WAIT_POLICY", "PASSIVE", 1);
 		execv(argv[0], argv);


### PR DESCRIPTION
Tested with the clang-omp package from Homebrew. Performance and
CPU usage is abysmal with or without the change, but it changes
nothing when compiled with the stock compiler, and it does compile