### PR TITLE
Resolve Bug #22133

### DIFF
--- a/src/game_initialization/multiplayer_create.cpp
+++ b/src/game_initialization/multiplayer_create.cpp
@@ -333,6 +333,9 @@ void create::process_event_impl(const process_event_data & data)
 				}
 			}
 
+			if (load.cancel_orders())
+				engine_.get_state().cancel_orders();
+
 			engine_.prepare_for_saved_game();
 			set_result(LOAD_GAME);
 


### PR DESCRIPTION
Resolving bug #22133, stating Cancel Orders does not work when loading a MP game.

Modelled from the Cancel Orders functionality in the single-player Load Game, game_launcher::load_game() of game_launcher.cpp.