### PR TITLE
Fixed bug #24496: story maps show all markers in journey trails again

### DIFF
--- a/src/storyscreen/render.cpp
+++ b/src/storyscreen/render.cpp
@@ -383,8 +383,12 @@ bool part_ui::render_floating_images()
 
 		if(!ri.image.null()) {
 			render_background();
-			sdl_blit(ri.image, NULL, video_.getSurface(), &ri.rect);
-			update_rect(ri.rect);
+			for (size_t i = 0; i <= fi_n; i++)
+			{
+				floating_image::render_input& old_ri = imgs_[i];
+				sdl_blit(old_ri.image, NULL, video_.getSurface(), &old_ri.rect);
+				update_rect(old_ri.rect);
+			}
 		}
 
 		if (!skip_)


### PR DESCRIPTION
I created a loop to redraw all markers because the background hid them.