### PR TITLE
Add female_text key to [animate_unit] and [unstore_unit]

### DIFF
--- a/changelog
+++ b/changelog
@@ -36,6 +36,7 @@ Version 1.13.1+dev:
    * Added support for has_flag= in terrain graphics [variant].
    * Added category= to [label] - allows grouping labels so that players can
      show/hide them
+   * Add female_text= to [animate_unit] and [unstore_unit] for easier translating
  * Editor:
    * Added Category field and color sliders to the Edit Label panel.
  * Miscellaneous and bug fixes:

--- a/data/campaigns/Dead_Water/units/Brawler.cfg
+++ b/data/campaigns/Dead_Water/units/Brawler.cfg
@@ -100,31 +100,11 @@
 
         {VARIABLE second_unit.status.stunned yes}
 
-        [if]
-            [variable]
-                name=second_unit.gender
-                equals=female
-            [/variable]
-
-            [then]
-                [set_variable]
-                    name=tmp_stunned_text
-                    value= _ "female^stunned"
-                [/set_variable]
-            [/then]
-
-            [else]
-                [set_variable]
-                    name=tmp_stunned_text
-                    value= _ "stunned"
-                [/set_variable]
-            [/else]
-        [/if]
-
         [unstore_unit]
             variable=second_unit
             find_vacant=no
-            text=$tmp_stunned_text
+            text= _ "stunned"
+            female_text= _ "female^stunned"
             red,green,blue=196,196,128
         [/unstore_unit]
 
@@ -146,10 +126,6 @@
                 value=no
             [/effect]
         [/object]
-
-        [clear_variable]
-            name=tmp_stunned_text
-        [/clear_variable]
     [/event]
 
     [event]

--- a/src/game_events/action_wml.cpp
+++ b/src/game_events/action_wml.cpp
@@ -1684,7 +1684,7 @@ WML_HANDLER_FUNCTION(unstore_unit, /*event_info*/, cfg)
 			resources::units->erase(loc);
 			resources::units->add(loc, *u);
 
-			config::attribute_value text = cfg["gender"].str() == "female" ? cfg["female_text"] : cfg["text"];
+			config::attribute_value text = var["gender"].str() == "female" ? cfg["female_text"] : cfg["male_text"];
 			if(text.blank()) {
 				text = cfg["text"];
 			}

--- a/src/game_events/action_wml.cpp
+++ b/src/game_events/action_wml.cpp
@@ -1684,7 +1684,10 @@ WML_HANDLER_FUNCTION(unstore_unit, /*event_info*/, cfg)
 			resources::units->erase(loc);
 			resources::units->add(loc, *u);
 
-			std::string text = cfg["text"];
+			config::attribute_value text = cfg["gender"].str() == "female" ? cfg["female_text"] : cfg["text"];
+			if(text.blank()) {
+				text = cfg["text"];
+			}
 			play_controller *controller = resources::controller;
 			if(!text.empty() && !controller->is_skipping_replay())
 			{

--- a/src/unit_display.cpp
+++ b/src/unit_display.cpp
@@ -868,9 +868,14 @@ void wml_animation_internal(unit_animator &animator, const vconfig &cfg, const m
 				secondary_loc = u->get_location().get_direction(dir);
 			}
 		}
+		config::attribute_value text = u->gender() == unit_race::FEMALE ? cfg["female_text"] : cfg["text"];
+		if(text.blank()) {
+			text = cfg["text"];
+		}
+		const std::string text_key = u->gender() == unit_race::FEMALE ? "female_text" : "text";
 		animator.add_animation(&*u, cfg["flag"], u->get_location(),
 			secondary_loc, cfg["value"], cfg["with_bars"].to_bool(),
-			cfg["text"], text_color, hits, primary, secondary,
+			text.str(), text_color, hits, primary, secondary,
 			cfg["value_second"]);
 	}
 	const vconfig::child_list sub_anims = cfg.get_children("animate");

--- a/src/unit_display.cpp
+++ b/src/unit_display.cpp
@@ -868,11 +868,10 @@ void wml_animation_internal(unit_animator &animator, const vconfig &cfg, const m
 				secondary_loc = u->get_location().get_direction(dir);
 			}
 		}
-		config::attribute_value text = u->gender() == unit_race::FEMALE ? cfg["female_text"] : cfg["text"];
+		config::attribute_value text = u->gender() == unit_race::FEMALE ? cfg["female_text"] : cfg["male_text"];
 		if(text.blank()) {
 			text = cfg["text"];
 		}
-		const std::string text_key = u->gender() == unit_race::FEMALE ? "female_text" : "text";
 		animator.add_animation(&*u, cfg["flag"], u->get_location(),
 			secondary_loc, cfg["value"], cfg["with_bars"].to_bool(),
 			text.str(), text_color, hits, primary, secondary,


### PR DESCRIPTION
Many other places make use of a female_XXX key to specify differing text for a female unit, and at least one place in mainline requires differing text for a female unit in this context. It's a convenience mainly, but it also feels more consistent.

I've also updated Dead Water to make use of this feature in the code for the stun weapon special. There may be other places in campaigns that could make use of it.