### PR TITLE
New syntax for campaign difficulty.

### DIFF
--- a/data/campaigns/An_Orcish_Incursion/_main.cfg
+++ b/data/campaigns/An_Orcish_Incursion/_main.cfg
@@ -6,20 +6,39 @@
 # wmlscope: set export=no
 [campaign]
     id=An_Orcish_Incursion
+    name= _ "An Orcish Incursion"
     icon="units/elves-wood/lord.png~TC(1,magenta)"
     image="data/campaigns/An_Orcish_Incursion/images/campaign_image.png"
-    name= _ "An Orcish Incursion"
     abbrev= _ "AOI"
     rank=15
     first_scenario=01_Defend_the_Forest
-    difficulties="EASY,NORMAL,HARD"
-    difficulty_descriptions={MENU_IMG_TXT2 "units/elves-wood/fighter.png~RC(magenta>red)" _"Fighter" _"(Beginner)"} +
-    ";*" + {MENU_IMG_TXT2 "units/elves-wood/lord.png~RC(magenta>red)" _"Lord" _"(Normal)"} +
-    ";" + {MENU_IMG_TXT2 "units/elves-wood/high-lord.png~RC(magenta>red)" _"High Lord" _"(Challenging)"}
-    define="CAMPAIGN_AN_ORCISH_INCURSION"
+
     description=_ "Defend the forests of the elves against the first orcs to reach the Great Continent, learning valuable tactics as you do so.
 
 " + _"(Novice level, 7 scenarios.)"
+
+    [difficulty]
+        define=EASY
+        image="units/elves-wood/fighter.png~RC(magenta>red)"
+        label= _ "Fighter"
+        description= _ "Beginner"
+    [/difficulty]
+
+    [difficulty]
+        default=yes
+        define=NORMAL
+        image="units/elves-wood/lord.png~RC(magenta>red)"
+        label= _ "Lord"
+        description= _ "Normal"
+    [/difficulty]
+
+    [difficulty]
+        define=HARD
+        image="units/elves-wood/high-lord.png~RC(magenta>red)"
+        label= _ "High Lord"
+        description= _ "Challenging"
+    [/difficulty]
+
     # Geographical and historical assumptions (ESR):
     #
     # As originally written by Josh Parsons, this campaign was not set in

--- a/data/campaigns/Dead_Water/_main.cfg
+++ b/data/campaigns/Dead_Water/_main.cfg
@@ -12,11 +12,12 @@
     abbrev= _ "DW"
     define=CAMPAIGN_DEAD_WATER
     first_scenario=01_Invasion
-    difficulties="EASY,NORMAL,HARD,NIGHTMARE"
-    difficulty_descriptions={MENU_IMG_TXT2 "data/campaigns/Dead_Water/images/units/merfolk/citizen.png~RC(magenta>red)" ( _ "Citizen") (_ "(Beginner)")} +
-    ";*" + {MENU_IMG_TXT2 "units/merfolk/fighter.png~RC(magenta>red)" ( _ "Fighter") (_ "(Normal)")} +
-    ";" + {MENU_IMG_TXT2 "units/merfolk/warrior.png~RC(magenta>red)" (_ "Warrior") (_ "(Challenging)")} +
-    ";" + {MENU_IMG_TXT2 "units/merfolk/triton.png~RC(magenta>red)" (_ "Triton") (_ "(Difficult)")}
+
+    {CAMPAIGN_DIFFICULTY EASY      "data/campaigns/Dead_Water/images/units/merfolk/citizen.png~RC(magenta>red)" ( _ "Citizen") ( _ "Beginner")}
+    {CAMPAIGN_DIFFICULTY NORMAL    "units/merfolk/fighter.png~RC(magenta>red)" ( _ "Fighter") ( _ "Normal")} {DEFAULT_DIFFICULTY}
+    {CAMPAIGN_DIFFICULTY HARD      "units/merfolk/warrior.png~RC(magenta>red)" ( _ "Warrior") ( _ "Challenging")}
+    {CAMPAIGN_DIFFICULTY NIGHTMARE "units/merfolk/triton.png~RC(magenta>red)" ( _ "Triton") ( _ "Difficult")}
+
     description= _ "You are Kai Krellis, son and heir of the last merman king but only a child. A necromancer is turning your subjects into undead slaves! Lead your people on a mission to convince a powerful mer-sorceress to help you repel the invasion. The oceans near the Northern Lands are perilous, so you will need cunning and bravery to survive. But first you need to gain the respect of your troops!
 
 " + _ "(Intermediate level, 10 scenarios.)"

--- a/data/campaigns/Delfadors_Memoirs/_main.cfg
+++ b/data/campaigns/Delfadors_Memoirs/_main.cfg
@@ -27,10 +27,10 @@
     icon="units/human-magi/elder-mage.png~RC(magenta>red)"
     image="data/campaigns/Delfadors_Memoirs/images/campaign_image.png"
     first_scenario=01_Overture
-    difficulties=EASY,NORMAL,HARD
-    difficulty_descriptions={MENU_IMG_TXT2 "data/core/images/units/human-magi/mage.png~RC(magenta>red)" _"Apprentice" _"(Normal)"} +
-    ";*" + {MENU_IMG_TXT2 "data/core/images/units/human-magi/red-mage.png~RC(magenta>red)" _"Mage" _"(Challenging)"} +
-    ";" + {MENU_IMG_TXT2 "data/core/images/units/human-magi/great-mage.png~RC(magenta>red)" _"Great Mage" _"(Difficult)"}
+
+    {CAMPAIGN_DIFFICULTY EASY   "data/core/images/units/human-magi/mage.png~RC(magenta>red)" ( _ "Apprentice") ( _ "Normal")}
+    {CAMPAIGN_DIFFICULTY NORMAL "data/core/images/units/human-magi/red-mage.png~RC(magenta>red)" ( _ "Mage") ( _ "Challenging")} {DEFAULT_DIFFICULTY}
+    {CAMPAIGN_DIFFICULTY HARD   "data/core/images/units/human-magi/great-mage.png~RC(magenta>red)" ( _ "Great Mage") ( _ "Difficult")}
 
     description= _ "Wesnoth seems to be slipping inexorably into chaos, as marauding orcs pour south across the Great River, and mysterious and deadly creatures roam the night. Who is the shadowy Iliah-Malal? Can you defeat him before he destroys all life in Wesnoth?
 

--- a/data/campaigns/Descent_Into_Darkness/_main.cfg
+++ b/data/campaigns/Descent_Into_Darkness/_main.cfg
@@ -13,10 +13,11 @@
     abbrev= _ "DiD"
     define=CAMPAIGN_DESCENT
     first_scenario=01_Saving_Parthyn
-    difficulties=EASY,NORMAL,HARD
-    difficulty_descriptions={MENU_IMG_TXT2 "units/undead-necromancers/adept.png~RC(magenta>black)" _"Neophyte" _"(Normal)"} +
-    ";*" + {MENU_IMG_TXT2 "units/undead-necromancers/dark-sorcerer.png~RC(magenta>black)" _"Evoker" _"(Challenging)"} +
-    ";" + {MENU_IMG_TXT2 "units/undead-necromancers/lich.png~RC(magenta>black)" _"Summoner" _"(Difficult)"}
+
+    {CAMPAIGN_DIFFICULTY EASY   "units/undead-necromancers/adept.png~RC(magenta>black)" ( _ "Neophyte") ( _ "Normal")}
+    {CAMPAIGN_DIFFICULTY NORMAL "units/undead-necromancers/dark-sorcerer.png~RC(magenta>black)" ( _ "Evoker") ( _ "Challenging")} {DEFAULT_DIFFICULTY}
+    {CAMPAIGN_DIFFICULTY HARD   "units/undead-necromancers/lich.png~RC(magenta>black)" ( _ "Summoner") ( _ "Difficult")}
+
     description=_ "Learn the dark arts of necromancy in order to save your people from an orcish incursion.
 
 " + _"(Intermediate level, 12 scenarios.)"

--- a/data/campaigns/Eastern_Invasion/_main.cfg
+++ b/data/campaigns/Eastern_Invasion/_main.cfg
@@ -12,10 +12,11 @@
     abbrev= _ "EI"
     define=CAMPAIGN_EASTERN_INVASION
     first_scenario=01_The_Outpost
-    difficulties=EASY,NORMAL,HARD
-    difficulty_descriptions={MENU_IMG_TXT2 "units/human-loyalists/spearman.png~RC(magenta>red)" _"Spearman" _"(Easy)"} +
-    ";*" + {MENU_IMG_TXT2 "units/human-loyalists/swordsman.png~RC(magenta>red)" _"Swordsman" _"(Normal)"} +
-    ";" + {MENU_IMG_TXT2 "units/human-loyalists/royalguard.png~RC(magenta>red)" _"Royal Guard" _"(Challenging)"}
+
+    {CAMPAIGN_DIFFICULTY EASY   "units/human-loyalists/spearman.png~RC(magenta>red)" ( _ "Spearman") ( _ "Easy")}
+    {CAMPAIGN_DIFFICULTY NORMAL "units/human-loyalists/swordsman.png~RC(magenta>red)" ( _ "Swordsman") ( _ "Normal")} {DEFAULT_DIFFICULTY}
+    {CAMPAIGN_DIFFICULTY HARD   "units/human-loyalists/royalguard.png~RC(magenta>red)" ( _ "Royal Guard") ( _ "Challenging")}
+
     description= _ "There are rumors of undead attacks on the eastern border of Wesnoth. You, an officer in the Royal Army, have been sent to the eastern front to protect the villagers and find out what is happening.
 
 " + _"(Intermediate level, 16 scenarios.)"

--- a/data/campaigns/Heir_To_The_Throne/_main.cfg
+++ b/data/campaigns/Heir_To_The_Throne/_main.cfg
@@ -6,20 +6,21 @@
 # wmlscope: set export=no
 [campaign]
     id=Heir_To_The_Throne
-    rank=5
-    icon="data/campaigns/Heir_To_The_Throne/images/units/konrad-lord-leading.png"
     name= _ "Heir to the Throne"
+    icon="data/campaigns/Heir_To_The_Throne/images/units/konrad-lord-leading.png"
+    image="data/campaigns/Heir_To_The_Throne/images/campaign_image.png"
     abbrev= _ "HttT"
+    rank=5
     define=CAMPAIGN_HEIR_TO_THE_THRONE
     first_scenario=01_The_Elves_Besieged
-    difficulties=EASY,NORMAL,HARD
-    difficulty_descriptions={MENU_IMG_TXT2 "units/elves-wood/fighter.png~RC(magenta>red)" _"Fighter" _"(Beginner)"} +
-    ";*" + {MENU_IMG_TXT2 "units/elves-wood/hero.png~RC(magenta>red)" _"Hero" _"(Normal)"} +
-    ";" + {MENU_IMG_TXT2 "units/elves-wood/champion.png~RC(magenta>red)" _"Champion" _"(Challenging)"}
+
     description= _ "Fight to regain the throne of Wesnoth, of which you are the legitimate heir.
 
 " + _"(Novice level, 23 scenarios.)"
-    image="data/campaigns/Heir_To_The_Throne/images/campaign_image.png"
+
+    {CAMPAIGN_DIFFICULTY EASY   "units/elves-wood/fighter.png~RC(magenta>red)" ( _ "Fighter") ( _ "Beginner")}
+    {CAMPAIGN_DIFFICULTY NORMAL "units/elves-wood/hero.png~RC(magenta>red)" ( _ "Hero") ( _ "Normal")} {DEFAULT_DIFFICULTY}
+    {CAMPAIGN_DIFFICULTY HARD   "units/elves-wood/champion.png~RC(magenta>red)" ( _ "Champion") ( _ "Challenging")}
 
     [about]
         images = story/httt_story1.jpg,story/httt_story2.jpg,story/httt_story3.jpg,story/httt_story4.jpg,story/httt_story5.jpg,story/httt_story6.jpg,story/httt_story7.jpg,story/httt_story8.jpg

--- a/data/campaigns/Legend_of_Wesmere/_main.cfg
+++ b/data/campaigns/Legend_of_Wesmere/_main.cfg
@@ -32,7 +32,6 @@
     id=LOW
     define=CAMPAIGN_LOW
     rank=125
-    difficulties=EASY,NORMAL,HARD
 
     type=hybrid
 
@@ -50,9 +49,10 @@
     description=_ "The tale of Kalenz, the High Lord who rallied his people after the second orcish invasion of the Great Continent and became the most renowned hero in the recorded history of the Elves.
 
 " + _"(Intermediate level, 18 scenarios.)"
-    difficulty_descriptions={MENU_IMG_TXT2 "units/elves-wood/fighter.png~RC(magenta>brown)"  _"Soldier"  _"(Easy)"} +
-    ";*" + {MENU_IMG_TXT2  "units/elves-wood/lord.png~RC(magenta>brown)" _"Lord"  _"(Normal)"} +
-    ";" + {MENU_IMG_TXT2   "units/elves-wood/high-lord.png~RC(magenta>brown)" _"High Lord"  _"(Challenging)"}
+
+    {CAMPAIGN_DIFFICULTY EASY   "units/elves-wood/fighter.png~RC(magenta>brown)" ( _ "Soldier") ( _ "Easy")}
+    {CAMPAIGN_DIFFICULTY NORMAL "units/elves-wood/lord.png~RC(magenta>brown)" ( _ "Lord") ( _ "Normal")} {DEFAULT_DIFFICULTY}
+    {CAMPAIGN_DIFFICULTY HARD   "units/elves-wood/high-lord.png~RC(magenta>brown)" ( _ "High Lord") ( _ "Challenging")}
 
     [about]
         title= _ "Creator and Lead Designer"

--- a/data/campaigns/Liberty/_main.cfg
+++ b/data/campaigns/Liberty/_main.cfg
@@ -11,14 +11,14 @@
     abbrev= _ "Liberty"
     rank=110
     first_scenario=01_The_Raid
-
     define=CAMPAIGN_LIBERTY
-    difficulties=EASY,NORMAL,HARD
-    difficulty_descriptions={MENU_IMG_TXT2 "units/human-peasants/peasant.png~RC(magenta>red)" _"Peasant" _"(Easy)"} +
-    ";" + {MENU_IMG_TXT2 "units/human-outlaws/outlaw.png~RC(magenta>red)" _"Outlaw" _"(Normal)"} +
-    ";" + {MENU_IMG_TXT2 "units/human-outlaws/fugitive.png~RC(magenta>red)" _"Fugitive" _"(Difficult)"}
     icon="units/human-outlaws/fugitive.png~RC(magenta>red)"
     image="data/campaigns/Liberty/images/campaign_image.png"
+
+    {CAMPAIGN_DIFFICULTY EASY   "units/human-peasants/peasant.png~RC(magenta>red)" ( _ "Peasant") ( _ "Easy")} {DEFAULT_DIFFICULTY}
+    {CAMPAIGN_DIFFICULTY NORMAL "units/human-outlaws/outlaw.png~RC(magenta>red)" ( _ "Outlaw") ( _ "Normal")}
+    {CAMPAIGN_DIFFICULTY HARD   "units/human-outlaws/fugitive.png~RC(magenta>red)" ( _ "Fugitive") ( _ "Difficult")}
+
     #po: Yes, that is "marchlanders", not "marshlanders".
     #po: "marchlander" is archaic English for an inhabitant of a border region.
     # wmllint: local spelling marchlanders

--- a/data/campaigns/Northern_Rebirth/_main.cfg
+++ b/data/campaigns/Northern_Rebirth/_main.cfg
@@ -11,10 +11,10 @@
     rank=240
     first_scenario=01_Breaking_the_Chains
     define=CAMPAIGN_NORTHERN_REBIRTH
-    difficulties=EASY,NORMAL,HARD
-    difficulty_descriptions={MENU_IMG_TXT2 "units/human-loyalists/spearman.png~RC(magenta>red)" _"Spearman" _"(Challenging)"} +
-    ";" + {MENU_IMG_TXT2 "units/human-loyalists/swordsman.png~RC(magenta>red)" _"Swordsman" _"(Difficult)"} +
-    ";" + {MENU_IMG_TXT2 "units/human-loyalists/royalguard.png~RC(magenta>red)" _"Royal Guard" _"(Nightmare)"}
+
+    {CAMPAIGN_DIFFICULTY EASY   "units/human-loyalists/spearman.png~RC(magenta>red)" ( _ "Spearman") ( _ "Challenging")} {DEFAULT_DIFFICULTY}
+    {CAMPAIGN_DIFFICULTY NORMAL "units/human-loyalists/swordsman.png~RC(magenta>red)" ( _ "Swordsman") ( _ "Difficult")}
+    {CAMPAIGN_DIFFICULTY HARD   "units/human-loyalists/royalguard.png~RC(magenta>red)" ( _ "Royal Guarde") ( _ "Nightmare")}
 
     description= _ "For the people of Dwarven Doors the choice was stark: either drudge as downtrodden slaves for the orcs until the end of their brief and miserable lives, or risk all for freedom and rise up against their cruel overlords. Little did they suspect that their struggle would be the hinge of great events that might restore the Northlands to the glory they had once known.
 

--- a/data/campaigns/Sceptre_of_Fire/_main.cfg
+++ b/data/campaigns/Sceptre_of_Fire/_main.cfg
@@ -14,10 +14,11 @@
     define="CAMPAIGN_SCEPTRE_FIRE"
     extra_defines=ENABLE_DWARVISH_RUNESMITH
     first_scenario="1_A_Bargain_is_Struck"
-    difficulties=EASY,NORMAL,HARD
-    difficulty_descriptions={MENU_IMG_TXT2 "units/dwarves/fighter.png~RC(magenta>red)" _"Fighter" _"(Normal)"} +
-    ";*" + {MENU_IMG_TXT2 "units/dwarves/steelclad.png~RC(magenta>red)" _"Steelclad" _"(Challenging)"} +
-    ";" + {MENU_IMG_TXT2 "units/dwarves/lord.png~RC(magenta>red)" (_"Lord") _"(Difficult)"}
+
+    {CAMPAIGN_DIFFICULTY EASY   "units/dwarves/fighter.png~RC(magenta>red)" ( _ "Fighter") ( _ "Normal")}
+    {CAMPAIGN_DIFFICULTY NORMAL "units/dwarves/steelclad.png~RC(magenta>red)" ( _ "Steelclad") ( _ "Challenging")} {DEFAULT_DIFFICULTY}
+    {CAMPAIGN_DIFFICULTY HARD   "units/dwarves/lord.png~RC(magenta>red)" ( _ "Lord") ( _ "Difficult")}
+
     # wmllint: directory spelling Dwarfdom
     description= _ "The land of Wesnoth’s banner bold
 Comes not from its own land;

--- a/data/campaigns/Son_Of_The_Black_Eye/_main.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/_main.cfg
@@ -11,10 +11,10 @@
     rank=220
     first_scenario=01_End_of_Peace
     define=CAMPAIGN_SON_OF_THE_BLACK_EYE
-    difficulties=EASY,NORMAL,HARD
-    difficulty_descriptions={MENU_IMG_TXT2 "units/orcs/grunt.png~RC(magenta>red)" _"Grunt" _"(Challenging)"} +
-    ";*" + {MENU_IMG_TXT2 "units/orcs/warrior.png~RC(magenta>red)" _"Warrior" _"(Difficult)"} +
-    ";" + {MENU_IMG_TXT2 "units/orcs/warlord.png~RC(magenta>red)" _"Warlord" _"(Nightmare)"}
+
+    {CAMPAIGN_DIFFICULTY EASY   "units/orcs/grunt.png~RC(magenta>red)" ( _ "Grunt") ( _ "Challenging")}
+    {CAMPAIGN_DIFFICULTY NORMAL "units/orcs/warrior.png~RC(magenta>red)" ( _ "Warrior") ( _ "Difficult")} {DEFAULT_DIFFICULTY}
+    {CAMPAIGN_DIFFICULTY HARD   "units/orcs/warlord.png~RC(magenta>red)" ( _ "Warlord") ( _ "Nightmare")}
 
     #the insult "wose-born" replaced "tree-shagger"
     description= _ "Your father Karun Black-Eye was the greatest orcish leader that ever lived. Now, as his son, it’s up to you to thwart the selfish designs of the humans who have broken the old agreements with the orcs and are bent upon taking your lands. Unite the warring orcish tribes, bring together the Orcish Council and call up the Great Horde to send the human-worms and their wose-born allies to the land of the dead!

--- a/data/campaigns/The_Hammer_of_Thursagan/_main.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/_main.cfg
@@ -13,10 +13,11 @@
     rank=140
     define=CAMPAIGN_THE_HAMMER_OF_THURSAGAN
     first_scenario=01_At_the_East_Gate
-    difficulties=EASY,NORMAL,HARD
-    difficulty_descriptions={MENU_IMG_TXT2 "units/dwarves/fighter.png~RC(magenta>red)" _"Fighter" _"(Easy)"} +
-    ";*" + {MENU_IMG_TXT2 "units/dwarves/steelclad.png~RC(magenta>red)" _"Steelclad" _"(Normal)"} +
-    ";" + {MENU_IMG_TXT2 "units/dwarves/lord.png~RC(magenta>red)" (_"Lord") _"(Challenging)"}
+
+    {CAMPAIGN_DIFFICULTY EASY   "units/dwarves/fighter.png~RC(magenta>red)" ( _ "Fighter") ( _ "Easy")}
+    {CAMPAIGN_DIFFICULTY NORMAL "units/dwarves/steelclad.png~RC(magenta>red)" ( _ "Steelclad") ( _ "Normal")} {DEFAULT_DIFFICULTY}
+    {CAMPAIGN_DIFFICULTY HARD   "units/dwarves/lord.png~RC(magenta>red)" ( _ "Lord") ( _ "Challenging")}
+
     # wmllint: directory spelling Kal Kartha
     description= _ "In the first years of the Northern Alliance, an expedition from Knalga seeks out their kin at Kal Kartha and to learn the fate of the legendary Hammer of Thursagan. The perils of their journey through the wild Northern Lands, though great, pale beside the evil they will face at its end.
 

--- a/data/campaigns/The_Rise_Of_Wesnoth/_main.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/_main.cfg
@@ -8,19 +8,20 @@
     id=The_Rise_of_Wesnoth
     rank=230
     name= _ "The Rise of Wesnoth"
+    icon="data/campaigns/The_Rise_Of_Wesnoth/images/units/noble-lord.png"
+    image="data/campaigns/The_Rise_Of_Wesnoth/images/campaign_image.png"
     abbrev= _ "TRoW"
     define=CAMPAIGN_THE_RISE_OF_WESNOTH
     extra_defines=DISABLE_GRAND_MARSHAL
     first_scenario=01_A_Summer_of_Storms
-    difficulties=EASY,NORMAL,HARD
-    difficulty_descriptions={MENU_IMG_TXT2 data/campaigns/The_Rise_Of_Wesnoth/images/units/noble-fighter.png _"Fighter" _"(Easy)"} +
-    ";*" + {MENU_IMG_TXT2 "data/campaigns/The_Rise_Of_Wesnoth/images/units/noble-commander.png" _"Commander" _"(Normal)"} +
-    ";" + {MENU_IMG_TXT2 "data/campaigns/The_Rise_Of_Wesnoth/images/units/noble-lord.png" _"Lord" _"(Challenging)"}
-    icon="data/campaigns/The_Rise_Of_Wesnoth/images/units/noble-lord.png"
+
+    {CAMPAIGN_DIFFICULTY EASY   "data/campaigns/The_Rise_Of_Wesnoth/images/units/noble-fighter.png" ( _ "Fighter") ( _ "Easy")}
+    {CAMPAIGN_DIFFICULTY NORMAL "data/campaigns/The_Rise_Of_Wesnoth/images/units/noble-commander.png" ( _ "Commander") ( _ "Normal")} {DEFAULT_DIFFICULTY}
+    {CAMPAIGN_DIFFICULTY HARD   "data/campaigns/The_Rise_Of_Wesnoth/images/units/noble-lord.png" ( _ "Lord") ( _ "Challenging")}
+
     description= _ "Lead Prince Haldric through the destruction of the Green Isle and across the Ocean to establish the very kingdom of Wesnoth itself. The confrontation with Lich-Lord Jevyan awaits...
 
 " + _"(Expert level, 24 scenarios.)"
-    image="data/campaigns/The_Rise_Of_Wesnoth/images/campaign_image.png"
 
     [about]
         title = _ "Campaign Design"

--- a/data/campaigns/The_South_Guard/_main.cfg
+++ b/data/campaigns/The_South_Guard/_main.cfg
@@ -18,10 +18,9 @@
 
 " + _"(Novice level, 9 scenarios.)"
 
-    difficulties=EASY,NORMAL,HARD
-    difficulty_descriptions={MENU_IMG_TXT2 "units/human-peasants/peasant.png~RC(magenta>red)" _"Civilian" _"(Beginner)"} +
-    ";" + {MENU_IMG_TXT2 "units/human-loyalists/spearman.png~RC(magenta>red)" _"Recruit" _"(Easy)"} +
-    ";" + {MENU_IMG_TXT2 "units/human-loyalists/javelineer.png~RC(magenta>red)" _"Soldier" _"(Normal)"}
+    {CAMPAIGN_DIFFICULTY EASY   "units/human-peasants/peasant.png~RC(magenta>red)" ( _ "Civilian") ( _ "Beginner")}
+    {CAMPAIGN_DIFFICULTY NORMAL "units/human-loyalists/spearman.png~RC(magenta>red)" ( _ "Recruit") ( _ "Easy")} {DEFAULT_DIFFICULTY}
+    {CAMPAIGN_DIFFICULTY HARD   "units/human-loyalists/javelineer.png~RC(magenta>red)" ( _ "Soldier") ( _ "Normal")}
 
     first_scenario=01_Born_to_the_Banner
 

--- a/data/campaigns/Two_Brothers/_main.cfg
+++ b/data/campaigns/Two_Brothers/_main.cfg
@@ -13,9 +13,10 @@
     abbrev= _ "AToTB"
     define="CAMPAIGN_TWO_BROTHERS"
     first_scenario="01_Rooting_Out_a_Mage"
-    difficulties=EASY,HARD
-    difficulty_descriptions={MENU_IMG_TXT2 "units/human-loyalists/horseman/horseman.png~RC(magenta>red)" _"Horseman" _"(Beginner)"} +
-    ";" + {MENU_IMG_TXT2 "units/human-loyalists/grand-knight/grand-knight.png~RC(magenta>red)" _"Knight" _"(Challenging)"}
+
+    {CAMPAIGN_DIFFICULTY EASY "units/human-loyalists/horseman/horseman.png~RC(magenta>red)" ( _ "Horseman") ( _ "Beginner")} {DEFAULT_DIFFICULTY}
+    {CAMPAIGN_DIFFICULTY HARD "units/human-loyalists/grand-knight/grand-knight.png~RC(magenta>red)" ( _ "Knight") ( _ "Challenging")}
+
     description= _ "An evil mage is threatening the small village of Maghre and its inhabitants. The village’s mage sends to his warrior brother for help, but not all goes as planned. Can you help?
 
 " + _"(Novice level, 4 scenarios.)"

--- a/data/campaigns/Under_the_Burning_Suns/_main.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/_main.cfg
@@ -8,21 +8,21 @@
 # wmlscope: set export=no
 [campaign]
     id=Under_the_Burning_Suns
+    name= _ "Under the Burning Suns"
     icon="data/campaigns/Under_the_Burning_Suns/images/units/elves-desert/kaleh.png"
     image="data/campaigns/Under_the_Burning_Suns/images/campaign_image.png"
-    name= _ "Under the Burning Suns"
     abbrev= _ "UtBS"
     rank=250
     define=CAMPAIGN_UNDER_THE_BURNING_SUNS
     first_scenario=01_The_Morning_After
-    difficulties=EASY,NORMAL,HARD
-    difficulty_descriptions={MENU_IMG_TXT2 "data/campaigns/Under_the_Burning_Suns/images/units/elves-desert/hunter.png~RC(magenta>red)" (_"Desert Hunter") _"(Normal)"} +
-    ";*" + {MENU_IMG_TXT2 "data/campaigns/Under_the_Burning_Suns/images/units/elves-desert/sentinel.png~RC(magenta>red)" (_"Desert Sentinel") _"(Challenging)"} +
-    ";"  + {MENU_IMG_TXT2 "data/campaigns/Under_the_Burning_Suns/images/units/elves-desert/prowler.png~RC(magenta>red)" (_"Desert Prowler") _"(Nightmare)"}
 
     description= _ "In the distant future a small band of elves struggles to survive amidst the ruins of fallen empires. Lead your people out of the desert on an epic journey to find a new home.
 
 " + _"(Expert level, 10 scenarios.)"
+
+    {CAMPAIGN_DIFFICULTY EASY   "data/campaigns/Under_the_Burning_Suns/images/units/elves-desert/hunter.png~RC(magenta>red)" ( _ "Desert Hunter") ( _ "Normal")}
+    {CAMPAIGN_DIFFICULTY NORMAL "data/campaigns/Under_the_Burning_Suns/images/units/elves-desert/sentinel.png~RC(magenta>red)" ( _ "Desert Sentinel") ( _ "Challenging")} {DEFAULT_DIFFICULTY}
+    {CAMPAIGN_DIFFICULTY HARD   "data/campaigns/Under_the_Burning_Suns/images/units/elves-desert/prowler.png~RC(magenta>red)" ( _ "Desert Prowler") ( _ "Nightmare")}
 
     # UTBS credits
     [about]

--- a/data/core/macros/scenario-utils.cfg
+++ b/data/core/macros/scenario-utils.cfg
@@ -65,3 +65,18 @@ Gg, Gg, Gg, Gg
         [/set_variable]
     [/event]
 #enddef
+
+#define CAMPAIGN_DIFFICULTY DEFINE IMAGE LABEL DESCRIPTION
+    [difficulty]
+        define={DEFINE}
+        image={IMAGE}
+        label={LABEL}
+        description={DESCRIPTION}
+    [/difficulty]
+#enddef
+
+#define DEFAULT_DIFFICULTY
+    [+difficulty]
+        default=yes
+    [/difficulty]
+#enddef

--- a/data/gui/default/window/campaign_difficulty.cfg
+++ b/data/gui/default/window/campaign_difficulty.cfg
@@ -51,6 +51,7 @@
 					border = "all"
 					border_size = 5
 					horizontal_alignment = "left"
+
 					[label]
 						id =  "title"
 						definition = "title"
@@ -104,78 +105,110 @@
 								[column]
 								 	vertical_grow = "true"
 								 	horizontal_grow = "true"
+
 								 	[toggle_panel]
 										definition = "default"
 										return_value_id = "ok"
+
 										[grid]
+
 											[row]
+
 												[column]
 													grow_factor = 0
 													horizontal_alignment = "left"
 													border = "all"
 													border_size = 5
+
 													[stacked_widget]
-														id = ""
 														definition = "default"
 														linked_group = "icon"
+
 														[stack]
+
 															[layer]
+
 																[row]
+
 																	[column]
 																		grow_factor = 1
 																		horizontal_grow = "true"
 																		border = "left"
 																		border_size = 3
+
 																		[image]
 																			id = "victory"
 																			definition = "default"
 																			label = "misc/laurel.png"
 																		[/image]
+
 																	[/column]
+
 																[/row]
+
 															[/layer]
+
 															[layer]
+
 																[row]
+
 																	[column]
 																		grow_factor = 1
 																		horizontal_grow = "true"
 																		border = "left"
 																		border_size = 3
+
 																		[image]
 																			id = "icon"
 																			definition = "default"
 																		[/image]
+
 																	[/column]
+
 																[/row]
+
 															[/layer]
+
 														[/stack]
+
 													[/stacked_widget]
+
 												[/column]
+
 												[column]
 													grow_factor = 1
 													horizontal_grow = "true"
 													border = "all"
 													border_size = 5
+
 													[label]
 														id = "label"
 														definition = "default"
 														linked_group = "label"
 													[/label]
+
 												[/column]
+
 												[column]
 													grow_factor = 1
 													horizontal_grow = "true"
 													border = "all"
 													border_size = 5
+
 													[label]
 														id = "description"
 														definition = "default"
 														linked_group = "description"
 													[/label]
+
 												[/column]
+												
 											[/row]
+
 										[/grid]
+
 									[/toggle_panel]
+
 								[/column]
 
 							[/row]

--- a/src/gui/dialogs/campaign_difficulty.cpp
+++ b/src/gui/dialogs/campaign_difficulty.cpp
@@ -77,21 +77,21 @@ tcampaign_difficulty::tcampaign_difficulty(
 	// Populate local config with difficulty children
 	difficulties_.append_children(campaign, "difficulty");
 
-	std::vector<std::string> difficulty_list_ = utils::split(campaign["difficulties"]);
-	std::vector<std::string> difficulty_opts_ = utils::split(campaign["difficulty_descriptions"], ';');
+	std::vector<std::string> difficulty_list = utils::split(campaign["difficulties"]);
+	std::vector<std::string> difficulty_opts = utils::split(campaign["difficulty_descriptions"], ';');
 
 	// Convert legacy format to new-style config if latter not present
 	if(difficulties_.empty()) {
-		if(difficulty_opts_.size() != difficulty_list_.size()) {
-			difficulty_opts_ = difficulty_list_;
+		if(difficulty_opts.size() != difficulty_list.size()) {
+			difficulty_opts = difficulty_list;
 		}
 
-		for(std::size_t i = 0; i < difficulty_opts_.size(); i++)
+		for(std::size_t i = 0; i < difficulty_opts.size(); i++)
 		{
 			config temp;
-			gui2::tlegacy_menu_item parsed(difficulty_opts_[i]);
+			gui2::tlegacy_menu_item parsed(difficulty_opts[i]);
 
-			temp["define"] = difficulty_list_[i];
+			temp["define"] = difficulty_list[i];
 			temp["image"] = parsed.icon();
 			temp["label"] = parsed.label();
 			temp["description"] = parsed.description();

--- a/src/gui/dialogs/campaign_difficulty.cpp
+++ b/src/gui/dialogs/campaign_difficulty.cpp
@@ -14,6 +14,10 @@
 
 #define GETTEXT_DOMAIN "wesnoth-lib"
 
+#include "config.hpp"
+#include "game_preferences.hpp"
+#include "formula_string_utils.hpp"
+
 #include "gui/dialogs/campaign_difficulty.hpp"
 
 #include "gui/auxiliary/find_widget.tpp"
@@ -65,12 +69,37 @@ namespace gui2
 REGISTER_DIALOG(campaign_difficulty)
 
 tcampaign_difficulty::tcampaign_difficulty(
-		const std::vector<std::pair<std::string, bool> >& items)
-	: index_(-1), items_()
+		const config& campaign)
+	: difficulties_()
+	, campaign_id_(campaign["id"])
+	, selected_difficulty_()
 {
-	FOREACH(const AUTO & p, items)
-	{
-		items_.push_back(std::make_pair(tlegacy_menu_item(p.first), p.second));
+	// Populate local config with difficulty children
+	difficulties_.append_children(campaign, "difficulty");
+
+	std::vector<std::string> difficulty_list_ = utils::split(campaign["difficulties"]);
+	std::vector<std::string> difficulty_opts_ = utils::split(campaign["difficulty_descriptions"], ';');
+
+	// Convert legacy format to new-style config if latter not present
+	if(difficulties_.empty()) {
+		if(difficulty_opts_.size() != difficulty_list_.size()) {
+			difficulty_opts_ = difficulty_list_;
+		}
+
+		for(std::size_t i = 0; i < difficulty_opts_.size(); i++)
+		{
+			config temp;
+			gui2::tlegacy_menu_item parsed(difficulty_opts_[i]);
+
+			temp["define"] = difficulty_list_[i];
+			temp["image"] = parsed.icon();
+			temp["label"] = parsed.label();
+			temp["description"] = parsed.description();
+			temp["default"] = parsed.is_default();
+			temp["old_markup"] = true; // To prevent double parentheses in the dialog
+
+			difficulties_.add_child("difficulty", temp);
+		}
 	}
 }
 
@@ -81,42 +110,41 @@ void tcampaign_difficulty::pre_show(CVideo& /*video*/, twindow& window)
 
 	std::map<std::string, string_map> data;
 
-	FOREACH(const AUTO & item, items_)
+	BOOST_FOREACH(const config &d, difficulties_.child_range("difficulty"))
 	{
-		if(item.first.is_default()) {
-			index_ = list.get_item_count();
-		}
-
-		data["icon"]["label"] = item.first.icon();
-		data["label"]["label"] = item.first.label();
+		data["icon"]["label"] = d["image"];
+		data["label"]["label"] = d["label"];
 		data["label"]["use_markup"] = "true";
-		data["description"]["label"] = item.first.description();
+		data["description"]["label"] = d["old_markup"].to_bool() ? d["description"]
+			: std::string("(") + d["description"] + std::string(")");
 		data["description"]["use_markup"] = "true";
 
 		list.add_row(data);
 
-		tgrid* grid = list.get_row_grid(list.get_item_count() - 1);
+		const int this_row = list.get_item_count() - 1;
+
+		if(d["default"].to_bool(false)) {
+			list.select_row(this_row);
+		}
+
+		tgrid* grid = list.get_row_grid(this_row);
 		assert(grid);
 
 		twidget *widget = grid->find("victory", false);
-		if (widget && !item.second) {
+		if (widget && !preferences::is_campaign_completed(campaign_id_, d["define"])) {
 			widget->set_visible(twidget::tvisible::hidden);
 		}
-	}
-
-	if(index_ != -1) {
-		list.select_row(index_);
 	}
 }
 
 void tcampaign_difficulty::post_show(twindow& window)
 {
 	if(get_retval() != twindow::OK) {
-		index_ = -1;
+		selected_difficulty_ = "CANCEL";
 		return;
 	}
 
 	tlistbox& list = find_widget<tlistbox>(&window, "listbox", false);
-	index_ = list.get_selected_row();
+	selected_difficulty_ = difficulties_.child("difficulty", list.get_selected_row())["define"].str();
 }
 }

--- a/src/gui/dialogs/campaign_difficulty.hpp
+++ b/src/gui/dialogs/campaign_difficulty.hpp
@@ -15,9 +15,9 @@
 #ifndef GUI_DIALOGS_CAMPAIGN_DIFFICULTY_HPP_INCLUDED
 #define GUI_DIALOGS_CAMPAIGN_DIFFICULTY_HPP_INCLUDED
 
+#include "config.hpp"
 #include "gui/dialogs/dialog.hpp"
 
-#include "gui/auxiliary/old_markup.hpp"
 #include <vector>
 
 namespace gui2
@@ -27,22 +27,23 @@ class tcampaign_difficulty : public tdialog
 {
 public:
 	/**
-	 * @param items vector of (difficulty description, already completed) pairs
+	 * @param config of the campaign difficulty is being chosen for
 	 */
-	explicit tcampaign_difficulty(const std::vector<std::pair<std::string, bool> >& items);
+	tcampaign_difficulty(const config& campaign);
 
 	/**
-	 * Returns the selected item index after displaying.
-	 * @return -1 if the dialog was canceled.
+	 * Returns the selected difficulty define after displaying.
+	 * @return 'CANCEL' if the dialog was canceled.
 	 */
-	int selected_index() const
+	std::string selected_difficulty() const
 	{
-		return index_;
+		return selected_difficulty_;
 	}
 
 private:
-	int index_;
-	std::vector<std::pair<tlegacy_menu_item, bool> > items_;
+	config difficulties_;
+	std::string campaign_id_;
+	std::string selected_difficulty_;
 
 	/** Inherited from tdialog, implemented by REGISTER_DIALOG. */
 	virtual const std::string& window_id() const;
@@ -54,6 +55,5 @@ private:
 	void post_show(twindow& window);
 };
 }
-
 
 #endif /* ! GUI_DIALOGS_CAMPAIGN_DIFFICULTY_HPP_INCLUDED */

--- a/src/tests/gui/test_gui2.cpp
+++ b/src/tests/gui/test_gui2.cpp
@@ -528,7 +528,7 @@ struct twrapper<gui2::tcampaign_difficulty>
 {
 	static gui2::tcampaign_difficulty* create()
 	{
-		static std::vector<std::pair<std::string, bool> > items;
+		static const config items;
 
 		return new gui2::tcampaign_difficulty(items);
 	}


### PR DESCRIPTION
This replaces the current difficulties/difficulty_descriptions syntax with a new one using a [difficulty] tag with the following syntax

```
[difficulty]
    define=
    image=
    label=
    description=
    default=
[/difficulty]
```

The old syntax is still completely supported and is translated to the new syntax at runtime.

Note that the old format doesn't have a deprecation warning right now, since I'm not sure where best to display it.