### PR TITLE
Fix the graphics corruption when scrolling with SDL2 enabled

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2226,6 +2226,13 @@ bool display::scroll(int xmove, int ymove, bool force)
 	srcrect.y -= dy;
 	if (!screen_.update_locked()) {
 
+		/* TODO: This is a workaround for a SDL2 bug when blitting on overlapping surfaces.
+		 * The bug only strikes during scrolling, but will then duplicate textures across
+		 * the entire map. */
+#if SDL_VERSION_ATLEAST(2,0,0)
+		surface screen_copy = make_neutral_surface(screen);
+		SDL_BlitSurface(screen_copy,&srcrect,screen,&dstrect);
+#else
 // Hack to workaround bug #17573
 #if defined(__GLIBC__)
 		if (do_reverse_memcpy_workaround_) {
@@ -2236,6 +2243,7 @@ bool display::scroll(int xmove, int ymove, bool force)
 		}
 #else
 		SDL_BlitSurface(screen,&srcrect,screen,&dstrect);
+#endif
 #endif
 	}
 


### PR DESCRIPTION
SDL2 has issues with overlapping surfaces when blitting, it seems to trigger an internal bug in SDL2. This causes the blitted surface to be incorrectly filled, causing a graphics corruption. This introduces a workaround that does a copy of the original surface before blitting, thus avoiding the bug. This behaviour seems to only occur while scrolling so it's a reasonably rare occurence.