### PR TITLE
Quck fix for textbox input under SDL2

### DIFF
--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -585,7 +585,7 @@ void textbox::handle_event(const SDL_Event& event, bool was_forwarded)
 	}
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-	ucs4::char_t character = key.scancode;
+	ucs4::char_t character = key.sym;
 #else
 	ucs4::char_t character = key.unicode;
 #endif


### PR DESCRIPTION
This is a quick fix to get input working, but it's sadly not foolproof. The correct way to deal with this would be to use SDL_TextInputEvent events under SDL2 instead.