### PR TITLE
Lua API changes (mainly relating to units)

### DIFF
--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -563,7 +563,7 @@ function wml_actions.store_unit(cfg)
 
 	for i,u in ipairs(units) do
 		utils.vwriter.write(writer, u.__cfg)
-		if kill_units then wesnoth.put_unit(u.x, u.y) end
+		if kill_units then wesnoth.erase_unit(u) end
 	end
 
 	if (not filter.x or filter.x == "recall") and (not filter.y or filter.y == "recall") then
@@ -572,7 +572,7 @@ function wml_actions.store_unit(cfg)
 			ucfg.x = "recall"
 			ucfg.y = "recall"
 			utils.vwriter.write(writer, ucfg)
-			if kill_units then wesnoth.extract_unit(u) end
+			if kill_units then wesnoth.erase_unit(u) end
 		end
 	end
 end
@@ -838,7 +838,7 @@ function wml_actions.petrify(cfg)
 		unit.status.petrified = true
 		-- Extract unit and put it back to update animation (not needed for recall units)
 		wesnoth.extract_unit(unit)
-		wesnoth.put_unit(unit, unit.x, unit.y)
+		wesnoth.put_unit(unit)
 	end
 
 	for index, unit in ipairs(wesnoth.get_recall_units(cfg)) do
@@ -851,7 +851,7 @@ function wml_actions.unpetrify(cfg)
 		unit.status.petrified = false
 		-- Extract unit and put it back to update animation (not needed for recall units)
 		wesnoth.extract_unit(unit)
-		wesnoth.put_unit(unit, unit.x, unit.y)
+		wesnoth.put_unit(unit)
 	end
 
 	for index, unit in ipairs(wesnoth.get_recall_units(cfg)) do
@@ -980,7 +980,7 @@ function wml_actions.harm_unit(cfg)
 
 			-- Extract unit and put it back to update animation if status was changed
 			wesnoth.extract_unit(unit_to_harm)
-			wesnoth.put_unit(unit_to_harm, unit_to_harm.x, unit_to_harm.y)
+			wesnoth.put_unit(unit_to_harm)
 
 			if add_tab then
 				text = string.format("%s%s", "\t", text)
@@ -1304,7 +1304,7 @@ function wml_actions.put_to_recall_list(cfg)
 			unit.status.slowed = false
 		end
 		wesnoth.put_recall_unit(unit, unit.side)
-		wesnoth.put_unit(unit.x, unit.y)
+		wesnoth.erase_unit(unit)
 	end
 end
 

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -4510,16 +4510,16 @@ void game_lua_kernel::initialize(const config& level)
 int game_lua_kernel::return_unit_method(lua_State *L, char const *m) {
 	static luaL_Reg const methods[] = {
 		{"matches",               &dispatch<&game_lua_kernel::intf_match_unit>},
-		{"to_recall_list",        &dispatch<&game_lua_kernel::intf_put_recall_unit>},
+		{"to_recall",             &dispatch<&game_lua_kernel::intf_put_recall_unit>},
 		{"clone",                 intf_copy_unit},
 		{"extract",               &dispatch<&game_lua_kernel::intf_extract_unit>},
 		{"advance",               intf_advance_unit},
 		{"add_modification",      intf_add_modification},
-		{"resistance_to",         intf_unit_resistance},
-		{"defense_on",            intf_unit_defense},
-		{"movement_on",           intf_unit_movement_cost},
-		{"under_ability",         intf_unit_ability},
-		{"transform_to",          intf_transform_unit},
+		{"resistance",            intf_unit_resistance},
+		{"defense",               intf_unit_defense},
+		{"movement",              intf_unit_movement_cost},
+		{"ability",               intf_unit_ability},
+		{"transform",             intf_transform_unit},
 	};
 	
 	BOOST_FOREACH(const luaL_Reg& r, methods) {

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -2663,6 +2663,36 @@ static int intf_unit_movement_cost(lua_State *L)
 }
 
 /**
+ * Returns unit vision cost on a given terrain.
+ * - Arg 1: unit userdata.
+ * - Arg 2: string containing the terrain type.
+ * - Ret 1: integer.
+ */
+static int intf_unit_vision_cost(lua_State *L)
+{
+	const unit_const_ptr u = luaW_checkunit(L, 1);
+	char const *m = luaL_checkstring(L, 2);
+	t_translation::t_terrain t = t_translation::read_terrain_code(m);
+	lua_pushinteger(L, u->vision_cost(t));
+	return 1;
+}
+
+/**
+ * Returns unit jamming cost on a given terrain.
+ * - Arg 1: unit userdata.
+ * - Arg 2: string containing the terrain type.
+ * - Ret 1: integer.
+ */
+static int intf_unit_jamming_cost(lua_State *L)
+{
+	const unit_const_ptr u = luaW_checkunit(L, 1);
+	char const *m = luaL_checkstring(L, 2);
+	t_translation::t_terrain t = t_translation::read_terrain_code(m);
+	lua_pushinteger(L, u->jamming_cost(t));
+	return 1;
+}
+
+/**
  * Returns unit defense on a given terrain.
  * - Arg 1: unit userdata.
  * - Arg 2: string containing the terrain type.
@@ -4219,6 +4249,8 @@ game_lua_kernel::game_lua_kernel(CVideo * video, game_state & gs, play_controlle
 		{ "unit_ability",             &intf_unit_ability             },
 		{ "unit_defense",             &intf_unit_defense             },
 		{ "unit_movement_cost",       &intf_unit_movement_cost       },
+		{ "unit_vision_cost",         &intf_unit_vision_cost         },
+		{ "unit_jamming_cost",        &intf_unit_jamming_cost        },
 		{ "unit_resistance",          &intf_unit_resistance          },
 		{ "unsynced",                 &intf_do_unsynced              },
 		{ "add_event_handler",         &dispatch<&game_lua_kernel::intf_add_event                  >        },
@@ -4543,6 +4575,8 @@ int game_lua_kernel::return_unit_method(lua_State *L, char const *m) {
 		{"resistance",            intf_unit_resistance},
 		{"defense",               intf_unit_defense},
 		{"movement",              intf_unit_movement_cost},
+		{"vision",                intf_unit_movement_cost},
+		{"jamming",               intf_unit_movement_cost},
 		{"ability",               intf_unit_ability},
 		{"transform",             intf_transform_unit},
 	};

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -1634,12 +1634,12 @@ int game_lua_kernel::impl_current_get(lua_State *L)
  */
 int game_lua_kernel::intf_message(lua_State *L)
 {
-	char const *m = luaL_checkstring(L, 1);
-	char const *h = m;
+	t_string m = luaW_checktstring(L, 1);
+	t_string h = m;
 	if (lua_isnone(L, 2)) {
 		h = "Lua";
 	} else {
-		m = luaL_checkstring(L, 2);
+		m = luaW_checktstring(L, 2);
 	}
 	lua_chat(h, m);
 	LOG_LUA << "Script says: \"" << m << "\"\n";

--- a/src/scripting/game_lua_kernel.hpp
+++ b/src/scripting/game_lua_kernel.hpp
@@ -115,6 +115,7 @@ class game_lua_kernel : public lua_kernel_base
 	int intf_play_sound(lua_State *L);
 	int intf_print(lua_State *L);
 	int intf_put_unit(lua_State *L);
+	int intf_erase_unit(lua_State *L);
 	int intf_put_recall_unit(lua_State *L);
 	int intf_extract_unit(lua_State *L);
 	int intf_find_vacant_tile(lua_State *L);

--- a/src/scripting/game_lua_kernel.hpp
+++ b/src/scripting/game_lua_kernel.hpp
@@ -184,6 +184,7 @@ public:
 
 	ai::lua_ai_context* create_lua_ai_context(char const *code, ai::engine_lua *engine);
 	ai::lua_ai_action_handler* create_lua_ai_action_handler(char const *code, ai::lua_ai_context &context);
+	int return_unit_method(lua_State *L, char const *m);
 };
 
 #endif

--- a/src/scripting/lua_race.cpp
+++ b/src/scripting/lua_race.cpp
@@ -54,6 +54,24 @@ static int impl_race_get(lua_State* L)
 	return_bool_attrib("ignore_global_traits", !race.uses_global_traits());
 	return_string_attrib("undead_variation", race.undead_variation());
 	return_cfgref_attrib("__cfg", race.get_cfg());
+	if (strcmp(m, "traits") == 0) {
+		lua_newtable(L);
+		if (race.uses_global_traits()) {
+			BOOST_FOREACH(const config& trait, unit_types.traits()) {
+				const std::string& id = trait["id"];
+				lua_pushlstring(L, id.c_str(), id.length());
+				luaW_pushconfig(L, trait);
+				lua_rawset(L, -3);
+			}
+		}
+		BOOST_FOREACH(const config& trait, race.additional_traits()) {
+			const std::string& id = trait["id"];
+			lua_pushlstring(L, id.c_str(), id.length());
+			luaW_pushconfig(L, trait);
+			lua_rawset(L, -3);
+		}
+		return 1;
+	}
 
 	return 0;
 }

--- a/src/scripting/lua_unit_type.cpp
+++ b/src/scripting/lua_unit_type.cpp
@@ -54,6 +54,16 @@ static int impl_unit_type_get(lua_State *L)
 	return_int_attrib("level", ut.level());
 	return_int_attrib("recall_cost", ut.recall_cost());
 	return_cfgref_attrib("__cfg", ut.get_cfg());
+	if (strcmp(m, "traits") == 0) {
+		lua_newtable(L);
+		BOOST_FOREACH(const config& trait, ut.possible_traits()) {
+			const std::string& id = trait["id"];
+			lua_pushlstring(L, id.c_str(), id.length());
+			luaW_pushconfig(L, trait);
+			lua_rawset(L, -3);
+		}
+		return 1;
+	}
 	return 0;
 }
 


### PR DESCRIPTION
The commit messages are pretty self-explanatory. This allows you to call functions involving units using the syntax `u:function(args)` instead of `wesnoth.function(u, args)` (the function names are also different in most cases, omitting the word "unit").