### PR TITLE
Lua vconfig iteration

### DIFF
--- a/data/lua/helper.lua
+++ b/data/lua/helper.lua
@@ -49,6 +49,31 @@ function helper.get_child(cfg, name, id)
 	end
 end
 
+--! Returns the nth subtag of @a cfg with the given @a name.
+--! (Indices start at 1, as always with Lua.)
+--! The function also returns the index of the subtag in the array.
+function helper.get_nth_child(cfg, name, n)
+	for i = 1, #cfg do
+		local v = cfg[i]
+		if v[1] == name then
+			n = n - 1
+			if n == 1 then return v[2], i end
+		end
+	end
+end
+
+--! Returns the number of subtags of @a with the given @a name.
+function helper.child_count(cfg, name)
+	local n = 0
+	for i = 1, #cfg do
+		local v = cfg[i]
+		if v[1] == name then
+			n = n + 1
+		end
+	end
+	return n
+end
+
 --! Returns an iterator over all the subtags of @a cfg with the given @a name.
 function helper.child_range(cfg, tag)
 	local function f(s)
@@ -62,6 +87,15 @@ function helper.child_range(cfg, tag)
 		return c[2]
 	end
 	return f, { i = 1 }
+end
+
+--! Returns an array from the subtags of @a cfg with the given @a name
+function helper.child_array(cfg, tag)
+	local result = {}
+	for val in helper.child_range(cfg, tag) do
+		table.insert(result, val)
+	end
+	return result
 end
 
 --! Modifies all the units satisfying the given @a filter.

--- a/data/lua/helper.lua
+++ b/data/lua/helper.lua
@@ -39,9 +39,7 @@ end
 --! If @a id is not nil, the "id" attribute of the subtag has to match too.
 --! The function also returns the index of the subtag in the array.
 function helper.get_child(cfg, name, id)
-	-- ipairs cannot be used on a vconfig object
-	for i = 1, #cfg do
-		local v = cfg[i]
+	for i,v in ipairs(cfg) do
 		if v[1] == name then
 			local w = v[2]
 			if not id or w.id == id then return w, i end
@@ -53,11 +51,10 @@ end
 --! (Indices start at 1, as always with Lua.)
 --! The function also returns the index of the subtag in the array.
 function helper.get_nth_child(cfg, name, n)
-	for i = 1, #cfg do
-		local v = cfg[i]
+	for i,v in ipairs(cfg) do
 		if v[1] == name then
 			n = n - 1
-			if n == 1 then return v[2], i end
+			if n == 0 then return v[2], i end
 		end
 	end
 end
@@ -65,8 +62,7 @@ end
 --! Returns the number of subtags of @a with the given @a name.
 function helper.child_count(cfg, name)
 	local n = 0
-	for i = 1, #cfg do
-		local v = cfg[i]
+	for i,v in ipairs(cfg) do
 		if v[1] == name then
 			n = n + 1
 		end

--- a/data/lua/helper.lua
+++ b/data/lua/helper.lua
@@ -73,10 +73,8 @@ end
 --! Returns an iterator over all the subtags of @a cfg with the given @a name.
 function helper.child_range(cfg, tag)
 	local iter, state, i = ipairs(cfg)
-	assert(state == cfg)
 	local function f(s)
 		local c
-		assert(s == cfg)
 		repeat
 			i,c = iter(s,i)
 			if not c then return end

--- a/data/lua/helper.lua
+++ b/data/lua/helper.lua
@@ -72,16 +72,18 @@ end
 
 --! Returns an iterator over all the subtags of @a cfg with the given @a name.
 function helper.child_range(cfg, tag)
-	local iter, s, i = ipairs(cfg)
+	local iter, state, i = ipairs(cfg)
+	assert(state == cfg)
 	local function f(s)
-		local i,c = s.i
+		local c
+		assert(s == cfg)
 		repeat
-			i,c = iter(cfg,i)
+			i,c = iter(s,i)
 			if not c then return end
 		until c[1] == tag
 		return c[2]
 	end
-	return f, {i = 1}
+	return f, state
 end
 
 --! Returns an array from the subtags of @a cfg with the given @a name

--- a/data/lua/helper.lua
+++ b/data/lua/helper.lua
@@ -72,17 +72,16 @@ end
 
 --! Returns an iterator over all the subtags of @a cfg with the given @a name.
 function helper.child_range(cfg, tag)
+	local iter, s, i = ipairs(cfg)
 	local function f(s)
-		local c
+		local i,c = s.i
 		repeat
-			local i = s.i
-			c = cfg[i]
+			i,c = iter(cfg,i)
 			if not c then return end
-			s.i = i + 1
 		until c[1] == tag
 		return c[2]
 	end
-	return f, { i = 1 }
+	return f, {i = 1}
 end
 
 --! Returns an array from the subtags of @a cfg with the given @a name

--- a/src/scripting/lua_common.cpp
+++ b/src/scripting/lua_common.cpp
@@ -285,9 +285,12 @@ static int impl_vconfig_ipairs_iter(lua_State *L)
 	}
 	std::pair<std::string, vconfig> value = *range.first++;
 	lua_pushinteger(L, i + 1);
+	lua_createtable(L, 2, 0);
 	lua_pushlstring(L, value.first.c_str(), value.first.length());
+	lua_rawseti(L, -2, 1);
 	luaW_pushvconfig(L, value.second);
-	return 3;
+	lua_rawseti(L, -2, 2);
+	return 2;
 }
 
 /**

--- a/src/scripting/lua_common.cpp
+++ b/src/scripting/lua_common.cpp
@@ -229,7 +229,7 @@ static int impl_vconfig_size(lua_State *L)
 static int impl_vconfig_collect(lua_State *L)
 {
 	vconfig *v = static_cast<vconfig *>(lua_touserdata(L, 1));
-	v->vconfig::~vconfig();
+	v->~vconfig();
 	return 0;
 }
 


### PR DESCRIPTION
This patch adds metamethods for the vconfig userdata to allow you to iterate over them just as if they were a plain WML table. It also adds a couple of config utility functions to the helper module.