### PR TITLE
Fix all compile warnings when SDL2 is enabled

### DIFF
--- a/src/desktop/open.cpp
+++ b/src/desktop/open.cpp
@@ -107,7 +107,7 @@ bool open_object(const std::string& path_or_url)
 
 #else
 
-	(void)(path_or_url); // silence gcc's -Wunused-parameter
+	UNUSED(path_or_url); // silence gcc's -Wunused-parameter
 	ERR_DU << "open_object(): unsupported platform" << std::endl;
 	return false;
 

--- a/src/global.hpp
+++ b/src/global.hpp
@@ -74,4 +74,6 @@
 #error "Compilation with NDEBUG defined isn't supported, Wesnoth depends on asserts."
 #endif
 
+#define UNUSED(x)  ((void)(x))     /* to avoid warnings */
+
 #endif //GLOBAL_HPP_INCLUDED

--- a/src/sdl/utils.cpp
+++ b/src/sdl/utils.cpp
@@ -1726,13 +1726,13 @@ surface blur_surface(const surface &surf, int depth, bool optimize)
 	return optimize ? create_optimized_surface(res) : res;
 }
 
-void blur_surface(surface& surf, SDL_Rect rect, unsigned depth)
+void blur_surface(surface& surf, SDL_Rect rect, int depth)
 {
 	if(surf == NULL) {
 		return;
 	}
 
-	const unsigned max_blur = 256;
+	const int max_blur = 256;
 	if(depth > max_blur) {
 		depth = max_blur;
 	}
@@ -1745,12 +1745,12 @@ void blur_surface(surface& surf, SDL_Rect rect, unsigned depth)
 	const unsigned pixel_offset = rect.y * surf->w + rect.x;
 
 	surface_lock lock(surf);
-	for(unsigned y = 0; y < rect.h; ++y) {
+	for(int y = 0; y < rect.h; ++y) {
 		const Uint32* front = &queue[0];
 		Uint32* back = &queue[0];
 		Uint32 red = 0, green = 0, blue = 0, avg = 0;
 		Uint32* p = lock.pixels() + pixel_offset + y * surf->w;
-		for(unsigned x = 0; x <= depth && x < rect.w; ++x, ++p) {
+		for(int x = 0; x <= depth && x < rect.w; ++x, ++p) {
 			red += ((*p) >> 16)&0xFF;
 			green += ((*p) >> 8)&0xFF;
 			blue += (*p)&0xFF;
@@ -1762,7 +1762,7 @@ void blur_surface(surface& surf, SDL_Rect rect, unsigned depth)
 		}
 
 		p = lock.pixels() + pixel_offset + y * surf->w;
-		for(unsigned x = 0; x < rect.w; ++x, ++p) {
+		for(int x = 0; x < rect.w; ++x, ++p) {
 			*p = 0xFF000000
 					| (std::min(red/avg,ff) << 16)
 					| (std::min(green/avg,ff) << 8)
@@ -1793,12 +1793,12 @@ void blur_surface(surface& surf, SDL_Rect rect, unsigned depth)
 		}
 	}
 
-	for(unsigned x = 0; x < rect.w; ++x) {
+	for(int x = 0; x < rect.w; ++x) {
 		const Uint32* front = &queue[0];
 		Uint32* back = &queue[0];
 		Uint32 red = 0, green = 0, blue = 0, avg = 0;
 		Uint32* p = lock.pixels() + pixel_offset + x;
-		for(unsigned y = 0; y <= depth && y < rect.h; ++y, p += surf->w) {
+		for(int y = 0; y <= depth && y < rect.h; ++y, p += surf->w) {
 			red += ((*p) >> 16)&0xFF;
 			green += ((*p) >> 8)&0xFF;
 			blue += *p&0xFF;
@@ -1810,7 +1810,7 @@ void blur_surface(surface& surf, SDL_Rect rect, unsigned depth)
 		}
 
 		p = lock.pixels() + pixel_offset + x;
-		for(unsigned y = 0; y < rect.h; ++y, p += surf->w) {
+		for(int y = 0; y < rect.h; ++y, p += surf->w) {
 			*p = 0xFF000000
 					| (std::min(red/avg,ff) << 16)
 					| (std::min(green/avg,ff) << 8)

--- a/src/sdl/utils.hpp
+++ b/src/sdl/utils.hpp
@@ -329,7 +329,7 @@ surface blur_surface(const surface &surf, int depth = 1, bool optimize=true);
  * @param rect                    The part of the surface to blur.
  * @param depth                   The depth of the blurring.
  */
-void blur_surface(surface& surf, SDL_Rect rect, unsigned depth = 1);
+void blur_surface(surface& surf, SDL_Rect rect, int depth = 1);
 
 /**
  * Cross-fades a surface with alpha channel.

--- a/src/tests/test_config.cpp
+++ b/src/tests/test_config.cpp
@@ -263,7 +263,7 @@ BOOST_AUTO_TEST_CASE ( test_variable_info )
 		BOOST_FOREACH(const config& child, variable_access_const("tag1", nonempty).as_array())
 		{
 			//silences unused variable warning.
-			(void)(child);
+			UNUSED(child);
 			++count;
 		}
 		BOOST_CHECK_EQUAL (count, 3);
@@ -271,7 +271,7 @@ BOOST_AUTO_TEST_CASE ( test_variable_info )
 		BOOST_FOREACH(const config& child, variable_access_const("tag1.tag2", nonempty).as_array())
 		{
 			//silences unused variable warning.
-			(void)(child);
+			UNUSED(child);
 			++count;
 		}
 		BOOST_CHECK_EQUAL (count, 0);
@@ -280,7 +280,7 @@ BOOST_AUTO_TEST_CASE ( test_variable_info )
 		BOOST_FOREACH(const config& child, variable_access_const("tag1.tag2[5]", nonempty).as_array())
 		{
 			//silences unused variable warning.
-			(void)(child);
+			UNUSED(child);
 			++count;
 		}
 		BOOST_CHECK_EQUAL (count, 1);

--- a/src/unit_drawer.cpp
+++ b/src/unit_drawer.cpp
@@ -407,7 +407,7 @@ void unit_drawer::draw_bar(const std::string& image, int xpos, int ypos,
 		bar_loc = scaled_bar_loc;
 	}
 
-	if(height > bar_loc.h) {
+	if(height > static_cast<size_t>(bar_loc.h)) {
 		height = bar_loc.h;
 	}
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -263,7 +263,7 @@ surface display_format_alpha(surface surf)
 		return SDL_ConvertSurface(surf,frameBuffer->format,0);
 	else
 #else
-		(void)(surf);
+		UNUSED(surf);
 #endif
 		return NULL;
 }
@@ -508,10 +508,10 @@ int CVideo::bppForMode( int x, int y, int flags)
 int CVideo::modePossible( int x, int y, int bits_per_pixel, int flags, bool current_screen_optimal )
 {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-	(void)(x);
-	(void)(y);
-	(void)(flags);
-	(void)(current_screen_optimal);
+	UNUSED(x);
+	UNUSED(y);
+	UNUSED(flags);
+	UNUSED(current_screen_optimal);
 
 	return bits_per_pixel;
 #else

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -95,7 +95,7 @@ struct event {
 	bool in;
 	event(const SDL_Rect& rect, bool i) : x(i ? rect.x : rect.x + rect.w), y(rect.y), w(rect.w), h(rect.h), in(i) { }
 };
-#ifndef SDL_GPU
+#if !SDL_GPU && !SDL_VERSION_ATLEAST(2, 0, 0)
 bool operator<(const event& a, const event& b) {
 	if (a.x != b.x) return a.x < b.x;
 	if (a.in != b.in) return a.in;
@@ -120,7 +120,7 @@ std::vector<SDL_Rect> update_rects;
 std::vector<event> events;
 std::map<int, segment> segments;
 
-#ifndef SDL_GPU
+#if !SDL_GPU && !SDL_VERSION_ATLEAST(2, 0, 0)
 static void calc_rects()
 {
 	events.clear();
@@ -218,8 +218,7 @@ static void calc_rects()
 
 bool update_all = false;
 }
-
-#ifndef SDL_GPU
+#if !SDL_GPU && !SDL_VERSION_ATLEAST(2, 0, 0)
 static void clear_updates()
 {
 	update_all = false;
@@ -231,6 +230,7 @@ namespace {
 
 surface frameBuffer = NULL;
 bool fake_interactive = false;
+
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 sdl::twindow* window = NULL;
 #endif
@@ -262,6 +262,8 @@ surface display_format_alpha(surface surf)
 	else if(frameBuffer != NULL)
 		return SDL_ConvertSurface(surf,frameBuffer->format,0);
 	else
+#else
+		(void)(surf);
 #endif
 		return NULL;
 }
@@ -506,6 +508,11 @@ int CVideo::bppForMode( int x, int y, int flags)
 int CVideo::modePossible( int x, int y, int bits_per_pixel, int flags, bool current_screen_optimal )
 {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
+	(void)(x);
+	(void)(y);
+	(void)(flags);
+	(void)(current_screen_optimal);
+
 	return bits_per_pixel;
 #else
 	int bpp = SDL_VideoModeOK( x, y, bits_per_pixel, get_flags(flags) );

--- a/src/widgets/menu.cpp
+++ b/src/widgets/menu.cpp
@@ -903,7 +903,7 @@ void menu::column_widths_item(const std::vector<std::string>& row, std::vector<i
 
 		if(col == widths.size()) {
 			widths.push_back(res.w + text_trailing_space);
-		} else if(res.w > widths[col] - text_trailing_space) {
+		} else if(static_cast<size_t>(res.w) > widths[col] - text_trailing_space) {
 			widths[col] = res.w + text_trailing_space;
 		}
 	}


### PR DESCRIPTION
This fixes all compile warnings by performing the correct typecasts or by modifying types to be suitable. The code has been compiled with and without SDL2 enabled to make sure there are no regressions.