### PR TITLE
Work-around 0% defence listing for Rails terrain (issue #1399)

### DIFF
--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -608,7 +608,8 @@ std::string unit_topic_generator::operator()() const {
 					continue;
 				const terrain_type& info = tdata->get_terrain_info(terrain);
 
-				if (info.union_type().size() == 1 && info.union_type()[0] == info.number() && info.is_nonnull() && info.id() != "rails") {
+				if (info.union_type().size() == 1 && info.union_type()[0] == info.number() && info.is_nonnull() &&
+					movement_type.movement_cost(terrain) < movetype::UNREACHABLE) {
 					std::vector<item> row;
 					const std::string& name = info.name();
 					const std::string& id = info.id();

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -608,7 +608,7 @@ std::string unit_topic_generator::operator()() const {
 					continue;
 				const terrain_type& info = tdata->get_terrain_info(terrain);
 
-				if (info.union_type().size() == 1 && info.union_type()[0] == info.number() && info.is_nonnull()) {
+				if (info.union_type().size() == 1 && info.union_type()[0] == info.number() && info.is_nonnull() && info.id() != "rails") {
 					std::vector<item> row;
 					const std::string& name = info.name();
 					const std::string& id = info.id();


### PR DESCRIPTION
Rails terrain listing can be confusing with 0% defence - it never appears on its own and so depends on other terrain layers' defence and movement ratings.

See discussion in #1399 for more details.

(Admittedly, special case conditions aren't really a good thing.)
