### PR TITLE
side specific variables.

### DIFF
--- a/src/carryover.cpp
+++ b/src/carryover.cpp
@@ -30,6 +30,7 @@ carryover::carryover(const config& side)
 		, previous_recruits_(side.has_attribute("recruit") ? utils::set_split(side["recruit"]) :utils::set_split(side["previous_recruits"]))
 		, recall_list_()
 		, save_id_(side["save_id"])
+		, variables_(side.child_or_empty("variables"))
 {
 	BOOST_FOREACH(const config& u, side.child_range("unit")){
 		recall_list_.push_back(u);
@@ -49,6 +50,7 @@ carryover::carryover(const team& t, const int gold, const bool add)
 		, previous_recruits_(t.recruits())
 		, recall_list_()
 		, save_id_(t.save_id())
+		, variables_(t.variables())
 {
 	BOOST_FOREACH(const unit_const_ptr & u, t.recall_list()) {
 		recall_list_.push_back(config());
@@ -73,7 +75,8 @@ void carryover::transfer_all_gold_to(config& side_cfg){
 	else if(gold_ > cfg_gold){
 		side_cfg["gold"] = gold_;
 	}
-
+	side_cfg.child_or_add("variables").swap(variables_);
+	variables_.clear();
 	gold_ = 0;
 }
 

--- a/src/carryover.hpp
+++ b/src/carryover.hpp
@@ -45,6 +45,7 @@ private:
 	//       case between scenarios.
 	std::vector<config> recall_list_;
 	std::string save_id_;
+	config variables_;
 
 	std::string get_recruits(bool erase=false);
 };

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -972,6 +972,43 @@ int game_lua_kernel::intf_get_variable(lua_State *L)
 }
 
 /**
+ * Gets a side specific WML variable.
+ * - Arg 1: integer side number.
+ * - Arg 2: string containing the variable name.
+ * - Ret 1: value of the variable, if any.
+ */
+int game_lua_kernel::intf_get_side_variable(lua_State *L)
+{
+	
+	unsigned side_index = luaL_checkinteger(L, 1) - 1;
+	if(side_index >= teams().size()) {
+		return luaL_argerror(L, 1, "invalid side number");
+	}
+	char const *m = luaL_checkstring(L, 1);
+	variable_access_const v(m, teams()[side_index].variables());
+	return LuaW_pushvariable(L, v) ? 1 : 0;
+}
+
+/**
+ * Gets a side specific WML variable.
+ * - Arg 1: integer side number.
+ * - Arg 2: string containing the variable name.
+ * - Arg 3: boolean/integer/string/table containing the value.
+ */
+int game_lua_kernel::intf_set_side_variable(lua_State *L)
+{
+	unsigned side_index = luaL_checkinteger(L, 1) - 1;
+	if(side_index >= teams().size()) {
+		return luaL_argerror(L, 1, "invalid side number");
+	}
+	char const *m = luaL_checkstring(L, 1);
+	//TODO: maybe support removing values with an empty arg3.
+	variable_access_create v(m, teams()[side_index].variables());
+	LuaW_checkvariable(L, v, 2);
+	return 0;
+}
+
+/**
  * Sets a WML variable.
  * - Arg 1: string containing the variable name.
  * - Arg 2: boolean/integer/string/table containing the value.
@@ -4301,6 +4338,7 @@ game_lua_kernel::game_lua_kernel(CVideo * video, game_state & gs, play_controlle
 		{ "get_unit",                  &dispatch<&game_lua_kernel::intf_get_unit                   >        },
 		{ "get_units",                 &dispatch<&game_lua_kernel::intf_get_units                  >        },
 		{ "get_variable",              &dispatch<&game_lua_kernel::intf_get_variable               >        },
+		{ "get_side_variable",         &dispatch<&game_lua_kernel::intf_get_side_variable          >        },
 		{ "get_villages",              &dispatch<&game_lua_kernel::intf_get_villages               >        },
 		{ "get_village_owner",         &dispatch<&game_lua_kernel::intf_get_village_owner          >        },
 		{ "get_displayed_unit",        &dispatch<&game_lua_kernel::intf_get_displayed_unit         >        },
@@ -4339,6 +4377,7 @@ game_lua_kernel::game_lua_kernel(CVideo * video, game_state & gs, play_controlle
 		{ "set_next_scenario",         &dispatch<&game_lua_kernel::intf_set_next_scenario          >        },
 		{ "set_terrain",               &dispatch<&game_lua_kernel::intf_set_terrain                >        },
 		{ "set_variable",              &dispatch<&game_lua_kernel::intf_set_variable               >        },
+		{ "set_side_variable",         &dispatch<&game_lua_kernel::intf_set_side_variable          >        },
 		{ "set_village_owner",         &dispatch<&game_lua_kernel::intf_set_village_owner          >        },
 		{ "simulate_combat",           &dispatch<&game_lua_kernel::intf_simulate_combat            >        },
 		{ "synchronize_choice",        &intf_synchronize_choice                                             },

--- a/src/scripting/game_lua_kernel.hpp
+++ b/src/scripting/game_lua_kernel.hpp
@@ -83,8 +83,10 @@ class game_lua_kernel : public lua_kernel_base
 	int intf_match_unit(lua_State *L);
 	int intf_get_recall_units(lua_State *L);
 	int intf_get_variable(lua_State *L);
+	int intf_get_side_variable(lua_State *L);
 	int intf_random(lua_State *L);
 	int intf_set_variable(lua_State *L);
+	int intf_set_side_variable(lua_State *L);
 	int intf_highlight_hex(lua_State *L);
 	int intf_is_enemy(lua_State *L);
 	int intf_view_locked(lua_State *L);

--- a/src/team.cpp
+++ b/src/team.cpp
@@ -147,6 +147,7 @@ void team::team_info::read(const config &cfg)
 	carryover_add = cfg["carryover_add"].to_bool(false);
 	carryover_bonus = cfg["carryover_bonus"].to_bool(false);
 	carryover_gold = cfg["carryover_gold"].to_int(0);
+	variables = cfg.child_or_empty("variables");
 
 	if(cfg.has_attribute("color")) {
 		color = cfg["color"].str();
@@ -272,6 +273,7 @@ void team::team_info::write(config& cfg) const
 	cfg["carryover_bonus"] = carryover_bonus;
 	cfg["carryover_gold"] = carryover_gold;
 
+	cfg.add_child("variables", variables);
 	cfg.add_child("ai", ai::manager::to_config(side));
 }
 

--- a/src/team.hpp
+++ b/src/team.hpp
@@ -22,6 +22,7 @@
 #include "savegame_config.hpp"
 #include "unit_ptr.hpp"
 #include "util.hpp"
+#include "config.hpp"
 
 #include <boost/shared_ptr.hpp>
 #include <boost/container/flat_set.hpp>
@@ -163,6 +164,7 @@ private:
 		bool carryover_add;
 		bool carryover_bonus;
 		int carryover_gold;
+		config variables;
 		void handle_legacy_share_vision(const config& cfg);
 	};
 
@@ -352,6 +354,8 @@ public:
 	bool carryover_bonus() const { return info_.carryover_bonus; }
 	void set_carryover_gold(int value) { info_.carryover_gold = value; }
 	int carryover_gold() const { return info_.carryover_gold; }
+	config& variables() { return info_.variables; }
+	const config& variables() const { return info_.variables; }
 
 	bool no_turn_confirmation() const { return info_.no_turn_confirmation; }
 	void set_no_turn_confirmation(bool value) { info_.no_turn_confirmation = value; }


### PR DESCRIPTION
http://gna.org/bugs/?23490

This makes it possible to store variables inside the side with the lua
functions get/set_side_variable. These variables are carried over along
other side specific data(units, gold)

It is currently not possible to write these variables without lua.

There are some advantages over storing these variables in the normal variables as found out in the bugerport:
1) It not trivial to store this data asociated with the sides save-id in wml variables, mainly because sides side id might be unsiuted to act as a variablename since it miight contain spaces or other unsuitable characters.
2) by storing these variables inside the side cvarryover data the variables are automatically removed along with the side if the side is removed (for exampple becase they have persistent=no or becasue they lost)