### PR TITLE
Resolve preferences file polluted with null-command hot-keys (Bug #21969)

### DIFF
--- a/changelog
+++ b/changelog
@@ -73,7 +73,9 @@ Version 1.13.2+dev:
    * Fixed oos caused by mp replay turn feature.
    * Fixed oos bugs caused by plattform dependent rounding from double to int in lua.
    * Fixed custom (lua-defined) scenario tags beeing removed from [replay_start]
-   * fixed savefile bloat caused by unit variations (walking corpses)
+   * Fixed savefile bloat caused by unit variations (walking corpses)
+   * Fixed preferences file bloat caused by null-command hot-keys (bug #21969)
+   * Fixed clearing of default hot-keys not working (bugs #21983/#22218/#23981)
 
 Version 1.13.2:
  * Add-ons client:

--- a/src/hotkey/command_executor.cpp
+++ b/src/hotkey/command_executor.cpp
@@ -514,7 +514,7 @@ static void event_execute( const SDL_Event& event, command_executor* executor)
 {
 	if (!executor) return;
 	const hotkey_ptr hk = get_hotkey(event);
-	if (!hk->active()) {
+	if (!hk->active() || hk->is_disabled()) {
 		return;
 	}
 

--- a/src/hotkey/hotkey_item.cpp
+++ b/src/hotkey/hotkey_item.cpp
@@ -462,7 +462,7 @@ void save_hotkeys(config& cfg)
 	cfg.clear_children("hotkey");
 
 	BOOST_FOREACH(hotkey_ptr item, hotkeys_) {
-		if (!item->is_default()) {
+		if (!item->is_default() && item->active()) {
 			item->save(cfg.add_child("hotkey"));
 		}
 	}

--- a/src/hotkey/hotkey_item.hpp
+++ b/src/hotkey/hotkey_item.hpp
@@ -49,7 +49,7 @@ public:
 	/**
 	 * Initialises a new empty hotkey that will be disabled
 	 */
-	hotkey_base() : command_("null"), is_default_(true), mod_(0)
+	hotkey_base() : command_("null"), is_default_(true), is_disabled_(false), mod_(0)
 	{}
 
 	void set_command(const std::string& command)
@@ -108,6 +108,19 @@ public:
 	void unset_default()
 	{
 		is_default_ = false;
+	}
+
+	bool is_disabled() const
+	{
+		return is_disabled_;
+	}
+	void disable()
+	{
+		is_disabled_ = true;
+	}
+	void enable()
+	{
+		is_disabled_ = false;
 	}
 
 	/**
@@ -203,12 +216,21 @@ protected:
 	std::string command_;
 
 	/**
-	 *
+	 * is_default_ is true if the hot-key is part of the default hot-key list defined in data/core/hotkeys.cfg.
+	 * is_default_ is false if it is not, in which case it would be defined in the user's preferences file.
 	 */
 	bool is_default_;
+
+	/*
+	 * The original design of using a "null" command to indicate a disabled hot-key is ambiguous with regards
+	 * to when to save a user hot-key to preferences as well as when a default hot-key should be flagged as
+	 * disabled. So introduce a separate disabled flag to resolve the ambiguity.
+	 * Where the flag is true, the hot-key should not be written to preferences unless it is a default hot-key.
+	 */
+	bool is_disabled_;
+
 	/*
 	 * Keyboard modifiers. Treat as opaque, only do comparisons.
-	 *
 	 */
 	unsigned int mod_;
 };


### PR DESCRIPTION
Re-open PR #530 but now based on master.

Only save non-default hot-keys to the preferences file if the hot-key is active (ie command != 'null').

Clearing hot-keys in memory (via the hot-key functions in the game) only sets the command to 'null', which currently gets written to the preferences file if it is a custom, ie non-default, hot-key. Over time, creating and clearing hot-keys results in a lot of redundant hot-key entries. The nice thing about this update is that it will remove redundant command='null' entries for existing preferences files as well as prevent it from being included in future ones..

To do: while this change achieves the intended result there is extra work to be done to allow the clearing of default hot-keys (bugs #21983, #22218, #23981).