### PR TITLE
Bugfix #23820 - Fix alpha blending under SDL2

### DIFF
--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -272,7 +272,7 @@ void draw(surface screen)
 			, cursor_y - shift_y[current_cursor]
 			, surf->w
 			, surf->h);
-	sdl_blit(screen,&area,cursor_buf,NULL);
+	sdl_copy_portion(screen,&area,cursor_buf,NULL);
 
 	// Blit the surface
 	sdl_blit(surf,NULL,screen,&area);

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -260,6 +260,10 @@ void floating_label::draw(surface screen)
 		return;
 	}
 
+	if(screen == NULL) {
+		return;
+	}
+
 	create_surface();
 	if(surf_ == NULL) {
 		return;
@@ -272,13 +276,9 @@ void floating_label::draw(surface screen)
 		}
 	}
 
-	if(screen == NULL) {
-		return;
-	}
-
 	SDL_Rect rect = sdl::create_rect(xpos(surf_->w), ypos_, surf_->w, surf_->h);
 	const clip_rect_setter clip_setter(screen, &clip_rect_);
-	sdl_blit(screen,&rect,buf_,NULL);
+	sdl_copy_portion(screen,&rect,buf_,NULL);
 	sdl_blit(surf_,NULL,screen,&rect);
 
 	update_rect(rect);

--- a/src/halo.cpp
+++ b/src/halo.cpp
@@ -240,7 +240,7 @@ bool halo_impl::effect::render()
 		buffer_.assign(get_surface_portion(screen,rect));
 	} else {
 		SDL_Rect rect = rect_;
-		sdl_blit(screen,&rect,buffer_,NULL);
+		sdl_copy_portion(screen,&rect,buffer_,NULL);
 	}
 
 	sdl_blit(surf_,NULL,screen,&rect);

--- a/src/sdl/utils.cpp
+++ b/src/sdl/utils.cpp
@@ -2548,7 +2548,7 @@ surface get_surface_portion(const surface &src, SDL_Rect &area, bool optimize_fo
 		return NULL;
 	}
 
-	sdl_blit(src, &area, dst, NULL);
+	sdl_copy_portion(src, &area, dst, NULL);
 
 	return optimize_format ? display_format_alpha(dst) : dst;
 }

--- a/src/sdl/utils.hpp
+++ b/src/sdl/utils.hpp
@@ -113,6 +113,17 @@ inline void sdl_blit(const surface& src, SDL_Rect* src_rect, surface& dst, SDL_R
 	SDL_BlitSurface(src, src_rect, dst, dst_rect);
 }
 
+inline void sdl_copy_portion(const surface& screen, SDL_Rect* screen_rect, surface& dst, SDL_Rect* dst_rect){
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	SDL_SetSurfaceBlendMode(screen, SDL_BLENDMODE_NONE);
+	SDL_SetSurfaceBlendMode(dst, SDL_BLENDMODE_NONE);
+#endif
+	SDL_BlitSurface(screen, screen_rect, dst, dst_rect);
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	SDL_SetSurfaceBlendMode(screen, SDL_BLENDMODE_BLEND);
+#endif
+}
+
 /**
  * This method blends a RGBA color. The method takes as input a surface,
  * the RGB color to blend and a value specifying how much blending to apply.


### PR DESCRIPTION
This commit introduces a new function, sdl_copy_portion that should be
used when copying portions of the screen area for later copying back
onto the screen area. The function does a copy without alpha blending,
thus emulating the functionality that SDL1.2 provides.