### PR TITLE
Resolve Bug #20036

### DIFF
--- a/src/editor/map/context_manager.cpp
+++ b/src/editor/map/context_manager.cpp
@@ -665,6 +665,7 @@ void context_manager::generate_map_dialog()
 		} else {
 			editor_map new_map(game_config_, map_string);
 			editor_action_whole_map a(new_map);
+			get_map_context().set_needs_labels_reset();		// Ensure Player Start labels are updated together with newly generated map
 			perform_refresh(a);
 		}
 		last_map_generator_ = map_generator;


### PR DESCRIPTION
When a map is generated, the labels for the player starting locations are correctly set. However, generating another map (or even loading a map and then generating a new one) results in the old labels remaining even after the new map has been generated and displayed.

Issue appears to be that the reset labels flag is not being set after a map generation. This change sets the reset labels flag and the subsequent perform_refresh() function then includes a reset of the map labels.