### PR TITLE
fix preferences dialog for loadgame hotkey

### DIFF
--- a/src/hotkey/hotkey_preferences_display.cpp
+++ b/src/hotkey/hotkey_preferences_display.cpp
@@ -639,6 +639,8 @@ void hotkey_preferences_dialog::show_binding_dialog(
 
 	// only if not canceled.
 	if (!(keycode == SDLK_ESCAPE && (mod & any_mod) == 0)) {
+		hotkey::scope_changer scope_restorer;
+		hotkey::set_active_scopes(hotkey::get_hotkey_command(id).scope);
 
 		hotkey::hotkey_item newhk(id);
 		const hotkey::hotkey_item* oldhk = NULL;


### PR DESCRIPTION
Some hotkeys (like the loadgame hotkey) are present in some, but not all hotkey scopes and teh hotkey preferences dialog was unable to handle that. One of the results was that it was not possible to assign the same hotkey to the loadgame hotkey and the loadmap hotkey, this commit attempts to fix that.