### PR TITLE
More corrections for hot-key detection in SDL1.2

### DIFF
--- a/src/hotkey/hotkey_item.cpp
+++ b/src/hotkey/hotkey_item.cpp
@@ -97,11 +97,9 @@ hotkey::hotkey_item& get_hotkey(int character, int keycode,
 	bool found = false;
 
 	for (itor = hotkeys_.begin(); itor != hotkeys_.end(); ++itor) {
-		// Special case for Ctrl+Return/Enter keys, which gets resolved to Ctrl-j and Ctrl-m characters (LF and CR respectively).
-		// In such cases, do not match by character but go straight to key code.
-		if (itor->get_character() != -1 &&
-			!(tolower(character) == 'j' && keycode != SDLK_j) &&
-			!(tolower(character) == 'm' && keycode != SDLK_m)) {
+		// If character is a letter, make sure it can match its key code. Otherwise combinations like Ctrl+Return/Enter can be mistaken for Ctrl+j or Ctrl+m (CR and LF respectively).
+		// Other printing characters that aren't alphabetic will be handled by key code matching below.
+		if (itor->get_character() != -1 && isalpha(character) && character == keycode) {
 			if (character == itor->get_character()) {
 				if (ctrl == itor->get_ctrl()
 						&& cmd == itor->get_cmd()
@@ -537,11 +535,9 @@ void hotkey_item::set_key(int character, int keycode,
 
 	// We handle simple cases by character, others by the actual key.
 	// @ and ` are exceptions related to the space character. Without these, combinations involving Ctrl or Ctrl+Shift often resolve the character value to null (or @ and `).
-	// j and m exceptions are to catch Ctrl+Return/Enter, which is interpreted as Ctrl+j and Ctrl+m characters (LF and CR respectively).
-	if (isprint(character) && !isspace(character) &&
-		character != '@' && character != '`' &&
-		!(tolower(character) == 'j' && keycode != SDLK_j) &&
-		!(tolower(character) == 'm' && keycode != SDLK_m)) {
+	// If character is read as a letter, only treat it as a letter if its key code matches that character. This covers cases such as Ctrl+Return/Enter, which would otherwise be mis-read as Ctrl+j or Ctrl+m (CR and LF respectively). 
+	if (character != '@' && character != '`' &&
+		( (isalpha(character) && islower(character) == keycode) || (!isalpha(character) && isprint(character) && !isspace(character)) )) {
 		character_ = character;
 		ctrl_      = ctrl;
 		cmd_       = cmd;


### PR DESCRIPTION
This is an extension of https://github.com/wesnoth/wesnoth/pull/450.

Instead of specifically checking for Ctrl+j and Ctrl+m, I now make this a general check: that letters should match their respective key codes. This will still cover the Ctrl+Return/Enter combination fixed in PR 450, but also some of the combinations noted in that PR.

Ctrl+Tab was one combination noted to not work in Linux (though it did in Windows) as it was being mis-read as Ctrl+i. Ctrl+Tab will now work correctly in Linux.

Strangely, Ctrl+Scroll Lock and Ctrl+Pause (while working in Linux) were both being mis-read as Ctrl+c in Windows. This change will cover Ctrl+Scroll Lock but Ctrl+Pause will also be read as Ctrl+Scroll Lock, because of the key code SDL detects. Similarly, Ctrl+Num Lock becomes Ctrl+Pause instead. I don't think this can be resolved with SDL1.2 because the key code is simply being read incorrectly.

Unfortunately, I cannot test whether there will be any improvement or regression in OS X.

With hot-key handling being rewritten for SDL2 this change may seem moot, but it will still improve things for the current 1.12 release. This change also resolves concerns some have had regarding the special-case nature of the Ctrl+j/Ctrl+m check previously used.