### PR TITLE
Add [replace_map] file= which will load the specified map at runtime

### DIFF
--- a/src/dialogs.cpp
+++ b/src/dialogs.cpp
@@ -760,11 +760,11 @@ void save_preview_pane::draw_contents()
 		const config &scenario = game_config_->find_child(summary["campaign_type"], "id", summary["scenario"]);
 		if (scenario && !scenario.find_child("side", "shroud", "yes")) {
 			map_data = scenario["map_data"].str();
-			if (map_data.empty() && scenario.has_attribute("map")) {
+			if (map_data.empty() && scenario.has_attribute("map_file")) {
 				try {
-					map_data = filesystem::read_map(scenario["map"]);
+					map_data = filesystem::read_map(scenario["map_file"]);
 				} catch(filesystem::io_exception& e) {
-					ERR_G << "could not read map '" << scenario["map"] << "': " << e.what() << '\n';
+					ERR_G << "could not read map '" << scenario["map_file"] << "': " << e.what() << '\n';
 				}
 			}
 		}

--- a/src/game_events/action_wml.cpp
+++ b/src/game_events/action_wml.cpp
@@ -609,7 +609,7 @@ WML_HANDLER_FUNCTION(replace_map, /*event_info*/, cfg)
 			map.read(cfg["map"], false);
 		}
 	} catch(incorrect_map_format_error&) {
-		const std::string log_map_name = cfg["map"].empty() ? cfg["file"] : std::string("from inline");
+		const std::string log_map_name = cfg["map"].empty() ? cfg["file"] : std::string("from inline data");
 		lg::wml_error << "replace_map: Unable to load map " << log_map_name << std::endl;
 		return;
 	} catch(twml_exception& e) {

--- a/src/game_initialization/multiplayer_lobby.cpp
+++ b/src/game_initialization/multiplayer_lobby.cpp
@@ -602,7 +602,7 @@ void gamebrowser::populate_game_item_map_info(gamebrowser::game_item & item, con
 
 	item.map_data = game["map_data"].str();
 	if(item.map_data.empty()) {
-		item.map_data = filesystem::read_map(game["map"]);
+		item.map_data = filesystem::read_map(game["map_file"]);
 	}
 	if(! item.map_data.empty()) {
 		try {

--- a/src/saved_game.cpp
+++ b/src/saved_game.cpp
@@ -364,10 +364,12 @@ void saved_game::expand_random_scenario()
 			update_label();
 			set_defaults();
 		}
-		//it looks like we support a map= where map=filename equals more or less map_data={filename}
-		if(starting_pos_["map_data"].empty() && !starting_pos_["map"].empty()) {
-			starting_pos_["map_data"] = filesystem::read_map(starting_pos_["map"]);
+
+		// If no map_data is provided, try to load the specified file directly
+		if(starting_pos_["map_data"].empty() && !starting_pos_["map_file"].empty()) {
+			starting_pos_["map_data"] = filesystem::read_map(starting_pos_["map_file"]);
 		}
+
 		// If the map should be randomly generated
 		// We don’t want that we accidentally to this twice so we check for starting_pos_["map_data"].empty()
 		if(starting_pos_["map_data"].empty() && !starting_pos_["map_generation"].empty()) {


### PR DESCRIPTION
This has an advantage over the map key behavior, where the contents of the map
file were preprocessed and written to savefiles.