### PR TITLE
DM S19: Add defeat condition for losing last undead (bug #23668)

### DIFF
--- a/changelog
+++ b/changelog
@@ -12,6 +12,9 @@ Version 1.13.0+dev:
  * Campaigns:
    * Dead Water:
      * The Stun effect now expires at the stunned unit's side turn end
+   * Delfador's Memoirs:
+     * Added defeat condition for death of the last undead veteran in
+       'Showdown in the Northern Swamp' (bug #23668)
    * Under the Burning Suns:
      * The Stun effect now expires at the stunned unit's side turn end
  * Editor:

--- a/data/campaigns/Delfadors_Memoirs/scenarios/19_Showdown_in_the_Northern_Swamp.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/19_Showdown_in_the_Northern_Swamp.cfg
@@ -159,6 +159,17 @@
                 description= _ "Death of Kalenz"
                 condition=lose
             [/objective]
+            [objective]
+                description= _ "Loss of all Undead veterans before Iliah-Malal is defeated"
+                condition=lose
+                [show_if]
+                    [have_unit]
+                        race=undead
+                        side=1
+                        search_recall_list=yes
+                    [/have_unit]
+                [/show_if]
+            [/objective]
 
             {TURNS_RUN_OUT}
 
@@ -307,6 +318,48 @@
 
                     # He gets the standard +3 hitpoints and full heal.
                     {ADVANCE_UNIT (id="Iliah-Malal") ()}
+                [/event]
+                
+                # If a player's undead unit is defeated,
+                # check if there are still undead veterans.
+                # Otherwise end the scenario in defeat.
+                
+                # Note that this still leaves the possibility of an unwinnable
+                # scenario if the player dismisses the last undead veteran.
+                
+                # We check that there at at least two undead units since the
+                # dying unit is counted in the [have_unit] filter
+                [event]
+                    name=die
+                    first_time_only=no
+                    [filter]
+                        race=undead
+                        side=1
+                    [/filter]
+                    [if]
+                        [not]
+                            [have_unit]
+                                race=undead
+                                side=1
+                                count=2
+                                search_recall_list=yes
+                            [/have_unit]
+                        [/not]
+                        [and]
+                            [have_unit]
+                                id=Iliah-Malal
+                            [/have_unit]
+                        [/and]
+                        [then]
+                            [message]
+                                speaker=Delfador
+                                message=_ "Alas! Without any undead to strike the killing blow, we will never be able to defeat Iliah-Malal!"
+                            [/message]
+                            [endlevel]
+                                result=defeat
+                            [/endlevel]
+                        [/then]
+                    [/if]
                 [/event]
             [/then]
             [else]

--- a/data/campaigns/Delfadors_Memoirs/scenarios/19_Showdown_in_the_Northern_Swamp.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/19_Showdown_in_the_Northern_Swamp.cfg
@@ -336,7 +336,7 @@
                         race=undead
                         side=1
                     [/filter]
-                    [if]
+                    [filter_condition]
                         [not]
                             [have_unit]
                                 race=undead
@@ -350,16 +350,14 @@
                                 id=Iliah-Malal
                             [/have_unit]
                         [/and]
-                        [then]
-                            [message]
-                                speaker=Delfador
-                                message=_ "Alas! Without any undead to strike the killing blow, we will never be able to defeat Iliah-Malal!"
-                            [/message]
-                            [endlevel]
-                                result=defeat
-                            [/endlevel]
-                        [/then]
-                    [/if]
+                    [/filter_condition]
+                    [message]
+                        speaker=Delfador
+                        message=_ "Alas! Without any undead to strike the killing blow, we will never be able to defeat Iliah-Malal!"
+                    [/message]
+                    [endlevel]
+                        result=defeat
+                    [/endlevel]
                 [/event]
             [/then]
             [else]

--- a/data/core/about.cfg
+++ b/data/core/about.cfg
@@ -1070,6 +1070,9 @@
         comment = "2012 Google Code-in Students' Micro AI development"
     [/entry]
     [entry]
+        name = "Gregory Gauthier (rjaguar3)"
+    [/entry]
+    [entry]
         name = "Groggy Dice (groggydice)"
         comment = "wmllint enhancements"
     [/entry]

--- a/players_changelog
+++ b/players_changelog
@@ -10,6 +10,9 @@ Version 1.13.0+dev:
  * Campaigns:
    * Dead Water:
      * The Stun effect now expires at the stunned unit's side turn end
+   * Delfador's Memoirs:
+     * Added defeat condition for death of the last undead veteran in
+       'Showdown in the Northern Swamp' (bug #23668)
    * Under the Burning Suns:
      * The Stun effect now expires at the stunned unit's side turn end
 


### PR DESCRIPTION
This change to DM S19 adds a defeat condition for losing the last undead veteran before Iliah-Malal is destroyed.  This fixes bug #23668.