### PR TITLE
Minor Windows Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ uninstall.vcproj
 *.vcproj.*.user
 projectfiles/VC[12]*
 src/**/*.vcproj
+/WindowsTimeout.ilk
+/WindowsTimeout.pdb
 
 # XCode
 projectfiles/Xcode/**/build
@@ -85,7 +87,7 @@ ReleaseDEBUG
 Debug (fast)
 tags
 
-# build results ect.
+# build results etc.
 wesnoth_zip
 wesnoth.exp
 wesnoth.ilk

--- a/src/SDL_gpu/SDL_gpu/GL_common/SDL_gpu_GL_common.inl
+++ b/src/SDL_gpu/SDL_gpu/GL_common/SDL_gpu_GL_common.inl
@@ -2,10 +2,14 @@
 See a particular renderer's *.c file for specifics. */
 
 
-// Visual C does not support static inline
+// static inline only supported in Visual C++ from version 2015 but can use static __inline instead for older versions
 #ifndef static_inline
     #ifdef _MSC_VER
-		#define static_inline static
+        #if _MSC_VER < 1900
+            #define static_inline static __inline
+        #else
+            #define static_inline static inline
+        #endif
     #else
         #define static_inline static inline
     #endif

--- a/src/SDL_gpu/SDL_gpu/GL_common/SDL_gpu_GL_matrix.c
+++ b/src/SDL_gpu/SDL_gpu/GL_common/SDL_gpu_GL_matrix.c
@@ -12,10 +12,14 @@
 #endif
 
 
-// Visual C does not support static inline
+// static inline only supported in Visual C++ from version 2015 but can use static __inline instead for older versions
 #ifndef static_inline
 	#ifdef _MSC_VER
-		#define static_inline static
+		#if _MSC_VER < 1900
+			#define static_inline static __inline
+		#else
+			#define static_inline static inline
+		#endif
 	#else
 		#define static_inline static inline
 	#endif

--- a/src/SDL_gpu/SDL_gpu/SDL_gpu.h
+++ b/src/SDL_gpu/SDL_gpu/SDL_gpu.h
@@ -800,9 +800,9 @@ struct GPU_Renderer
 
 // Setup calls
 
-// Visual C does not support static inline
-#ifdef _MSC_VER
-static SDL_version GPU_GetCompiledVersion(void)
+// static inline only supported in Visual C++ from version 2015 but can use static __inline instead for older versions
+#if _MSC_VER < 1900
+static __inline SDL_version GPU_GetCompiledVersion(void)
 #else
 static inline SDL_version GPU_GetCompiledVersion(void)
 #endif

--- a/src/SDL_gpu/SDL_gpu/SDL_gpu.h
+++ b/src/SDL_gpu/SDL_gpu/SDL_gpu.h
@@ -801,8 +801,12 @@ struct GPU_Renderer
 // Setup calls
 
 // static inline only supported in Visual C++ from version 2015 but can use static __inline instead for older versions
+#ifdef _MSC_VER
 #if _MSC_VER < 1900
 static __inline SDL_version GPU_GetCompiledVersion(void)
+#else
+static inline SDL_version GPU_GetCompiledVersion(void)
+#endif
 #else
 static inline SDL_version GPU_GetCompiledVersion(void)
 #endif

--- a/src/gui/dialogs/label_settings.cpp
+++ b/src/gui/dialogs/label_settings.cpp
@@ -98,6 +98,6 @@ bool tlabel_settings::execute(display_context& dc, CVideo& video) {
 }
 
 void tlabel_settings::toggle_category(twidget& box, std::string category) {
-	all_labels[category] = static_cast<ttoggle_button&>(box).get_value();
+	all_labels[category] = (static_cast<ttoggle_button&>(box).get_value() != 0);
 }
 }


### PR DESCRIPTION
Can use static inline in Visual C++ 2015

Also add WindowsTImeout to .gitignore.