### PR TITLE
Add synced=yes(default)/no to [set_menu_item]

### DIFF
--- a/src/game_events/menu_item.hpp
+++ b/src/game_events/menu_item.hpp
@@ -69,7 +69,7 @@ public:
 	{ return use_hotkey_ ? hotkey_id_ : description_.str() + ' '; } // The space is to prevent accidental hotkey binding.
 	/// Writes *this to the provided config.
 	void to_config(config & cfg) const;
-
+	bool is_synced() const { return is_synced_; }
 private: // Functions
 	/// Updates *this based on @a vcfg.
 	void update(const vconfig & vcfg);
@@ -103,6 +103,9 @@ private: // Data
 	bool use_hotkey_;
 	/// If true, allow using the menu to trigger this item.
 	bool use_wml_menu_;
+	/// If true, this item will be sended ot ther clients.
+	/// The command shall not change the gamestate if !is_synced_
+	bool is_synced_;
 
 	/// A link back to my manager
 	mutable boost::weak_ptr<manager * const> my_manager_;

--- a/src/game_events/wmi_container.hpp
+++ b/src/game_events/wmi_container.hpp
@@ -95,10 +95,9 @@ public:
 private:
 	/// Returns an iterator to a menu item with the given @a id, if one exists.
 	iterator find(const std::string & id)             { return iterator(wml_menu_items_.find(id)); }
+public:
 	/// Returns an iterator to a menu item with the given @a id, if one exists.
 	const_iterator find(const std::string & id) const { return const_iterator(wml_menu_items_.find(id)); }
-
-public:
 	// Iteration support:
 	iterator begin()  { return iterator(wml_menu_items_.begin()); }
 	iterator end()    { return iterator(wml_menu_items_.end()); }

--- a/src/game_state.cpp
+++ b/src/game_state.cpp
@@ -350,3 +350,8 @@ game_events::wmi_container& game_state::get_wml_menu_items()
 {
 	return this->events_manager_->wml_menu_items_;
 }
+
+const game_events::wmi_container& game_state::get_wml_menu_items() const
+{
+	return this->events_manager_->wml_menu_items_;
+}

--- a/src/game_state.hpp
+++ b/src/game_state.hpp
@@ -55,6 +55,7 @@ public:
 
 
 	game_events::wmi_container& get_wml_menu_items();
+	const game_events::wmi_container& get_wml_menu_items() const;
 	int first_human_team_; //needed to initialize the viewpoint during setup
 
 	game_state(const config & level, const tdata_cache & tdata);

--- a/src/hotkey_handler_sp.cpp
+++ b/src/hotkey_handler_sp.cpp
@@ -21,6 +21,8 @@
 #include "play_controller.hpp"
 #include "playsingle_controller.hpp"
 #include "whiteboard/manager.hpp"
+#include "game_events/menu_item.hpp"
+#include "game_events/wmi_container.hpp"
 
 #include "unit.hpp"
 
@@ -187,8 +189,19 @@ bool playsingle_controller::hotkey_handler::can_execute_command(const hotkey::ho
 	switch (command){
 
 		case hotkey::HOTKEY_WML:
-			//code mixed from play_controller::show_menu and code here
-			return viewing_team_is_playing() && !events::commands_disabled && viewing_team().is_local_human() && !linger() && !browse();
+		{
+
+			int prefixlen = wml_menu_hotkey_prefix.length();
+			if(cmd.command.compare(0, prefixlen, wml_menu_hotkey_prefix) != 0) {
+				return false;
+			}
+			game_events::wmi_container::const_iterator it = gamestate().get_wml_menu_items().find(cmd.command.substr(prefixlen));
+			if(it == gamestate().get_wml_menu_items().end()) {
+				return false;
+			}
+
+			return !(**it).is_synced() || (viewing_team_is_playing() && !events::commands_disabled && viewing_team().is_local_human() && !linger() && !browse());
+		}
 		case hotkey::HOTKEY_UNIT_HOLD_POSITION:
 		case hotkey::HOTKEY_END_UNIT_TURN:
 			return !browse() && !linger() && !events::commands_disabled;


### PR DESCRIPTION
Unested.

Allows to add 'unsynced' wml menu hotkeys which are not sended to other
players and are also clickable off-turn.

This can for example used for help menus and similar.
