### PR TITLE
Correct Surface Alpha Blending in SDL2

### DIFF
--- a/src/sdl/alpha.cpp
+++ b/src/sdl/alpha.cpp
@@ -19,6 +19,11 @@
 int SDL_SetAlpha(SDL_Surface* surface, Uint32 flag, Uint8 alpha)
 {
 	if(flag & SDL_SRCALPHA) {
+		// Need to specify the alpha blend mode if not setting alpha as opaque
+		int blendModeResult = SDL_SetSurfaceBlendMode (surface, SDL_BLENDMODE_BLEND);
+		if (blendModeResult != 0)
+			return blendModeResult;
+
 		return SDL_SetSurfaceAlphaMod(surface, alpha);
 	} else {
 		return SDL_SetSurfaceAlphaMod(surface, SDL_ALPHA_OPAQUE);


### PR DESCRIPTION
alpha.cpp was apparently written as a compatibility wrapper for SDL2, as SDL_SetAlpha() has been replaced with other functions in SDL2. As it currently stands, it neglects to set the alpha blend mode which is now required when in SDL2.

A quick check of the code indicates that in most places where SDL_SetAlpha() is called, the alpha parameter is only set as SDL_ALPHA_OPAQUE, or the flag input parameter does not include SDL_SRCALPHA. So in either case there is no alpha blending anyway and so this omission didn't make a difference.

However, alpha blending *is* used in fill_rect_alpha of rect.cpp. This is most noticeable in dialogues with sorted lists, such as the hot-key bindings in the preferences, where the background colour of the headings turns opaque white instead of the alpha-blended grey that it is in an SDL1.2 build. There is at least one graphical blending issue resolved with this change as well - it's possible others may be included with this.