### PR TITLE
Restore loading of user hot-keys at start-up (bug #24427)

### DIFF
--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -770,6 +770,8 @@ static int do_gameloop(const std::vector<std::string>& args)
 				? gui2::ttitle_screen::LOAD_GAME
 				: gui2::ttitle_screen::NOTHING;
 
+		preferences::load_hotkeys();
+
 		const font::floating_label_context label_manager;
 
 		cursor::set(cursor::NORMAL);


### PR DESCRIPTION
Loading of user preferences - or user hot-keys at the very least - were broken with the deletion at https://github.com/wesnoth/wesnoth/commit/28be388d6d59783e140aeaad1f3410766212d056#diff-fce7a1e6525522f3e4ab47349051a806L770

This restores loading of user preferences at start-up.