### PR TITLE
Added password hashing to campaignd

### DIFF
--- a/data/core/about.cfg
+++ b/data/core/about.cfg
@@ -1169,6 +1169,11 @@
         name = "Joeri Melis"
     [/entry]
     [entry]
+        name = "John Anthony"
+        email = "john@jo.hnanthony.com"
+        comment = "campaignd work, mainly security-based"
+    [/entry]
+    [entry]
         name = "John B. Messerly (jbm)"
     [/entry]
     [entry]


### PR DESCRIPTION
As suggested here:

http://wiki.wesnoth.org/NotSoEasyCoding#Passphrase_hashing

Currently the hashing function is 10-iteration MD5, but should really be something like scrypt (best) or bcrypt (acceptable), but it means pulling in a dependency and Wesnoth already includes an MD5 utility.