### PR TITLE
Fix cmake reference to make_enum.cpp.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1029,7 +1029,7 @@ set(libwesnoth-game_STAT_SRC
 	language.cpp
 	loadscreen.cpp
 	lobby_preferences.cpp
-	make_enum.cpp
+	utils/make_enum.cpp
 	map/label.cpp
 	marked-up_text.cpp
 	minimap.cpp


### PR DESCRIPTION
make_enum.cpp was moved to utils/make_enum.cpp, and src/CMakeLists.txt
wasn't updated.