### PR TITLE
Make the story screen resize aware

### DIFF
--- a/src/storyscreen/controller.cpp
+++ b/src/storyscreen/controller.cpp
@@ -146,6 +146,9 @@ void controller::resolve_wml(const vconfig& cfg)
 
 STORY_RESULT controller::show(START_POSITION startpos)
 {
+
+	events::event_context story_context;
+
 	if(parts_.empty()) {
 		LOG_NG << "no storyscreen parts to show\n";
 		return NEXT;

--- a/src/storyscreen/render.hpp
+++ b/src/storyscreen/render.hpp
@@ -23,6 +23,7 @@
 
 #include "key.hpp"
 #include "storyscreen/part.hpp"
+#include "events.hpp"
 // #include "widgets/button.hpp"
 
 class display;
@@ -39,7 +40,7 @@ namespace storyscreen {
  * assumed that the screen dimensions remain constant between the
  * constructor call, and the destruction of the objects.
  */
-class part_ui
+class part_ui : public events::sdl_handler
 {
 public:
 	/** Storyscreen result. */
@@ -63,6 +64,8 @@ public:
 	 */
 	RESULT show();
 
+	virtual void handle_event(const SDL_Event& event);
+
 private:
 	part& p_;
 	display& disp_;
@@ -72,6 +75,8 @@ private:
 	gui::button& next_button_;
 	gui::button& back_button_;
 	gui::button& play_button_;
+
+	bool dirty_;
 
 	RESULT ret_;
 	bool skip_, last_key_;
@@ -101,6 +106,7 @@ private:
 	/** Constructor implementation details. */
 	void prepare_floating_images();
 
+	part_ui::RESULT render_all();
 	void render_background();
 	void render_title_box();
 	void render_story_box();

--- a/src/storyscreen/render.hpp
+++ b/src/storyscreen/render.hpp
@@ -106,7 +106,6 @@ private:
 	/** Constructor implementation details. */
 	void prepare_floating_images();
 
-	part_ui::RESULT render_all();
 	void render_background();
 	void render_title_box();
 	void render_story_box();


### PR DESCRIPTION
These changes make the storyscreen resize aware by adding an event
handler to the UI component and giving it its own event context. On an
window-event it'll restart relayout the entire scene and re-start the
drawing of the text.

Known issue: Gamescreen buttons appear when you move over them. This is beyond the scope of this commit and will be fixed in other changes.