### PR TITLE
remove support for [terrain_graphics][tile]loc=x,y

### DIFF
--- a/src/terrain_builder.cpp
+++ b/src/terrain_builder.cpp
@@ -878,13 +878,6 @@ void terrain_builder::parse_config(const config &cfg, bool local)
 			if (const config::attribute_value *v = tc.get("y")) {
 				loc.y = *v;
 			}
-			if (const config::attribute_value *v = tc.get("loc")) {
-				std::vector<std::string> sloc = utils::split(*v);
-				if(sloc.size() == 2) {
-					loc.x = atoi(sloc[0].c_str());
-					loc.y = atoi(sloc[1].c_str());
-				}
-			}
 			if(loc.valid()) {
 				add_constraints(pbr.constraints, loc, tc, br);
 			}


### PR DESCRIPTION
loc=x,y was previously undocumented so it's unlikeley that someone used it.
loc=4,2 had the same effect as x,y=4,2