### PR TITLE
Correct transparent damage graphs in SDL2

### DIFF
--- a/src/attack_prediction_display.cpp
+++ b/src/attack_prediction_display.cpp
@@ -471,7 +471,7 @@ void battle_prediction_pane::get_hp_distrib_surface(const std::vector<std::pair<
 
 		// Death line is red.
 		if(hp == 0) {
-			SDL_Color color = {0xe5, 0, 0, 0};
+			SDL_Color color = {0xe5, 0, 0, 255};
 			row_color = color;
 		}
 
@@ -479,17 +479,17 @@ void battle_prediction_pane::get_hp_distrib_surface(const std::vector<std::pair<
 		else if(hp < static_cast<int>(stats.hp)) {
 			// Stone is grey.
 			if(opp_stats.petrifies) {
-				SDL_Color color = {0x9a, 0x9a, 0x9a, 0};
+				SDL_Color color = {0x9a, 0x9a, 0x9a, 255};
 				row_color = color;
 			} else {
-				SDL_Color color = {0xf4, 0xc9, 0, 0};
+				SDL_Color color = {0xf4, 0xc9, 0, 255};
 				row_color = color;
 			}
 		}
 
 		// Current hitpoints value and above is green.
 		else {
-			SDL_Color color = {0x08, 0xca, 0, 0};
+			SDL_Color color = {0x08, 0xca, 0, 255};
 			row_color = color;
 		}
 
@@ -518,16 +518,16 @@ void battle_prediction_pane::get_hp_distrib_surface(const std::vector<std::pair<
 		sdl::fill_rect(surf, &bar_rect_4, blend_rgba(surf, row_color.r, row_color.g, row_color.b, row_color.a, 0));
 #else
 		SDL_Rect bar_rect_1 = sdl::create_rect(hp_sep + 4, 6 + (fs + 2) * i, bar_len, 8);
-				sdl::fill_rect(surf, &bar_rect_1, blend_rgba(surf, row_color.r, row_color.g, row_color.b, row_color.unused, 100));
+		sdl::fill_rect(surf, &bar_rect_1, blend_rgba(surf, row_color.r, row_color.g, row_color.b, row_color.unused, 100));
 
-				SDL_Rect bar_rect_2 = sdl::create_rect(hp_sep + 4, 7 + (fs + 2) * i, bar_len, 6);
-				sdl::fill_rect(surf, &bar_rect_2, blend_rgba(surf, row_color.r, row_color.g, row_color.b, row_color.unused, 66));
+		SDL_Rect bar_rect_2 = sdl::create_rect(hp_sep + 4, 7 + (fs + 2) * i, bar_len, 6);
+		sdl::fill_rect(surf, &bar_rect_2, blend_rgba(surf, row_color.r, row_color.g, row_color.b, row_color.unused, 66));
 
-				SDL_Rect bar_rect_3 = sdl::create_rect(hp_sep + 4, 8 + (fs + 2) * i, bar_len, 4);
-				sdl::fill_rect(surf, &bar_rect_3, blend_rgba(surf, row_color.r, row_color.g, row_color.b, row_color.unused, 33));
+		SDL_Rect bar_rect_3 = sdl::create_rect(hp_sep + 4, 8 + (fs + 2) * i, bar_len, 4);
+		sdl::fill_rect(surf, &bar_rect_3, blend_rgba(surf, row_color.r, row_color.g, row_color.b, row_color.unused, 33));
 
-				SDL_Rect bar_rect_4 = sdl::create_rect(hp_sep + 4, 9 + (fs + 2) * i, bar_len, 2);
-				sdl::fill_rect(surf, &bar_rect_4, blend_rgba(surf, row_color.r, row_color.g, row_color.b, row_color.unused, 0));
+		SDL_Rect bar_rect_4 = sdl::create_rect(hp_sep + 4, 9 + (fs + 2) * i, bar_len, 2);
+		sdl::fill_rect(surf, &bar_rect_4, blend_rgba(surf, row_color.r, row_color.g, row_color.b, row_color.unused, 0));
 #endif
 
 		// Draw probability percentage, aligned right.
@@ -553,5 +553,3 @@ attack_prediction_displayer::RESULT attack_prediction_displayer::button_pressed(
 
 	return gui::CONTINUE_DIALOG;
 }
-
-


### PR DESCRIPTION
Alpha channel was set to 0, which means that these graphs are not displayed under SDL2. Changed alpha values to 255 to restore the graphs.

SDL1.2 builds are unaffected because they (at least going by the struct definition) ignore the value fourth colour channel.

Other changes are just white-space formatting.