### PR TITLE
Movetype patching

### DIFF
--- a/changelog
+++ b/changelog
@@ -72,6 +72,7 @@ Version 1.13.1+dev:
      * apply_to=attack - add set_ versions of all existing increase_ keys
      * apply_to=attack - add increase_movement_used and set_movement_used to change the
        number of movement points the attack consumes
+   * Ability to patch movetypes to account for custom terrains or damage types
  * Editor:
    * Added Category field and color sliders to the Edit Label panel.
  * Miscellaneous and bug fixes:

--- a/src/unit_types.cpp
+++ b/src/unit_types.cpp
@@ -1031,7 +1031,7 @@ void unit_type_data::set_config(config &cfg)
 	{
 		const std::string& dmg_type = r["type"];
 		config temp_cfg;
-		BOOST_FOREACH(const config::attribute &attr, cfg.attribute_range()) {
+		BOOST_FOREACH(const config::attribute &attr, r.attribute_range()) {
 			const std::string &mt = attr.first;
 			if (mt == "type" || mt == "default" || movement_types_.find(mt) == movement_types_.end()) {
 				continue;
@@ -1043,18 +1043,21 @@ void unit_type_data::set_config(config &cfg)
 				original.add(p.first, val);
 			}
 			temp_cfg[dmg_type] = formula(original);
-			movement_types_[mt].get_resistances().merge(temp_cfg, false);
+			movement_types_[mt].get_resistances().merge(temp_cfg, true);
 		}
-		if (cfg.has_attribute("default")) {
-			gui2::tformula<int> formula(cfg["default"]);
+		if (r.has_attribute("default")) {
+			gui2::tformula<int> formula(r["default"]);
 			game_logic::map_formula_callable original;
 			BOOST_FOREACH(movement_type_map::value_type &mt, movement_types_) {
+				if (r.has_attribute(mt.first)) {
+					continue;
+				}
 				BOOST_FOREACH(const utils::string_map::value_type& p,mt.second.damage_table()) {
 					variant val(lexical_cast<int>(p.second));
 					original.add(p.first, val);
 				}
 				temp_cfg[dmg_type] = formula(original);
-				mt.second.get_resistances().merge(temp_cfg, false);
+				mt.second.get_resistances().merge(temp_cfg, true);
 			}
 		}
 	}

--- a/src/unit_types.cpp
+++ b/src/unit_types.cpp
@@ -1023,6 +1023,20 @@ void unit_type_data::set_config(config &cfg)
 		races_.insert(std::pair<std::string,unit_race>(race.id(),race));
 		loadscreen::increment_progress();
 	}
+	
+	BOOST_FOREACH(const config &r, cfg.child_range("damage"))
+	{
+		const std::string& dmg_type = r["type"];
+		config temp_cfg;
+		BOOST_FOREACH(const config::attribute &attr, cfg.attribute_range()) {
+			const std::string &mt = attr.first;
+			if (mt == "type" || movement_types_.find(mt) == movement_types_.end()) {
+				continue;
+			}
+			temp_cfg[dmg_type] = attr.second;
+			movement_types_[mt].get_resistances().merge(temp_cfg, false);
+		}
+	}
 
 	// Apply base units.
 	BOOST_FOREACH(config &ut, cfg.child_range("unit_type"))

--- a/src/unit_types.cpp
+++ b/src/unit_types.cpp
@@ -1027,14 +1027,22 @@ void unit_type_data::set_config(config &cfg)
 	BOOST_FOREACH(const config &r, cfg.child_range("damage"))
 	{
 		const std::string& dmg_type = r["type"];
-		config temp_cfg;
+		config temp_cfg, default_cfg;
 		BOOST_FOREACH(const config::attribute &attr, cfg.attribute_range()) {
 			const std::string &mt = attr.first;
+			if (mt == "default") {
+				default_cfg[dmg_type] = attr.second;
+			}
 			if (mt == "type" || movement_types_.find(mt) == movement_types_.end()) {
 				continue;
 			}
 			temp_cfg[dmg_type] = attr.second;
 			movement_types_[mt].get_resistances().merge(temp_cfg, false);
+		}
+		if (!default_cfg[dmg_type].empty()) {
+			BOOST_FOREACH(movement_type_map::value_type &mt, movement_types_) {
+				mt.second.get_resistances().merge(default_cfg, false);
+			}
 		}
 	}
 

--- a/src/unit_types.cpp
+++ b/src/unit_types.cpp
@@ -1047,13 +1047,13 @@ void unit_type_data::set_config(config &cfg)
 	}
 	
 	// Movetype resistance patching
-	BOOST_FOREACH(const config &r, cfg.child_range("damage"))
+	BOOST_FOREACH(const config &r, cfg.child_range("resistance_defaults"))
 	{
-		const std::string& dmg_type = r["type"];
+		const std::string& dmg_type = r["id"];
 		config temp_cfg;
 		BOOST_FOREACH(const config::attribute &attr, r.attribute_range()) {
 			const std::string &mt = attr.first;
-			if (mt == "type" || mt == "default" || movement_types_.find(mt) == movement_types_.end()) {
+			if (mt == "id" || mt == "default" || movement_types_.find(mt) == movement_types_.end()) {
 				continue;
 			}
 			patch_movetype(movement_types_[mt].get_resistances(), dmg_type, attr.second, 100);
@@ -1069,9 +1069,9 @@ void unit_type_data::set_config(config &cfg)
 	}
 	
 	// Movetype move/defend patching
-	BOOST_FOREACH(const config &terrain, cfg.child_range("terrain"))
+	BOOST_FOREACH(const config &terrain, cfg.child_range("terrain_defaults"))
 	{
-		const std::string& ter_type = terrain["type"];
+		const std::string& ter_type = terrain["id"];
 		config temp_cfg;
 		static const std::string terrain_info_tags[] = {"movement", "vision", "jamming", "defense"};
 		BOOST_FOREACH(const std::string &tag, terrain_info_tags) {
@@ -1081,7 +1081,7 @@ void unit_type_data::set_config(config &cfg)
 			const config& info = terrain.child(tag);
 			BOOST_FOREACH(const config::attribute &attr, info.attribute_range()) {
 				const std::string &mt = attr.first;
-				if (mt == "type" || mt == "default" || movement_types_.find(mt) == movement_types_.end()) {
+				if (mt == "default" || movement_types_.find(mt) == movement_types_.end()) {
 					continue;
 				}
 				if (tag == "defense") {

--- a/src/unit_types.cpp
+++ b/src/unit_types.cpp
@@ -31,6 +31,9 @@
 #include "unit.hpp"
 #include "unit_abilities.hpp"
 #include "unit_animation.hpp"
+#include "util.hpp"
+
+#include "gui/auxiliary/formula.hpp"
 
 #include <boost/foreach.hpp>
 #include <boost/static_assert.hpp>
@@ -1036,7 +1039,13 @@ void unit_type_data::set_config(config &cfg)
 			if (mt == "type" || movement_types_.find(mt) == movement_types_.end()) {
 				continue;
 			}
-			temp_cfg[dmg_type] = attr.second;
+			gui2::tformula<int> formula(attr.second);
+			game_logic::map_formula_callable original;
+			BOOST_FOREACH(const utils::string_map::value_type& p, movement_types_[mt].damage_table()) {
+				variant val(lexical_cast<int>(p.second));
+				original.add(p.first, val);
+			}
+			temp_cfg[dmg_type] = formula(original);
 			movement_types_[mt].get_resistances().merge(temp_cfg, false);
 		}
 		if (!default_cfg[dmg_type].empty()) {


### PR DESCRIPTION
This introduces a way for custom terrains or damage types to be patched into pre-existing movetypes; previously the only way (as far as I know) to get this sort of effect would've been to use `[base_unit]` to make duplicates of all the unit types with the movetype you wanted to change. It uses the formula engine to allow you to set the new resistance/defence/cost base on the value of one or more resistances/defences/costs from the original movetype; for example, if you added a new "sonic" damage type, you could declare that the sonic resist level is equal to half the impact resist level for some movetypes.

Although the purpose is for adding custom damage type and terrain support to existing movetypes, this could in theory be used for any kind of tweaking of existing movetypes.

An example of the syntax (this goes inside `[units]`):
```
[damage]
	type=sonic
	default="(impact - 10)"
	smallfly="(impact / 2)"
[/damage]
[terrain]
	type=fire
	[defense]
		default="(unwalkable)"
		largefoot=30
	[/defense]
	[movement]
		default="(unwalkable)"
		largefoot=8
	[/movement]
	# [jamming] and [vision] subtags also supported here
[/terrain]
```