### PR TITLE
Revert "Added Death of Galtrid to losing conditions for the Human All…

### DIFF
--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg
@@ -415,10 +415,6 @@ Chapter Four"
                 description= _ "Death of Aldar"
                 condition=lose
             [/objective]
-            [objective]
-                description= _ "Death of Galtrid"
-                condition=lose
-            [/objective]
 
             [gold_carryover]
                 bonus=no


### PR DESCRIPTION
Reverts wesnoth/wesnoth#526

Sorry, this should be reverted.  Galtrid is removed from the scenario in 1.13, so this applies to branch 1.12 (pr #527).