### PR TITLE
Change id of broken ai to get it off the top of list in mp debug.

### DIFF
--- a/data/ai/dev/akihara_recruitment.cfg
+++ b/data/ai/dev/akihara_recruitment.cfg
@@ -5,7 +5,7 @@
 #endif
 
 [ai]
-    id=ai_akihara
+    id=ai_dev_akihara
     description=_"Multiplayer_AI^Dev AI: Default + Experimental Recruitment (C++ Akihara)" # wmllint: no spellcheck
     version=10800
     [stage]


### PR DESCRIPTION
A quick fix to get Default RCA to top of list in debug mode, so add-on development is easier.

It's a quick fix, as there's the possibility that the abandoned ai's might be removed.