### PR TITLE
Fix [for] loop not iterating the correct number of times

### DIFF
--- a/data/test/scenarios/for-loops.cfg
+++ b/data/test/scenarios/for-loops.cfg
@@ -184,6 +184,46 @@
 
 #undef FOR_LOOP_ARRAY_TEST
 
+{GENERIC_UNIT_TEST forloop_array_mutate (
+	[event]
+		name=start
+		[set_variables]
+			name=array
+			[value]
+				value=10
+			[/value]
+			[value]
+				value=7
+			[/value]
+			[value]
+				value=2
+			[/value]
+			[value]
+				value=37
+			[/value]
+		[/set_variables]
+		{VARIABLE n 0}
+		[for]
+			array=array
+			[do]
+				{VARIABLE n $array[$i].value}
+				{CLEAR_VARIABLE ("array[$($array.length - 1)]")}
+			[/do]
+		[/for]
+		[fire_event]
+			name=no_error
+		[/fire_event]
+	[/event]
+	[event]
+		name=no_error
+		{RETURN ({VARIABLE_CONDITIONAL n equals 7})}
+	[/event]
+	[event]
+		name=start
+		{FAIL}
+	[/event]
+)}
+
 #define FOR_LOOP_TEST_STEP NAME START END EXTRA CONTENT
 	{GENERIC_UNIT_TEST NAME (
 		[event]


### PR DESCRIPTION
This fixes the `[for]` loop (and by extension, the `{FOREACH}` macro) not iterating the correct number of times if the array length changes during the loop. It does this by re-evaluating the endpoint and step size on each loop iteration, meaning that if someone uses variables in these fields, both the step size and endpoint could change during iteration.