### PR TITLE
Added event type "unit placed"

### DIFF
--- a/changelog
+++ b/changelog
@@ -4,6 +4,9 @@ Version 1.13.2+dev:
      * Updated sprites for Naga Hunter and Naga Guardian line.
  * Language and i18n:
    * Updated translations: British English, Russian, Swedish
+ * WML engine:
+   * Added new event "unit placed", which triggers when (and regardless of how)
+     a unit appears on the map.
  * Miscellaneous and bug fixes:
    * Fix the new log code on Windows to actually use Unicode-aware functions
      in a couple of places so Wesnoth does not quit on startup when trying to

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1160,6 +1160,7 @@ namespace {
 					newunit.heal_all();
 				}
 				units_.add(death_loc, newunit);
+				resources::game_events->pump().fire("unit placed", death_loc);
 				preferences::encountered_units().insert(newunit.type_id());
 				if (update_display_) {
 					resources::screen->invalidate(death_loc);

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1160,7 +1160,10 @@ namespace {
 					newunit.heal_all();
 				}
 				units_.add(death_loc, newunit);
-				resources::game_events->pump().fire("unit placed", death_loc);
+
+				game_events::entity_location reanim_loc(defender.loc_, newunit.underlying_id());
+				resources::game_events->pump().fire("unit placed", reanim_loc);
+
 				preferences::encountered_units().insert(newunit.type_id());
 				if (update_display_) {
 					resources::screen->invalidate(death_loc);

--- a/src/actions/create.cpp
+++ b/src/actions/create.cpp
@@ -641,6 +641,8 @@ place_recruit_result place_recruit(const unit &u, const map_location &recruit_lo
 	recruit_checksums(new_unit, wml_triggered);
 	resources::whiteboard->on_gamestate_change();
 
+	resources::game_events->pump().fire("unit placed", current_loc);
+
 	if ( fire_event ) {
 		const std::string event_name = is_recall ? "prerecall" : "prerecruit";
 		LOG_NG << "firing " << event_name << " event\n";

--- a/src/actions/unit_creator.cpp
+++ b/src/actions/unit_creator.cpp
@@ -24,6 +24,8 @@
 #include "../config.hpp"
 #include "../filter_context.hpp"
 #include "../game_board.hpp"
+#include "../game_events/manager.hpp"
+#include "../game_events/pump.hpp"
 #include "../game_preferences.hpp"
 #include "../game_data.hpp" // for resources::gamedata conversion variable_set
 #include "../gettext.hpp"
@@ -214,6 +216,8 @@ void unit_creator::post_create(const map_location &loc, const unit &new_unit, bo
 			actions::get_village(loc, new_unit.side());
 		}
 	}
+
+	resources::game_events->pump().fire("unit placed", loc);
 
 	if (resources::screen!=NULL) {
 

--- a/src/game_events/action_wml.cpp
+++ b/src/game_events/action_wml.cpp
@@ -1335,6 +1335,8 @@ WML_HANDLER_FUNCTION(unstore_unit, /*event_info*/, cfg)
 			resources::units->erase(loc);
 			resources::units->add(loc, *u);
 
+			resources::game_events->pump().fire("unit placed", loc);
+
 			config::attribute_value text = var["gender"].str() == "female" ? cfg["female_text"] : cfg["male_text"];
 			if(text.blank()) {
 				text = cfg["text"];

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -373,6 +373,13 @@ void play_controller::fire_prestart()
 	// as those may cause the display to be refreshed.
 	update_locker lock_display(gui_->video());
 	gamestate().gamedata_.set_phase(game_data::PRESTART);
+
+	// Fire these right before prestart events, to catch only the units sides
+	// have started with.
+	BOOST_FOREACH(const unit& u, gamestate().board_.units()) {
+		pump().fire("unit placed", map_location(u.get_location()));
+	}
+
 	pump().fire("prestart");
 	// prestart event may modify start turn with WML, reflect any changes.
 	gamestate().gamedata_.get_variable("turn_number") = int(turn());

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -2357,6 +2357,8 @@ int game_lua_kernel::intf_put_unit(lua_State *L)
 		units().insert(u);
 	}
 
+	play_controller_.pump().fire("unit placed", loc);
+
 	return 0;
 }
 

--- a/src/synced_commands.cpp
+++ b/src/synced_commands.cpp
@@ -476,6 +476,7 @@ SYNCED_COMMAND_HANDLER_FUNCTION(debug_create_unit, child,  use_undo, /*show*/, e
 	// Add the unit to the board.
 	std::pair<unit_map::iterator, bool> add_result = resources::units->replace(loc, created);
 	resources::screen->invalidate_unit();
+	resources::game_events->pump().fire("unit placed", loc);
 	unit_display::unit_recruited(loc);
 
 	// Village capture?


### PR DESCRIPTION
This is intended to allow event-driven abilities and other modifications to immediately take action when any unit appears on the map.

Still needs some more testing in context of replays and multiplayer.