### PR TITLE
Make Deoran the grandson of Haldiel

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,5 +1,7 @@
 Version 1.13.1+dev:
  * Campaigns:
+   * The South Guard:
+     * Deoran is now the grandson of the Haldiel in HttT instead.
    * Eastern Invasion:
      * Fixed scenario events not working right on easy difficulty in 'Captured'.
    * Delfador's Memoirs:

--- a/data/campaigns/The_South_Guard/utils/sg_story.cfg
+++ b/data/campaigns/The_South_Guard/utils/sg_story.cfg
@@ -30,7 +30,7 @@
         [/part]
         [part]
             background=story/summer.jpg
-            story= _ "King Haldric summoned a young, undistinguished but promising cavalry officer named Deoran. Deoran was the son of Haldiel, who had fought with distinction alongside Konrad I in the wars against the orcs. The King had a mission for Haldiel’s son."
+            story= _ "King Haldric summoned a young, undistinguished but promising cavalry officer named Deoran. Deoran was the grandson of Haldiel, who had fought with distinction alongside Konrad I in the war to reclaim the throne. The King had a mission for him."
         [/part]
         [part]
             background=story/summer.jpg


### PR DESCRIPTION
Changed Deoran to be the grandson of HttT Haldiel, instead of son,
because the 2 campaigns has 87 years between them.