### PR TITLE
Fix bug #24209 and add a global event context

### DIFF
--- a/src/events.hpp
+++ b/src/events.hpp
@@ -55,6 +55,9 @@ public:
 	virtual void join(); /*joins the current event context*/
 	virtual void leave(); /*leave the event context*/
 
+	virtual void join_global(); /*join the global event context*/
+	virtual void leave_global(); /*leave the global event context*/
+
 protected:
 	sdl_handler(const bool auto_join=true);
 	virtual ~sdl_handler();
@@ -68,6 +71,7 @@ private:
 	int unicode_;
 #endif
 	bool has_joined_;
+	bool has_joined_global_;
 };
 
 void focus_handler(const sdl_handler* ptr);

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -218,6 +218,12 @@ class CVideo : private boost::noncopyable {
 
 private:
 
+	class video_event_handler : public events::sdl_handler {
+	public:
+		virtual void handle_event(const SDL_Event &event);
+		video_event_handler() :	sdl_handler(false) {}
+	};
+
 	void initSDL();
 #ifdef SDL_GPU
 	void update_overlay(SDL_Rect *rect = NULL);
@@ -232,6 +238,8 @@ private:
 
 	//if there is no display at all, but we 'fake' it for clients
 	bool fake_screen_;
+
+	video_event_handler event_handler_;
 
 	//variables for help strings
 	int help_string_;


### PR DESCRIPTION
This adds a global event scope that an sdl_handler can register to in
order to receive all current events, regardless of the current
scope. Care should be taken to not be registerd in a local event
context and the global context at the same time as it will lead to the
event handler potentially being invoked twice.

This also adds the workaround needed for #24209 in the new event
handler in the video class.