### PR TITLE
Ensure var_end is not beyond res.end()

### DIFF
--- a/src/formula_string_utils.cpp
+++ b/src/formula_string_utils.cpp
@@ -146,7 +146,7 @@ static std::string do_interpolation(const std::string &str, const variable_set& 
 		// That matters for random=, e.g. $x..$y
 		var_end = std::adjacent_find(var_name_begin, var_end, two_dots);
 		/// the default value is specified after ''?'
-		const std::string::iterator default_start = *var_end == '?' ? var_end + 1 : res.end();
+		const std::string::iterator default_start = var_end < res.end() && *var_end == '?' ? var_end + 1 : res.end();
 
 		// If the last character is '.', then it can't be a sub-variable.
 		// It's probably meant to be a period instead. Don't include it.


### PR DESCRIPTION
MSVC debug mode complains that var_end cannot be dereferenced if it hits the end of the string.