### PR TITLE
Properly correct the broken Desert Sands / Oasis help entry (bug #23023)

### DIFF
--- a/data/core/terrain.cfg
+++ b/data/core/terrain.cfg
@@ -315,7 +315,6 @@ Most units receive 20 to 40% defense in sand."
     symbol_image=sand/desert-oasis
     id=oasis
     name= _ "Oasis"
-    editor_name= _ "Oasis"
     default_base=Dd
     string=^Do
     aliasof=_bas

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -203,7 +203,7 @@ terrain_type::terrain_type(const terrain_type& base, const terrain_type& overlay
 	editor_image_(base.editor_image_ + "~BLIT(" + overlay.editor_image_ +")"),
 	id_(base.id_+"^"+overlay.id_),
 	name_(overlay.name_),
-	editor_name_(base.editor_name_ + " / " + (overlay.editor_name_.empty() ? overlay.name_ : overlay.editor_name_)),	// Resolve Bug #23023: fall back to overlay name if overlay editor name is empty
+	editor_name_((base.editor_name_.empty() ? base.name_ : base.editor_name_) + " / " + (overlay.editor_name_.empty() ? overlay.name_ : overlay.editor_name_)),
 	description_(overlay.description()),
 	help_topic_text_(),
 	number_(t_translation::t_terrain(base.number_.base, overlay.number_.overlay)),

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -203,7 +203,7 @@ terrain_type::terrain_type(const terrain_type& base, const terrain_type& overlay
 	editor_image_(base.editor_image_ + "~BLIT(" + overlay.editor_image_ +")"),
 	id_(base.id_+"^"+overlay.id_),
 	name_(overlay.name_),
-	editor_name_(base.editor_name_ + " / " + overlay.editor_name_),
+	editor_name_(base.editor_name_ + " / " + (overlay.editor_name_.empty() ? overlay.name_ : overlay.editor_name_)),	// Resolve Bug #23023: fall back to overlay name if overlay editor name is empty
 	description_(overlay.description()),
 	help_topic_text_(),
 	number_(t_translation::t_terrain(base.number_.base, overlay.number_.overlay)),


### PR DESCRIPTION
Reverts the previous change to the terrain.cfg and allows the terrain code to fall back to name if editor name is unavailable.

This is a proper fix and supersedes PR #537.