### PR TITLE
scons/sdl.py: Absolute filename gives C++ warnings on Windows

### DIFF
--- a/scons/sdl.py
+++ b/scons/sdl.py
@@ -99,7 +99,7 @@ def CheckOgg(context):
     }
 \n
 '''
-    test_program1 = context.env.Clone(TESTFILE = File("data/core/music/main_menu.ogg").rfile().abspath).subst(test_program)
+    test_program1 = context.env.Clone(TESTFILE = "data/core/music/main_menu.ogg").subst(test_program)
     #context.env.AppendUnique(LIBS = "SDL_mixer")
     context.Message("Checking for Ogg Vorbis support in SDL... ")
     if context.env["host"]:


### PR DESCRIPTION
```
scons: Configure: Checking for Ogg Vorbis support in SDL...
build\sconf_temp\conftest_25.c <-
  |#include <SDL_mixer.h>
  | #include <stdlib.h>
  |
  | int main(int argc, char **argv)
  | {
  | Mix_Music* music = Mix_LoadMUS("E:\r\wesnoth-old\data\core\music\main_menu.ogg");
  | if (music == NULL) {
  |            exit(1);
  |        }
  |        exit(0);
  |    }
gcc -o build\sconf_temp\conftest_25.o -c -D_GNU_SOURCE -I.locally\SDL-1.2.15\include\SDL -I.locally\boost_1_57_0 build\sconf_temp\conftest_25.c
build\sconf_temp\conftest_25.c: In function 'main':
build\sconf_temp\conftest_25.c:6:33: warning: unknown escape sequence: '\w'
  Mix_Music* music = Mix_LoadMUS("E:\r\wesnoth-old\data\core\music\main_menu.ogg");
                                 ^
build\sconf_temp\conftest_25.c:6:33: warning: unknown escape sequence: '\d'
build\sconf_temp\conftest_25.c:6:33: warning: unknown escape sequence: '\c'
build\sconf_temp\conftest_25.c:6:33: warning: unknown escape sequence: '\m'
build\sconf_temp\conftest_25.c:6:33: warning: unknown escape sequence: '\m'
```