### PR TITLE
Enhanced looping tags

### DIFF
--- a/changelog
+++ b/changelog
@@ -104,6 +104,8 @@ Version 1.13.1+dev:
      These operators are applied after the existing '-' operator that takes the
      opposite direction.
    * Adjacency filters in abilities and weapon specials now support count= and is_enemy=
+   * Add new looping tags: [for], [foreach], [repeat]
+   * Add new flow control tags: [break], [continue], [return]
  * Editor:
    * Added Category field and color sliders to the Edit Label panel.
  * Miscellaneous and bug fixes:

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -300,12 +300,11 @@ wml_actions["if"] = function(cfg)
 		if wesnoth.eval_conditional(elseif_child) then -- we'll evaluate the [elseif] tags one by one
 			for then_tag in helper.child_range(elseif_child, "then") do
 				local action = utils.handle_event_commands(then_tag, "conditional")
-				if action ~= "none" then goto exit end
+				if action ~= "none" then break end
 			end
 			return -- stop on first matched condition
 		end
 	end
-	::exit::
 
 	-- no matched condition, try the [else] tags
 	for else_child in helper.child_range(cfg, "else") do

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -350,7 +350,9 @@ end
 wml_actions["repeat"] = function(cfg)
 	local times = cfg.times or 1
 	for i = 1, times do
-		handle_event_commands(cfg)
+		for do_child in helper.child_range( cfg, "do" ) do
+			handle_event_commands(do_child, "loop")
+		end
 	end
 end
 

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -363,7 +363,7 @@ wesnoth.wml_actions["for"] = function(cfg)
 		step = cfg.step or ((last - first) / math.abs(last - first))
 	end
 	local i_var = cfg.variable or "i"
-	local save_i = start_var_scope(i_var)
+	local save_i = utils.start_var_scope(i_var)
 	wesnoth.set_variable(i_var, first)
 	while wesnoth.get_variable(i_var) <= last do
 		for do_child in helper.child_range( cfg, "do" ) do
@@ -381,7 +381,7 @@ wesnoth.wml_actions["for"] = function(cfg)
 		wesnoth.set_variable(i_var, wesnoth.get_variable(i_var) + 1)
 	end
 	::exit::
-	end_var_scope(i_var, save_i)
+	utils.end_var_scope(i_var, save_i)
 end
 
 wml_actions["repeat"] = function(cfg)
@@ -407,9 +407,9 @@ function wml_actions.foreach(cfg)
 	local array = helper.get_variable_array(array_name)
 	if #array == 0 then return end -- empty and scalars unwanted
 	local item_name = cfg.item_var or "this_item"
-	local this_item = start_var_scope(item_name) -- if this_item is already set
+	local this_item = utils.start_var_scope(item_name) -- if this_item is already set
 	local i_name = cfg.index_var or "i"
-	local i = start_var_scope(i_name) -- if i is already set
+	local i = utils.start_var_scope(i_name) -- if i is already set
 	local array_length = wesnoth.get_variable(array_name .. ".length")
 	
 	for index, value in ipairs(array) do
@@ -442,8 +442,8 @@ function wml_actions.foreach(cfg)
 	::exit::
 	
 	-- house cleaning
-	wesnoth.set_variable(item_name)
-	wesnoth.set_variable(i)
+	utils.end_var_scope(item_name)
+	utils.end_var_scope(i)
 	
 	-- restore the array
 	helper.set_variable_array(array_name, array)

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -371,6 +371,10 @@ function wml_actions.foreach(cfg)
 		for do_child in helper.child_range(cfg, "do") do
 			handle_event_commands(do_child, "loop")
 		end
+		-- set back the content, in case the author made some modifications
+		if not cfg.readonly then
+			array[index] = wesnoth.get_variable(item_name)
+		end
 	end
 	
 	-- house cleaning

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -362,8 +362,14 @@ function wml_actions.foreach(cfg)
 	local this_item = start_var_scope(item_name) -- if this_item is already set
 	local i_name = cfg.index_var or "i"
 	local i = start_var_scope(i_name) -- if i is already set
+	local array_length = wesnoth.get_variable(array_name .. ".length")
 	
 	for index, value in ipairs(array) do
+		-- Some protection against external modification
+		-- It's not perfect, though - it'd be nice if *any* change could be detected
+		if array_length ~= wesnoth.get_variable(array_name .. ".length") then
+			helper.wml_error("WML array length changed during [foreach] iteration")
+		end
 		wesnoth.set_variable(item_name, value)
 		-- set index variable
 		wesnoth.set_variable(i_name, index-1) -- here -1, because of WML array

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -354,6 +354,33 @@ wml_actions["repeat"] = function(cfg)
 	end
 end
 
+function wml_actions.foreach(cfg)
+	local array_name = cfg.variable or helper.wml_error "[foreach] missing required variable= attribute"
+	local array = helper.get_variable_array(array_name)
+	if #array == 0 then return end -- empty and scalars unwanted
+	local item_name = cfg.item_var or "this_item"
+	local this_item = start_var_scope(item_name) -- if this_item is already set
+	local i_name = cfg.index_var or "i"
+	local i = start_var_scope(i_name) -- if i is already set
+	
+	for index, value in ipairs(array) do
+		wesnoth.set_variable(item_name, value)
+		-- set index variable
+		wesnoth.set_variable(i_name, index-1) -- here -1, because of WML array
+		-- perform actions
+		for do_child in helper.child_range(cfg, "do") do
+			handle_event_commands(do_child, "loop")
+		end
+	end
+	
+	-- house cleaning
+	wesnoth.set_variable(item_name)
+	wesnoth.set_variable(i)
+	
+	-- restore the array
+	helper.set_variable_array(array_name, array)
+end
+
 function wml_actions.switch(cfg)
 	local var_value = wesnoth.get_variable(cfg.variable)
 	local found = false

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -445,7 +445,19 @@ function wml_actions.foreach(cfg)
 	utils.end_var_scope(item_name)
 	utils.end_var_scope(i)
 	
-	-- restore the array
+	--[[
+		This forces the readonly key to be taken literally.
+		
+		If readonly=yes, then this line guarantees that the array
+		is unchanged after the [foreach] loop ends.
+		
+		If readonly=no, then this line updates the array with any
+		changes the user has applied through the $this_item
+		variable (or whatever variable was given in item_var).
+		
+		Note that altering the array via indexing (with the index_var)
+		is not supported; any such changes will be reverted by this line.
+	]]
 	helper.set_variable_array(array_name, array)
 end
 

--- a/data/lua/wml-utils.lua
+++ b/data/lua/wml-utils.lua
@@ -141,7 +141,7 @@ function utils.handle_event_commands(cfg, scope_type)
 	end
 	scope_stack:pop()
 	if #scope_stack == 0 then
-		if current_exit ==  "continue" and scope_type ~= "loop" then
+		if current_exit == "continue" and scope_type ~= "loop" then
 			helper.wml_error("[continue] found outside a loop scope!")
 		end
 		current_exit = "none"

--- a/data/lua/wml-utils.lua
+++ b/data/lua/wml-utils.lua
@@ -98,6 +98,7 @@ function utils.handle_event_commands(cfg, scope_type)
 	-- [insert_tag] with [set_variables] and [clear_variable], so we
 	-- have to be careful not to get confused by tags vanishing during
 	-- the execution, hence the manual handling of [insert_tag].
+	scope_type = scope_type or "plain"
 	scope_stack:push(scope_type)
 	local cmds = helper.shallow_literal(cfg)
 	for i = 1,#cmds do

--- a/data/test/macros/wml_unit_test_macros.cfg
+++ b/data/test/macros/wml_unit_test_macros.cfg
@@ -56,3 +56,11 @@
         {CONTENT}
     [/test]
 #enddef
+
+#define FAIL
+	{RETURN ([false][/false])}
+#enddef
+
+#define SUCCEED
+	{RETURN ([true][/true])}
+#enddef

--- a/data/test/scenarios/break_replay_with_lua_random.cfg
+++ b/data/test/scenarios/break_replay_with_lua_random.cfg
@@ -56,7 +56,7 @@
         [/event]
         [event]
             name = side 2 turn 60
-            {RETURN ([true][/true])}
+            {SUCCEED}
         [/event]
         [event]
             name = side 2 turn refresh

--- a/data/test/scenarios/characterize_pathfinding.cfg
+++ b/data/test/scenarios/characterize_pathfinding.cfg
@@ -343,7 +343,7 @@
         [/event]
         [event]
             name = side 1 turn refresh
-            {RETURN ([true][/true])}
+            {SUCCEED}
         [/event]
     [/test]
 #enddef
@@ -442,7 +442,7 @@
         [/event]
         [event]
             name = side 1 turn refresh
-            {RETURN ([true][/true])}
+            {SUCCEED}
         [/event]
     [/test]
 #enddef

--- a/data/test/scenarios/conditionals.cfg
+++ b/data/test/scenarios/conditionals.cfg
@@ -16,7 +16,7 @@
                 [false][/false]
             [/not]
             [then]
-                {RETURN [true][/true]}
+                {SUCCEED}
             [/then]
         [/if]
     [/event]
@@ -35,7 +35,7 @@
                 [false][/false]
             [/or]
             [then]
-                {RETURN [true][/true]}
+                {SUCCEED}
             [/then]
         [/if]
     [/event]

--- a/data/test/scenarios/facing.cfg
+++ b/data/test/scenarios/facing.cfg
@@ -42,7 +42,7 @@
     [/event]
     [event]
         name = side 1 turn 7
-        {RETURN ([true][/true])}
+        {SUCCEED}
     [/event]
     [event]
         name = side turn

--- a/data/test/scenarios/feeding.cfg
+++ b/data/test/scenarios/feeding.cfg
@@ -157,6 +157,6 @@
         {TEST_FEEDING bob 1}
         {TEST_FEEDING bob 1}
 
-        {RETURN ([true][/true])}
+        {SUCCEED}
     [/event]
 )}

--- a/data/test/scenarios/filter_vision.cfg
+++ b/data/test/scenarios/filter_vision.cfg
@@ -162,6 +162,6 @@
         {assert_test_false (side=4) (side=2)}
         {assert_test_false () (side=5)}
 
-        {RETURN ([true][/true])}
+        {SUCCEED}
     [/event]
 )}

--- a/data/test/scenarios/has_ally.cfg
+++ b/data/test/scenarios/has_ally.cfg
@@ -116,6 +116,6 @@
                 [/have_unit]
             [/not]
         )}
-        {RETURN ([true][/true])}
+        {SUCCEED}
     [/event]
 )}

--- a/data/test/scenarios/interrupts.cfg
+++ b/data/test/scenarios/interrupts.cfg
@@ -35,7 +35,7 @@
 				{VARIABLE_OP x add 1}
 			[/do]
 		[/while]
-		{RETURN ([false][/false])}
+		{FAIL}
 	[/event]
 	[event]
 		name=start
@@ -48,14 +48,14 @@
 		name=start
 		{VARIABLE x 0}
 		[while]
-			{VARIABLE_CONDITIONAL x less_than 1}
+			{VARIABLE_CONDITIONAL x less_than 5}
 			[do]
-				{VARIABLE_OP x add 1}
+				{VARIABLE_OP x add 5}
 				[continue][/continue]
-				{RETURN ([false][/false])}
+				{FAIL}
 			[/do]
 		[/while]
-		{RETURN ([true][/true])}
+		{RETURN ({VARIABLE_CONDITIONAL x equals 5})}
 	[/event]
 )}
 
@@ -63,11 +63,11 @@
 	[event]
 		name=start
 		[break][/break]
-		{RETURN ([false][/false])}
+		{FAIL}
 	[/event]
 	[event]
 		name=start
-		{RETURN ([true][/true])}
+		{SUCCEED}
 	[/event]
 )}
 
@@ -90,11 +90,11 @@
 	[/event]
 	[event]
 		name=success
-		{RETURN ([true][/true])}
+		{SUCCEED}
 	[/event]
 	[event]
 		name=fail
-		{RETURN ([false][/false])}
+		{FAIL}
 	[/event]
 )}
 
@@ -103,12 +103,89 @@
 		name=start
 		[command]
 			[return][/return]
-			{RETURN ([false][/false])}
+			{FAIL}
 		[/command]
-		{RETURN ([false][/false])}
+		{FAIL}
 	[/event]
 	[event]
 		name=start
-		{RETURN ([true][/true])}
+		{SUCCEED}
+	[/event]
+)}
+
+{GENERIC_UNIT_TEST check_interrupts_elseif (
+	[event]
+		name=start
+		{VARIABLE x 9}
+		[if]
+			{VARIABLE_CONDITIONAL x greater_than 10}
+			[then]
+				{FAIL}
+			[/then]
+			[elseif]
+				{VARIABLE_CONDITIONAL x less_than 10}
+				[then]
+					[return][/return]
+				[/then]
+			[/elseif]
+			[else]
+				[wml_message]
+					message="Reached the [else] block!"
+					logger=error
+				[/wml_message]
+				{FAIL}
+			[/else]
+		[/if]
+		[wml_message]
+			message="Passed the [if] block!"
+			logger=error
+		[/wml_message]
+		{FAIL}
+	[/event]
+	[event]
+		name=start
+		{SUCCEED}
+	[/event]
+)}
+
+{GENERIC_UNIT_TEST check_interrupts_case (
+	[event]
+		name=start
+		{VARIABLE x 0}
+		[switch]
+			variable=x
+			[case]
+				value=1,3,5,7,9
+				{FAIL}
+			[/case]
+			[case]
+				value=0,2,4,6,8
+				[return][/return]
+			[/case]
+			[case]
+				value=0
+				[wml_message]
+					message="Reached next [case] block!"
+					logger=error
+				[/wml_message]
+				{FAIL}
+			[/case]
+			[else]
+				[wml_message]
+					message="Reached the [else] block!"
+					logger=error
+				[/wml_message]
+				{FAIL}
+			[/else]
+		[/switch]
+		[wml_message]
+			message="Passed the [switch] block!"
+			logger=error
+		[/wml_message]
+		{FAIL}
+	[/event]
+	[event]
+		name=start
+		{SUCCEED}
 	[/event]
 )}

--- a/data/test/scenarios/prestart_settings.cfg
+++ b/data/test/scenarios/prestart_settings.cfg
@@ -63,11 +63,11 @@
     [/event]
     [event]
         name=side 1 turn 1
-        {RETURN ([false][/false])}
+        {FAIL}
     [/event]
     [event]
         name=side 1 turn 42
-        {RETURN ([true][/true])}
+        {SUCCEED}
     [/event]
 )}
 
@@ -80,11 +80,11 @@
     [/event]
     [event]
         name=side 1 turn 1 refresh
-        {RETURN ([true][/true])}
+        {SUCCEED}
     [/event]
     [event]
         name=side 1 turn 42
-        {RETURN ([false][/false])}
+        {FAIL}
     [/event]
 )}
 
@@ -102,15 +102,15 @@
     [/event]
     [event]
         name=side 1 turn 1 end
-        {RETURN ([false][/false])}
+        {FAIL}
     [/event]
     [event]
         name=side 2 turn 42
-        {RETURN ([true][/true])}
+        {SUCCEED}
     [/event]
     [event]
         name=side 1 turn 43
-        {RETURN ([false][/false])}
+        {FAIL}
     [/event]
 )}
 

--- a/data/test/scenarios/recruit_facing.cfg
+++ b/data/test/scenarios/recruit_facing.cfg
@@ -74,7 +74,7 @@
     [/event]
     [event]
         name=side 1 turn 2
-        {RETURN ([true][/true])}
+        {SUCCEED}
     [/event]
 )}
 
@@ -114,7 +114,7 @@
     [/event]
     [event]
         name=side 1 turn 4 refresh
-        {RETURN ([true][/true])}
+        {SUCCEED}
     [/event]
 )}
 
@@ -193,7 +193,7 @@ Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg"
     {RECRUIT_AND_CHECK 8 ("se") (7,4)}
     [event]
         name=side 1 turn 9 refresh
-        {RETURN ([true][/true])}
+        {SUCCEED}
     [/event]
 )}
 {RECRUIT_TEST recruit_facing_center (
@@ -210,6 +210,6 @@ Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg"
     {RECALL_AND_CHECK 8 ("nw") (7,4)}
     [event]
         name=side 1 turn 9 refresh
-        {RETURN ([true][/true])}
+        {SUCCEED}
     [/event]
 )}

--- a/data/test/scenarios/sighted_events.cfg
+++ b/data/test/scenarios/sighted_events.cfg
@@ -126,7 +126,7 @@
         #If we got this far without triggering sighted, we fail the test.
         [event]
             name = side 2 turn 2
-            {RETURN ([false][/false])}
+            {FAIL}
         [/event]
 
         #This makes the sides pass their turns, when the other events have taken place.

--- a/data/test/scenarios/test_check_victory.cfg
+++ b/data/test/scenarios/test_check_victory.cfg
@@ -77,7 +77,7 @@
     [/event]
     [event]
         name=side 2 turn 1
-        {RETURN ([false][/false])}
+        {FAIL}
     [/event]
 #enddef
 

--- a/data/test/scenarios/test_dofile.cfg
+++ b/data/test/scenarios/test_dofile.cfg
@@ -13,6 +13,6 @@
         {ASSERT ({VARIABLE_CONDITIONAL b equals 2})}
         {ASSERT ({VARIABLE_CONDITIONAL c equals 3})}
         {ASSERT ({VARIABLE_CONDITIONAL d equals 4})}
-        {RETURN [true][/true]}
+        {SUCCEED}
     [/event]
 )}

--- a/data/test/scenarios/test_end_turn.cfg
+++ b/data/test/scenarios/test_end_turn.cfg
@@ -8,6 +8,6 @@
     [/event]
     [event]
         name = side 2 turn 1
-        {RETURN ([true][/true])}
+        {SUCCEED}
     [/event]
 )}

--- a/data/test/scenarios/test_grunt_tod_damage.cfg
+++ b/data/test/scenarios/test_grunt_tod_damage.cfg
@@ -79,7 +79,7 @@
     #If we got this far without failing an assertion, we pass the test.
     [event]
         name = side 2 turn 6
-        {RETURN ([true][/true])}
+        {SUCCEED}
     [/event]
 
     #This makes all sides pass their turns, when the other events have taken place.
@@ -160,7 +160,7 @@
         [/time_area]
         {TEST_GRUNT_DAMAGE test3 1 6 "$(11*2)"}
 
-        {RETURN ([true][/true])}
+        {SUCCEED}
     [/event]
 [/test]
 
@@ -210,6 +210,6 @@
 
         {TEST_GRUNT_DAMAGE test3 1 6 "$(11*2)"}
 
-        {RETURN ([true][/true])}
+        {SUCCEED}
     [/event]
 [/test]

--- a/data/test/scenarios/test_lua_wml.cfg
+++ b/data/test/scenarios/test_lua_wml.cfg
@@ -72,6 +72,6 @@
 				[/and]
 			[/not])}
 
-		{RETURN ([true][/true])}
+		{SUCCEED}
 	[/event]
 )}

--- a/data/test/scenarios/test_menu_items.cfg
+++ b/data/test/scenarios/test_menu_items.cfg
@@ -21,7 +21,7 @@
 
         {ASSERT {VARIABLE_CONDITIONAL mx equals 3}}
         {ASSERT {VARIABLE_CONDITIONAL my equals 3}}
-        {RETURN ([true][/true])}
+        {SUCCEED}
     [/event]
 )}
 

--- a/data/test/scenarios/test_move.cfg
+++ b/data/test/scenarios/test_move.cfg
@@ -54,7 +54,7 @@
                     y={PY}
                 [/move]
             [/do_command]
-            {RETURN ([true][/true])}
+            {SUCCEED}
         [/event]
     [/test]
 #enddef

--- a/data/test/scenarios/test_move_unit.cfg
+++ b/data/test/scenarios/test_move_unit.cfg
@@ -111,6 +111,6 @@
             [/have_unit]
         )}
 
-        {RETURN ([true][/true])}
+        {SUCCEED}
     [/event]
 )}

--- a/data/test/scenarios/test_role_types.cfg
+++ b/data/test/scenarios/test_role_types.cfg
@@ -37,7 +37,7 @@
             [/have_unit]
         )}
 
-        {RETURN ([true][/true])}
+        {SUCCEED}
     [/event]
 )}
 
@@ -71,7 +71,7 @@
             [/have_unit]
         )}
 
-        {RETURN ([true][/true])}
+        {SUCCEED}
     [/event]
 )}
 
@@ -92,7 +92,7 @@
             [/have_unit]
         )}
 
-        {RETURN ([true][/true])}
+        {SUCCEED}
     [/event]
 )}
 
@@ -127,6 +127,6 @@
             [/have_unit]
         )}
 
-        {RETURN ([true][/true])}
+        {SUCCEED}
     [/event]
 )}

--- a/data/test/scenarios/test_unit_map.cfg
+++ b/data/test/scenarios/test_unit_map.cfg
@@ -138,6 +138,6 @@
         [/do_command]
         {ASSERT_YES_9_5}
 
-        {RETURN ([true][/true])}
+        {SUCCEED}
     [/event]
 )}

--- a/data/test/scenarios/test_victory_attacks.cfg
+++ b/data/test/scenarios/test_victory_attacks.cfg
@@ -102,7 +102,7 @@
 
     [event]
         name= side turn end
-        {RETURN [false][/false]}
+        {FAIL}
     [/event]
 )}
 
@@ -130,7 +130,7 @@
 
     [event]
         name= side turn end
-        {RETURN [false][/false]}
+        {FAIL}
     [/event]
 )}
 
@@ -159,7 +159,7 @@
 
     [event]
         name= side turn end
-        {RETURN [false][/false]}
+        {FAIL}
     [/event]
 )}
 
@@ -190,7 +190,7 @@
     [/event]
     [event]
         name= side 2 turn end
-        {RETURN [false][/false]}
+        {FAIL}
     [/event]
 )}
 
@@ -221,7 +221,7 @@
     [/event]
     [event]
         name= side 2 turn end
-        {RETURN [false][/false]}
+        {FAIL}
     [/event]
 )}
 
@@ -253,6 +253,6 @@
     [/event]
     [event]
         name= side 2 turn end
-        {RETURN [false][/false]}
+        {FAIL}
     [/event]
 )}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -154,3 +154,5 @@
 0 check_interrupts_break_global
 0 check_interrupts_return_nested
 0 check_interrupts_continue_global
+0 check_interrupts_elseif
+0 check_interrupts_case


### PR DESCRIPTION
This commit adds three new control flow structure tags to WML: [for], [repeat], and [foreach].

The [for] tag is a general range-for loop, with special support for the common case of running over an array. It can be used as a drop-in substitute for the {FOREACH}/{NEXT} macros.

The [repeat] tag is a drop-in substitute for the {REPEAT} macro, with the added bonus that it doesn't break down if nested.

The [foreach] tag is an opaque foreach loop. It disallows adding or removing elements during iteration (though the contents of elements can be changed). If you need to add or remove elements, you can use [for] instead.