### PR TITLE
fix mp scenario transitions bugged in scenarios that change controllers WIP

### DIFF
--- a/src/server/simple_wml.cpp
+++ b/src/server/simple_wml.cpp
@@ -137,6 +137,8 @@ char* compress_buffer(const char* input, string_span* span, bool bzip2)
 		state = 7;
 
 		char* small_out = new char[len];
+		//FIXME: This assertion can fail.
+		//A possible cause might be this: https://svn.boost.org/trac/boost/ticket/5237
 		memcpy(small_out, &buf[0], len);
 		state = 8;
 


### PR DESCRIPTION
Currently, when a player advances to the next scenario the server will send him information about starting side controllers generated form the current side controllers of that game. This causes multiple bugs:
#1483 becasue current controllers might not match the stating controller of that game.
and
https://gna.org/bugs/?23679

Also note that it is not possible to store the starting controllers when the game starts because if we used connection numbers or player names for that it would cause bugs if a player reentered the game.

There are 2 solutions of that problems that i know:
1) Add a new (integer) player_game_id that is unique for that player in that game (so that the player gets a new id when he rejoins)
2) Make All players joining from previous scenario observers at the beginning. and give them controller updates later.

This pr uses approach 2) The main problem is that when a player joins as observers they also get vision form the other team in that time. To fix this we'd have to seperate 'vision' form 'controlling' which would alo give of features like 'observe as player' (idk if thats useful).

The advantages of this approach over 1) approach are:

We don't change the wml interface of controller= not sure if this is really an advantage.
We are a little more robut against OOS that might appear if a side was deassigned controll before it advance to the next scenario.
We get an 'observe as player' feature

The advantages of approach 1) are
We don't need to seperate 'vision' form 'controlling'  which might be easier
We the side contorller fiels gets simpler becasue we wouldnt need 'network' and 'network_ai' controllers
The serversided code might be easier because teh server can send the same data to all clients
