### PR TITLE
show confirmation dialog when quitting

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1104,6 +1104,7 @@ set(libwesnoth-game_STAT_SRC
 	preferences.cpp
 	preferences_display.cpp
 	race.cpp
+	quit_confirmation.cpp
 	reports.cpp
 	show_dialog.cpp
 	simple_rng.cpp

--- a/src/SConscript
+++ b/src/SConscript
@@ -117,6 +117,7 @@ libwesnoth_sources = Split("""
     pathutils.cpp
     preferences.cpp
     preferences_display.cpp
+    quit_confirmation.cpp
     race.cpp
     reports.cpp
     show_dialog.cpp

--- a/src/controller_base.hpp
+++ b/src/controller_base.hpp
@@ -42,6 +42,7 @@
 #include "hotkey/hotkey_command.hpp"
 #include "joystick.hpp"
 #include "key.hpp"
+#include "quit_confirmation.hpp"
 
 class CVideo;
 class display;
@@ -53,7 +54,7 @@ namespace hotkey { class command_executor; }
 
 namespace soundsource { class manager; }
 
-class controller_base : public events::sdl_handler
+class controller_base : public events::sdl_handler, quit_confirmation
 {
 public:
 	controller_base(const config& game_config, CVideo& video);

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -229,6 +229,8 @@ display::display(const display_context * dc, CVideo& video, boost::weak_ptr<wb::
 	, do_reverse_memcpy_workaround_(false)
 #endif
 {
+	//The following assertion fails when starting a campaign
+	//assert(singleton_ == NULL);
 	singleton_ = this;
 
 	resources::fake_units = fake_unit_man_.get();

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -19,6 +19,7 @@
 #include "events.hpp"
 #include "log.hpp"
 #include "sound.hpp"
+#include "quit_confirmation.hpp"
 #include "video.hpp"
 #if defined _WIN32
 #include "desktop/windows_tray_notification.hpp"
@@ -415,7 +416,7 @@ void pump()
 #endif
 
 			case SDL_QUIT: {
-				throw CVideo::quit();
+				quit_confirmation::quit();
 			}
 		}
 

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -417,6 +417,7 @@ void pump()
 
 			case SDL_QUIT: {
 				quit_confirmation::quit();
+				continue; //this event is already handled.
 			}
 		}
 

--- a/src/quit_confirmation.cpp
+++ b/src/quit_confirmation.cpp
@@ -1,3 +1,16 @@
+/*
+   Copyright (C) 2015 - 2015 by David White <dave@whitevine.net>
+   Part of the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
 
 #include "quit_confirmation.hpp"
 #include "gettext.hpp"

--- a/src/quit_confirmation.cpp
+++ b/src/quit_confirmation.cpp
@@ -1,0 +1,35 @@
+
+#include "quit_confirmation.hpp"
+#include "gettext.hpp"
+#include "display.hpp"
+#include "gui/dialogs/message.hpp"
+#include "gui/widgets/window.hpp"
+#include "resources.hpp"
+
+int quit_confirmation::count_ = 0;
+bool quit_confirmation::open_ = false;
+void quit_confirmation::quit()
+{
+	if(count_ != 0 && display::get_singleton() && !open_)
+	{
+		quit(display::get_singleton()->video());
+	}
+	else
+	{
+		throw CVideo::quit();
+	}
+}
+
+void quit_confirmation::quit(CVideo& video)
+{
+	assert(!open_);
+	open_ = true;
+	const int res = gui2::show_message(video, _("Quit"),
+		_("Do you really want to quit?"), gui2::tmessage::yes_no_buttons);
+	open_ = false;
+	if(res != gui2::twindow::CANCEL) {
+		throw CVideo::quit();
+	} else {
+		return;
+	}
+}

--- a/src/quit_confirmation.hpp
+++ b/src/quit_confirmation.hpp
@@ -1,0 +1,15 @@
+#pragma once
+class CVideo;
+
+class quit_confirmation
+{
+public:
+	quit_confirmation() { ++count_; }
+	quit_confirmation(const quit_confirmation&) { ++count_; }
+	~quit_confirmation() { --count_; }
+	static void quit();
+	static void quit(CVideo& video );
+private:
+	static int count_;
+	static bool open_;
+};

--- a/src/quit_confirmation.hpp
+++ b/src/quit_confirmation.hpp
@@ -1,12 +1,14 @@
 #pragma once
 class CVideo;
 
+/// Any object of this type will prevent the game from quitting immediately, instad a confirmation dialog will pop up when attepmting to close. 
 class quit_confirmation
 {
 public:
 	quit_confirmation() { ++count_; }
 	quit_confirmation(const quit_confirmation&) { ++count_; }
 	~quit_confirmation() { --count_; }
+	/// Shows the quit confirmation if needed, throws CVideo::quit to exit.
 	static void quit();
 	static void quit(CVideo& video );
 private:

--- a/src/quit_confirmation.hpp
+++ b/src/quit_confirmation.hpp
@@ -1,5 +1,20 @@
+/*
+   Copyright (C) 2015 - 2015 by David White <dave@whitevine.net>
+   Part of the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
 #pragma once
 class CVideo;
+
+#include <cassert>
 
 /// Any object of this type will prevent the game from quitting immediately, instad a confirmation dialog will pop up when attepmting to close. 
 class quit_confirmation
@@ -7,7 +22,7 @@ class quit_confirmation
 public:
 	quit_confirmation() { ++count_; }
 	quit_confirmation(const quit_confirmation&) { ++count_; }
-	~quit_confirmation() { --count_; }
+	~quit_confirmation() { --count_; assert(count_ >= 0); }
 	/// Shows the quit confirmation if needed, throws CVideo::quit to exit.
 	static void quit();
 	static void quit(CVideo& video );


### PR DESCRIPTION
when quitting (for example by clicking on the red cross in the corner) the
game now asks for a confirmation, if there is currently a (re-)play or
the editor running.