### PR TITLE
Fix [message] issues

### DIFF
--- a/data/lua/wml/message.lua
+++ b/data/lua/wml/message.lua
@@ -237,6 +237,9 @@ function wesnoth.wml_actions.message(cfg)
 			wesnoth.set_variable(text_input.variable or "input", choice.text)
 		end
 	end
+	
+	-- Unhilight the speaker
+	wesnoth.deselect_hex()
 
 	if #options > 0 then
 		if option_chosen > #options then

--- a/data/lua/wml/message.lua
+++ b/data/lua/wml/message.lua
@@ -15,7 +15,7 @@ local function get_image(cfg, speaker)
 	local image = cfg.image
 
 	if speaker and image == nil then
-		image = speaker.__cfg.profile
+		image = speaker.portrait
 	end
 
 	if image == "none" or image == nil then

--- a/data/lua/wml/message.lua
+++ b/data/lua/wml/message.lua
@@ -211,7 +211,8 @@ function wesnoth.wml_actions.message(cfg)
 			wesnoth.scroll_to_tile(speaker.x, speaker.y)
 		end
 
-		wesnoth.select_hex(speaker.x, speaker.y, false)
+		wesnoth.select_hex(speaker.x, speaker.y, true)
+		wesnoth.fire("redraw")
 	end
 
 	if cfg.sound then wesnoth.play_sound(cfg.sound) end

--- a/data/lua/wml/message.lua
+++ b/data/lua/wml/message.lua
@@ -147,11 +147,16 @@ function wesnoth.wml_actions.message(cfg)
 				-- Legacy format
 				table.insert(options, option.message)
 			else
-				local opt = helper.parsed(option)
-				if opt.message then
-					if not opt.label then
+				local opt = {
+					label = option.label,
+					description = option.description,
+					image = option.image,
+					default = option.default,
+				}
+				if option.message then
+					if not option.label then
 						-- Support either message or description
-						opt.label = opt.message
+						opt.label = option.message
 					else
 						log("[option] has both label= and message=, ignoring the latter", "warning")
 					end

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -347,6 +347,7 @@ static int impl_unit_get(lua_State *L)
 	return_string_attrib("variation", u.variation());
 	return_bool_attrib("zoc", u.get_emit_zoc());
 	return_string_attrib("facing", map_location::write_direction(u.facing()));
+	return_string_attrib("portrait", u.big_profile() == u.absolute_image() ? u.absolute_image() + u.image_mods() : u.big_profile());
 	return_cfg_attrib("__cfg", u.write(cfg); u.get_location().write(cfg));
 
 	return lua_kernel_base::get_lua_kernel<game_lua_kernel>(L).return_unit_method(L, m);

--- a/src/scripting/lua_common.hpp
+++ b/src/scripting/lua_common.hpp
@@ -137,7 +137,7 @@ bool LuaW_checkvariable(lua_State *L, variable_access_create& v, int n);
 	}
 
 #define return_string_attrib(name, accessor) \
-	return_cstring_attrib(name, accessor.c_str())
+	return_cstring_attrib(name, (accessor).c_str())
 
 #define return_int_attrib(name, accessor) \
 	if (strcmp(m, name) == 0) { \


### PR DESCRIPTION
This fixes some issues with the Lua implementation of `[message]`.

* The last unit who spoke ends up selected after the event ends.
* The speaking unit is not correctly highlighted on the map
* Units without portraits show non-team-coloured sprites.

My build doesn't have team colour at all for some reason, so I need someone else to test the TC part of this.