### PR TITLE
Make the game compile with SDL2.

### DIFF
--- a/changelog
+++ b/changelog
@@ -43,6 +43,7 @@ Version 1.13.1+dev:
      Windows now display console output directly instead of using stdout.txt
      and stderr.txt.
    * Remember last selected modifications separately for single and multiplayer.
+   * Fixed SDL2 compilation issues.
 
 Version 1.13.1:
  * Security fixes:

--- a/data/core/about.cfg
+++ b/data/core/about.cfg
@@ -985,6 +985,9 @@
         name = "Andrea Palmatè (afxgroup)"
     [/entry]
     [entry]
+        name = "Andreas Löf (Aginor)"
+    [/entry]
+    [entry]
         name = "Andrius Šilinskas (thunderstruck)"
     [/entry]
     [entry]

--- a/src/attack_prediction_display.cpp
+++ b/src/attack_prediction_display.cpp
@@ -504,17 +504,31 @@ void battle_prediction_pane::get_hp_distrib_surface(const std::vector<std::pair<
 
 		int bar_len = std::max<int>(static_cast<int>((prob * (bar_space - 4)) + 0.5), 2);
 
+#if SDL_VERSION_ATLEAST(2,0,0)
 		SDL_Rect bar_rect_1 = sdl::create_rect(hp_sep + 4, 6 + (fs + 2) * i, bar_len, 8);
-		sdl::fill_rect(surf, &bar_rect_1, blend_rgba(surf, row_color.r, row_color.g, row_color.b, row_color.unused, 100));
+		sdl::fill_rect(surf, &bar_rect_1, blend_rgba(surf, row_color.r, row_color.g, row_color.b, row_color.a, 100));
 
 		SDL_Rect bar_rect_2 = sdl::create_rect(hp_sep + 4, 7 + (fs + 2) * i, bar_len, 6);
-		sdl::fill_rect(surf, &bar_rect_2, blend_rgba(surf, row_color.r, row_color.g, row_color.b, row_color.unused, 66));
+		sdl::fill_rect(surf, &bar_rect_2, blend_rgba(surf, row_color.r, row_color.g, row_color.b, row_color.a, 66));
 
 		SDL_Rect bar_rect_3 = sdl::create_rect(hp_sep + 4, 8 + (fs + 2) * i, bar_len, 4);
-		sdl::fill_rect(surf, &bar_rect_3, blend_rgba(surf, row_color.r, row_color.g, row_color.b, row_color.unused, 33));
+		sdl::fill_rect(surf, &bar_rect_3, blend_rgba(surf, row_color.r, row_color.g, row_color.b, row_color.a, 33));
 
 		SDL_Rect bar_rect_4 = sdl::create_rect(hp_sep + 4, 9 + (fs + 2) * i, bar_len, 2);
-		sdl::fill_rect(surf, &bar_rect_4, blend_rgba(surf, row_color.r, row_color.g, row_color.b, row_color.unused, 0));
+		sdl::fill_rect(surf, &bar_rect_4, blend_rgba(surf, row_color.r, row_color.g, row_color.b, row_color.a, 0));
+#else
+		SDL_Rect bar_rect_1 = sdl::create_rect(hp_sep + 4, 6 + (fs + 2) * i, bar_len, 8);
+				sdl::fill_rect(surf, &bar_rect_1, blend_rgba(surf, row_color.r, row_color.g, row_color.b, row_color.unused, 100));
+
+				SDL_Rect bar_rect_2 = sdl::create_rect(hp_sep + 4, 7 + (fs + 2) * i, bar_len, 6);
+				sdl::fill_rect(surf, &bar_rect_2, blend_rgba(surf, row_color.r, row_color.g, row_color.b, row_color.unused, 66));
+
+				SDL_Rect bar_rect_3 = sdl::create_rect(hp_sep + 4, 8 + (fs + 2) * i, bar_len, 4);
+				sdl::fill_rect(surf, &bar_rect_3, blend_rgba(surf, row_color.r, row_color.g, row_color.b, row_color.unused, 33));
+
+				SDL_Rect bar_rect_4 = sdl::create_rect(hp_sep + 4, 9 + (fs + 2) * i, bar_len, 2);
+				sdl::fill_rect(surf, &bar_rect_4, blend_rgba(surf, row_color.r, row_color.g, row_color.b, row_color.unused, 0));
+#endif
 
 		// Draw probability percentage, aligned right.
 		format_prob(str_buf, prob);

--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -73,6 +73,7 @@ version_table_manager::version_table_manager()
 	SDL_version sdl_version;
 	const SDL_version* sdl_rt_version = NULL;
 
+
 	//
 	// SDL
 	//
@@ -80,10 +81,15 @@ version_table_manager::version_table_manager()
 	SDL_VERSION(&sdl_version);
 	compiled[LIB_SDL] = format_version(sdl_version);
 
+#if SDL_VERSION_ATLEAST(2,0,0)
+	SDL_GetVersion(&sdl_version);
+	linked[LIB_SDL] = format_version(sdl_version);
+#else
 	sdl_rt_version = SDL_Linked_Version();
 	if(sdl_rt_version) {
 		linked[LIB_SDL] = format_version(*sdl_rt_version);
 	}
+#endif
 
 	names[LIB_SDL] = "SDL";
 

--- a/src/desktop/clipboard.cpp
+++ b/src/desktop/clipboard.cpp
@@ -59,6 +59,11 @@ void handle_system_event(const SDL_Event& /*event*/)
 {
 }
 
+bool available()
+{
+	return false;
+}
+
 } // end namespace clipboard
 
 } // end namespace desktop

--- a/src/filesystem_common.cpp
+++ b/src/filesystem_common.cpp
@@ -201,15 +201,25 @@ const file_tree_checksum& data_tree_checksum(bool reset)
 	return checksum;
 }
 
-
+#if SDL_VERSION_ATLEAST(2,0,0)
+static Sint64 ifs_size (struct SDL_RWops * context);
+static Sint64 SDLCALL ifs_seek(struct SDL_RWops *context, Sint64 offset, int whence);
+static size_t SDLCALL ifs_read(struct SDL_RWops *context, void *ptr, size_t size, size_t maxnum);
+static size_t SDLCALL ifs_write(struct SDL_RWops *context, const void *ptr, size_t size, size_t num);
+static int SDLCALL ifs_close(struct SDL_RWops *context);
+#else
 static int SDLCALL ifs_seek(struct SDL_RWops *context, int offset, int whence);
 static int SDLCALL ifs_read(struct SDL_RWops *context, void *ptr, int size, int maxnum);
 static int SDLCALL ifs_write(struct SDL_RWops *context, const void *ptr, int size, int num);
 static int SDLCALL ifs_close(struct SDL_RWops *context);
+#endif
 
 SDL_RWops* load_RWops(const std::string &path) {
 	SDL_RWops *rw = SDL_AllocRW();
 
+#if SDL_VERSION_ATLEAST(2,0,0)
+	rw->size = &ifs_size;
+#endif
 	rw->seek = &ifs_seek;
 	rw->read = &ifs_read;
 	rw->write = &ifs_write;
@@ -228,7 +238,29 @@ SDL_RWops* load_RWops(const std::string &path) {
 	return rw;
 }
 
+
+#if SDL_VERSION_ATLEAST(2,0,0)
+static Sint64 ifs_size (struct SDL_RWops * context) {
+	std::istream *ifs = static_cast<std::istream*>(context->hidden.unknown.data1);
+	std::streampos orig = ifs->tellg();
+
+	ifs->seekg(0, std::ios::end);
+
+	std::streampos len = ifs->tellg();
+
+	ifs->seekg(orig);
+
+	return len;
+
+}
+#endif
+
+#if SDL_VERSION_ATLEAST(2,0,0)
+static Sint64 SDLCALL ifs_seek(struct SDL_RWops *context, Sint64 offset, int whence) {
+#else
 static int SDLCALL ifs_seek(struct SDL_RWops *context, int offset, int whence) {
+#endif
+
 	std::ios_base::seekdir seekdir;
 	switch(whence){
 	case RW_SEEK_SET:
@@ -261,7 +293,12 @@ static int SDLCALL ifs_seek(struct SDL_RWops *context, int offset, int whence) {
 	std::streamsize pos = ifs->tellg();
 	return static_cast<int>(pos);
 }
+
+#if SDL_VERSION_ATLEAST(2,0,0)
+static size_t SDLCALL ifs_read(struct SDL_RWops *context, void *ptr, size_t size, size_t maxnum) {
+#else
 static int SDLCALL ifs_read(struct SDL_RWops *context, void *ptr, int size, int maxnum) {
+#endif
 	std::istream *ifs = static_cast<std::istream*>(context->hidden.unknown.data1);
 
 	// This seems overly simplistic, but it's the same as mem_read's implementation
@@ -274,7 +311,12 @@ static int SDLCALL ifs_read(struct SDL_RWops *context, void *ptr, int size, int 
 
 	return static_cast<int>(num);
 }
+
+#if SDL_VERSION_ATLEAST(2,0,0)
+static size_t SDLCALL ifs_write(struct SDL_RWops * /*context*/, const void * /*ptr*/, size_t /*size*/, size_t /*num*/) {
+#else
 static int SDLCALL ifs_write(struct SDL_RWops * /*context*/, const void * /*ptr*/, int /*size*/, int /*num*/) {
+#endif
 	SDL_SetError("Writing not implemented");
 	return 0;
 }

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -23,6 +23,10 @@
 #include <set>
 #include <stack>
 
+#if SDL_VERSION_ATLEAST(2,0,0)
+#include "sdl/alpha.hpp"
+#endif
+
 static lg::log_domain log_font("font");
 #define DBG_FT LOG_STREAM(debug, log_font)
 #define LOG_FT LOG_STREAM(info, log_font)

--- a/src/loadscreen.cpp
+++ b/src/loadscreen.cpp
@@ -205,7 +205,13 @@ void loadscreen::draw_screen(const std::string &text)
 	// Pump events and make sure to redraw the logo if there's a chance that it's been obscured
 	SDL_Event ev;
 	while(SDL_PollEvent(&ev)) {
+#if SDL_VERSION_ATLEAST(2,0,0)
+		if (ev.type == SDL_WINDOWEVENT &&
+				(ev.window.type == SDL_WINDOWEVENT_RESIZED ||
+						ev.window.type == SDL_WINDOWEVENT_EXPOSED))
+#else
 		if(ev.type == SDL_VIDEORESIZE || ev.type == SDL_VIDEOEXPOSE)
+#endif
 		{
 			logo_drawn_ = false;
 		}

--- a/src/sdl/window.cpp
+++ b/src/sdl/window.cpp
@@ -99,6 +99,7 @@ void twindow::set_icon(const surface& icon)
 	SDL_SetWindowIcon(window_, icon);
 }
 
+#if TTEXTURE
 ttexture twindow::create_texture(const int access, const int w, const int h)
 {
 	return ttexture(*SDL_GetRenderer(window_), pixel_format_, access, w, h);
@@ -119,6 +120,7 @@ void twindow::draw(ttexture& texture, const int x, const int y)
 {
 	texture.draw(*SDL_GetRenderer(window_), x, y);
 }
+#endif
 
 twindow::operator SDL_Window*()
 {

--- a/src/sdl/window.cpp
+++ b/src/sdl/window.cpp
@@ -99,29 +99,6 @@ void twindow::set_icon(const surface& icon)
 	SDL_SetWindowIcon(window_, icon);
 }
 
-#if TTEXTURE
-ttexture twindow::create_texture(const int access, const int w, const int h)
-{
-	return ttexture(*SDL_GetRenderer(window_), pixel_format_, access, w, h);
-}
-
-ttexture twindow::create_texture(const int access,
-								 SDL_Surface* source_surface__)
-{
-	return ttexture(*SDL_GetRenderer(window_), access, source_surface__);
-}
-
-ttexture twindow::create_texture(const int access, const surface& surface)
-{
-	return ttexture(*SDL_GetRenderer(window_), access, surface);
-}
-
-void twindow::draw(ttexture& texture, const int x, const int y)
-{
-	texture.draw(*SDL_GetRenderer(window_), x, y);
-}
-#endif
-
 twindow::operator SDL_Window*()
 {
 	return window_;

--- a/src/sdl/window.hpp
+++ b/src/sdl/window.hpp
@@ -133,57 +133,6 @@ public:
 	 */
 	void set_icon(const surface& icon);
 
-#if TTEXTURE
-	/**
-	 * Creates a texture for the renderer of this object.
-	 *
-	 * @param access              Used as access for @ref SDL_CreateTexture.
-	 * @param w                   Used as w for @ref SDL_CreateTexture.
-	 * @param h                   Used as x for @ref SDL_CreateTexture.
-	 */
-	ttexture create_texture(const int access, const int w, const int h);
-
-	/**
-	 * Creates a texture for the renderer.
-	 *
-	 * This is a helper function forwarded to the constructor of the
-	 * @ref ttexture class.
-	 *
-	 * See @ref texture::ttexture.
-	 *
-	 * @param access              Forwarded to @ref texture::ttexture.
-	 * @param source_surface__    Forwarded to @ref texture::ttexture.
-	 */
-	ttexture create_texture(const int access, SDL_Surface* source_surface__);
-
-	/**
-	 * Creates a texture for the renderer.
-	 *
-	 * This is a helper function forwarded to the constructor of the
-	 * @ref ttexture class.
-	 *
-	 * See @ref texture::ttexture.
-	 *
-	 * @param access              Forwarded to @ref texture::ttexture.
-	 * @param surface             Forwarded to @ref texture::ttexture.
-	 */
-	ttexture create_texture(const int access, const surface& surface);
-
-
-	/***** ***** ***** Draw function overloads. ***** ***** *****/
-
-	/**
-	 * Draw a texture on the window's renderer.
-	 *
-	 * The function is forwareded to @ref ttexture::draw.
-	 *
-	 * @param texture             The texture whose draw function to call.
-	 * @param x                   Forwarded to @ref ttexture::draw.
-	 * @param y                   Forwarded to @ref ttexture::draw.
-	 */
-	void draw(ttexture& texture, const int x, const int y);
-#endif
-
 	/***** ***** ***** Conversion operators. ***** ***** *****/
 
 	/**

--- a/src/sdl/window.hpp
+++ b/src/sdl/window.hpp
@@ -38,7 +38,9 @@ struct SDL_Renderer;
 namespace sdl
 {
 
+#if TTEXTURE
 class ttexture;
+#endif
 
 /**
  * The wrapper class for the @ref SDL_Window class.
@@ -131,6 +133,7 @@ public:
 	 */
 	void set_icon(const surface& icon);
 
+#if TTEXTURE
 	/**
 	 * Creates a texture for the renderer of this object.
 	 *
@@ -179,7 +182,7 @@ public:
 	 * @param y                   Forwarded to @ref ttexture::draw.
 	 */
 	void draw(ttexture& texture, const int x, const int y);
-
+#endif
 
 	/***** ***** ***** Conversion operators. ***** ***** *****/
 

--- a/src/storyscreen/render.cpp
+++ b/src/storyscreen/render.cpp
@@ -315,6 +315,12 @@ void part_ui::prepare_floating_images()
 void part_ui::render_background()
 {
 #if SDL_VERSION_ATLEAST(2,0,0)
+	sdl::draw_solid_tinted_rectangle(
+			0, 0, video_.getx(), video_.gety(), 0, 0, 0, 1.0,
+			video_.getSurface()
+	);
+	sdl_blit(background_, NULL, video_.getSurface(), NULL);
+#if 0
 	sdl::twindow *wnd = CVideo::get_window();
 	wnd->fill(0, 0, 0);
 	for (size_t i = 0; i<background_images_.size(); i++) {
@@ -323,6 +329,7 @@ void part_ui::render_background()
 
 		wnd->draw(background_images_[i], x, y);
 	}
+#endif
 #else
 #ifdef SDL_GPU
 	GPU_Target *target = get_render_target();

--- a/src/storyscreen/render.cpp
+++ b/src/storyscreen/render.cpp
@@ -320,16 +320,6 @@ void part_ui::render_background()
 			video_.getSurface()
 	);
 	sdl_blit(background_, NULL, video_.getSurface(), NULL);
-#if 0
-	sdl::twindow *wnd = CVideo::get_window();
-	wnd->fill(0, 0, 0);
-	for (size_t i = 0; i<background_images_.size(); i++) {
-		const int x = background_positions_[i].first;
-		const int y = background_positions_[i].second;
-
-		wnd->draw(background_images_[i], x, y);
-	}
-#endif
 #else
 #ifdef SDL_GPU
 	GPU_Target *target = get_render_target();

--- a/src/text.hpp
+++ b/src/text.hpp
@@ -258,13 +258,8 @@ private:
 	/** The surface to render upon used as a cache. */
 	mutable surface surface_;
 
-#if SDL_VERSION_ATLEAST(2,0,0)
-	/** The texture to render upon used as a cache. */
-	mutable sdl::ttexture texture_;
-#else
 #ifdef SDL_GPU
 	mutable sdl::timage texture_;
-#endif
 #endif
 
 	/** The text to draw (stored as UTF-8). */


### PR DESCRIPTION
This does the bare minimum to get the game compiling and running again with SDL 2. It fixes all of the compile errors, adds a missing seek operation to the SDL_RWops. The missing seek operation caused a NULL pointer dereference during game start.