### PR TITLE
Resolve Bug #20900

### DIFF
--- a/changelog
+++ b/changelog
@@ -189,6 +189,8 @@ Version 1.13.1+dev:
    * Fixed bug 23060: unit stat tooltips do not show.
    * wmllint, wmlscope, wmlindent and wmllint-1.4 now run on Python 3
    * Text boxes tab completion now lists whisperer nicks for easier answer
+   * Fixed hang when attempting to make a screenshot from a non-existent map via
+     command-line (bug #20900)
    * Fixed Cancel Orders not working when loading MP game (bug #22133)
    * Fixed broken Oasis terrain help entry (bug #23023)
    * Fixed load game hot-key not working in the main menu (bug #23215)

--- a/src/editor/editor_main.cpp
+++ b/src/editor/editor_main.cpp
@@ -35,20 +35,23 @@ EXIT_STATUS start(const config& game_conf, CVideo& video, const std::string& fil
 		hotkey::deactivate_all_scopes();
 		hotkey::set_scope_active(hotkey::SCOPE_EDITOR);
 		editor_controller editor(game_conf, video);
-		if (!filename.empty()) {
+		if (!filename.empty() && filesystem::file_exists (filename)) {
 			if (filesystem::is_directory(filename)) {
 				editor.context_manager_->set_default_dir(filename);
 				editor.context_manager_->load_map_dialog(true);
 			} else {
 				editor.context_manager_->load_map(filename, false);
 			}
+
+			if (take_screenshot) {
+				editor.do_screenshot(screenshot_filename);
+				e = EXIT_NORMAL;
+			}
 		}
-		if(take_screenshot) {
-			editor.do_screenshot(screenshot_filename);
-			e = EXIT_NORMAL;
-		} else {
+
+		if (!take_screenshot)
 			e = editor.main_loop();
-		}
+
 	} catch (editor_exception& e) {
 		ERR_ED << "Editor exception in editor::start: " << e.what() << std::endl;
 		throw;


### PR DESCRIPTION
Bug report refers to a more thorough patch #3972 which seems to have never been accepted. All I'm trying to do here is add the file_exists check which fixes the hanging while minimising the changes needed.

(MSVC debug mode still fails due to a vector assertion failure (teams vector reference), which makes testing/debugging the editor difficult.)

If anyone feels like adding all the error messages/handling included from the patch, go right ahead.