### PR TITLE
Two AMLA changes

### DIFF
--- a/changelog
+++ b/changelog
@@ -36,6 +36,11 @@ Version 1.13.1+dev:
    * Added support for has_flag= in terrain graphics [variant].
    * Added category= to [label] - allows grouping labels so that players can
      show/hide them
+   * AMLAs in [modifications] now use [advancement] tags instead of [advance] tags.
+     This means you can add an AMLA to placed unit by simply using its definition macro,
+     for example {AMLA_DEFAULT}.
+   * Add exclude_amla= key in [advancement] which disables the advancment if the unit
+     has already taken certain other advancements.
    * The WML preprocessor now writes warnings to stderr for macros redefined
      without #undef, to help detect unintentional name clashes.
    * Fix macro definition line numbers being offset by 1 in WML preprocessor

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1538,7 +1538,7 @@ unit_ptr get_amla_unit(const unit &u, const config &mod_option)
 {
 	unit_ptr amla_unit(new unit(u));
 	amla_unit->set_experience(amla_unit->experience() - amla_unit->max_experience());
-	amla_unit->add_modification("advance", mod_option);
+	amla_unit->add_modification("advancement", mod_option);
 	return amla_unit;
 }
 

--- a/src/ai/simulated_actions.cpp
+++ b/src/ai/simulated_actions.cpp
@@ -257,7 +257,7 @@ void helper_advance_unit(const map_location& loc){
 	}else{
 		const config &mod_option = mod_options[advance_choice-options.size()];
 		advanced_unit.set_experience(advanced_unit.experience()-advanced_unit.max_experience());
-		advanced_unit.add_modification("advance", mod_option);
+		advanced_unit.add_modification("advancement", mod_option);
 	}
 
 	resources::units->replace(loc, advanced_unit);

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -3278,6 +3278,7 @@ static int intf_add_modification(lua_State *L)
 	std::string sm = m;
 	if (sm == "advance") { // Maintain backwards compatibility
 		sm = "advancement";
+		lg::wml_error << "(Lua) Modifications of type \"advance\" are deprecated, use \"advancement\" instead\n";
 	}
 	if (sm != "advancement" && sm != "object" && sm != "trait") {
 		return luaL_argerror(L, 2, "unknown modification type");

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -3276,8 +3276,12 @@ static int intf_add_modification(lua_State *L)
 	unit_ptr u = luaW_checkunit(L, 1);
 	char const *m = luaL_checkstring(L, 2);
 	std::string sm = m;
-	if (sm != "advance" && sm != "object" && sm != "trait")
+	if (sm == "advance") { // Maintain backwards compatibility
+		sm = "advancement";
+	}
+	if (sm != "advancement" && sm != "object" && sm != "trait") {
 		return luaL_argerror(L, 2, "unknown modification type");
+	}
 
 	config cfg = luaW_checkconfig(L, 3);
 	u->add_modification(sm, cfg);

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -1578,23 +1578,23 @@ std::vector<config> unit::get_modification_advances() const
 		if (modification_count("advancement", adv["id"]) >= unsigned(adv["max_times"].to_int(1)))
 			continue;
 
-		std::vector<std::string> temp = utils::split(adv["require_amla"]);
-		std::vector<std::string> temp2 = utils::split(adv["exclude_amla"]);
-		if (temp.empty() && temp2.empty()) {
+		std::vector<std::string> temp_require = utils::split(adv["require_amla"]);
+		std::vector<std::string> temp_exclude = utils::split(adv["exclude_amla"]);
+		if (temp_require.empty() && temp_exclude.empty()) {
 			res.push_back(adv);
 			continue;
 		}
 
-		std::sort(temp.begin(), temp.end());
-		std::sort(temp2.begin(), temp2.end());
-		std::vector<std::string> uniq, uniq2;
-		std::unique_copy(temp.begin(), temp.end(), std::back_inserter(uniq));
-		std::unique_copy(temp2.begin(), temp2.end(), std::back_inserter(uniq2));
+		std::sort(temp_require.begin(), temp_require.end());
+		std::sort(temp_exclude.begin(), temp_exclude.end());
+		std::vector<std::string> uniq_require, uniq_exclude;
+		std::unique_copy(temp_require.begin(), temp_require.end(), std::back_inserter(uniq_require));
+		std::unique_copy(temp_exclude.begin(), temp_exclude.end(), std::back_inserter(uniq_exclude));
 		
 		bool exclusion_found = false;
-		BOOST_FOREACH(const std::string &s, uniq2)
+		BOOST_FOREACH(const std::string &s, uniq_exclude)
 		{
-			int max_num = std::count(temp2.begin(), temp2.end(), s);
+			int max_num = std::count(temp_exclude.begin(), temp_exclude.end(), s);
 			int mod_num = modification_count("advancement", s);
 			if (mod_num >= max_num) {
 				exclusion_found = true;
@@ -1606,9 +1606,9 @@ std::vector<config> unit::get_modification_advances() const
 		}
 
 		bool requirements_done = true;
-		BOOST_FOREACH(const std::string &s, uniq)
+		BOOST_FOREACH(const std::string &s, uniq_require)
 		{
-			int required_num = std::count(temp.begin(), temp.end(), s);
+			int required_num = std::count(temp_require.begin(), temp_require.end(), s);
 			int mod_num = modification_count("advancement", s);
 			if (required_num > mod_num) {
 				requirements_done = false;

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -2069,6 +2069,9 @@ void unit::apply_modifications()
 
 	for(size_t i = 0; i != NumModificationTypes; ++i) {
 		const std::string& mod = ModificationTypes[i];
+		if(mod == "advance" && modifications_.has_child(mod)) {
+			lg::wml_error << "[modifications][advance] is deprecated, use [advancement] instead\n";
+		}
 		BOOST_FOREACH(const config &m, modifications_.child_range(mod)) {
 			log_scope("add mod");
 			add_modification(ModificationTypes[i], m, true);

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -88,7 +88,8 @@ static lg::log_domain log_enginerefac("enginerefac");
 #define LOG_RG LOG_STREAM(info, log_enginerefac)
 
 namespace {
-	const std::string ModificationTypes[] = { "advance", "trait", "object" };
+	// "advance" only kept around for backwards compatibility; only "advancement" should be used
+	const std::string ModificationTypes[] = { "advancement", "advance", "trait", "object" };
 	const size_t NumModificationTypes = sizeof(ModificationTypes)/
 										sizeof(*ModificationTypes);
 
@@ -1558,7 +1559,7 @@ std::vector<std::pair<std::string,std::string> > unit::amla_icons() const
 		icon.first = adv["icon"].str();
 		icon.second = adv["description"].str();
 
-		for (unsigned j = 0, j_count = modification_count("advance", adv["id"]);
+		for (unsigned j = 0, j_count = modification_count("advancement", adv["id"]);
 		     j < j_count; ++j)
 		{
 			temp.push_back(icon);
@@ -1574,7 +1575,7 @@ std::vector<config> unit::get_modification_advances() const
 	{
 		if (adv["strict_amla"].to_bool() && !advances_to_.empty())
 			continue;
-		if (modification_count("advance", adv["id"]) >= unsigned(adv["max_times"].to_int(1)))
+		if (modification_count("advancement", adv["id"]) >= unsigned(adv["max_times"].to_int(1)))
 			continue;
 
 		std::vector<std::string> temp = utils::split(adv["require_amla"]);
@@ -1591,7 +1592,7 @@ std::vector<config> unit::get_modification_advances() const
 		BOOST_FOREACH(const std::string &s, uniq)
 		{
 			int required_num = std::count(temp.begin(), temp.end(), s);
-			int mod_num = modification_count("advance", s);
+			int mod_num = modification_count("advancement", s);
 			if (required_num > mod_num) {
 				requirements_done = false;
 				break;
@@ -1620,6 +1621,11 @@ size_t unit::modification_count(const std::string& mod_type, const std::string& 
 		if (item["id"] == id) {
 			++res;
 		}
+	}
+	
+	// For backwards compatibility, if asked for "advancement", also count "advance"
+	if (mod_type == "advancement") {
+		res += modification_count("advance", id);
 	}
 
 	return res;

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -1579,14 +1579,30 @@ std::vector<config> unit::get_modification_advances() const
 			continue;
 
 		std::vector<std::string> temp = utils::split(adv["require_amla"]);
-		if (temp.empty()) {
+		std::vector<std::string> temp2 = utils::split(adv["exclude_amla"]);
+		if (temp.empty() && temp2.empty()) {
 			res.push_back(adv);
 			continue;
 		}
 
 		std::sort(temp.begin(), temp.end());
-		std::vector<std::string> uniq;
+		std::sort(temp2.begin(), temp2.end());
+		std::vector<std::string> uniq, uniq2;
 		std::unique_copy(temp.begin(), temp.end(), std::back_inserter(uniq));
+		std::unique_copy(temp2.begin(), temp2.end(), std::back_inserter(uniq2));
+		
+		bool exclusion_found = false;
+		BOOST_FOREACH(const std::string &s, uniq2)
+		{
+			int mod_num = modification_count("advancement", s);
+			if (mod_num > 0) {
+				exclusion_found = true;
+				break;
+			}
+		}
+		if (exclusion_found) {
+			continue;
+		}
 
 		bool requirements_done = true;
 		BOOST_FOREACH(const std::string &s, uniq)
@@ -1598,8 +1614,9 @@ std::vector<config> unit::get_modification_advances() const
 				break;
 			}
 		}
-		if (requirements_done)
+		if (requirements_done) {
 			res.push_back(adv);
+		}
 	}
 
 	return res;

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -1594,8 +1594,9 @@ std::vector<config> unit::get_modification_advances() const
 		bool exclusion_found = false;
 		BOOST_FOREACH(const std::string &s, uniq2)
 		{
+			int max_num = std::count(temp2.begin(), temp2.end(), s);
 			int mod_num = modification_count("advancement", s);
-			if (mod_num > 0) {
+			if (mod_num >= max_num) {
 				exclusion_found = true;
 				break;
 			}


### PR DESCRIPTION
The first change (using `[modifications][advancement]` instead of `[modifications][advance]`) makes it possible to use the same macro (eg `{AMLA_DEFAULT}`) both for adding an advancement possibility to a unit type and for adding that an advancement to a specific placed unit. The implementation is designed to be backwards compatible.

The second change allows making AMLA possibilities mutually exclusive. There is currently no way to indicate to the player that this is the case though; it would be nice to have some indication so that the player knows that certain choices will be eliminated by the choice they've made. However, I think that's a separate issue (in fact, it already affects 1.12 if you use strict_amla=no).