### PR TITLE
AOI: Make the named loyal units unnameable.

### DIFF
--- a/data/campaigns/An_Orcish_Incursion/scenarios/01_Defend_the_Forest.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/01_Defend_the_Forest.cfg
@@ -68,6 +68,7 @@
             id=Lomarfel
             name= _ "Lomarfel"
             profile=portraits/lomarfel.png
+            unrenamable=yes
             x,y=15,18
             [modifications]
                 {TRAIT_LOYAL}

--- a/data/campaigns/An_Orcish_Incursion/scenarios/07_Showdown.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/07_Showdown.cfg
@@ -119,6 +119,7 @@
             id=Lomarfel
             name= _ "Lomarfel"
             profile=portraits/lomarfel.png
+            unrenamable=yes
             x,y=16,18
             [modifications]
                 {TRAIT_LOYAL}
@@ -139,6 +140,7 @@
             id=Celodith
             name= _ "Celodith"
             gender=female
+            unrenamable=yes
             x,y=17,18
             side=1
             [modifications]
@@ -159,6 +161,7 @@
             id=Earanduil
             name= _ "Earanduil"
             gender=male
+            unrenamable=yes
             x,y=17,19
             side=1
             [modifications]
@@ -179,6 +182,7 @@
             id=Elvyniel
             name= _ "Elvyniel"
             gender=female
+            unrenamable=yes
             x,y=18,18
             side=1
             [modifications]
@@ -199,6 +203,7 @@
             id=Delorfilith
             name= _ "Delorfilith"
             gender=male
+            unrenamable=yes
             x,y=18,19
             side=1
             [modifications]


### PR DESCRIPTION
Somebody went to the trouble of giving them specific names, Similar is done in spots in HttT, and it seems silly to allow Lomarfel to be renamed.