### PR TITLE
gui2: removed never accessed code path and related functions

### DIFF
--- a/src/gui/widgets/container.cpp
+++ b/src/gui/widgets/container.cpp
@@ -137,14 +137,6 @@ void tcontainer_::set_visible_rectangle(const SDL_Rect& rectangle)
 	grid_.set_visible_rectangle(rectangle);
 }
 
-void tcontainer_::impl_draw_children(surface& frame_buffer)
-{
-	assert(get_visible() == twidget::tvisible::visible
-		   && grid_.get_visible() == twidget::tvisible::visible);
-
-	grid_.draw_children(frame_buffer);
-}
-
 void tcontainer_::impl_draw_children(surface& frame_buffer,
 									 int x_offset,
 									 int y_offset)

--- a/src/gui/widgets/container.hpp
+++ b/src/gui/widgets/container.hpp
@@ -108,9 +108,6 @@ public:
 	virtual void set_visible_rectangle(const SDL_Rect& rectangle) OVERRIDE;
 
 	/** See @ref twidget::impl_draw_children. */
-	virtual void impl_draw_children(surface& frame_buffer) OVERRIDE;
-
-	/** See @ref twidget::impl_draw_children. */
 	virtual void impl_draw_children(surface& frame_buffer,
 									int x_offset,
 									int y_offset) OVERRIDE;

--- a/src/gui/widgets/control.cpp
+++ b/src/gui/widgets/control.cpp
@@ -392,14 +392,6 @@ int tcontrol::get_text_maximum_height() const
 	return get_height() - config_->text_extra_height;
 }
 
-void tcontrol::impl_draw_background(surface& frame_buffer)
-{
-	DBG_GUI_D << LOG_HEADER << " label '" << debug_truncate(label_) << "' size "
-			  << get_rectangle() << ".\n";
-
-	canvas(get_state()).blit(frame_buffer, get_rectangle());
-}
-
 void tcontrol::impl_draw_background(surface& frame_buffer,
 									int x_offset,
 									int y_offset)
@@ -409,11 +401,6 @@ void tcontrol::impl_draw_background(surface& frame_buffer,
 
 	canvas(get_state()).blit(frame_buffer,
 							 calculate_blitting_rectangle(x_offset, y_offset));
-}
-
-void tcontrol::impl_draw_foreground(surface& /*frame_buffer*/)
-{
-	/* DO NOTHING */
 }
 
 void tcontrol::impl_draw_foreground(surface& /*frame_buffer*/

--- a/src/gui/widgets/control.hpp
+++ b/src/gui/widgets/control.hpp
@@ -429,15 +429,9 @@ public:
 
 protected:
 	/** See @ref twidget::impl_draw_background. */
-	virtual void impl_draw_background(surface& frame_buffer) OVERRIDE;
-
-	/** See @ref twidget::impl_draw_background. */
 	virtual void impl_draw_background(surface& frame_buffer,
 									  int x_offset,
 									  int y_offset) OVERRIDE;
-
-	/** See @ref twidget::impl_draw_foreground. */
-	virtual void impl_draw_foreground(surface& frame_buffer) OVERRIDE;
 
 	/** See @ref twidget::impl_draw_foreground. */
 	virtual void impl_draw_foreground(surface& frame_buffer,

--- a/src/gui/widgets/generator.hpp
+++ b/src/gui/widgets/generator.hpp
@@ -270,9 +270,6 @@ public:
 	virtual void set_visible_rectangle(const SDL_Rect& rectangle) OVERRIDE = 0;
 
 	/** See @ref twidget::impl_draw_children. */
-	virtual void impl_draw_children(surface& frame_buffer) OVERRIDE = 0;
-
-	/** See @ref twidget::impl_draw_children. */
 	virtual void impl_draw_children(surface& frame_buffer,
 									int x_offset,
 									int y_offset) OVERRIDE = 0;

--- a/src/gui/widgets/generator_private.hpp
+++ b/src/gui/widgets/generator_private.hpp
@@ -873,23 +873,6 @@ public:
 	}
 
 	/** See @ref twidget::impl_draw_children. */
-	virtual void impl_draw_children(surface& frame_buffer) OVERRIDE
-	{
-		assert(this->get_visible() == twidget::tvisible::visible);
-
-		calculate_order();
-		FOREACH(AUTO index, order_)
-		{
-			titem* item = items_[index];
-			if(item->grid.get_visible() == twidget::tvisible::visible
-			   && item->shown) {
-
-				item->grid.draw_children(frame_buffer);
-			}
-		}
-	}
-
-	/** See @ref twidget::impl_draw_children. */
 	virtual void impl_draw_children(surface& frame_buffer,
 									int x_offset,
 									int y_offset) OVERRIDE

--- a/src/gui/widgets/grid.cpp
+++ b/src/gui/widgets/grid.cpp
@@ -906,48 +906,7 @@ void tgrid::layout(const tpoint& origin)
 	}
 }
 
-void tgrid::impl_draw_children(surface& frame_buffer)
-{
-	/*
-	 * The call to SDL_PumpEvents seems a bit like black magic.
-	 * With the call the resizing doesn't seem to lose resize events.
-	 * But when added the queue still only contains one resize event and the
-	 * internal SDL queue doesn't seem to overflow (rarely more than 50 pending
-	 * events).
-	 * Without the call when resizing larger a black area of remains, this is
-	 * the area not used for resizing the screen, this call `fixes' that.
-	 */
-#if !SDL_VERSION_ATLEAST(2,0,0)
-	SDL_PumpEvents();
-#endif
-
-
-	assert(get_visible() == twidget::tvisible::visible);
-	set_is_dirty(false);
-
-	FOREACH(AUTO & child, children_)
-	{
-
-		twidget* widget = child.widget();
-		assert(widget);
-
-		if(widget->get_visible() != twidget::tvisible::visible) {
-			continue;
-		}
-
-		if(widget->get_drawing_action() == twidget::tredraw_action::none) {
-			continue;
-		}
-
-		widget->draw_background(frame_buffer);
-		widget->draw_children(frame_buffer);
-		widget->draw_foreground(frame_buffer);
-		widget->set_is_dirty(false);
-	}
-}
-
-void
-tgrid::impl_draw_children(surface& frame_buffer, int x_offset, int y_offset)
+void tgrid::impl_draw_children(surface& frame_buffer, int x_offset, int y_offset)
 {
 	/*
 	 * The call to SDL_PumpEvents seems a bit like black magic.

--- a/src/gui/widgets/grid.hpp
+++ b/src/gui/widgets/grid.hpp
@@ -486,9 +486,6 @@ private:
 	void layout(const tpoint& origin);
 
 	/** See @ref twidget::impl_draw_children. */
-	virtual void impl_draw_children(surface& frame_buffer) OVERRIDE;
-
-	/** See @ref twidget::impl_draw_children. */
 	virtual void impl_draw_children(surface& frame_buffer,
 									int x_offset,
 									int y_offset) OVERRIDE;

--- a/src/gui/widgets/minimap.cpp
+++ b/src/gui/widgets/minimap.cpp
@@ -231,27 +231,6 @@ const surface tminimap::get_image(const int w, const int h) const
 	return NULL;
 }
 
-void tminimap::impl_draw_background(surface& frame_buffer)
-{
-	if(!terrain_)
-		return;
-	assert(terrain_);
-
-	DBG_GUI_D << LOG_HEADER << " size " << get_rectangle() << ".\n";
-
-	if(map_data_.empty()) {
-		return;
-	}
-
-	SDL_Rect rect = get_rectangle();
-	assert(rect.w > 0 && rect.h > 0);
-
-	const ::surface surf = get_image(rect.w, rect.h);
-	if(surf) {
-		sdl_blit(surf, NULL, frame_buffer, &rect);
-	}
-}
-
 void tminimap::impl_draw_background(surface& frame_buffer,
 									int x_offset,
 									int y_offset)

--- a/src/gui/widgets/minimap.hpp
+++ b/src/gui/widgets/minimap.hpp
@@ -96,9 +96,6 @@ private:
 	const surface get_image(const int w, const int h) const;
 
 	/** See @ref twidget::impl_draw_background. */
-	virtual void impl_draw_background(surface& frame_buffer) OVERRIDE;
-
-	/** See @ref twidget::impl_draw_background. */
 	virtual void impl_draw_background(surface& frame_buffer,
 									  int x_offset,
 									  int y_offset) OVERRIDE;

--- a/src/gui/widgets/multi_page.cpp
+++ b/src/gui/widgets/multi_page.cpp
@@ -156,11 +156,6 @@ void tmulti_page::finalize(const std::vector<string_map>& page_data)
 	swap_grid(NULL, &grid(), generator_, "_content_grid");
 }
 
-void tmulti_page::impl_draw_background(surface& /*frame_buffer*/)
-{
-	/* DO NOTHING */
-}
-
 void tmulti_page::impl_draw_background(surface& /*frame_buffer*/
 									   ,
 									   int /*x_offset*/

--- a/src/gui/widgets/multi_page.hpp
+++ b/src/gui/widgets/multi_page.hpp
@@ -155,9 +155,6 @@ private:
 	tbuilder_grid_const_ptr page_builder_;
 
 	/** See @ref twidget::impl_draw_background. */
-	virtual void impl_draw_background(surface& frame_buffer) OVERRIDE;
-
-	/** See @ref twidget::impl_draw_background. */
 	virtual void impl_draw_background(surface& frame_buffer,
 									  int x_offset,
 									  int y_offset) OVERRIDE;

--- a/src/gui/widgets/panel.cpp
+++ b/src/gui/widgets/panel.cpp
@@ -58,15 +58,7 @@ unsigned tpanel::get_state() const
 	return 0;
 }
 
-void tpanel::impl_draw_background(surface& frame_buffer)
-{
-	DBG_GUI_D << LOG_HEADER << " size " << get_rectangle() << ".\n";
-
-	canvas(0).blit(frame_buffer, get_rectangle());
-}
-
-void
-tpanel::impl_draw_background(surface& frame_buffer, int x_offset, int y_offset)
+void tpanel::impl_draw_background(surface& frame_buffer, int x_offset, int y_offset)
 {
 	DBG_GUI_D << LOG_HEADER << " size " << get_rectangle() << ".\n";
 
@@ -74,13 +66,7 @@ tpanel::impl_draw_background(surface& frame_buffer, int x_offset, int y_offset)
 				   calculate_blitting_rectangle(x_offset, y_offset));
 }
 
-void tpanel::impl_draw_foreground(surface& frame_buffer)
-{
-	canvas(1).blit(frame_buffer, get_rectangle());
-}
-
-void
-tpanel::impl_draw_foreground(surface& frame_buffer, int x_offset, int y_offset)
+void tpanel::impl_draw_foreground(surface& frame_buffer, int x_offset, int y_offset)
 {
 	canvas(1).blit(frame_buffer,
 				   calculate_blitting_rectangle(x_offset, y_offset));

--- a/src/gui/widgets/panel.hpp
+++ b/src/gui/widgets/panel.hpp
@@ -50,15 +50,9 @@ public:
 
 private:
 	/** See @ref twidget::impl_draw_background. */
-	virtual void impl_draw_background(surface& frame_buffer) OVERRIDE;
-
-	/** See @ref twidget::impl_draw_background. */
 	virtual void impl_draw_background(surface& frame_buffer,
 									  int x_offset,
 									  int y_offset) OVERRIDE;
-
-	/** See @ref twidget::impl_draw_foreground. */
-	virtual void impl_draw_foreground(surface& frame_buffer) OVERRIDE;
 
 	/** See @ref twidget::impl_draw_foreground. */
 	virtual void impl_draw_foreground(surface& frame_buffer,

--- a/src/gui/widgets/scrollbar_container.cpp
+++ b/src/gui/widgets/scrollbar_container.cpp
@@ -763,17 +763,6 @@ void tscrollbar_container::set_horizontal_scrollbar_mode(
 	}
 }
 
-void tscrollbar_container::impl_draw_children(surface& frame_buffer)
-{
-	assert(get_visible() == twidget::tvisible::visible
-		   && content_grid_->get_visible() == twidget::tvisible::visible);
-
-	// Inherited.
-	tcontainer_::impl_draw_children(frame_buffer);
-
-	content_grid_->draw_children(frame_buffer);
-}
-
 void tscrollbar_container::impl_draw_children(surface& frame_buffer,
 											  int x_offset,
 											  int y_offset)

--- a/src/gui/widgets/scrollbar_container.hpp
+++ b/src/gui/widgets/scrollbar_container.hpp
@@ -468,9 +468,6 @@ private:
 	virtual void layout_children() OVERRIDE;
 
 	/** See @ref twidget::impl_draw_children. */
-	virtual void impl_draw_children(surface& frame_buffer) OVERRIDE;
-
-	/** See @ref twidget::impl_draw_children. */
 	virtual void impl_draw_children(surface& frame_buffer,
 									int x_offset,
 									int y_offset) OVERRIDE;

--- a/src/gui/widgets/spacer.cpp
+++ b/src/gui/widgets/spacer.cpp
@@ -54,11 +54,6 @@ bool tspacer::disable_click_dismiss() const
 	return false;
 }
 
-void tspacer::impl_draw_background(surface& /*frame_buffer*/)
-{
-	/* DO NOTHING */
-}
-
 void tspacer::impl_draw_background(surface& /*frame_buffer*/
 								   ,
 								   int /*x_offset*/

--- a/src/gui/widgets/spacer.hpp
+++ b/src/gui/widgets/spacer.hpp
@@ -69,9 +69,6 @@ private:
 	tpoint best_size_;
 
 	/** See @ref twidget::impl_draw_background. */
-	virtual void impl_draw_background(surface& frame_buffer) OVERRIDE;
-
-	/** See @ref twidget::impl_draw_background. */
 	virtual void impl_draw_background(surface& frame_buffer,
 									  int x_offset,
 									  int y_offset) OVERRIDE;

--- a/src/gui/widgets/toggle_panel.cpp
+++ b/src/gui/widgets/toggle_panel.cpp
@@ -193,13 +193,6 @@ void ttoggle_panel::set_state(const tstate state)
 	assert(conf);
 }
 
-void ttoggle_panel::impl_draw_background(surface& frame_buffer)
-{
-	// We don't have a fore and background and need to draw depending on
-	// our state, like a control. So we use the controls drawing method.
-	tcontrol::impl_draw_background(frame_buffer);
-}
-
 void ttoggle_panel::impl_draw_background(surface& frame_buffer,
 										 int x_offset,
 										 int y_offset)
@@ -207,13 +200,6 @@ void ttoggle_panel::impl_draw_background(surface& frame_buffer,
 	// We don't have a fore and background and need to draw depending on
 	// our state, like a control. So we use the controls drawing method.
 	tcontrol::impl_draw_background(frame_buffer, x_offset, y_offset);
-}
-
-void ttoggle_panel::impl_draw_foreground(surface& frame_buffer)
-{
-	// We don't have a fore and background and need to draw depending on
-	// our state, like a control. So we use the controls drawing method.
-	tcontrol::impl_draw_foreground(frame_buffer);
 }
 
 void ttoggle_panel::impl_draw_foreground(surface& frame_buffer,

--- a/src/gui/widgets/toggle_panel.hpp
+++ b/src/gui/widgets/toggle_panel.hpp
@@ -157,15 +157,9 @@ private:
 	boost::function<void(twidget&)> callback_mouse_left_double_click_;
 
 	/** See @ref twidget::impl_draw_background. */
-	virtual void impl_draw_background(surface& frame_buffer) OVERRIDE;
-
-	/** See @ref twidget::impl_draw_background. */
 	virtual void impl_draw_background(surface& frame_buffer,
 									  int x_offset,
 									  int y_offset) OVERRIDE;
-
-	/** See @ref twidget::impl_draw_foreground. */
-	virtual void impl_draw_foreground(surface& frame_buffer) OVERRIDE;
 
 	/** See @ref twidget::impl_draw_foreground. */
 	virtual void impl_draw_foreground(surface& frame_buffer,

--- a/src/gui/widgets/tree_view_node.cpp
+++ b/src/gui/widgets/tree_view_node.cpp
@@ -518,20 +518,6 @@ void ttree_view_node::set_visible_rectangle(const SDL_Rect& rectangle)
 	}
 }
 
-void ttree_view_node::impl_draw_children(surface& frame_buffer)
-{
-	grid_.draw_children(frame_buffer);
-
-	if(is_folded()) {
-		return;
-	}
-
-	FOREACH(AUTO & node, children_)
-	{
-		node.impl_draw_children(frame_buffer);
-	}
-}
-
 void ttree_view_node::impl_draw_children(surface& frame_buffer,
 										 int x_offset,
 										 int y_offset)

--- a/src/gui/widgets/tree_view_node.hpp
+++ b/src/gui/widgets/tree_view_node.hpp
@@ -263,9 +263,6 @@ private:
 	virtual void set_visible_rectangle(const SDL_Rect& rectangle) OVERRIDE;
 
 	/** See @ref twidget::impl_draw_children. */
-	virtual void impl_draw_children(surface& frame_buffer) OVERRIDE;
-
-	/** See @ref twidget::impl_draw_children. */
 	virtual void impl_draw_children(surface& frame_buffer,
 									int x_offset,
 									int y_offset) OVERRIDE;

--- a/src/gui/widgets/widget.cpp
+++ b/src/gui/widgets/widget.cpp
@@ -346,20 +346,6 @@ void twidget::draw_background(surface& frame_buffer, int x_offset, int y_offset)
 	}
 }
 
-void twidget::draw_background(surface& frame_buffer)
-{
-	assert(visible_ == tvisible::visible);
-
-	if(redraw_action_ == tredraw_action::partly) {
-		clip_rect_setter clip(frame_buffer, &clipping_rectangle_);
-		draw_debug_border(frame_buffer);
-		impl_draw_background(frame_buffer);
-	} else {
-		draw_debug_border(frame_buffer);
-		impl_draw_background(frame_buffer);
-	}
-}
-
 void twidget::draw_children(surface& frame_buffer, int x_offset, int y_offset)
 {
 	assert(visible_ == tvisible::visible);
@@ -375,18 +361,6 @@ void twidget::draw_children(surface& frame_buffer, int x_offset, int y_offset)
 	}
 }
 
-void twidget::draw_children(surface& frame_buffer)
-{
-	assert(visible_ == tvisible::visible);
-
-	if(redraw_action_ == tredraw_action::partly) {
-		clip_rect_setter clip(frame_buffer, &clipping_rectangle_);
-		impl_draw_children(frame_buffer);
-	} else {
-		impl_draw_children(frame_buffer);
-	}
-}
-
 void twidget::draw_foreground(surface& frame_buffer, int x_offset, int y_offset)
 {
 	assert(visible_ == tvisible::visible);
@@ -399,18 +373,6 @@ void twidget::draw_foreground(surface& frame_buffer, int x_offset, int y_offset)
 		impl_draw_foreground(frame_buffer, x_offset, y_offset);
 	} else {
 		impl_draw_foreground(frame_buffer, x_offset, y_offset);
-	}
-}
-
-void twidget::draw_foreground(surface& frame_buffer)
-{
-	assert(visible_ == tvisible::visible);
-
-	if(redraw_action_ == tredraw_action::partly) {
-		clip_rect_setter clip(frame_buffer, &clipping_rectangle_);
-		impl_draw_foreground(frame_buffer);
-	} else {
-		impl_draw_foreground(frame_buffer);
 	}
 }
 

--- a/src/gui/widgets/widget.hpp
+++ b/src/gui/widgets/widget.hpp
@@ -542,7 +542,6 @@ public:
 	 *                            @p frame_buffer to draw.
 	 */
 	void draw_background(surface& frame_buffer, int x_offset, int y_offset);
-	void draw_background(surface& frame_buffer);
 
 	/**
 	 * Draws the children of a widget.
@@ -559,7 +558,6 @@ public:
 	 *                            @p frame_buffer to draw.
 	 */
 	void draw_children(surface& frame_buffer, int x_offset, int y_offset);
-	void draw_children(surface& frame_buffer);
 
 	/**
 	 * Draws the foreground of the widget.
@@ -577,7 +575,6 @@ public:
 	 *                            @p frame_buffer to draw.
 	 */
 	void draw_foreground(surface& frame_buffer, int x_offset, int y_offset);
-	void draw_foreground(surface& frame_buffer);
 
 private:
 	/** See @ref draw_background. */
@@ -593,9 +590,6 @@ private:
 	}
 
 	/** See @ref draw_children. */
-	virtual void impl_draw_children(surface& /*frame_buffer*/)
-	{
-	}
 	virtual void impl_draw_children(surface& /*frame_buffer*/
 									,
 									int /*x_offset*/
@@ -605,9 +599,6 @@ private:
 	}
 
 	/** See @ref draw_foreground. */
-	virtual void impl_draw_foreground(surface& /*frame_buffer*/)
-	{
-	}
 	virtual void impl_draw_foreground(surface& /*frame_buffer*/
 									  ,
 									  int /*x_offset*/

--- a/src/gui/widgets/window.cpp
+++ b/src/gui/widgets/window.cpp
@@ -872,64 +872,26 @@ void twindow::draw()
 		SDL_Rect rect = get_rectangle();
 		sdl_blit(restorer_, 0, frame_buffer, &rect);
 
-/**
- * @todo Remove the if an always use the true branch.
- *
- * When removing that code the draw functions with only a frame_buffer
- * as parameter should also be removed since they will be unused from
- * that moment.
- */
-#if 0
-		if(new_widgets)
-#else
-		if(true)
-#endif
-		{
-			// Background.
-			for(std::vector<twidget*>::iterator itor = item.begin();
-				itor != item.end();
-				++itor) {
+		// Background.
+		for(std::vector<twidget*>::iterator itor = item.begin();
+			itor != item.end();
+			++itor) {
 
-				(**itor).draw_background(frame_buffer, 0, 0);
-			}
-
-			// Children.
-			if(!item.empty()) {
-				item.back()->draw_children(frame_buffer, 0, 0);
-			}
-
-			// Foreground.
-			for(std::vector<twidget*>::reverse_iterator ritor = item.rbegin();
-				ritor != item.rend();
-				++ritor) {
-
-				(**ritor).draw_foreground(frame_buffer, 0, 0);
-				(**ritor).set_is_dirty(false);
-			}
+			(**itor).draw_background(frame_buffer, 0, 0);
 		}
-		else
-		{
-			// Background.
-			for(std::vector<twidget*>::iterator itor = item.begin();
-				itor != item.end();
-				++itor) {
 
-				(**itor).draw_background(frame_buffer);
-			}
+		// Children.
+		if(!item.empty()) {
+			item.back()->draw_children(frame_buffer, 0, 0);
+		}
 
-			// Children.
-			if(!item.empty()) {
-				item.back()->draw_children(frame_buffer);
-			}
+		// Foreground.
+		for(std::vector<twidget*>::reverse_iterator ritor = item.rbegin();
+			ritor != item.rend();
+			++ritor) {
 
-			// Foreground.
-			for(std::vector<twidget*>::reverse_iterator ritor = item.rbegin();
-				ritor != item.rend();
-				++ritor) {
-
-				(**ritor).draw_foreground(frame_buffer);
-				(**ritor).set_is_dirty(false);
-			}
+			(**ritor).draw_foreground(frame_buffer, 0, 0);
+			(**ritor).set_is_dirty(false);
 		}
 
 		update_rect(dirty_rect);


### PR DESCRIPTION
According to a comment in the code, the functions with only a frame_buffer as a argument could be removed. Since they were never called before, this shouldn't break anything, but PR-ing it so travis can run through.