### PR TITLE
Bug Fixes from Master (1.12)

### DIFF
--- a/changelog
+++ b/changelog
@@ -4,7 +4,7 @@ Version 1.12.4+dev:
      * Fixed scenario events not working right on easy difficulty in 'Captured'.
    * Legend of Wesmere
      * Fixed carryover bugs in scenarios 5-12.
-       (units misssing fron carryover, units appering twice on map...)
+       (units missing from carryover, units appearing twice on map...)
  * Editor:
    * Add Recent Files menu with a list of recently saved or loaded maps or
      scenarios, up to a custom limit (by default 10) that can be set in
@@ -18,7 +18,7 @@ Version 1.12.4+dev:
    * Made MP lobby filter option filter on eras and mods too (bug #22987).
    * Fix scenario ending to early for players that are defeated if there are
      still players fighting and victory_when_enemies_defeated=no.
-   * Fix 'enemies defated' event causing OOS error in mp scenarios.
+   * Fix 'enemies defeated' event causing OOS error in mp scenarios.
  * Terrains:
    * Removed unit elevation from N-S hanging bridges
    * Added unit elevation to NW-SE and SW-NE stone chasm bridges

--- a/changelog
+++ b/changelog
@@ -53,6 +53,7 @@ Version 1.12.4+dev:
    * Several fixes to the handling of key combinations including
      non-alphanumeric keys (Enter, Tab, F1-F12, etc.), especially relevant for
      assigning custom hotkeys to actions in Preferences.
+   * Fixed broken Oasis terrain help entry (bug #23023)
 
 Version 1.12.4:
  * Security fixes:

--- a/changelog
+++ b/changelog
@@ -9,6 +9,8 @@ Version 1.12.4+dev:
    * Add Recent Files menu with a list of recently saved or loaded maps or
      scenarios, up to a custom limit (by default 10) that can be set in
      Advanced Preferences.
+   * Fixed Player Start labels not being updated with repeat map generations
+     (bug #20036)
  * Language and i18n:
    * Updated translations: French, Hungarian, Japanese, Latvian
    * Fixed crashes during start-up on Windows resulting from add-ons containing

--- a/data/core/terrain.cfg
+++ b/data/core/terrain.cfg
@@ -313,6 +313,7 @@ Most units receive 20 to 40% defense in sand."
     symbol_image=sand/desert-oasis
     id=oasis
     name= _ "Oasis"
+    editor_name= _ "Oasis"
     default_base=Dd
     string=^Do
     aliasof=_bas

--- a/players_changelog
+++ b/players_changelog
@@ -15,6 +15,7 @@ Version 1.12.4+dev:
 
  * Miscellaneous and bug fixes:
    * Fixed OOS on random maps, where clients placed sides in different castles.
+   * Fixed broken Oasis terrain help entry (bug #23023)
 
 
 Version 1.12.4:

--- a/src/editor/map/context_manager.cpp
+++ b/src/editor/map/context_manager.cpp
@@ -705,6 +705,7 @@ void context_manager::generate_map_dialog()
 		} else {
 			editor_map new_map(game_config_, map_string);
 			editor_action_whole_map a(new_map);
+			get_map_context().set_needs_labels_reset();		// Ensure Player Start labels are updated together with newly generated map
 			perform_refresh(a);
 		}
 	}

--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -68,7 +68,7 @@ bool game_config_manager::init_game_config(FORCE_RELOAD_CONFIG force_reload)
 	// Add preproc defines according to the command line arguments.
 	game_config::scoped_preproc_define multiplayer("MULTIPLAYER",
 		cmdline_opts_.multiplayer);
-	game_config::scoped_preproc_define test("TEST", cmdline_opts_.test);
+	game_config::scoped_preproc_define test("TEST", bool(cmdline_opts_.test));
 	game_config::scoped_preproc_define editor("EDITOR", jump_to_editor_);
 	game_config::scoped_preproc_define title_screen("TITLE_SCREEN",
 		!cmdline_opts_.multiplayer && !cmdline_opts_.test && !jump_to_editor_);

--- a/src/global.hpp
+++ b/src/global.hpp
@@ -17,8 +17,10 @@
 
 #ifdef _MSC_VER
 
+#if _MSC_VER < 1900	// snprintf() is supported from MSVC 14 (2015) onwards
 #undef snprintf
 #define snprintf _snprintf
+#endif
 
 // Disable warning about source encoding not in current code page.
 #pragma warning(disable: 4819)


### PR DESCRIPTION
Add a couple of bug fixes from master. I thought I'd be able to get the MP Load Game Cancel Orders fix into this as well but it looks like there was some rewriting of the load game dialogues for 1.13.x.

Also a couple of updates to get compilation working in MSVC14/2015 (adapted from changes already in master).