### PR TITLE
Tab-completion added for in-game whispers

### DIFF
--- a/changelog
+++ b/changelog
@@ -174,6 +174,7 @@ Version 1.13.1+dev:
      eg if an add-on tries to set an invalid variable
    * Fixed bug 23060: unit stat tooltips do not show.
    * wmllint, wmlscope, wmlindent and wmllint-1.4 now run on Python 3
+   * Text boxes tab completion now lists whisperer nicks for easier answer
 
 Version 1.13.1:
  * Security fixes:

--- a/data/core/about.cfg
+++ b/data/core/about.cfg
@@ -1086,6 +1086,9 @@
         name = "FAAB"
     [/entry]
     [entry]
+	name = "Federico Pasco (neverEnough)"
+    [/entry]
+    [entry]
         name = "Fedor Khod'kov (teddy/fkhodkov)"
     [/entry]
     [entry]

--- a/players_changelog
+++ b/players_changelog
@@ -35,6 +35,7 @@ Version 1.13.1+dev:
    * Fixed OOS on random maps, where clients placed sides in different castles.
    * Fixed possibility of corrupting saved games in certain instances,
      eg if an add-on tries to set an invalid variable
+   * Enhanced tab completion in text boxes for easier whispers answer.
 
 
 Version 1.13.1:

--- a/src/display_chat_manager.cpp
+++ b/src/display_chat_manager.cpp
@@ -55,6 +55,7 @@ void display_chat_manager::add_chat_message(const time_t& time, const std::strin
 	std::string sender = speaker;
 	if (whisper) {
 		sender.assign(speaker, 9, speaker.size());
+		add_whisperer( sender );
 	}
 	if (!preferences::parse_should_show_lobby_join(sender, message)) return;
 	if (preferences::is_ignored(sender)) return;

--- a/src/display_chat_manager.hpp
+++ b/src/display_chat_manager.hpp
@@ -32,6 +32,9 @@ public:
 	void add_observer(const std::string& name) { observers_.insert(name); }
 	void remove_observer(const std::string& name) { observers_.erase(name); }
 	const std::set<std::string>& observers() const { return observers_; }
+	
+	void add_whisperer(const std::string& nick) { whisperers_.insert(nick); }
+	const std::set<std::string>& whisperers() const { return whisperers_; }
 
 	void add_chat_message(const time_t& time, const std::string& speaker,
 		int side, const std::string& msg, events::chat_handler::MESSAGE_TYPE type, bool bell);
@@ -40,6 +43,7 @@ public:
 	friend class game_display; //needed because it calls prune_chat_message
 private:
 	std::set<std::string> observers_;
+	std::set<std::string> whisperers_; //nicks who whisper you for tab-completition purpose
 
 	struct chat_message
 	{

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -653,6 +653,12 @@ void play_controller::tab()
 		BOOST_FOREACH(const std::string& o, gui_->observers()){
 			dictionary.insert(o);
 		}
+		
+		// Add nicks who whispered you
+		BOOST_FOREACH(const std::string& w, gui_->get_chat_manager().whisperers()){
+			dictionary.insert(w);
+		}
+		
 		//Exclude own nick from tab-completion.
 		//NOTE why ?
 		dictionary.erase(preferences::login());


### PR DESCRIPTION
In the game lobby you can tab-complete ANY nick, both from the lobby or from a match running. While playing you can only tab-complete ingame players and observers.
This patch works in the match, it helps answering whispers from people in lobby or in other games.
The nick will be added to a string (in the same way as observers already work) and get recalled with TAB key.