### PR TITLE
Resolve bug #20299

### DIFF
--- a/changelog
+++ b/changelog
@@ -189,6 +189,7 @@ Version 1.13.1+dev:
    * Fixed bug 23060: unit stat tooltips do not show.
    * wmllint, wmlscope, wmlindent and wmllint-1.4 now run on Python 3
    * Text boxes tab completion now lists whisperer nicks for easier answer
+   * Fixed cases of wrong unit type used in planning moves (bug #20299)
    * Fixed hang when attempting to make a screenshot from a non-existent map via
      command-line (bug #20900)
    * Fixed Cancel Orders not working when loading MP game (bug #22133)

--- a/src/whiteboard/manager.cpp
+++ b/src/whiteboard/manager.cpp
@@ -713,7 +713,9 @@ void manager::create_temp_move()
 
 			if(path.size() >= 2)
 			{
-				if(!fake_unit)
+				// Bug #20299 demonstrates a situation where an incorrect fake/ghosted unit can be used.
+				// So before assuming that a pre-existing fake_unit can be re-used, check that its ID matches the unit being moved.
+				if(!fake_unit || fake_unit.get_unit_ptr()->id() != temp_moved_unit->id())
 				{
 					// Create temp ghost unit
 					fake_unit = fake_unit_ptr(unit_ptr (new unit(*temp_moved_unit)), resources::fake_units);


### PR DESCRIPTION
Check IDs match before re-using an existing fake_unit. IDs can be different in the situation described by bug #20299, where the user selects the next unit while planning a move.