### PR TITLE
Tweaked Elf Path of The South Guard

### DIFF
--- a/data/campaigns/The_South_Guard/scenarios/03_A_Desparate_Errand.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/03_A_Desparate_Errand.cfg
@@ -62,7 +62,8 @@
         user_team_name=_"Bandits"
         controller=ai
 
-        {GOLD 20 40 70}
+        {GOLD 40 60 80}
+        {INCOME 0 2 3}
 
         canrecruit=yes
         [ai]

--- a/data/campaigns/The_South_Guard/scenarios/06a_Tidings_Good_and_Ill.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/06a_Tidings_Good_and_Ill.cfg
@@ -92,8 +92,8 @@
     [event]
         name=prestart
 
-        # Store away Deoran, his human troops, Ethiliel and her bodyguards, so
-        # that only Gerrick and the rest of the elves remain.
+        # Store away Deoran, Ethiliel and her bodyguards, so
+        # that only Gerrick, human troops and the rest of the elves remain.
         # wmllint: recognize Ethiliel
         # wmllint: recognize Minister Hylas
         # wmllint: recognize Elvish Bodyguard
@@ -290,6 +290,11 @@
             [objective]
                 description= _ "Defeat the Queen Xeila"
                 condition=win
+                [show_if]
+                    [have_unit]
+                        id=Queen Xeila
+                    [/have_unit]
+                [/show_if]
             [/objective]
             [objective]
                 description= _ "Death of Sir Gerrick"
@@ -328,7 +333,7 @@
 
                 [message]
                     speaker=Sir Gerrick
-                    message= _ "if they are hostile to us, they could endanger Deoran and Ethiliel as well. Perhaps their leader can be reasoned with."
+                    message= _ "If they are hostile to us, they could endanger Deoran and Ethiliel as well. Perhaps their leader can be reasoned with."
                 [/message]
             [/then]
         [/if]

--- a/data/campaigns/The_South_Guard/scenarios/06b_The_Long_March.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/06b_The_Long_March.cfg
@@ -126,6 +126,16 @@
         {VARIABLE secret_path.x 18}
         {VARIABLE secret_path.y 35}
 
+#ifdef EASY
+        {VARIABLE first_undead_spawn_turn 3}
+#endif
+#ifdef NORMAL
+        {VARIABLE first_undead_spawn_turn 2}
+#endif
+#ifdef HARD
+        {VARIABLE first_undead_spawn_turn 1}
+#endif		
+		
         [while]
             [variable]
                 name=new_path_hex.y
@@ -1020,12 +1030,11 @@ _f, _f, Re, _f
 
     [event]
         name=new turn
-        first_time_only=no
-
+        first_time_only=no		
         [if]
             [variable]
                 name=turn_number
-                greater_than=1
+                greater_than=$first_undead_spawn_turn
             [/variable]
 
             [then]

--- a/data/campaigns/The_South_Guard/scenarios/08a_Return_to_Kerlath.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/08a_Return_to_Kerlath.cfg
@@ -96,8 +96,8 @@
             {TRAIT_INTELLIGENT}
         [/modifications]
 
-        {GOLD 60 80 100}
-        {INCOME 2 3 5}
+        {GOLD 75 100 125}
+        {INCOME 3 6 8}
 
         team_name=bandits
         user_team_name=_"Bandits"


### PR DESCRIPTION
Increased the difficulties of scenario 3 and scenario 8a in the South
Guard;
Fixed the objective display after killing the naga queen in scenario 6a