### PR TITLE
Help: Fix typo in Help -> Encyclopedia -> Geography -> Great Ocean.

### DIFF
--- a/data/core/encyclopedia/geography.cfg
+++ b/data/core/encyclopedia/geography.cfg
@@ -30,7 +30,7 @@
 [topic]
     id=great_ocean
     title= _ "Great Ocean"
-    text= _ "Lies to the west of the <ref>dst='great_continent' text='continent'</ref> and all rivers eventually flow to it. Far to the west in the the Great Ocean is a huge archipelago called <ref>dst='morogor' text='Morogor'</ref>."
+    text= _ "Lies to the west of the <ref>dst='great_continent' text='continent'</ref> and all rivers eventually flow to it. Far to the west in the Great Ocean is a huge archipelago called <ref>dst='morogor' text='Morogor'</ref>."
 [/topic]
 
 [topic]


### PR DESCRIPTION
Fixes a typo reported on https://wiki.wesnoth.org/SpellingMistakes

@Vultraz: Should I clear the entry in the wiki? Or do we wait until a release is made?
Also, this one can be backported to 1.12 if that's still being done.