### PR TITLE
Disable Planned Recruits (Bug #24022)

### DIFF
--- a/src/whiteboard/manager.cpp
+++ b/src/whiteboard/manager.cpp
@@ -874,6 +874,8 @@ bool manager::save_recruit(const std::string& name, int side_num, const map_loca
 
 			print_help_once();
 #else
+			UNUSED (name);
+			UNUSED (recruit_hex);
 			created_planned_recruit = false;
 #endif
 		}

--- a/src/whiteboard/manager.cpp
+++ b/src/whiteboard/manager.cpp
@@ -858,6 +858,10 @@ bool manager::save_recruit(const std::string& name, int side_num, const map_loca
 		}
 		else
 		{
+// Bug #24022 highlights one of the many problems with planning mode
+// Without anyone knowledgeable about the whiteboard/planning code the most expedient
+// solution as of December 2015 appears to be to simply disable planned recruits
+#ifdef ENABLE_PLANNED_RECRUITS
 			side_actions& sa = *viewer_actions();
 			unit* recruiter;
 			{ wb::future_map raii;
@@ -869,6 +873,9 @@ bool manager::save_recruit(const std::string& name, int side_num, const map_loca
 			created_planned_recruit = true;
 
 			print_help_once();
+#else
+			created_planned_recruit = false;
+#endif
 		}
 	}
 	return created_planned_recruit;


### PR DESCRIPTION
Bug #24022 highlights one of many issues with planned recruits. gfgtdf suggests it might be worthwhile to simply disable recruits in planning mode.

This change will no longer allow fake recruits, but a normal recruit will still take place on attempting to do so during planning mode. It can be applied to 1.12 as well, if accepted, but I can understand if it is not as this is not an ideal solution.