### PR TITLE
Avoid tstring/string conflict error in team_info.

### DIFF
--- a/src/team.cpp
+++ b/src/team.cpp
@@ -124,7 +124,7 @@ void team::team_info::read(const config &cfg)
 	income = cfg["income"];
 	team_name = cfg["team_name"].str();
 	user_team_name = cfg["user_team_name"];
-	side_name = cfg["side_name"];
+	side_name = cfg["side_name"].str();
 	save_id = cfg["save_id"].str();
 	current_player = cfg["current_player"].str();
 	countdown_time = cfg["countdown_time"].str();

--- a/src/team.hpp
+++ b/src/team.hpp
@@ -117,7 +117,7 @@ private:
 		std::set<std::string> can_recruit;
 		std::string team_name;
 		t_string user_team_name;
-		t_string side_name;
+		std::string side_name;
 		std::string save_id;
 		// 'id' of the current player (not necessarily unique)
 		std::string current_player;


### PR DESCRIPTION
Declare team_name as a std::string rather than a tstring to avoid a
compilation error when used in a ternary expression with another
std:string.

Translate by calling .str() after reading from the config file.

I'm a new contributor here and ran into this as soon as I tried to build. Let me know if this is the correct approach -- the contributor guide had some warnings with regards to the proper handling of `std::string` vs `t_string`.

The error was
```
In file included from src/actions/../display.hpp:57:0,
                 from src/actions/../game_display.hpp:28,
                 from src/actions/attack.cpp:29:
src/actions/../team.hpp: In member function ‘const string& team::side_name() const’:
src/actions/../team.hpp:306:72: error: operands to ?: have different types ‘const string {aka const std::__cxx11::basic_string<char>}’ and ‘const t_string’
  const std::string& side_name() const { return info_.side_name.empty() ? info_.current_player : info_.side_name; }
                                                                        ^
src/actions/../team.hpp:306:72: note:   and each type can be converted to the other

```