### PR TITLE
Fix lack of confirmation when quitting via Cmd-Q

### DIFF
--- a/changelog
+++ b/changelog
@@ -31,6 +31,7 @@ Version 1.13.1+dev:
        visible.
    * Added a version dialog button to the title screen, replacing the Paths
      option previously found in Preferences -> General.
+   * Add confirmation dialog when quitting via Cmd-Q / Alt-F4 / window close button / etc
  * WML engine:
    * Added support for mod_x,mod_y= in [terrain_graphics].
    * Added support for has_flag= in terrain graphics [variant].

--- a/src/controller_base.cpp
+++ b/src/controller_base.cpp
@@ -99,6 +99,9 @@ void controller_base::handle_event(const SDL_Event& event)
 			show_menu(get_display().get_theme().context_menu()->items(),event.button.x,event.button.y,true, get_display());
 		}
 		break;
+	case SDL_QUIT:
+		process_quit_request();
+		break;
 #if !SDL_VERSION_ATLEAST(2, 0, 0)
 	case SDL_ACTIVEEVENT:
 		if (event.active.state == SDL_APPMOUSEFOCUS && event.active.gain == 0) {
@@ -128,6 +131,10 @@ void controller_base::handle_event(const SDL_Event& event)
 bool controller_base::have_keyboard_focus()
 {
 	return true;
+}
+
+void controller_base::process_quit_request() {
+	throw CVideo::quit();
 }
 
 void controller_base::process_focus_keydown_event(const SDL_Event& /*event*/) {

--- a/src/controller_base.hpp
+++ b/src/controller_base.hpp
@@ -127,6 +127,12 @@ protected:
 	 * Overridden in derived classes
 	 */
 	virtual void process_keyup_event(const SDL_Event& event);
+	
+	/**
+	 * Process quit request.
+	 * Overridden in derived classes
+	 */
+	virtual void process_quit_request();
 
 	virtual void show_menu(const std::vector<std::string>& items_arg, int xloc, int yloc, bool context_menu, display& disp);
 	virtual void execute_action(const std::vector<std::string>& items_arg, int xloc, int yloc, bool context_menu);

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -415,7 +415,7 @@ void pump()
 #endif
 
 			case SDL_QUIT: {
-				throw CVideo::quit();
+				break; // Nothing to do anymore
 			}
 		}
 

--- a/src/gui/auxiliary/event/handler.cpp
+++ b/src/gui/auxiliary/event/handler.cpp
@@ -436,6 +436,9 @@ void thandler::handle_event(const SDL_Event& event)
 		case SDL_KEYUP:
 		case DOUBLE_CLICK_EVENT:
 			break;
+			
+		case SDL_QUIT:
+			throw CVideo::quit();
 
 		default:
 			WRN_GUI_E << "Unhandled event " << static_cast<Uint32>(event.type)

--- a/src/gui/dialogs/message.hpp
+++ b/src/gui/dialogs/message.hpp
@@ -208,6 +208,23 @@ void show_error_message(CVideo& video,
 						const std::string& message,
 						bool message_use_markup = false);
 
+///**
+// * Shows a message asking the player if they really want to quit.
+// * Returns if they chose "No", throws if they chose "Yes".
+// *
+// * @tparam Except  The exception to throw if the player selects "Yes".
+// *
+// * @param video    The video which contains the surface to draw upon.
+// * @param except   The exception instance to throw.
+// */
+//template<typename Except>
+//void show_quit_confirm(CVideo& video, Except except = Except()) {
+//	const int res = show_message(video(), _("Quit"), _("Do you really want to quit?"), tmessage::yes_no_buttons);
+//	if (res != twindow::CANCEL) {
+//		throw except;
+//	}
+//}
+
 } // namespace gui2
 
 #endif

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -38,6 +38,8 @@
 #include "map_label.hpp"
 #include "gettext.hpp"
 #include "gui/dialogs/transient_message.hpp"
+#include "gui/dialogs/message.hpp"
+#include "gui/widgets/window.hpp"
 #include "halo.hpp"
 #include "hotkey/command_executor.hpp"
 #include "loadscreen.hpp"
@@ -708,6 +710,16 @@ void play_controller::process_focus_keydown_event(const SDL_Event& event)
 		tab();
 	} else if(event.key.keysym.sym == SDLK_RETURN || event.key.keysym.sym == SDLK_KP_ENTER) {
 		enter_textbox();
+	}
+}
+
+void play_controller::process_quit_request() {
+	if (gui_->in_game()) {
+		const int res = gui2::show_message(gui_->video(), _("Quit"),
+					_("Do you really want to quit?"), gui2::tmessage::yes_no_buttons);
+		if (res != gui2::twindow::CANCEL) {
+			controller_base::process_quit_request();
+		}
 	}
 }
 

--- a/src/play_controller.hpp
+++ b/src/play_controller.hpp
@@ -222,6 +222,7 @@ protected:
 	void process_focus_keydown_event(const SDL_Event& event);
 	void process_keydown_event(const SDL_Event& event);
 	void process_keyup_event(const SDL_Event& event);
+	void process_quit_request();
 
 	void init_managers();
 	///preload events cannot be synced

--- a/src/widgets/button.cpp
+++ b/src/widgets/button.cpp
@@ -718,6 +718,7 @@ void button::mouse_up(SDL_MouseButtonEvent const &event)
 
 void button::handle_event(const SDL_Event& event)
 {
+	widget::handle_event(event);
 	if (hidden() || !enabled())
 		return;
 

--- a/src/widgets/multimenu.cpp
+++ b/src/widgets/multimenu.cpp
@@ -37,6 +37,7 @@ namespace gui {
 	}
 
 	void multimenu::handle_event(const SDL_Event &event) {
+		widget::handle_event(event);
 		if (event.type == SDL_MOUSEBUTTONDOWN) {
 			int hit_box = hit_checkbox(event.button.x, event.button.y);
 			if (hit_box != -1) {

--- a/src/widgets/scrollarea.cpp
+++ b/src/widgets/scrollarea.cpp
@@ -150,6 +150,7 @@ unsigned scrollarea::scrollbar_width() const
 
 void scrollarea::handle_event(const SDL_Event& event)
 {
+	widget::handle_event(event);
 	if (mouse_locked() || hidden())
 		return;
 

--- a/src/widgets/scrollbar.cpp
+++ b/src/widgets/scrollbar.cpp
@@ -323,6 +323,7 @@ void scrollbar::draw_contents()
 
 void scrollbar::handle_event(const SDL_Event& event)
 {
+	widget::handle_event(event);
 	if (mouse_locked() || hidden())
 		return;
 

--- a/src/widgets/slider.cpp
+++ b/src/widgets/slider.cpp
@@ -314,6 +314,7 @@ bool slider::requires_event_focus(const SDL_Event* event) const
 
 void slider::handle_event(const SDL_Event& event)
 {
+	widget::handle_event(event);
 	if (!enabled() || hidden())
 		return;
 

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -442,6 +442,7 @@ void textbox::handle_event(const SDL_Event& event)
 
 void textbox::handle_event(const SDL_Event& event, bool was_forwarded)
 {
+	widget::handle_event(event);
 	if(!enabled())
 		return;
 

--- a/src/widgets/widget.cpp
+++ b/src/widgets/widget.cpp
@@ -22,6 +22,9 @@
 #include "sdl/rect.hpp"
 #include "tooltips.hpp"
 
+#include "resources.hpp" // for screen
+#include "game_display.hpp"
+
 #include <cassert>
 
 namespace {
@@ -344,7 +347,12 @@ void widget::process_tooltip_string(int mousex, int mousey)
 
 void widget::handle_event(SDL_Event const &event) {
 	if (event.type == SDL_QUIT) {
-		throw CVideo::quit();
+		if(resources::screen && resources::screen->in_game()) {
+			// TODO: Show confirmation dialog
+		} else {
+			// Either there's no screen or we're not in a game, so just quit now
+			throw CVideo::quit();
+		}
 	}
 }
 

--- a/src/widgets/widget.cpp
+++ b/src/widgets/widget.cpp
@@ -342,5 +342,11 @@ void widget::process_tooltip_string(int mousex, int mousey)
 	}
 }
 
+void widget::handle_event(SDL_Event const &event) {
+	if (event.type == SDL_QUIT) {
+		throw CVideo::quit();
+	}
+}
+
 
 }

--- a/src/widgets/widget.cpp
+++ b/src/widgets/widget.cpp
@@ -25,6 +25,11 @@
 #include "resources.hpp" // for screen
 #include "game_display.hpp"
 
+// For quit confirmation dialog
+#include "gettext.hpp"
+#include "gui/dialogs/message.hpp"
+#include "gui/widgets/window.hpp"
+
 #include <cassert>
 
 namespace {
@@ -344,11 +349,17 @@ void widget::process_tooltip_string(int mousex, int mousey)
 			tooltips::add_tooltip(rect_, tooltip_text_ );
 	}
 }
-
+//Okay shadowm, some questions regarding PR467. 1) How do you suppose I should determine whether to show a confirmation dialog from the GUI2 event handling code? Should I use the same test of resources::screen that I used in the GUI1 handling code, or do you have better ideas? 2) The exact same code to show a confirmation dialog is now duplicated in three places. I'd like to break it out into a function, but have no idea where would be a good place to store it. Any suggestions? 3) This still doesn't show a quit confirmation in the map editor. Would you like me to poke around and figure out how to add one there?
 void widget::handle_event(SDL_Event const &event) {
 	if (event.type == SDL_QUIT) {
 		if(resources::screen && resources::screen->in_game()) {
-			// TODO: Show confirmation dialog
+			leave();
+			const int res = gui2::show_message(video(), _("Quit"),
+							_("Do you really want to quit?"), gui2::tmessage::yes_no_buttons);
+			if (res != gui2::twindow::CANCEL) {
+				throw CVideo::quit();
+			}
+			join();
 		} else {
 			// Either there's no screen or we're not in a game, so just quit now
 			throw CVideo::quit();

--- a/src/widgets/widget.hpp
+++ b/src/widgets/widget.hpp
@@ -89,7 +89,7 @@ protected:
 	const SDL_Rect* clip_rect() const;
 	virtual sdl_handler_vector member_handlers() { return sdl_handler::handler_members(); }
 
-	virtual void handle_event(SDL_Event const &/*event*/) {}
+	virtual void handle_event(SDL_Event const &event);
 	bool focus_;		// Should user input be ignored?
 
 	bool mouse_locked() const;


### PR DESCRIPTION
This shows a confirmation dialog when either pressing Cmd-Q (I'm guessing it also works for Alt-F4) or clicking the close button on the titlebar while a game is in progress.

This is not a complete fix for the mishandling of Cmd-Q - for example, if you press it while the recruit dialog is open, there will be no confirmation and the game will quit. Similarly, no confirmation dialog has been added to the editor. However, I think in the middle of a game is probably the most important place to require a confirmation.