### PR TITLE
adding location of macro definition to preprocessor argument error message

### DIFF
--- a/src/serialization/preprocessor.cpp
+++ b/src/serialization/preprocessor.cpp
@@ -1075,8 +1075,10 @@ bool preprocessor_data::get_chunk()
 				size_t nb_arg = strings_.size() - token.stack_pos - 1;
 				if (nb_arg != val.arguments.size())
 				{
+					std::vector< std::string > locations = utils::quoted_split(val.location, ' ');
 					std::ostringstream error;
-					error << "Preprocessor symbol '" << symbol << "' expects "
+					error << "Preprocessor symbol '" << symbol << "' defined at "
+					      << get_filename(locations[0]) << ":" << val.linenum << " expects "
 					      << val.arguments.size() << " arguments, but has "
 					      << nb_arg << " arguments";
 					target_.error(error.str(), linenum_);


### PR DESCRIPTION
This is the first bullet item under [this wiki section](http://wiki.wesnoth.org/NotSoEasyCoding#Improve_WML_error_reporting). Planning on tackling the rest of them shortly.