### PR TITLE
Added Death of Galtrid to losing conditions for the Human Alliance.

### DIFF
--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg
@@ -415,6 +415,10 @@ Chapter Four"
                 description= _ "Death of Aldar"
                 condition=lose
             [/objective]
+            [objective]
+                description= _ "Death of Galtrid"
+                condition=lose
+            [/objective]
 
             [gold_carryover]
                 bonus=no


### PR DESCRIPTION
Verified in debug mode that the death of Galtrid is the only death missing from the losing conditions.  Rebuilt and verified death of Galtrid is listed in the objectives as a losing condition.