### PR TITLE
Prefix `apt-get -qq  with `travis_wait`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,9 +49,9 @@ before_install:
 
 install:
     - sudo add-apt-repository -y "deb http://old-releases.ubuntu.com/ubuntu/ saucy main universe"
-    - sudo apt-get update -qq
-    - sudo apt-get install -qq libboost-filesystem-dev libboost-iostreams-dev libboost-random-dev libboost-program-options-dev libboost-regex-dev libboost-system-dev libboost-test-dev libboost-locale-dev libcairo2-dev libfribidi-dev libpango1.0-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-net1.2-dev libsdl-ttf2.0-dev gdb moreutils
-    - if [ "$CXX" = "g++" ]; then sudo apt-get -qq install g++-4.8; fi
+    - travis_wait sudo apt-get update -qq
+    - travis_wait sudo apt-get install -qq libboost-filesystem-dev libboost-iostreams-dev libboost-random-dev libboost-program-options-dev libboost-regex-dev libboost-system-dev libboost-test-dev libboost-locale-dev libcairo2-dev libfribidi-dev libpango1.0-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-net1.2-dev libsdl-ttf2.0-dev gdb moreutils
+    - if [ "$CXX" = "g++" ]; then travis_wait sudo apt-get -qq install g++-4.8; fi
     - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8"; fi
 #    - if [ "$CPP_TESTS" = true ]; then sudo update-alternatives --remove postmaster.1.gz /usr/share/postgresql/9.1/man/man1/postmaster.1.gz; fi
 #    - if [ "$CPP_TESTS" = true ]; then sudo apt-get -f; fi


### PR DESCRIPTION
`apt-get -qq` is completely quiet. If `apt-get` takes more than 10
minutes to execute, nothing will be outputted for 10 minutes, and travis
will kill the build. Using `travis_wait` ensures the commands will not be
killed for 20 minutes. See [the documentation] for details.

[the documentation]: http://docs.travis-ci.com/user/build-timeouts/#Build-times-out-because-no-output-was-received)