### PR TITLE
Fix TODO by removing workaround for a resolved SDL issue.

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2239,15 +2239,6 @@ bool display::scroll(int xmove, int ymove, bool force)
 #endif
 	}
 
-//This is necessary to avoid a crash in some SDL versions on some systems
-//see http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=462794
-//FIXME remove this once the latest stable SDL release doesn't crash as 1.2.13 does
-#ifdef _MSC_VER
-    __asm{cld};
-#elif defined(__GNUG__) && (defined(__i386__) || defined(__x86_64__))
-    asm("cld");
-#endif
-
 	// Invalidate locations in the newly visible rects
 
 	if (dy != 0) {


### PR DESCRIPTION
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=462794 was reported and fixed in 2008. The issue was reported fro libsdl 1.2.13, the latest/last version was 1.2.15. Debian is still shipping 1.2.13, but have applied a patch to fix the issue. I would also expect that other platforms will also have resolved this issue since if they are still shipping that version of the library.