### PR TITLE
Add CURRENT_FILE proprocessor macro

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -528,6 +528,14 @@ void config::append_children(const config &cfg)
 	}
 }
 
+void config::append_attributes(const config &cfg)
+{
+	check_valid(cfg);
+	BOOST_FOREACH(const attribute &v, cfg.values) {
+		values[v.first] = v.second;
+	}
+}
+
 void config::append_children(const config &cfg, const std::string& key)
 {
 	check_valid(cfg);

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -675,6 +675,11 @@ public:
 	void append_children(const config &cfg, const std::string& key);
 
 	/**
+	 * Adds attributes from @a cfg.
+	 */
+	void append_attributes(const config &cfg);
+
+	/**
 	 * All children with the given key will be merged
 	 * into the first element with that key.
 	 */

--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -103,7 +103,7 @@ bool looks_like_pbl(const std::string& file);
 /** Basic disk I/O - read file. */
 std::string read_file(const std::string &fname);
 std::istream *istream_file(const std::string &fname, bool treat_failure_as_error = true);
-std::ostream *ostream_file(std::string const &fname);
+std::ostream *ostream_file(std::string const &fname, bool create_directory = true);
 /** Throws io_exception if an error occurs. */
 void write_file(const std::string& fname, const std::string& data);
 

--- a/src/filesystem_boost.cpp
+++ b/src/filesystem_boost.cpp
@@ -603,9 +603,7 @@ void set_user_config_dir(std::string newconfigdir)
 
 static const path &get_user_data_path()
 {
-	// TODO:
-	// This function is called frequently. The file_exists call may slow things down a lot.
-	if (user_data_dir.empty() || !file_exists(user_data_dir))
+	if (user_data_dir.empty())
 	{
 		set_user_data_dir(std::string());
 	}

--- a/src/filesystem_boost.cpp
+++ b/src/filesystem_boost.cpp
@@ -818,7 +818,7 @@ std::istream *istream_file(const std::string &fname, bool treat_failure_as_error
 	}
 }
 
-std::ostream *ostream_file(std::string const &fname)
+std::ostream *ostream_file(std::string const &fname, bool create_directory)
 {
 	LOG_FS << "streaming " << fname << " for writing.\n";
 #if 1
@@ -829,6 +829,12 @@ std::ostream *ostream_file(std::string const &fname)
 	}
 	catch(BOOST_IOSTREAMS_FAILURE& e)
 	{
+		// If this operation failed because the parent directoy didn't exist, create the parent directoy and retry.
+		error_code ec_unused;
+		if(create_directory && bfs::create_directories(bfs::path(fname).parent_path(), ec_unused))
+		{
+			return ostream_file(fname, false);
+		}
 		throw filesystem::io_exception(e.what());
 	}
 #else

--- a/src/filesystem_boost.cpp
+++ b/src/filesystem_boost.cpp
@@ -763,7 +763,7 @@ std::string read_file(const std::string &fname)
 	return ss.str();
 }
 
-#if BOOST_VERSION < 1048000
+#if BOOST_VERSION < 104800
 //boost iostream < 1.48 expects boost filesystem v2 paths. This is an adapter
 struct iostream_path
 {

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -301,7 +301,7 @@ static int impl_unit_get(lua_State *L)
 		return 1;
 	}
 	if (strcmp(m, "advancements") == 0) {
-		lua_push(L, boost::iterator_range<config::const_child_iterator>(u.modification_advancements()));
+		lua_push(L, u.modification_advancements());
 		return 1;
 	}
 	if (strcmp(m, "overlays") == 0) {

--- a/src/scripting/push_check.hpp
+++ b/src/scripting/push_check.hpp
@@ -184,7 +184,7 @@ namespace lua_check_impl
 			for (int i = 1, i_end = lua_rawlen(L, n); i <= i_end; ++i)
 			{
 				lua_rawgeti(L, n, i);
-				res.push_back(lua_check_impl::lua_check<typename remove_constref<typename T::value_type>::type>(L, -1));
+				res.push_back(lua_check_impl::lua_check<typename remove_constref<typename T::reference>::type>(L, -1));
 			}
 			return res;
 		}
@@ -218,7 +218,7 @@ namespace lua_check_impl
 		assert(list.size() >= 0);
 		lua_createtable(L, list.size(), 0);
 		for(size_t i = 0, size = static_cast<size_t>(list.size()); i < size; ++i) {
-			lua_check_impl::lua_push<typename remove_constref<typename T::value_type>::type>(L, list[i]);
+			lua_check_impl::lua_push<typename remove_constref<typename T::reference>::type>(L, list[i]);
 			lua_rawseti(L, -2, i + 1);
 		}
 	}

--- a/src/serialization/preprocessor.cpp
+++ b/src/serialization/preprocessor.cpp
@@ -109,18 +109,6 @@ static std::string get_location(const std::string& loc)
 	return res;
 }
 
-// decode the filenames placed in a location
-static std::string get_current_file(const std::string& loc)
-{
-	std::string res;
-	std::vector< std::string > pos = utils::quoted_split(loc, ' ');
-	if(pos.empty()) {
-		return res;
-	}
-	else {
-		return get_filename(pos.front());
-	}
-}
 
 bool preproc_define::operator==(preproc_define const &v) const {
 	return value == v.value && arguments == v.arguments;
@@ -219,7 +207,10 @@ public:
 	 * Preprocesses and sends some text to the #target_ buffer.
 	 * @return false when the input has no data left.
 	 */
+	preprocessor * get_old_preprocessor() { return old_preprocessor_; }
 	virtual bool get_chunk() = 0;
+	///retruns 1 if this parses a macro, -1 if this doesnt parse text (if this is no preprocessor_data). 0 otherwise (this parses a file).
+	virtual int is_macro() { return -1; }
 	virtual ~preprocessor();
 };
 
@@ -250,10 +241,32 @@ class preprocessor_streambuf: public streambuf
 	friend struct preprocessor_deleter;
 	preprocessor_streambuf(preprocessor_streambuf const &);
 public:
+	std::string get_current_file();
 	preprocessor_streambuf(preproc_map *);
 	void error(const std::string &, int);
 	void warning(const std::string &, int);
 };
+
+// decode the filenames placed in a location
+std::string preprocessor_streambuf::get_current_file()
+{
+	unsigned nested_level = 0;
+	preprocessor* pre = current_;
+	while(pre && pre->is_macro()) {
+		if(pre->is_macro() == 1) {
+			++nested_level;
+		}
+		pre = pre->get_old_preprocessor();
+	}
+	std::string res;
+	std::vector< std::string > pos = utils::quoted_split(location_, ' ');
+	if(pos.size() <= 2*nested_level) {
+		return res;
+	}
+	else {
+		return get_filename(pos[2*nested_level]);
+	}
+}
 
 preprocessor_streambuf::preprocessor_streambuf(preproc_map *def) :
 	streambuf(),
@@ -497,6 +510,8 @@ class preprocessor_data: preprocessor
 	 */
 	int skipping_;
 	int linenum_;
+	///true iff we are currently parsing a macros content, otherwise false.
+	bool is_define_;
 
 	std::string read_word();
 	std::string read_line();
@@ -515,10 +530,10 @@ public:
 	                  std::string const &history,
 	                  std::string const &name, int line,
 	                  std::string const &dir, std::string const &domain,
-	                  std::map<std::string, std::string> *defines);
+	                  std::map<std::string, std::string> *defines, bool is_define = false);
 	~preprocessor_data();
 	virtual bool get_chunk();
-
+	virtual int is_macro() { return is_define_ ? 1 : 0; }
 	friend bool operator==(preprocessor_data::token_desc::TOKEN_TYPE, char);
 	friend bool operator==(char, preprocessor_data::token_desc::TOKEN_TYPE);
 	friend bool operator!=(preprocessor_data::token_desc::TOKEN_TYPE, char);
@@ -591,7 +606,7 @@ bool preprocessor_file::get_chunk()
 preprocessor_data::preprocessor_data(preprocessor_streambuf &t,
 	std::istream *i, std::string const &history, std::string const &name, int linenum,
 	std::string const &directory, std::string const &domain,
-	std::map<std::string, std::string> *defines) :
+	std::map<std::string, std::string> *defines, bool is_define) :
 	preprocessor(t),
 	in_scope_(i),
 	in_(*i),
@@ -601,7 +616,8 @@ preprocessor_data::preprocessor_data(preprocessor_streambuf &t,
 	tokens_(),
 	slowpath_(0),
 	skipping_(0),
-	linenum_(linenum)
+	linenum_(linenum),
+	is_define_(is_define)
 {
 	std::ostringstream s;
 
@@ -1084,13 +1100,12 @@ bool preprocessor_data::get_chunk()
 			// If this is a known pre-processing symbol, then we insert it,
 			// otherwise we assume it's a file name to load.
 			if(symbol == current_file_str && strings_.size() - token.stack_pos == 1) {
-				
 				pop_token();
-				put(get_current_file(target_.location_));
+				put(target_.get_current_file());
 			}
 			else if(symbol == current_dir_str && strings_.size() - token.stack_pos == 1) {
 				pop_token();
-				put(filesystem::directory_name(get_current_file(target_.location_)));
+				put(filesystem::directory_name(target_.get_current_file()));
 			}
 			else if (local_defines_ &&
 			    (arg = local_defines_->find(symbol)) != local_defines_->end())
@@ -1133,7 +1148,7 @@ bool preprocessor_data::get_chunk()
 				if (!slowpath_) {
 					DBG_PREPROC << "substituting macro " << symbol << '\n';
 					new preprocessor_data(target_, buffer, val.location, "",
-					                      val.linenum, dir, val.textdomain, defines);
+					                      val.linenum, dir, val.textdomain, defines, true);
 				} else {
 					DBG_PREPROC << "substituting (slow) macro " << symbol << '\n';
 					std::ostringstream res;
@@ -1144,7 +1159,7 @@ bool preprocessor_data::get_chunk()
 					buf->textdomain_ = target_.textdomain_;
 					{	std::istream in(buf);
 						new preprocessor_data(*buf, buffer, val.location, "",
-						                      val.linenum, dir, val.textdomain, defines);
+						                      val.linenum, dir, val.textdomain, defines, true);
 						res << in.rdbuf(); }
 					delete buf;
 					put(res.str());

--- a/src/unit.hpp
+++ b/src/unit.hpp
@@ -19,6 +19,7 @@
 
 #include <boost/tuple/tuple.hpp>
 #include <boost/scoped_ptr.hpp>
+#include <boost/ptr_container/ptr_vector.hpp>
 
 #include "unit_types.hpp"
 #include "unit_ptr.hpp"
@@ -310,9 +311,11 @@ public:
 	std::vector<std::pair<std::string,std::string> > amla_icons() const;
 
 	std::vector<config> get_modification_advances() const;
-	config::const_child_itors modification_advancements() const
-	{ return cfg_.child_range("advancement"); }
+
+	typedef boost::ptr_vector<config> t_advancements;
 	void set_advancements(std::vector<config> advancements);
+	const t_advancements& modification_advancements() const
+	{ return advancements_; }
 
 	size_t modification_count(const std::string& type, const std::string& id) const;
 
@@ -496,7 +499,8 @@ private:
 	double hp_bar_scaling_, xp_bar_scaling_;
 
 	config modifications_;
-
+	config abilities_;
+	t_advancements advancements_;
 	/**
 	 * Hold the visibility status cache for a unit, when not uncovered.
 	 * This is mutable since it is a cache.

--- a/src/unit_abilities.cpp
+++ b/src/unit_abilities.cpp
@@ -132,12 +132,11 @@ bool unit::get_ability_bool(const std::string& tag_name, const map_location& loc
 {
 	assert(resources::teams);
 
-	if (const config &abilities = cfg_.child("abilities"))
-	{
-		BOOST_FOREACH(const config &i, abilities.child_range(tag_name)) {
-			if (ability_active(tag_name, i, loc) &&
-			    ability_affects_self(tag_name, i, loc))
-				return true;
+	BOOST_FOREACH(const config &i, this->abilities_.child_range(tag_name)) {
+		if (ability_active(tag_name, i, loc) &&
+			ability_affects_self(tag_name, i, loc))
+		{
+			return true;
 		}
 	}
 
@@ -155,14 +154,13 @@ bool unit::get_ability_bool(const std::string& tag_name, const map_location& loc
 		// ourself.
 		if ( &*it == this )
 			continue;
-		const config &adj_abilities = it->cfg_.child("abilities");
-		if (!adj_abilities)
-			continue;
-		BOOST_FOREACH(const config &j, adj_abilities.child_range(tag_name)) {
+		BOOST_FOREACH(const config &j, it->abilities_.child_range(tag_name)) {
 			if (affects_side(j, *resources::teams, side(), it->side()) &&
 			    it->ability_active(tag_name, j, adjacent[i]) &&
 			    ability_affects_adjacent(tag_name,  j, i, loc, *it))
+			{
 				return true;
+			}
 		}
 	}
 
@@ -175,12 +173,11 @@ unit_ability_list unit::get_abilities(const std::string& tag_name, const map_loc
 
 	unit_ability_list res;
 
-	if (const config &abilities = cfg_.child("abilities"))
-	{
-		BOOST_FOREACH(const config &i, abilities.child_range(tag_name)) {
-			if (ability_active(tag_name, i, loc) &&
-			    ability_affects_self(tag_name, i, loc))
-				res.push_back(unit_ability(&i, loc));
+	BOOST_FOREACH(const config &i, this->abilities_.child_range(tag_name)) {
+		if (ability_active(tag_name, i, loc) &&
+			ability_affects_self(tag_name, i, loc))
+		{
+			res.push_back(unit_ability(&i, loc));
 		}
 	}
 
@@ -198,14 +195,13 @@ unit_ability_list unit::get_abilities(const std::string& tag_name, const map_loc
 		// ourself.
 		if ( &*it == this )
 			continue;
-		const config &adj_abilities = it->cfg_.child("abilities");
-		if (!adj_abilities)
-			continue;
-		BOOST_FOREACH(const config &j, adj_abilities.child_range(tag_name)) {
+		BOOST_FOREACH(const config &j, it->abilities_.child_range(tag_name)) {
 			if (affects_side(j, *resources::teams, side(), it->side()) &&
 			    it->ability_active(tag_name, j, adjacent[i]) &&
 			    ability_affects_adjacent(tag_name, j, i, loc, *it))
+			{
 				res.push_back(unit_ability(&j, adjacent[i]));
+			}
 		}
 	}
 
@@ -217,9 +213,7 @@ std::vector<std::string> unit::get_ability_list() const
 {
 	std::vector<std::string> res;
 
-	const config &abilities = cfg_.child("abilities");
-	if (!abilities) return res;
-	BOOST_FOREACH(const config::any_child &ab, abilities.all_children_range()) {
+	BOOST_FOREACH(const config::any_child &ab, this->abilities_.all_children_range()) {
 		std::string const &id = ab.cfg["id"];
 		if (!id.empty())
 			res.push_back(id);
@@ -272,10 +266,7 @@ std::vector<boost::tuple<t_string,t_string,t_string> > unit::ability_tooltips(st
 	if ( active_list )
 		active_list->clear();
 
-	const config &abilities = cfg_.child("abilities");
-	if (!abilities) return res;
-
-	BOOST_FOREACH(const config::any_child &ab, abilities.all_children_range())
+	BOOST_FOREACH(const config::any_child &ab, this->abilities_.all_children_range())
 	{
 		if ( !active_list || ability_active(ab.key, ab.cfg, loc_) )
 		{
@@ -429,11 +420,8 @@ bool unit::ability_affects_self(const std::string& ability,const config& cfg,con
 
 bool unit::has_ability_type(const std::string& ability) const
 {
-	if (const config &list = cfg_.child("abilities")) {
-		config::const_child_itors itors = list.child_range(ability);
-		return itors.first != itors.second;
-	}
-	return false;
+	config::const_child_itors itors = this->abilities_.child_range(ability);
+	return itors.first != itors.second;
 }
 
 

--- a/src/unit_types.cpp
+++ b/src/unit_types.cpp
@@ -762,8 +762,9 @@ bool unit_type::show_variations_in_help() const
  */
 const config & unit_type::build_unit_cfg() const
 {
-	// We start with everything.
-	unit_cfg_ = cfg_;
+	// We start with all attributes.
+	assert(unit_cfg_.empty());
+	unit_cfg_.append_attributes(cfg_);
 
 	// Remove "pure" unit_type attributes (attributes that do not get directly
 	// copied to units; some do get copied, but under different keys).
@@ -776,27 +777,6 @@ const config & unit_type::build_unit_cfg() const
 	BOOST_FOREACH(const char *attr, unit_type_attrs) {
 		unit_cfg_.remove_attribute(attr);
 	}
-
-	// Remove gendered children.
-	unit_cfg_.clear_children("male");
-	unit_cfg_.clear_children("female");
-
-	// Remove movement type data (it will be received via a movetype object).
-	unit_cfg_.clear_children("movement_costs");
-	unit_cfg_.clear_children("vision_costs");
-	unit_cfg_.clear_children("jamming_costs");
-	unit_cfg_.clear_children("defense");
-	unit_cfg_.clear_children("resistance");
-
-	// Units use unit_type::attacks() to get their attacks
-	unit_cfg_.clear_children("attack");
-	// Units (animation component) use unit_type::animations()
-	BOOST_FOREACH(const std::string& tag_name, unit_animation::all_tag_names()) {
-		unit_cfg_.clear_children(tag_name);
-	}
-	// [portrait] is not used yet by unit class.
-	unit_cfg_.clear_children("portrait");
-
 	built_unit_cfg_ = true;
 	return unit_cfg_;
 }

--- a/src/unit_types.hpp
+++ b/src/unit_types.hpp
@@ -170,6 +170,13 @@ public:
 
 	config::const_child_itors possible_traits() const
 	{ return possible_traits_.child_range("trait"); }
+
+	const config& abilities_cfg() const
+	{ return cfg_.child_or_empty("abilities"); }
+
+	config::const_child_itors advancements() const
+	{ return cfg_.child_range("advancement"); }
+
 	bool has_random_traits() const;
 
 	/// The returned vector will not be empty, provided this has been built


### PR DESCRIPTION
this adds a new proprocessor macro called as {CURRENT_FILE}/{CURRENT_DIRECTORY} whcih expands to the current file/directory name. the intention is to use for example as
```
[lua]
code = "wesnoth.dofile({CURRENT_DIRECTORY}lua/myfile.lua)"
[/lua]
```

This also contains 2 other (unrelated) changes:
It cleans up the units cdfg_ field so that it only contains atributes, no child tags. This also Fixes a savefiles bloat becase the [variation]s, specially of walking corpses aren't stored in the [unit] wml anymore.

It adds "./dir/file.lua" support to lua dofile/require, this is also not optimial yet, becase lua chunknames shoudl only contains teh relative name (~add-ons/..  ../myfile.lua) while it currently contains the complate path (C:\users\..    ../add-ons/..   ../myfile.lua)
