### PR TITLE
Fix broken build in VC

### DIFF
--- a/src/replay.hpp
+++ b/src/replay.hpp
@@ -23,6 +23,7 @@
 #include "map_location.hpp"
 
 #include <deque>
+#include <iterator>
 #include <map>
 #include <set>
 class replay_recorder_base;


### PR DESCRIPTION
#include <iterator> is needed for back_insert_iterator. This was included in config.hpp, but inclusion of that header here was removed in the previous commit. It might not be needed in Linux, but it looks like it's required for VC/Windows.