### PR TITLE
Fix SDL2 crash; update mouse_handler_base.cpp for OS X to look for ctrl-click instead of cmd-click

### DIFF
--- a/changelog
+++ b/changelog
@@ -11,6 +11,7 @@ Version 1.13.2+dev:
      definitely fixed this time).
    * Fix bug #23108: exclude aborted attacks from statistics
    * imgcheck now runs on Python 3
+   * Fix bug #15259: Secondary click uses control-click instead of command-click in OS X
  * Greatly improved SDL2 support. SDL2 is now the default build.
    * Fix bug #24138: SDL2 crash on resize after starting a game and returning to title screen
    * Fix bug #23908: SDL2 SDL_BlitSurface Causes Crashes

--- a/projectfiles/Xcode/Mac Sources/SDLMain.m
+++ b/projectfiles/Xcode/Mac Sources/SDLMain.m
@@ -16,7 +16,6 @@ static char  **gArgv;
 @interface SDLApplication : NSApplication
 @end
 
-#if !SDL_VERSION_ATLEAST(2,0,0)
 @implementation SDLApplication
 /* Invoked from the Quit menu item */
 - (void)terminate:(id)sender
@@ -46,7 +45,6 @@ static char  **gArgv;
 	}
 }
 @end
-#endif
 
 /* The main class of the application, the application's delegate */
 @implementation SDLMain

--- a/src/mouse_handler_base.cpp
+++ b/src/mouse_handler_base.cpp
@@ -42,7 +42,7 @@ int commands_disabled= 0;
 static bool command_active()
 {
 #ifdef __APPLE__
-	return (SDL_GetModState()&KMOD_META) != 0;
+	return (SDL_GetModState()&KMOD_CTRL) != 0;
 #else
 	return false;
 #endif


### PR DESCRIPTION
Two patches:

**First:**
For OS X, control is the default modifier key that is used for contextual menus throughout the system

KMOD_CTRL will check for a control-click instead of a command click. This fixes [#15259](https://gna.org/bugs/?15259).

I’ve built and verified with this patch, and it works correctly. Native secondary-clicking (like two-finger clicking on a trackpad) still works, and is unaffected.

**Second:**
Delete two lines in SDLMain.m to fix an SDL2 crash. Tested successfully.