### PR TITLE
Use native colour cursors

### DIFF
--- a/data/advanced_preferences.cfg
+++ b/data/advanced_preferences.cfg
@@ -186,15 +186,13 @@
     default=no
 [/advanced_preference]
 
-#ifndef APPLE
 [advanced_preference]
     field=color_cursors
     name= _ "Show color cursors"
-    description= _ "Use colored mouse cursors, which may be slower or break the game (use at your own risk)"
+    description= _ "Use colored mouse cursors"
     type=boolean
     default=no
 [/advanced_preference]
-#endif
 
 #ifdef __UNUSED__
 [advanced_preference]

--- a/src/cursor.hpp
+++ b/src/cursor.hpp
@@ -38,8 +38,11 @@ void set(CURSOR_TYPE type = NUM_CURSORS);
 void set_dragging(bool drag);
 CURSOR_TYPE get();
 
+// These aren't used, but leaving the prototypes doesn't hurt and allows avoiding an SDL include
+//#if !SDL_VERSION_ATLEAST(2,0,0)
 void draw(surface screen);
 void undraw(surface screen);
+//#endif
 
 void set_focus(bool focus);
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1414,11 +1414,15 @@ void display::flip()
 	font::draw_floating_labels(frameBuffer);
 #endif
 	events::raise_volatile_draw_event();
+#if !SDL_VERSION_ATLEAST(2,0,0)
 	cursor::draw(frameBuffer);
+#endif
 
 	video().flip();
 
+#if !SDL_VERSION_ATLEAST(2,0,0)
 	cursor::undraw(frameBuffer);
+#endif
 	events::raise_volatile_undraw_event();
 #ifdef SDL_GPU
 	font::undraw_floating_labels(screen_);

--- a/src/gui/auxiliary/event/handler.cpp
+++ b/src/gui/auxiliary/event/handler.cpp
@@ -541,9 +541,13 @@ void thandler::draw(const bool force)
 
 		surface frame_buffer = video.getSurface();
 
+#if !SDL_VERSION_ATLEAST(2,0,0)
 		cursor::draw(frame_buffer);
+#endif
 		video.flip();
+#if !SDL_VERSION_ATLEAST(2,0,0)
 		cursor::undraw(frame_buffer);
+#endif
 	}
 }
 


### PR DESCRIPTION
This fixes bug #18112 and re-enables colour cursors on OSX