### PR TITLE
Resolve Bug #23023

### DIFF
--- a/data/core/terrain.cfg
+++ b/data/core/terrain.cfg
@@ -315,6 +315,7 @@ Most units receive 20 to 40% defense in sand."
     symbol_image=sand/desert-oasis
     id=oasis
     name= _ "Oasis"
+    editor_name= _ "Oasis"
     default_base=Dd
     string=^Do
     aliasof=_bas


### PR DESCRIPTION
Correct Desert Sands / Oasis help entry.

From what I can tell of show_terrain_description(), the oasis terrain help entry is meant to be combined with the desert terrain help entry. But it incorrectly shows just 'Desert Sands /' in the title - explicitly adding the editor_name seems to resolve this.

In contrast, the nearby rubble and crater terrain types don't have a editor_name presumably because they will re-use the name string, and these seem to work because they are stand-alone help entries.