### PR TITLE
Fix some startup crashes

### DIFF
--- a/data/core/about.cfg
+++ b/data/core/about.cfg
@@ -1212,6 +1212,9 @@
         name = "Justin DiSabatino (Turuk)"
     [/entry]
     [entry]
+        name = "Jyrki Vesterinen"
+    [/entry]
+    [entry]
         name = "Kamil Kaczmarczyk (lampak)"
     [/entry]
     [entry]

--- a/src/filesystem_boost.cpp
+++ b/src/filesystem_boost.cpp
@@ -675,7 +675,15 @@ std::string get_cwd()
 std::string get_exe_dir()
 {
 #ifdef _WIN32
-    return get_cwd();
+    wchar_t process_path[MAX_PATH];
+    SetLastError(ERROR_SUCCESS);
+    GetModuleFileNameW(NULL, process_path, MAX_PATH);
+    if (GetLastError() != ERROR_SUCCESS) {
+        return get_cwd();
+    }
+
+    path exe(process_path);
+    return exe.parent_path().string();
 #else
     if (bfs::exists("/proc/")) {
         path self_exe("/proc/self/exe");

--- a/src/serialization/string_utils.hpp
+++ b/src/serialization/string_utils.hpp
@@ -240,6 +240,12 @@ std::string &strip(std::string &str);
 /** Remove whitespace from the back of the string 'str'. */
 std::string &strip_end(std::string &str);
 
+/** Surround the string 'str' with double quotes. */
+inline std::string quote(const std::string &str)
+{
+	return '"' + str + '"';
+}
+
 /** Convert no, false, off, 0, 0.0 to false, empty to def, and others to true */
 bool string_bool(const std::string& str,bool def=false);
 

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -951,7 +951,7 @@ static void restart_process(const std::vector<std::string>& commandline)
 	ZeroMemory(&process_info, sizeof(process_info));
 
 	CreateProcessW(process_path, commandline_c_str, NULL, NULL,
-		false, ABOVE_NORMAL_PRIORITY_CLASS, NULL, NULL, &startup_info, &process_info);
+		false, 0u, NULL, NULL, &startup_info, &process_info);
 
 	CloseHandle(process_info.hProcess);
 	CloseHandle(process_info.hThread);

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -926,7 +926,7 @@ static void wesnoth_terminate_handler(int) {
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_OPENMP) && _MSC_VER >= 1600
 static void restart_process(const std::vector<std::string>& commandline)
 {
 	wchar_t process_path[MAX_PATH];

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -934,7 +934,7 @@ static void restart_process(const std::vector<std::string>& commandline)
 	GetModuleFileNameW(NULL, process_path, MAX_PATH);
 	if (GetLastError() != ERROR_SUCCESS)
 	{
-		throw std::exception("Failed to retrieve the process path");
+		throw std::runtime_error("Failed to retrieve the process path");
 	}
 
 	std::wstring commandline_str = unicode_cast<std::wstring>(utils::join(commandline, " "));

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -1033,6 +1033,12 @@ int main(int argc, char** argv)
 			else if(filesystem::file_exists(exe_dir + "/../data/_main.cfg")) {
 				auto_dir = filesystem::normalize_path(exe_dir + "/..");
 			}
+			// In Windows debug builds, the EXE is placed away from the game data dir
+			// (in projectfiles\VCx\Debug), but the working directory is set to the
+			// game data dir. Thus, check if the working dir is the game data dir.
+			else if(filesystem::file_exists(filesystem::get_cwd() + "/data/_main.cfg")) {
+				auto_dir = filesystem::get_cwd();
+			}
 
 			if(!auto_dir.empty()) {
 				std::cerr << "Automatically found a possible data directory at "


### PR DESCRIPTION
I compiled Battle for Wesnoth from source code, and attempted to launch it with this batch file (placed into the folder which contains the "wesnoth" and "external" folders):

    SET PATH=%PATH%;%~d0%~p0external\dll
    START "" "%~d0%~p0wesnoth\wesnoth.exe"

It crashed on startup.

Debugging showed me that this code right in main() is the culprit:

```c++
#ifdef _OPENMP
	// Wesnoth is a special case for OMP
	// OMP wait strategy is to have threads busy-loop for 100ms
	// if there is nothing to do, they then go to sleep.
	// this avoids the scheduler putting the thread to sleep when work
	// is about to be available
	//
	// However Wesnoth has a lot of very small jobs that need to be done
	// at each redraw => 50fps every 2ms.
	// All the threads are thus busy-waiting all the time, hogging the CPU
	// To avoid that problem, we need to set the OMP_WAIT_POLICY env var
	// but that var is read by OMP at library loading time (before main)
	// thus the relaunching of ourselves after setting the variable.
#if !defined(_WIN32) && !defined(__APPLE__)
	if (!getenv("OMP_WAIT_POLICY")) {
		setenv("OMP_WAIT_POLICY", "PASSIVE", 1);
		execv(argv[0], argv);
	}
#elif _MSC_VER >= 1600
	if (!getenv("OMP_WAIT_POLICY")) {
		_putenv_s("OMP_WAIT_POLICY", "PASSIVE");
		_execv(argv[0], argv);
	}
#endif
#endif //_OPENMP
```

In the first launch, argv contains only the EXE path:

> argv[0] = "I:\Battle for Wesnoth\wesnoth\wesnoth.exe"

When the game relaunches itself, it passes argv to _execv(), unmodified. _execv() splits the path on spaces. That behavior is mentioned here: https://msdn.microsoft.com/en-us/library/431x4c1w.aspx

> Spaces embedded in strings may cause unexpected behavior; for example, passing **_exec** the string `"hi there"` will result in the new process getting two arguments, `"hi"` and `"there"`. If the intent was to have the new process open a file named "hi there", the process would fail. You can avoid this by quoting the string: `"\"hi there\""`.

On the second launch, argv is like this:

> argv[0] = "I:\Battle for Wesnoth\wesnoth\wesnoth.exe"
> argv[1] = "I:\Battle"
> argv[2] = "for"
> argv[3] = "Wesnoth\wesnoth\wesnoth.exe"

Boost::program_options thinks that argv[1] through argv[3] are positional options, and crashes the game because only one positional option is allowed.

The first of these commits fixes that crash by quoting argv[0] before passing it to _execv().

After fixing the issue, the game continued to crash. Automatic detection of the data directory wasn't working.

```c++
		const std::string& exe_dir = filesystem::get_exe_dir();
		if(!exe_dir.empty()) {
			// Try to autodetect the location of the game data dir. Note that
			// the root of the source tree currently doubles as the data dir.
			std::string auto_dir;

			// scons leaves the resulting binaries at the root of the source
			// tree by default.
			if(filesystem::file_exists(exe_dir + "/data/_main.cfg")) {
				auto_dir = exe_dir;
			}
			// cmake encourages creating a subdir at the root of the source
			// tree for the build, and the resulting binaries are found in it.
			else if(filesystem::file_exists(exe_dir + "/../data/_main.cfg")) {
				auto_dir = filesystem::normalize_path(exe_dir + "/..");
			}

			if(!auto_dir.empty()) {
				std::cerr << "Automatically found a possible data directory at "
						  << auto_dir << '\n';
				game_config::path = auto_dir;
			}
		}
```

The problem with this code is that, on Windows, filesystem::get_exe_dir() returns the working directory instead of the directory where the EXE is. The second commit in this pull request fixes that.

Unfortunately Windows debug builds were relying on filesystem::get_exe_dir() returning the working directory. In the third commit, I added code that explicitly checks if the working directory is the data directory.

**Summary:** these commits fix a crash on startup on Windows if the game is located into a path with spaces, and another crash on startup on Windows if the game is launched with the working directory set to something other than the data directory.