### PR TITLE
Add SDL2 support to CMake, advertise clipboard availabilty and remove a small piece of dead code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,13 @@ set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS true)
 # use our own version of FindBoost.cmake and other Find* scripts
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
-find_package(SDL 1.2.7 REQUIRED)
+
+if(ENABLE_SDL2)
+	find_package(SDL2 2.0.0 REQUIRED)
+else(ENABLE_SDL2)
+	find_package(SDL 1.2.7 REQUIRED) 
+endif(ENABLE_SDL2)
+  
 find_package(Boost 1.36 REQUIRED COMPONENTS iostreams program_options regex system)
 find_package(Boost 1.40 REQUIRED COMPONENTS random)
 
@@ -30,10 +36,17 @@ find_package(Gettext)
 find_package(X11)
 
 if(NOT MSVC)
-	#needed to get some SDL defines in... (as of rev31694 -D_GNU_SOURCE=1 is required!)
-	set(SDL_CONFIG "sdl-config" CACHE STRING "Path to sdl-config script")
-	exec_program(${SDL_CONFIG} ARGS "--cflags" OUTPUT_VARIABLE SDL_CFLAGS)
-	add_definitions(${SDL_CFLAGS})
+	if(ENABLE_SDL2)
+		#needed to get some SDL2 defines in... (as of rev31694 -D_GNU_SOURCE=1 is required!)
+		set(SDL2_CONFIG "sdl2-config" CACHE STRING "Path to sdl2-config script")
+		exec_program(${SDL2_CONFIG} ARGS "--cflags" OUTPUT_VARIABLE SDL2_CFLAGS)
+		add_definitions(${SDL2_CFLAGS})
+	  else(ENABLE_SDL2)
+		#needed to get some SDL defines in... (as of rev31694 -D_GNU_SOURCE=1 is required!)
+		set(SDL_CONFIG "sdl-config" CACHE STRING "Path to sdl-config script")
+		exec_program(${SDL_CONFIG} ARGS "--cflags" OUTPUT_VARIABLE SDL_CFLAGS)
+		add_definitions(${SDL_CFLAGS})
+	endif(ENABLE_SDL2)
 endif(NOT MSVC)
 
 if(NOT WIN32)
@@ -79,6 +92,7 @@ option(ENABLE_CAMPAIGN_SERVER "Enable compilation of campaign server")
 option(ENABLE_SERVER "Enable compilation of server" ON)
 option(ENABLE_TOOLS "Enable building and installation of tools for artists and WML maintainers")
 option(ENABLE_SDL2_TOOLS "Enable building and installation of tools for testing with SDL2" OFF)
+option(ENABLE_SDL2 "Enable building the game with SDL2" OFF)
 option(ENABLE_TESTS "Build unit tests")
 option(ENABLE_NLS "Enable building of translations" ON)
 option(ENABLE_LOW_MEM "Reduce memory usage by removing extra functionality" OFF)
@@ -176,14 +190,14 @@ set(BINARY_PREFIX "" CACHE STRING "Prefix in front of all binaries")
 # -Wnot_supported_flag. For that case all not-named parameters will be added to
 # the target instead.
 #
-# param target                    The variable to add the compiler flag to.
-# param flag                      The compiler flag to test.
-# param variable                  The test macro needs a variable to store the
-#                                 result of the test, this paramter holds that
-#                                 variable.
-# param ...                       If this variable is set it will be added to
-#                                 target instead of flag when the compiler
-#                                 supports flag.
+# param target			  The variable to add the compiler flag to.
+# param flag			  The compiler flag to test.
+# param variable		  The test macro needs a variable to store the
+#				  result of the test, this paramter holds that
+#				  variable.
+# param ...			  If this variable is set it will be added to
+#				  target instead of flag when the compiler
+#				  supports flag.
 macro(check_compiler_has_flag target flag variable)
 	check_cxx_compiler_flag(${flag} ${variable})
 	if(${variable})
@@ -553,23 +567,35 @@ endif(ENABLE_DEBUG_WINDOW_LAYOUT)
 #
 
 if(ENABLE_TOOLS OR ENABLE_GAME OR ENABLE_TESTS)
-	find_package( SDL_image 1.2 REQUIRED )
+	if(ENABLE_SDL2)
+		find_package( SDL2_image 2.0.0 REQUIRED )
+	else(ENABLE_SDL2)
+		find_package( SDL_image 1.2 REQUIRED )
+	endif(ENABLE_SDL2)
 endif(ENABLE_TOOLS OR ENABLE_GAME OR ENABLE_TESTS)
 if(ENABLE_GAME OR ENABLE_TESTS)
-	find_package( SDL_mixer 1.2.12 REQUIRED )
-	find_package( SDL_ttf 2.0.8 REQUIRED )
-
+	if(ENABLE_SDL2)
+		find_package( SDL2_mixer 2.0.0 REQUIRED )
+		find_package( SDL2_ttf 2.0.8 REQUIRED )
+	else(ENABLE_SDL2)
+		find_package( SDL_mixer 1.2.12 REQUIRED )
+		find_package( SDL_ttf 2.0.8 REQUIRED )
+	endif(ENABLE_SDL2)
 	if(NOT MSVC)
 		find_package(VorbisFile REQUIRED)
 		find_package( PkgConfig REQUIRED )
 		pkg_check_modules( PANGOCAIRO REQUIRED pangocairo>=1.21.3 )
 		pkg_check_modules( FONTCONFIG REQUIRED fontconfig>=2.4.1 )
-        pkg_check_modules( SYSTEMD systemd )
+	pkg_check_modules( SYSTEMD systemd )
 	endif(NOT MSVC)
 
 endif(ENABLE_GAME OR ENABLE_TESTS)
 if(ENABLE_GAME OR ENABLE_SERVER OR ENABLE_CAMPAIGN_SERVER OR ENABLE_TESTS)
-	find_package( SDL_net REQUIRED )
+	if(ENABLE_SDL2)
+		find_package( SDL2_net 2.0.0 REQUIRED )
+	else(ENABLE_SDL2)
+		find_package( SDL_net REQUIRED )
+	endif(ENABLE_SDL2)
 endif(ENABLE_GAME OR ENABLE_SERVER OR ENABLE_CAMPAIGN_SERVER OR ENABLE_TESTS)
 if(ENABLE_TOOLS)
 	find_package( ZLIB REQUIRED )
@@ -680,10 +706,10 @@ if(ENABLE_SERVER AND FIFO_DIR)
 	install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory \$ENV{DESTDIR}/${FIFO_DIR})")
     # install systemd stuff if it is installed
     if(SYSTEMD_FOUND)
-#        configure_file(packaging/systemd/wesnothd.tmpfiles.conf.in ${CMAKE_BINARY_DIR}/wesnothd.conf)
-#        configure_file(packaging/systemd/wesnothd.service.in ${CMAKE_BINARY_DIR}/wesnothd.service)
-#        install(FILES ${CMAKE_BINARY_DIR}/wesnothd.conf DESTINATION lib/tmpfiles.d)
-#       install(FILES ${CMAKE_BINARY_DIR}/wesnothd.service DESTINATION lib/systemd/system)
+#	 configure_file(packaging/systemd/wesnothd.tmpfiles.conf.in ${CMAKE_BINARY_DIR}/wesnothd.conf)
+#	 configure_file(packaging/systemd/wesnothd.service.in ${CMAKE_BINARY_DIR}/wesnothd.service)
+#	 install(FILES ${CMAKE_BINARY_DIR}/wesnothd.conf DESTINATION lib/tmpfiles.d)
+#	install(FILES ${CMAKE_BINARY_DIR}/wesnothd.service DESTINATION lib/systemd/system)
     endif()
 	if(SERVER_UID AND SERVER_GID)
 		install(CODE "execute_process(COMMAND chown ${SERVER_UID}:${SERVER_GID} \$ENV{DESTDIR}/${FIFO_DIR})")

--- a/cmake/FindSDL2.cmake
+++ b/cmake/FindSDL2.cmake
@@ -1,0 +1,221 @@
+#.rst:
+# FindSDL2
+# -------
+#
+# Locate SDL2 library
+#
+# This module defines
+#
+# ::
+#
+#   SDL2_LIBRARY, the name of the library to link against
+#   SDL2_FOUND, if false, do not try to link to SDL2
+#   SDL2_INCLUDE_DIR, where to find SDL2.h
+#   SDL2_VERSION_STRING, human-readable string containing the version of SDL2
+#
+#
+#
+# This module responds to the flag:
+#
+# ::
+#
+#   SDL2_BUILDING_LIBRARY
+#     If this is defined, then no SDL2_main will be linked in because
+#     only applications need main().
+#     Otherwise, it is assumed you are building an application and this
+#     module will attempt to locate and set the proper link flags
+#     as part of the returned SDL2_LIBRARY variable.
+#
+#
+#
+# Don't forget to include SDL2main.h and SDL2main.m your project for the
+# OS X framework based version.  (Other versions link to -lSDL2main which
+# this module will try to find on your behalf.) Also for OS X, this
+# module will automatically add the -framework Cocoa on your behalf.
+#
+#
+#
+# Additional Note: If you see an empty SDL2_LIBRARY_TEMP in your
+# configuration and no SDL2_LIBRARY, it means CMake did not find your SDL2
+# library (SDL2.dll, libsdl.so, SDL2.framework, etc).  Set
+# SDL2_LIBRARY_TEMP to point to your SDL2 library, and configure again.
+# Similarly, if you see an empty SDL2MAIN_LIBRARY, you should set this
+# value as appropriate.  These values are used to generate the final
+# SDL2_LIBRARY variable, but when these values are unset, SDL2_LIBRARY
+# does not get created.
+#
+#
+#
+# $SDL2DIR is an environment variable that would correspond to the
+# ./configure --prefix=$SDL2DIR used in building SDL2.  l.e.galup 9-20-02
+#
+# Modified by Eric Wing.  Added code to assist with automated building
+# by using environmental variables and providing a more
+# controlled/consistent search behavior.  Added new modifications to
+# recognize OS X frameworks and additional Unix paths (FreeBSD, etc).
+# Also corrected the header search path to follow "proper" SDL2
+# guidelines.  Added a search for SDL2main which is needed by some
+# platforms.  Added a search for threads which is needed by some
+# platforms.  Added needed compile switches for MinGW.
+#
+# On OSX, this will prefer the Framework version (if found) over others.
+# People will have to manually change the cache values of SDL2_LIBRARY to
+# override this selection or set the CMake environment
+# CMAKE_INCLUDE_PATH to modify the search paths.
+#
+# Note that the header path has changed from SDL2/SDL.h to just SDL.h
+# This needed to change because "proper" SDL convention is #include
+# "SDL.h", not <SDL2/SDL.h>.  This is done for portability reasons
+# because not all systems place things in SDL/ (see FreeBSD).
+
+#=============================================================================
+# Copyright 2003-2009 Kitware, Inc.
+# Copyright 2012 Benjamin Eikel
+# Copyright 2015 Andreas Löf
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+# * Neither the names of Kitware, Inc., the Insight Software Consortium,
+#   nor the names of their contributors may be used to endorse or promote
+#   products derived from this software without specific prior written
+#   permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#=============================================================================
+
+
+find_path(SDL2_INCLUDE_DIR SDL.h
+  HINTS
+    ENV SDL2DIR
+  PATH_SUFFIXES SDL2 
+                # path suffixes to search inside ENV{SDLDIR}
+                include/SDL2 include
+)
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set(VC_LIB_PATH_SUFFIX lib/x64)
+else()
+  set(VC_LIB_PATH_SUFFIX lib/x86)
+endif()
+
+find_library(SDL2_LIBRARY_TEMP
+  NAMES SDL2
+  HINTS
+    ENV SDL2DIR
+  PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
+)
+
+if(NOT SDL2_BUILDING_LIBRARY)
+  if(NOT SDL2_INCLUDE_DIR MATCHES ".framework")
+    # Non-OS X framework versions expect you to also dynamically link to
+    # SDLmain. This is mainly for Windows and OS X. Other (Unix) platforms
+    # seem to provide SDLmain for compatibility even though they don't
+    # necessarily need it.
+    find_library(SDL2MAIN_LIBRARY
+      NAMES SDLmain SDLmain-1.1
+      HINTS
+        ENV SDL2DIR
+      PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
+      PATHS
+      /sw
+      /opt/local
+      /opt/csw
+      /opt
+    )
+  endif()
+endif()
+
+# SDL2 may require threads on your system.
+# The Apple build may not need an explicit flag because one of the
+# frameworks may already provide it.
+# But for non-OSX systems, I will use the CMake Threads package.
+if(NOT APPLE)
+  find_package(Threads)
+endif()
+
+# MinGW needs an additional library, mwindows
+# It's total link flags should look like -lmingw32 -lSDL2main -lSDL2 -lmwindows
+# (Actually on second look, I think it only needs one of the m* libraries.)
+if(MINGW)
+  set(MINGW32_LIBRARY mingw32 CACHE STRING "mwindows for MinGW")
+endif()
+
+if(SDL2_LIBRARY_TEMP)
+  # For SDL2main
+  if(SDL2MAIN_LIBRARY AND NOT SDL2_BUILDING_LIBRARY)
+    list(FIND SDL2_LIBRARY_TEMP "${SDL2MAIN_LIBRARY}" _SDL2_MAIN_INDEX)
+    if(_SDL2_MAIN_INDEX EQUAL -1)
+      set(SDL2_LIBRARY_TEMP "${SDL2MAIN_LIBRARY}" ${SDL2_LIBRARY_TEMP})
+    endif()
+    unset(_SDL2_MAIN_INDEX)
+  endif()
+
+  # For OS X, SDL2 uses Cocoa as a backend so it must link to Cocoa.
+  # CMake doesn't display the -framework Cocoa string in the UI even
+  # though it actually is there if I modify a pre-used variable.
+  # I think it has something to do with the CACHE STRING.
+  # So I use a temporary variable until the end so I can set the
+  # "real" variable in one-shot.
+  if(APPLE)
+    set(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} "-framework Cocoa")
+  endif()
+
+  # For threads, as mentioned Apple doesn't need this.
+  # In fact, there seems to be a problem if I used the Threads package
+  # and try using this line, so I'm just skipping it entirely for OS X.
+  if(NOT APPLE)
+    set(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} ${CMAKE_THREAD_LIBS_INIT})
+  endif()
+
+  # For MinGW library
+  if(MINGW)
+    set(SDL2_LIBRARY_TEMP ${MINGW32_LIBRARY} ${SDL2_LIBRARY_TEMP})
+  endif()
+
+  # Set the final string here so the GUI reflects the final state.
+  set(SDL2_LIBRARY ${SDL2_LIBRARY_TEMP} CACHE STRING "Where the SDL2 Library can be found")
+  # Set the temp variable to INTERNAL so it is not seen in the CMake GUI
+  set(SDL2_LIBRARY_TEMP "${SDL2_LIBRARY_TEMP}" CACHE INTERNAL "")
+endif()
+
+if(SDL2_INCLUDE_DIR AND EXISTS "${SDL2_INCLUDE_DIR}/SDL_version.h")
+  file(STRINGS "${SDL2_INCLUDE_DIR}/SDL_version.h" SDL_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL_MAJOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_INCLUDE_DIR}/SDL_version.h" SDL_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL_MINOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_INCLUDE_DIR}/SDL_version.h" SDL_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL_PATCHLEVEL[ \t]+[0-9]+$")
+  string(REGEX REPLACE "^#define[ \t]+SDL_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL_VERSION_MAJOR "${SDL_VERSION_MAJOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL_VERSION_MINOR "${SDL_VERSION_MINOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL_VERSION_PATCH "${SDL_VERSION_PATCH_LINE}")
+  set(SDL2_VERSION_STRING ${SDL_VERSION_MAJOR}.${SDL_VERSION_MINOR}.${SDL_VERSION_PATCH})
+  unset(SDL_VERSION_MAJOR_LINE)
+  unset(SDL_VERSION_MINOR_LINE)
+  unset(SDL_VERSION_PATCH_LINE)
+  unset(SDL_VERSION_MAJOR)
+  unset(SDL_VERSION_MINOR)
+  unset(SDL_VERSION_PATCH)
+endif()
+
+#include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2
+                                  REQUIRED_VARS SDL2_LIBRARY SDL2_INCLUDE_DIR
+                                  VERSION_VAR SDL2_VERSION_STRING)

--- a/cmake/FindSDL2_image.cmake
+++ b/cmake/FindSDL2_image.cmake
@@ -1,0 +1,130 @@
+#.rst:
+# FindSDL2_image
+# -------------
+#
+# Locate SDL2_image library
+#
+# This module defines:
+#
+# ::
+#
+#   SDL2_IMAGE_LIBRARIES, the name of the library to link against
+#   SDL2_IMAGE_INCLUDE_DIRS, where to find the headers
+#   SDL2_IMAGE_FOUND, if false, do not try to link against
+#   SDL2_IMAGE_VERSION_STRING - human-readable string containing the
+#                              version of SDL2_image
+#
+#
+#
+# For backward compatiblity the following variables are also set:
+#
+# ::
+#
+#   SDL2IMAGE_LIBRARY (same value as SDL2_IMAGE_LIBRARIES)
+#   SDL2IMAGE_INCLUDE_DIR (same value as SDL2_IMAGE_INCLUDE_DIRS)
+#   SDL2IMAGE_FOUND (same value as SDL2_IMAGE_FOUND)
+#
+#
+#
+# $SDL2DIR is an environment variable that would correspond to the
+# ./configure --prefix=$SDL2DIR used in building SDL2.
+#
+# Created by Andreas Löf.  This was influenced by the FindSDL_image.cmake
+# module, but with modifications to use SDL2.
+#
+#=============================================================================
+# Copyright 2005-2009 Kitware, Inc.
+# Copyright 2012 Benjamin Eikel
+# Copyright 2015 Andreas Löf
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+# * Neither the names of Kitware, Inc., the Insight Software Consortium,
+#   nor the names of their contributors may be used to endorse or promote
+#   products derived from this software without specific prior written
+#   permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#=============================================================================
+
+if(NOT SDL2_IMAGE_INCLUDE_DIR AND SDL2IMAGE_INCLUDE_DIR)
+  set(SDL2_IMAGE_INCLUDE_DIR ${SDL2IMAGE_INCLUDE_DIR} CACHE PATH "directory cache
+entry initialized from old variable name")
+endif()
+find_path(SDL2_IMAGE_INCLUDE_DIR SDL_image.h
+  HINTS
+    ENV SDL2IMAGEDIR
+    ENV SDL2DIR
+  PATH_SUFFIXES SDL2
+                # path suffixes to search inside ENV{SDL2DIR}
+                include/SDL2
+)
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set(VC_LIB_PATH_SUFFIX lib/x64)
+else()
+  set(VC_LIB_PATH_SUFFIX lib/x86)
+endif()
+
+if(NOT SDL2_IMAGE_LIBRARY AND SDL2IMAGE_LIBRARY)
+  set(SDL2_IMAGE_LIBRARY ${SDL2IMAGE_LIBRARY} CACHE FILEPATH "file cache entry
+initialized from old variable name")
+endif()
+find_library(SDL2_IMAGE_LIBRARY
+  NAMES SDL2_image
+  HINTS
+    ENV SDL2IMAGEDIR
+    ENV SDL2DIR
+  PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
+)
+
+if(SDL2_IMAGE_INCLUDE_DIR AND EXISTS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h")
+  file(STRINGS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h" SDL_IMAGE_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL_IMAGE_MAJOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h" SDL_IMAGE_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL_IMAGE_MINOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h" SDL_IMAGE_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL_IMAGE_PATCHLEVEL[ \t]+[0-9]+$")
+  string(REGEX REPLACE "^#define[ \t]+SDL_IMAGE_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL_IMAGE_VERSION_MAJOR "${SDL_IMAGE_VERSION_MAJOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL_IMAGE_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL_IMAGE_VERSION_MINOR "${SDL_IMAGE_VERSION_MINOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL_IMAGE_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL_IMAGE_VERSION_PATCH "${SDL_IMAGE_VERSION_PATCH_LINE}")
+  set(SDL2_IMAGE_VERSION_STRING ${SDL_IMAGE_VERSION_MAJOR}.${SDL_IMAGE_VERSION_MINOR}.${SDL_IMAGE_VERSION_PATCH})
+  unset(SDL_IMAGE_VERSION_MAJOR_LINE)
+  unset(SDL_IMAGE_VERSION_MINOR_LINE)
+  unset(SDL_IMAGE_VERSION_PATCH_LINE)
+  unset(SDL_IMAGE_VERSION_MAJOR)
+  unset(SDL_IMAGE_VERSION_MINOR)
+  unset(SDL_IMAGE_VERSION_PATCH)
+endif()
+
+set(SDL2_IMAGE_LIBRARIES ${SDL2_IMAGE_LIBRARY})
+set(SDL2_IMAGE_INCLUDE_DIRS ${SDL2_IMAGE_INCLUDE_DIR})
+
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_image
+                                  REQUIRED_VARS SDL2_IMAGE_LIBRARIES SDL2_IMAGE_INCLUDE_DIRS
+                                  VERSION_VAR SDL2_IMAGE_VERSION_STRING)
+
+# for backward compatiblity
+set(SDL2IMAGE_LIBRARY ${SDL2_IMAGE_LIBRARIES})
+set(SDL2IMAGE_INCLUDE_DIR ${SDL2_IMAGE_INCLUDE_DIRS})
+set(SDL2IMAGE_FOUND ${SDL2_IMAGE_FOUND})
+
+mark_as_advanced(SDL2_IMAGE_LIBRARY SDL2_IMAGE_INCLUDE_DIR)

--- a/cmake/FindSDL2_mixer.cmake
+++ b/cmake/FindSDL2_mixer.cmake
@@ -1,0 +1,129 @@
+#.rst:
+# FindSDL2_mixer
+# -------------
+#
+# Locate SDL2_mixer library
+#
+# This module defines:
+#
+# ::
+#
+#   SDL2_MIXER_LIBRARIES, the name of the library to link against
+#   SDL2_MIXER_INCLUDE_DIRS, where to find the headers
+#   SDL2_MIXER_FOUND, if false, do not try to link against
+#   SDL2_MIXER_VERSION_STRING - human-readable string containing the
+#                              version of SDL2_mixer
+#
+#
+#
+# For backward compatiblity the following variables are also set:
+#
+# ::
+#
+#   SDL2MIXER_LIBRARY (same value as SDL2_MIXER_LIBRARIES)
+#   SDL2MIXER_INCLUDE_DIR (same value as SDL2_MIXER_INCLUDE_DIRS)
+#   SDL2MIXER_FOUND (same value as SDL2_MIXER_FOUND)
+#
+#
+#
+# $SDL2DIR is an environment variable that would correspond to the
+# ./configure --prefix=$SDL2DIR used in building SDL2.
+#
+# Created by Andreas Löf.  This was influenced by the FindSDL_mixer.cmake
+# module, but with modifications to use SDL2.
+#
+#=============================================================================
+# Copyright 2005-2009 Kitware, Inc.
+# Copyright 2012 Benjamin Eikel
+# Copyright 2015 Andreas Löf
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+# * Neither the names of Kitware, Inc., the Insight Software Consortium,
+#   nor the names of their contributors may be used to endorse or promote
+#   products derived from this software without specific prior written
+#   permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#=============================================================================
+
+if(NOT SDL2_MIXER_INCLUDE_DIR AND SDL2MIXER_INCLUDE_DIR)
+  set(SDL2_MIXER_INCLUDE_DIR ${SDL2MIXER_INCLUDE_DIR} CACHE PATH "directory cache
+entry initialized from old variable name")
+endif()
+find_path(SDL2_MIXER_INCLUDE_DIR SDL_mixer.h
+  HINTS
+    ENV SDL2MIXERDIR
+    ENV SDL2DIR
+  PATH_SUFFIXES SDL2
+                # path suffixes to search inside ENV{SDL2DIR}
+                include/SDL2
+)
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set(VC_LIB_PATH_SUFFIX lib/x64)
+else()
+  set(VC_LIB_PATH_SUFFIX lib/x86)
+endif()
+
+if(NOT SDL2_MIXER_LIBRARY AND SDL2MIXER_LIBRARY)
+  set(SDL2_MIXER_LIBRARY ${SDL2MIXER_LIBRARY} CACHE FILEPATH "file cache entry
+initialized from old variable name")
+endif()
+find_library(SDL2_MIXER_LIBRARY
+  NAMES SDL2_mixer
+  HINTS
+    ENV SDL2MIXERDIR
+    ENV SDL2DIR
+  PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
+)
+
+if(SDL2_MIXER_INCLUDE_DIR AND EXISTS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h")
+  file(STRINGS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h" SDL_MIXER_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL_MIXER_MAJOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h" SDL_MIXER_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL_MIXER_MINOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h" SDL_MIXER_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL_MIXER_PATCHLEVEL[ \t]+[0-9]+$")
+  string(REGEX REPLACE "^#define[ \t]+SDL_MIXER_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL_MIXER_VERSION_MAJOR "${SDL_MIXER_VERSION_MAJOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL_MIXER_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL_MIXER_VERSION_MINOR "${SDL_MIXER_VERSION_MINOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL_MIXER_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL_MIXER_VERSION_PATCH "${SDL_MIXER_VERSION_PATCH_LINE}")
+  set(SDL2_MIXER_VERSION_STRING ${SDL_MIXER_VERSION_MAJOR}.${SDL_MIXER_VERSION_MINOR}.${SDL_MIXER_VERSION_PATCH})
+  unset(SDL_MIXER_VERSION_MAJOR_LINE)
+  unset(SDL_MIXER_VERSION_MINOR_LINE)
+  unset(SDL_MIXER_VERSION_PATCH_LINE)
+  unset(SDL_MIXER_VERSION_MAJOR)
+  unset(SDL_MIXER_VERSION_MINOR)
+  unset(SDL_MIXER_VERSION_PATCH)
+endif()
+
+set(SDL2_MIXER_LIBRARIES ${SDL2_MIXER_LIBRARY})
+set(SDL2_MIXER_INCLUDE_DIRS ${SDL2_MIXER_INCLUDE_DIR})
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_mixer
+                                  REQUIRED_VARS SDL2_MIXER_LIBRARIES SDL2_MIXER_INCLUDE_DIRS
+                                  VERSION_VAR SDL2_MIXER_VERSION_STRING)
+
+# for backward compatiblity
+set(SDL2MIXER_LIBRARY ${SDL2_MIXER_LIBRARIES})
+set(SDL2MIXER_INCLUDE_DIR ${SDL2_MIXER_INCLUDE_DIRS})
+set(SDL2MIXER_FOUND ${SDL2_MIXER_FOUND})
+
+mark_as_advanced(SDL2_MIXER_LIBRARY SDL2_MIXER_INCLUDE_DIR)

--- a/cmake/FindSDL2_net.cmake
+++ b/cmake/FindSDL2_net.cmake
@@ -1,0 +1,128 @@
+#.rst:
+# FindSDL2_net
+# -----------
+#
+# Locate SDL2_net library
+#
+# This module defines:
+#
+# ::
+#
+#   SDL2_NET_LIBRARIES, the name of the library to link against
+#   SDL2_NET_INCLUDE_DIRS, where to find the headers
+#   SDL2_NET_FOUND, if false, do not try to link against
+#   SDL2_NET_VERSION_STRING - human-readable string containing the version of SDL2_net
+#
+#
+#
+# For backward compatiblity the following variables are also set:
+#
+# ::
+#
+#   SDL2NET_LIBRARY (same value as SDL2_NET_LIBRARIES)
+#   SDL2NET_INCLUDE_DIR (same value as SDL2_NET_INCLUDE_DIRS)
+#   SDL2NET_FOUND (same value as SDL2_NET_FOUND)
+#
+#
+#
+# $SDL2DIR is an environment variable that would correspond to the
+# ./configure --prefix=$SDL2DIR used in building SDL2.
+#
+# Created by Andreas Löf.  This was influenced by the FindSDL_net.cmake
+# module, but with modifications to use SDL2.
+#
+#=============================================================================
+# Copyright 2005-2009 Kitware, Inc.
+# Copyright 2012 Benjamin Eikel
+# Copyright 2015 Andreas Löf
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+# * Neither the names of Kitware, Inc., the Insight Software Consortium,
+#   nor the names of their contributors may be used to endorse or promote
+#   products derived from this software without specific prior written
+#   permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#=============================================================================
+
+if(NOT SDL2_NET_INCLUDE_DIR AND SDL2NET_INCLUDE_DIR)
+  set(SDL2_NET_INCLUDE_DIR ${SDL2NET_INCLUDE_DIR} CACHE PATH "directory cache
+entry initialized from old variable name")
+endif()
+find_path(SDL2_NET_INCLUDE_DIR SDL_net.h
+  HINTS
+    ENV SDL2NETDIR
+    ENV SDL2DIR
+  PATH_SUFFIXES SDL2
+                # path suffixes to search inside ENV{SDL2DIR}
+                include/SDL2
+)
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set(VC_LIB_PATH_SUFFIX lib/x64)
+else()
+  set(VC_LIB_PATH_SUFFIX lib/x86)
+endif()
+
+if(NOT SDL2_NET_LIBRARY AND SDL2NET_LIBRARY)
+  set(SDL2_NET_LIBRARY ${SDL2NET_LIBRARY} CACHE FILEPATH "file cache entry
+initialized from old variable name")
+endif()
+find_library(SDL2_NET_LIBRARY
+  NAMES SDL2_net
+  HINTS
+    ENV SDL2NETDIR
+    ENV SDL2DIR
+  PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
+)
+
+if(SDL2_NET_INCLUDE_DIR AND EXISTS "${SDL2_NET_INCLUDE_DIR}/SDL_net.h")
+  file(STRINGS "${SDL2_NET_INCLUDE_DIR}/SDL_net.h" SDL_NET_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL_NET_MAJOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_NET_INCLUDE_DIR}/SDL_net.h" SDL_NET_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL_NET_MINOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_NET_INCLUDE_DIR}/SDL_net.h" SDL_NET_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL_NET_PATCHLEVEL[ \t]+[0-9]+$")
+  string(REGEX REPLACE "^#define[ \t]+SDL_NET_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL_NET_VERSION_MAJOR "${SDL_NET_VERSION_MAJOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL_NET_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL_NET_VERSION_MINOR "${SDL_NET_VERSION_MINOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL_NET_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL_NET_VERSION_PATCH "${SDL_NET_VERSION_PATCH_LINE}")
+  set(SDL2_NET_VERSION_STRING ${SDL_NET_VERSION_MAJOR}.${SDL_NET_VERSION_MINOR}.${SDL_NET_VERSION_PATCH})
+  unset(SDL_NET_VERSION_MAJOR_LINE)
+  unset(SDL_NET_VERSION_MINOR_LINE)
+  unset(SDL_NET_VERSION_PATCH_LINE)
+  unset(SDL_NET_VERSION_MAJOR)
+  unset(SDL_NET_VERSION_MINOR)
+  unset(SDL_NET_VERSION_PATCH)
+endif()
+
+set(SDL2_NET_LIBRARIES ${SDL2_NET_LIBRARY})
+set(SDL2_NET_INCLUDE_DIRS ${SDL2_NET_INCLUDE_DIR})
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_net
+                                  REQUIRED_VARS SDL2_NET_LIBRARIES SDL2_NET_INCLUDE_DIRS
+                                  VERSION_VAR SDL2_NET_VERSION_STRING)
+
+# for backward compatiblity
+set(SDL2NET_LIBRARY ${SDL2_NET_LIBRARIES})
+set(SDL2NET_INCLUDE_DIR ${SDL2_NET_INCLUDE_DIRS})
+set(SDL2NET_FOUND ${SDL2_NET_FOUND})
+
+mark_as_advanced(SDL2_NET_LIBRARY SDL2_NET_INCLUDE_DIR)

--- a/cmake/FindSDL2_ttf.cmake
+++ b/cmake/FindSDL2_ttf.cmake
@@ -1,0 +1,128 @@
+#.rst:
+# FindSDL2_ttf
+# -----------
+#
+# Locate SDL2_ttf library
+#
+# This module defines:
+#
+# ::
+#
+#   SDL2_TTF_LIBRARIES, the name of the library to link against
+#   SDL2_TTF_INCLUDE_DIRS, where to find the headers
+#   SDL2_TTF_FOUND, if false, do not try to link against
+#   SDL2_TTF_VERSION_STRING - human-readable string containing the version of SDL2_ttf
+#
+#
+#
+# For backward compatiblity the following variables are also set:
+#
+# ::
+#
+#   SDL2TTF_LIBRARY (same value as SDL2_TTF_LIBRARIES)
+#   SDL2TTF_INCLUDE_DIR (same value as SDL2_TTF_INCLUDE_DIRS)
+#   SDL2TTF_FOUND (same value as SDL2_TTF_FOUND)
+#
+#
+#
+# $SDL2DIR is an environment variable that would correspond to the
+# ./configure --prefix=$SDL2DIR used in building SDL2.
+#
+# Created by Andreas Löf.  This was influenced by the FindSDL_ttf.cmake
+# module, but with modifications to use SDL2.
+#
+#=============================================================================
+# Copyright 2005-2009 Kitware, Inc.
+# Copyright 2012 Benjamin Eikel
+# Copyright 2015 Andreas Löf
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+# * Neither the names of Kitware, Inc., the Insight Software Consortium,
+#   nor the names of their contributors may be used to endorse or promote
+#   products derived from this software without specific prior written
+#   permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#=============================================================================
+
+if(NOT SDL2_TTF_INCLUDE_DIR AND SDL2TTF_INCLUDE_DIR)
+  set(SDL2_TTF_INCLUDE_DIR ${SDL2TTF_INCLUDE_DIR} CACHE PATH "directory cache
+entry initialized from old variable name")
+endif()
+find_path(SDL2_TTF_INCLUDE_DIR SDL_ttf.h
+  HINTS
+    ENV SDL2TTFDIR
+    ENV SDL2DIR
+  PATH_SUFFIXES SDL2
+                # path suffixes to search inside ENV{SDL2DIR}
+                include/SDL2 include/SDL12 include/SDL11 include
+)
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set(VC_LIB_PATH_SUFFIX lib/x64)
+else()
+  set(VC_LIB_PATH_SUFFIX lib/x86)
+endif()
+
+if(NOT SDL2_TTF_LIBRARY AND SDL2TTF_LIBRARY)
+  set(SDL2_TTF_LIBRARY ${SDL2TTF_LIBRARY} CACHE FILEPATH "file cache entry
+initialized from old variable name")
+endif()
+find_library(SDL2_TTF_LIBRARY
+  NAMES SDL2_ttf
+  HINTS
+    ENV SDL2TTFDIR
+    ENV SDL2DIR
+  PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
+)
+
+if(SDL2_TTF_INCLUDE_DIR AND EXISTS "${SDL2_TTF_INCLUDE_DIR}/SDL_ttf.h")
+  file(STRINGS "${SDL2_TTF_INCLUDE_DIR}/SDL_ttf.h" SDL_TTF_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL_TTF_MAJOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_TTF_INCLUDE_DIR}/SDL_ttf.h" SDL_TTF_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL_TTF_MINOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_TTF_INCLUDE_DIR}/SDL_ttf.h" SDL_TTF_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL_TTF_PATCHLEVEL[ \t]+[0-9]+$")
+  string(REGEX REPLACE "^#define[ \t]+SDL_TTF_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL_TTF_VERSION_MAJOR "${SDL_TTF_VERSION_MAJOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL_TTF_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL_TTF_VERSION_MINOR "${SDL_TTF_VERSION_MINOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL_TTF_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL_TTF_VERSION_PATCH "${SDL_TTF_VERSION_PATCH_LINE}")
+  set(SDL2_TTF_VERSION_STRING ${SDL_TTF_VERSION_MAJOR}.${SDL_TTF_VERSION_MINOR}.${SDL_TTF_VERSION_PATCH})
+  unset(SDL_TTF_VERSION_MAJOR_LINE)
+  unset(SDL_TTF_VERSION_MINOR_LINE)
+  unset(SDL_TTF_VERSION_PATCH_LINE)
+  unset(SDL_TTF_VERSION_MAJOR)
+  unset(SDL_TTF_VERSION_MINOR)
+  unset(SDL_TTF_VERSION_PATCH)
+endif()
+
+set(SDL2_TTF_LIBRARIES ${SDL2_TTF_LIBRARY})
+set(SDL2_TTF_INCLUDE_DIRS ${SDL2_TTF_INCLUDE_DIR})
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_ttf
+                                  REQUIRED_VARS SDL2_TTF_LIBRARIES SDL2_TTF_INCLUDE_DIRS
+                                  VERSION_VAR SDL2_TTF_VERSION_STRING)
+
+# for backward compatiblity
+set(SDL2TTF_LIBRARY ${SDL2_TTF_LIBRARIES})
+set(SDL2TTF_INCLUDE_DIR ${SDL2_TTF_INCLUDE_DIRS})
+set(SDL2TTF_FOUND ${SDL2_TTF_FOUND})
+
+mark_as_advanced(SDL2_TTF_LIBRARY SDL2_TTF_INCLUDE_DIR)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,26 +15,56 @@ else(MSVC)
 endif(MSVC)
 
 
-include_directories(SYSTEM ${SDL_INCLUDE_DIR} )
 include_directories(SYSTEM ${PANGOCAIRO_INCLUDE_DIRS} )
 include_directories(SYSTEM ${GETTEXT_INCLUDE_DIR} )
 include_directories(SYSTEM ${LIBDBUS_INCLUDE_DIRS} )
 include_directories(SYSTEM ${LIBINTL_INCLUDE_DIR} )
 include_directories(SYSTEM ${VORBISFILE_INCLUDE_DIR} )
 
-#optional dependencies
-if(SDLIMAGE_INCLUDE_DIR)
-	include_directories(SYSTEM ${SDLIMAGE_INCLUDE_DIR} )
-endif()
-if(SDLMIXER_INCLUDE_DIR)
-	include_directories(SYSTEM ${SDLMIXER_INCLUDE_DIR} )
-endif()
-if(SDLNET_INCLUDE_DIR)
-	include_directories(SYSTEM ${SDLNET_INCLUDE_DIR} )
-endif()
-if(SDLTTF_INCLUDE_DIR)
-	include_directories(SYSTEM ${SDLTTF_INCLUDE_DIR} )
-endif()
+if(ENABLE_SDL2)
+	include_directories(SYSTEM ${SDL2_INCLUDE_DIR} )
+	set(sdl-lib ${SDL2_LIBRARY})
+	set(sdlmain-lib ${SDL2MAIN_LIBRARY})
+	#optional dependencies
+	if(SDL2IMAGE_INCLUDE_DIR)
+		include_directories(SYSTEM ${SDL2IMAGE_INCLUDE_DIR} )
+		set(sdl_image-lib ${SDL2_IMAGE_LIBRARY})
+	endif()
+	if(SDL2MIXER_INCLUDE_DIR)
+		include_directories(SYSTEM ${SDL2MIXER_INCLUDE_DIR} )
+		set(sdl_mixer-lib ${SDL2_MIXER_LIBRARY})
+	endif()
+	if(SDL2NET_INCLUDE_DIR)
+		include_directories(SYSTEM ${SDL2NET_INCLUDE_DIR} )
+		set(sdl_net-lib ${SDL2_NET_LIBRARY})
+	endif()
+	if(SDL2TTF_INCLUDE_DIR)
+		include_directories(SYSTEM ${SDL2TTF_INCLUDE_DIR} )
+		set(sdl_ttf-lib ${SDL2_TTF_LIBRARY})
+	endif()
+else(ENABLE_SDL2)
+	include_directories(SYSTEM ${SDL_INCLUDE_DIR} )
+	set(sdl-lib ${SDL_LIBRARY})
+	set(sdlmain-lib ${SDLMAIN_LIBRARY})
+	#optional dependencies
+	if(SDLIMAGE_INCLUDE_DIR)
+		include_directories(SYSTEM ${SDLIMAGE_INCLUDE_DIR} )
+		set(sdl_image-lib ${SDLIMAGE_LIBRARY})
+	endif()
+	if(SDLMIXER_INCLUDE_DIR)
+		include_directories(SYSTEM ${SDLMIXER_INCLUDE_DIR} )
+		set(sdl_mixer-lib ${SDLMIXER_LIBRARY})
+	endif()
+	if(SDLNET_INCLUDE_DIR)
+		include_directories(SYSTEM ${SDLNET_INCLUDE_DIR} )
+		set(sdl_net-lib ${SDLNET_LIBRARY})
+	endif()
+	if(SDLTTF_INCLUDE_DIR)
+		include_directories(SYSTEM ${SDLTTF_INCLUDE_DIR} )
+		set(sdl_ttf-lib ${SDLTTF_LIBRARY})
+	endif()
+endif(ENABLE_SDL2)
+
 if(ZLIB_INCLUDE_DIR)
 	include_directories(SYSTEM ${ZLIB_INCLUDE_DIR} )
 endif()
@@ -65,14 +95,14 @@ if(MSVC)
 	# Since MSVC does autolinking of boost adding those files will duplicate
 	# the includes and cause build errors.
 	set(common-external-libs
-		${SDL_LIBRARY}
-		${SDLMAIN_LIBRARY}
+		${sdl-lib}
+		${sdlmain-lib}
 		ws2_32.lib
 		${sdl_gpu-lib-vc}
 	)
 else(MSVC)
 	set(common-external-libs
-		${SDL_LIBRARY}
+		${sdl-lib}
 		${Boost_IOSTREAMS_LIBRARY}
 		${Boost_REGEX_LIBRARY}
 		${Boost_PROGRAM_OPTIONS_LIBRARY}
@@ -101,9 +131,9 @@ set(game-external-libs
 	${common-external-libs}
 	${Boost_SYSTEM_LIBRARIES}
 	${Boost_RANDOM_LIBRARY}
-	${SDLIMAGE_LIBRARY}
-	${SDLMIXER_LIBRARY}
-	${SDLTTF_LIBRARY}
+	${sdl_image-lib}
+	${sdl_mixer-lib}
+	${sdl_ttf-lib}
 	${PANGOCAIRO_LIBRARIES}
 	${FONTCONFIG_LIBRARIES}
 	${LIBDBUS_LIBRARIES}
@@ -136,18 +166,18 @@ endif(MSVC)
 
 set(server-external-libs
 	${common-external-libs}
-	${SDLNET_LIBRARY}
+	${sdl_net-lib}
 	${Boost_SYSTEM_LIBRARIES}
 )
 
 set(game-external-libs
 	${game-external-libs}
-	${SDLNET_LIBRARY}
+	${sdl_net-lib}
 )
 
 set(tools-external-libs
 	${common-external-libs}
-	${SDLIMAGE_LIBRARY}
+	${sdl_image-lib}
 	${Boost_FILESYSTEM_LIBRARY}
 	${Boost_SYSTEM_LIBRARIES}
 	${Boost_RANDOM_LIBRARY}
@@ -432,8 +462,8 @@ add_library(wesnoth-sdl
 )
 
 target_link_libraries(wesnoth-sdl
-	${SDL_LIBRARY}
-	${SDLIMAGE_LIBRARY}
+	${sdl-lib}
+	${sdl_image-lib}
 )
 
 # The main library is rather huge especially in debug mode, causing quite a bit

--- a/src/desktop/clipboard.cpp
+++ b/src/desktop/clipboard.cpp
@@ -61,7 +61,7 @@ void handle_system_event(const SDL_Event& /*event*/)
 
 bool available()
 {
-	return false;
+	return true;
 }
 
 } // end namespace clipboard

--- a/src/sdl/window.hpp
+++ b/src/sdl/window.hpp
@@ -38,10 +38,6 @@ struct SDL_Renderer;
 namespace sdl
 {
 
-#if TTEXTURE
-class ttexture;
-#endif
-
 /**
  * The wrapper class for the @ref SDL_Window class.
  *


### PR DESCRIPTION
This adds support for doing SDL2 builds with CMake, as well as the required modules to find SDL2 and its dependencies.
To enable:
`-DENABLE_SDL2=TRUE`
SDL2 is disabled by default.

I have also made sure that clipboard is properly enabled for SDL2, and remove a piece of dead code for the defunct ttexture class.