### PR TITLE
South Guard text change

### DIFF
--- a/data/campaigns/The_South_Guard/scenarios/05_Choice_In_The_Fog.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/05_Choice_In_The_Fog.cfg
@@ -227,7 +227,7 @@
 
         [message]
             speaker=Ethiliel
-            message= _ "The Black River is before us. No elf, still living, has crossed it. If the undead come from across the river, then we must search for them carefully, for I know not the way."
+            message= _ "The Black River is before us. Few elves have crossed it, and fewer still have lingered there long. If the undead come from across the river, then we must search for them carefully, for I know not the way."
         [/message]
 
         [message]
@@ -516,6 +516,73 @@
             speaker=Deoran
             message= _ "Hmm... I have to consider this... If I ally with the elves, I must fight the bandits, but if I ally with the bandits I will make enemies of the elves..."
             [option]
+                message= _ "Your crimes are too great. You will fall with the rest of the foul undead!"
+                [command]
+                    [music]
+                        name=knolls.ogg
+                        immediate=no
+                        append=no
+                    [/music]
+                    [music]
+                        name=nunc_dimittis.ogg
+                        append=yes
+                    [/music]
+
+                    [message]
+                        speaker=Urza Afalas
+                        message= _ "Then this parley is over! You may have sounded the doom of all of us!"
+                    [/message]
+
+                    [message]
+                        speaker=Ethiliel
+                        image=portraits/ethiliel-mad.png
+                        message= _ "You will pay for taking Mebrin from us! If he is harmed..."
+                    [/message]
+
+                    [set_variable]
+                        name=side_with_bandits
+                        value=no
+                    [/set_variable]
+
+                    [objectives]
+                        side=1
+                        [objective]
+                            description= _ "Find the source of the undead and destroy it"
+                            condition=win
+                        [/objective]
+                        [objective]
+                            description= _ "Defeat Urza Afalas"
+                            condition=win
+                        [/objective]
+                        [objective]
+                            description= _ "Death of Deoran"
+                            condition=lose
+                        [/objective]
+                        [objective]
+                            description= _ "Death of Sir Gerrick"
+                            condition=lose
+                        [/objective]
+                        [objective]
+                            description= _ "Death of Minister Hylas"
+                            condition=lose
+                        [/objective]
+                        [objective]
+                            description= _ "Death of Ethiliel"
+                            condition=lose
+                        [/objective]
+
+                        {TURNS_RUN_OUT}
+
+                        [gold_carryover]
+                            bonus=yes
+                            carryover_percentage=40
+                        [/gold_carryover]
+                    [/objectives]
+                [/command]
+            [/option]
+
+
+            [option]
                 message= _ "Very well. All men must unite against the undead."
                 [command]
                     [music]
@@ -623,72 +690,6 @@
                         [/objective]
                         [objective]
                             description= _ "Death of Urza Afalas"
-                            condition=lose
-                        [/objective]
-
-                        {TURNS_RUN_OUT}
-
-                        [gold_carryover]
-                            bonus=yes
-                            carryover_percentage=40
-                        [/gold_carryover]
-                    [/objectives]
-                [/command]
-            [/option]
-
-            [option]
-                message= _ "Your crimes are too great. You will fall with the rest of the foul undead!"
-                [command]
-                    [music]
-                        name=knolls.ogg
-                        immediate=no
-                        append=no
-                    [/music]
-                    [music]
-                        name=nunc_dimittis.ogg
-                        append=yes
-                    [/music]
-
-                    [message]
-                        speaker=Urza Afalas
-                        message= _ "Then this parley is over! You may have sounded the doom of all of us!"
-                    [/message]
-
-                    [message]
-                        speaker=Ethiliel
-                        image=portraits/ethiliel-mad.png
-                        message= _ "You will pay for taking Mebrin from us! If he is harmed..."
-                    [/message]
-
-                    [set_variable]
-                        name=side_with_bandits
-                        value=no
-                    [/set_variable]
-
-                    [objectives]
-                        side=1
-                        [objective]
-                            description= _ "Find the source of the undead and destroy it"
-                            condition=win
-                        [/objective]
-                        [objective]
-                            description= _ "Defeat Urza Afalas"
-                            condition=win
-                        [/objective]
-                        [objective]
-                            description= _ "Death of Deoran"
-                            condition=lose
-                        [/objective]
-                        [objective]
-                            description= _ "Death of Sir Gerrick"
-                            condition=lose
-                        [/objective]
-                        [objective]
-                            description= _ "Death of Minister Hylas"
-                            condition=lose
-                        [/objective]
-                        [objective]
-                            description= _ "Death of Ethiliel"
                             condition=lose
                         [/objective]
 

--- a/data/campaigns/The_South_Guard/scenarios/09a_Vengeance.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/09a_Vengeance.cfg
@@ -376,6 +376,14 @@
             y=15
         [/filter]
 
+        # Added a delay too make the end of the campaign less abrupt; maybe some dialogue is better 
+        [sound]
+            name=magic-faeriefire.ogg
+        [/sound]
+        [delay]
+            time=2000
+        [/delay]		
+		
         [endlevel]
             result=victory
             carryover_report=no

--- a/data/campaigns/The_South_Guard/utils/sg_story.cfg
+++ b/data/campaigns/The_South_Guard/utils/sg_story.cfg
@@ -130,7 +130,7 @@
         [/part]
         [part]
             background=story/winter.jpg
-            story= _ "Sir Deoran, Knight of Wesnoth, was summoned to Weldyn for a council with King Haldric himself. Storm clouds were brewing throughout the realm, and every commander would be needed to weather the storm..."
+            story= _ "Sir Deoran, Knight of Wesnoth, was summoned to Weldyn for a council with King Haldric himself. Dark clouds were brewing throughout the realm, and every commander would be needed to weather the storm..."
             music=traveling_minstrels.ogg
         [/part]
     [/story]
@@ -170,7 +170,7 @@
 
         [part]
             background=story/winter.jpg
-            story= _ "Sir Deoran, Knight of Wesnoth, was summoned to Weldyn for a council with King Haldric himself. Storm clouds were brewing throughout the realm, and every commander would be needed to weather the onslaught..."
+            story= _ "Sir Deoran, Knight of Wesnoth, was summoned to Weldyn for a council with King Haldric himself. Dark clouds were brewing throughout the realm, and every commander would be needed to weather the storm..."
             music=traveling_minstrels.ogg
         [/part]
     [/story]


### PR DESCRIPTION
1. Swap option positions to make Elf Path the default choice;
2. Made it slightly less obvious that Epilogues are outdated reference
to Eastern Invasion
3. Added a delay at victory in 9a, to make it less abrupt