### PR TITLE
Fix a compilation error with XCode Version 6.2 on OSX 10.9

### DIFF
--- a/src/synced_context.hpp
+++ b/src/synced_context.hpp
@@ -132,6 +132,7 @@ public:
 	class server_choice
 	{
 	public:
+		virtual ~server_choice(){};
 		/// We are in a game with no mp server and need to do this choice locally
 		virtual config local_choice() const = 0;
 		/// the request which is sended to the mp server.


### PR DESCRIPTION
The error was that `server_choice` is a class with virtual functions but no virtual destructor.