### PR TITLE
Revert all recent improvements to SDL1.2 hot-key handling (1.12)

### DIFF
--- a/changelog
+++ b/changelog
@@ -3,6 +3,10 @@ Version 1.12.5+dev:
    * Updated translations: Galician, Italian, RACV, Russian, Slovak, Swedish
  * User interface:
    * GUI1 comboboxes now use the thinner menu frame style.
+ * Miscellaneous and bug fixes:
+   * Revert all updates to hot-key handling which broke letter-based short-cuts
+     on non-US keyboard layouts, where characters are in different key
+     locations (bug #24186).
 
 Version 1.12.5:
  * Campaigns:

--- a/src/hotkey/hotkey_item.cpp
+++ b/src/hotkey/hotkey_item.cpp
@@ -98,9 +98,7 @@ hotkey::hotkey_item& get_hotkey(int character, int keycode,
 	bool found = false;
 
 	for (itor = hotkeys_.begin(); itor != hotkeys_.end(); ++itor) {
-		// If character is a letter, make sure it can match its key code. Otherwise combinations like Ctrl+Return/Enter can be mistaken for Ctrl+j or Ctrl+m (CR and LF respectively).
-		// Character may not match key code in case of punctuation, eg key code for semi-colon is different from key code for colon yet on US keyboards they are represented by the same key.
-		if (itor->get_character() != -1 && (isalpha(character) && keycode != -1 ? tolower(character) == keycode : true)) {
+		if (itor->get_character() != -1) {
 			if (character == itor->get_character()) {
 				if (ctrl == itor->get_ctrl()
 						&& cmd == itor->get_cmd()
@@ -532,10 +530,7 @@ void hotkey_item::set_key(int character, int keycode,
 		character -= 32; }
 
 	// We handle simple cases by character, others by the actual key.
-	// @ and ` are exceptions related to the space character. Without these, combinations involving Ctrl or Ctrl+Shift often resolve the character value to null (or @ and `).
-	// If character is read as a letter, only treat it as a letter if its key code matches that character. This covers cases such as Ctrl+Return/Enter, which would otherwise be mis-read as Ctrl+j or Ctrl+m (CR and LF respectively). 
-	if (character != '@' && character != '`' &&
-		( (isalpha(character) && tolower(character) == keycode) || (!isalpha(character) && isprint(character) && !isspace(character)) )) {
+	if (isprint(character) && !isspace(character)) {
 		character_ = character;
 		ctrl_      = ctrl;
 		cmd_       = cmd;


### PR DESCRIPTION
Unfortunately, the US/QWERTY-centric nature of SDL 1.2 keyboard handling means that the previous commit breaks character-based hot-keys for non-US/QWERTY keyboard layouts. (Bug #24186)

This reversion wipes out all improvements to hot-key handling introduced for US/QWERTY keyboards.