### PR TITLE
Resolve translated logo images not being used (bug #24357)

### DIFF
--- a/changelog
+++ b/changelog
@@ -92,6 +92,8 @@ Version 1.13.4+dev:
        still work, but any future code should use wfl/wflend instead.
        Use of the .fai file extension is still fine for FormulaAI code;
        for other formula code in a separate file, .wfl is recommended instead.
+ * Miscellaneous and bug fixes:
+   * Resolve translated logo images not being used (bug #24357)
 
 Version 1.13.4:
  * Language and i18n:

--- a/po/wesnoth-lib/af.po
+++ b/po/wesnoth-lib/af.po
@@ -6156,7 +6156,7 @@ msgstr "Druk verlangde Kortpadsleutel"
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr ""
+msgstr "af"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/ang.po
+++ b/po/wesnoth-lib/ang.po
@@ -5738,7 +5738,7 @@ msgstr ""
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr ""
+msgstr "ang"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/ar.po
+++ b/po/wesnoth-lib/ar.po
@@ -6223,7 +6223,7 @@ msgstr "اضغط على المفتاح المُراد"
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr ""
+msgstr "ar"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/ast.po
+++ b/po/wesnoth-lib/ast.po
@@ -5739,7 +5739,7 @@ msgstr ""
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr ""
+msgstr "ast"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/bg.po
+++ b/po/wesnoth-lib/bg.po
@@ -6206,7 +6206,7 @@ msgstr "Натиснете желаният клавиш"
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr ""
+msgstr "bg"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/ca.po
+++ b/po/wesnoth-lib/ca.po
@@ -6237,7 +6237,7 @@ msgstr "Premeu la tecla desitjada (o cancel·leu amb la tecla d'escapada)"
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr ""
+msgstr "ca"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/ca_ES@valencia.po
+++ b/po/wesnoth-lib/ca_ES@valencia.po
@@ -6235,7 +6235,7 @@ msgstr "Premeu la tecla desitjada (o cancel·leu amb la tecla d'escapada)"
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr ""
+msgstr "ca@valencia,ca"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/da.po
+++ b/po/wesnoth-lib/da.po
@@ -6234,7 +6234,7 @@ msgstr "Tryk ønsket genvejstast"
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr ""
+msgstr "da,sv"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/el.po
+++ b/po/wesnoth-lib/el.po
@@ -6078,7 +6078,7 @@ msgstr "Πατήστε τη Συντόμευση Πληκτρολογίου πο
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr ""
+msgstr "el"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/eo.po
+++ b/po/wesnoth-lib/eo.po
@@ -6219,7 +6219,7 @@ msgstr "Premu klavon, kiun vi volas uzi"
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr ""
+msgstr "eo"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/et.po
+++ b/po/wesnoth-lib/et.po
@@ -6109,7 +6109,7 @@ msgstr "Vajuta soovitud kiirklahvi (Esc tühistab)"
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr "et_EE"
+msgstr "et_EE,et"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/eu.po
+++ b/po/wesnoth-lib/eu.po
@@ -6147,7 +6147,7 @@ msgstr "Hautatutako lasterbidea sakatu"
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr ""
+msgstr "eu"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/fur_IT.po
+++ b/po/wesnoth-lib/fur_IT.po
@@ -5737,7 +5737,7 @@ msgstr ""
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr ""
+msgstr "fur"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/ga.po
+++ b/po/wesnoth-lib/ga.po
@@ -6094,7 +6094,7 @@ msgstr ""
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr "ga_IE"
+msgstr "ga_IE,ga"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/hr.po
+++ b/po/wesnoth-lib/hr.po
@@ -5739,7 +5739,7 @@ msgstr ""
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr ""
+msgstr "hr"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/id.po
+++ b/po/wesnoth-lib/id.po
@@ -6104,7 +6104,7 @@ msgstr "Tekan hotkey yang diinginkan (Esc membatalkan)"
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr "kode bahasa untuk sumber daya yang dilokalisir"
+msgstr "id"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/is.po
+++ b/po/wesnoth-lib/is.po
@@ -6254,7 +6254,7 @@ msgstr "Ýttu á ósksaðan flýtilykil (Esc hættir við)"
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr ""
+msgstr "is"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/ko.po
+++ b/po/wesnoth-lib/ko.po
@@ -6100,7 +6100,7 @@ msgstr "원하는 단축키를 누르세요 (Esc는 취소)"
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr ""
+msgstr "ko"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/lv.po
+++ b/po/wesnoth-lib/lv.po
@@ -6113,7 +6113,7 @@ msgstr "Nospied vēlamo karsto taustiņu (Esc atceļ)"
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr "lv_LV"
+msgstr "lv_LV,lv"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/mk.po
+++ b/po/wesnoth-lib/mk.po
@@ -5813,7 +5813,7 @@ msgstr ""
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr ""
+msgstr "mk"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/mr.po
+++ b/po/wesnoth-lib/mr.po
@@ -5737,7 +5737,7 @@ msgstr ""
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr ""
+msgstr "mr"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/nb_NO.po
+++ b/po/wesnoth-lib/nb_NO.po
@@ -6251,7 +6251,7 @@ msgstr "Trykk ønsket hurtigtast (Esc avbryter)"
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr ""
+msgstr "nb,no"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/racv.po
+++ b/po/wesnoth-lib/racv.po
@@ -6228,7 +6228,7 @@ msgstr "Pulsa la tecla desijada"
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr ""
+msgstr "racv"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/ro.po
+++ b/po/wesnoth-lib/ro.po
@@ -5870,7 +5870,7 @@ msgstr ""
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr ""
+msgstr "ro"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/tl.po
+++ b/po/wesnoth-lib/tl.po
@@ -6023,7 +6023,7 @@ msgstr ""
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr ""
+msgstr "tl"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."

--- a/po/wesnoth-lib/tr.po
+++ b/po/wesnoth-lib/tr.po
@@ -6258,7 +6258,7 @@ msgstr "Klavye kısayolunu gir (Esc iptal eder)"
 #. translate this message as "sv,da", while Danish as "da,sv".
 #: src/image.cpp:452
 msgid "language code for localized resources^en_US"
-msgstr ""
+msgstr "tr"
 
 #: src/marked-up_text.cpp:443
 msgid "The maximum text width is less than 1."


### PR DESCRIPTION
I recognise that translations are normally supposed to go through Ivanovic. But since this pertains to the code's handling of translated images and not translated text, I think this should be an acceptable exception.