### PR TITLE
An Easter Egg in HttT, Konrad wins loyalty

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/01_The_Elves_Besieged.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/01_The_Elves_Besieged.cfg
@@ -47,6 +47,19 @@
                 carryover_percentage=40
             [/gold_carryover]
         [/objectives]
+		
+        #store and unstore Konrad, so his [unit][event] functions; can be removed after the corresponding bug fixed
+        [store_unit]
+            variable=konrad_store
+            kill=yes
+            [filter]
+                id=Konrad
+            [/filter]
+        [/store_unit]
+        [unstore_unit]
+            variable=konrad_store
+        [/unstore_unit]
+        {CLEAR_VARIABLE konrad_store}
     [/event]
 
     {campaigns/Heir_To_The_Throne/utils/intro.cfg}
@@ -141,6 +154,8 @@
             [/leader_goal]
         [/ai]
         {FLAG_VARIANT long}
+
+        {KONRAD_WINS_LOYALTY_EVENTS}
     [/side]
 
 #ifdef HARD

--- a/data/campaigns/Heir_To_The_Throne/scenarios/01_The_Elves_Besieged.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/01_The_Elves_Besieged.cfg
@@ -47,19 +47,6 @@
                 carryover_percentage=40
             [/gold_carryover]
         [/objectives]
-		
-        #store and unstore Konrad, so his [unit][event] functions; can be removed after the corresponding bug fixed
-        [store_unit]
-            variable=konrad_store
-            kill=yes
-            [filter]
-                id=Konrad
-            [/filter]
-        [/store_unit]
-        [unstore_unit]
-            variable=konrad_store
-        [/unstore_unit]
-        {CLEAR_VARIABLE konrad_store}
     [/event]
 
     {campaigns/Heir_To_The_Throne/utils/intro.cfg}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/25_HttT_Epilogue.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/25_HttT_Epilogue.cfg
@@ -76,4 +76,4 @@
 #	- if you kill one of the Death Knights in the Swamp of Dread, it will drop a strong piece of armor
 #	- if you kill all 4 of the Death Knights in the Swamp of Dread, it severely weakens the Lich, dropping its HP by half
 #	- if you kill Asheviere with one of the three main human characters, you are treated to different coup-de-grace speeches
-#	- if a unit is attacked and mortally wounded, but the attacker is killed on the very next attack by Konrad, and the unit lives until the start of the next turn, the unit becomes loyal > not finished yet
+#	- if a unit is attacked and mortally wounded, but the attacker is killed on the very next attack by Konrad, and the unit lives until the start of the next turn, the unit becomes loyal

--- a/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
@@ -738,3 +738,137 @@ _f,    _f,    _f,    _f,    _f,    _f,    Re,    _f,    _f,    _f,    _f,    _f,
         [/object]
     [/unit]
 #enddef
+
+#define KONRAD_WINS_LOYALTY_EVENTS
+#---- The events for the easter egg: 
+#----     if a unit is attacked and mortally wounded, but the attacker is killed on the very next attack by Konrad, 
+#----     and the unit lives until the start of the next turn, the unit becomes loyal; 
+#---- note: hp<=8, very next attack, 50% chance to happen, only happen once
+[event]
+    # when a unloyal unit gets mortally wounded by an enemy, he hates him for a turn.
+    id=an_enemy_get_hated
+    name=attack end
+    first_time_only=no
+
+    [filter_second]
+        side=1
+        canrecruit=no
+    [/filter_second]
+    [filter_condition]
+        [variable]
+            name=second_unit.upkeep
+            equals="full"
+        [/variable]
+        [variable]
+            name=second_unit.hitpoints
+            less_than=9
+        [/variable]
+    [/filter_condition]
+    [object]
+        silent=yes
+        duration=turn
+        name="Being_Hated"
+        hater_id=$second_unit.id
+        [filter]
+            id=$unit.id
+        [/filter]
+    [/object]
+[/event]
+
+[event]
+    # if someone else attacks the hated unit, the hater doesn't hate any more
+    id=hated_one_is_attacked
+    name=attack end
+    first_time_only=no
+
+    [filter_condition]
+        [variable]
+    	    name=unit.id
+            not_equals=Konrad
+        [/variable]
+        [variable]
+            name=second_unit.side
+            greater_than=1			
+        [/variable]
+    [/filter_condition]
+
+    {FOREACH second_unit.modifications.object object_i}
+        [if]
+            [variable]
+                name=second_unit.modifications.object[$object_i].name
+                equals="Being_Hated"
+            [/variable]
+            [then]
+                [store_unit]
+                    variable=hated_unit
+                    kill=yes
+                    [filter]
+                        id=$second_unit.id
+                    [/filter]					
+                [/store_unit]
+
+                {CLEAR_VARIABLE hated_unit.modifications.object[$object_i]}
+
+                [unstore_unit]
+                    variable=hated_unit
+                [/unstore_unit]
+                {CLEAR_VARIABLE hated_unit}
+            [/then]
+        [/if]
+    {NEXT object_i}
+[/event]
+
+
+[event]
+    # if Konrad kills the hated unit, there is a chance that he wins the loyalty
+    id=konrad_kills_the_hated
+    name=die
+	first_time_only=no
+	[filter_second]
+        id=Konrad
+    [/filter_second]
+	
+	{RANDOM 0..99}	
+    {FOREACH unit.modifications.object object_i}
+        [if]
+            [variable]
+                name=unit.modifications.object[$object_i].name
+                equals="Being_Hated"
+            [/variable]
+            [variable] # only happen once
+                name=loyalty_already_won
+                not_equals="yes"
+            [/variable]
+            [have_unit]
+                id=$unit.modifications.object[$object_i].hater_id
+            [/have_unit]
+            [variable]  # the event happens with a 50% chance
+                name=random
+                less_than=50
+            [/variable]
+			
+            [then]    # Konrad wins the heart.
+                [message]
+                    id=$unit.modifications.object[$object_i].hater_id
+                    message= _ "That $unit.type almost killed me, but you denied his fierce attempt by ending his life. I'm grateful, sir! You have my loyalty now!"
+                [/message]
+                [message]
+                    speaker=Konrad
+                    message= _ "Very well, surely it would help."
+                [/message]
+
+                [modify_unit]
+                    [filter]
+                        id=$unit.modifications.object[$object_i].hater_id
+                    [/filter] 
+                    {TRAIT_LOYAL}
+                    {IS_LOYAL}
+                [/modify_unit]
+                {VARIABLE loyalty_already_won "yes"}
+            [/then]
+        [/if]
+    {NEXT object_i}
+	
+	{CLEAR_VARIABLE random}
+[/event]
+#enddef


### PR DESCRIPTION
Coded a planned easter egg in HttT, that enables Konrad to win loyalty
from a heavily wounded unit by immediately killing the attacker.

Note: Heavily wounded means hp<=8, 50% chance to trigger, only happen once.