### PR TITLE
Fix bug #23711 about selecting last map generator used in editor

### DIFF
--- a/changelog
+++ b/changelog
@@ -29,6 +29,8 @@ Version 1.13.1+dev:
    * Added a version dialog button to the title screen, replacing the Paths
      option previously found in Preferences -> General.
  * Miscellaneous and bug fixes:
+   * Fixed Generate Map dialog bug that caused last choice of map
+     generator to not be actually selected (bug #23711).
    * Fixed unbound memory read in internal time formatting code with
      specially-crafted input.
    * Child wesnothd processes spawned by the Host Network Game option on

--- a/data/core/about.cfg
+++ b/data/core/about.cfg
@@ -1177,6 +1177,9 @@
         name = "Karol Kozub (automagic)"
     [/entry]
     [entry]
+        name = "Kevin Montalva (Ryckes)"
+    [/entry]
+    [entry]
         name = "Kristoffer Grönlund (kegie)"
     [/entry]
     [entry]

--- a/src/gui/dialogs/editor_generate_map.cpp
+++ b/src/gui/dialogs/editor_generate_map.cpp
@@ -127,6 +127,13 @@ void teditor_generate_map::pre_show(CVideo& /*video*/, twindow& window)
 		}
 	}
 
+	if (last_map_generator_ != NULL) {
+		// We need to call this manually because it won't be called by
+		// list.select_row() even if we set the callback before
+		// calling it
+		this->do_generator_selected(window);
+	}
+
 	list.set_callback_item_change(
 			boost::bind(&teditor_generate_map::do_generator_selected, this, boost::ref(window)));
 


### PR DESCRIPTION
It just modifies `pre_show()` to call `do_generator_selected()` after selecting the last map generator used in the list. It would not be called even if the callback was set before selecting the row with `list.select_row()`.