### PR TITLE
Added faction_name field for unit table in Lua API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ cmake_install.cmake
 CPack*Config.cmake
 uninstall.cmake
 CMakeCache.txt
+install_manifest.txt
 
 # scons
 .scons-option-cache

--- a/changelog
+++ b/changelog
@@ -134,10 +134,12 @@ Version 1.13.4+dev:
      * abilities - list of the IDs of all abilities
    * Additional fields in table returned by wesnoth.get_terrain_info:
      * icon, editor_image, light
-   * Additional fields in unit type proxu:
+   * Additional fields in unit type proxy:
      * race, id, alignment
      * attacks, which returns the same thing as unit.attacks
      * abilities, same as unit.abilities
+   * Additional field in side proxy:
+     * faction_name
    * LuaAI:
      * The table returned by check_*() now has a "result" field which
        gives a description of the action's result; similar to "status"

--- a/data/multiplayer/scenarios/2p_Hornshark_Island.cfg
+++ b/data/multiplayer/scenarios/2p_Hornshark_Island.cfg
@@ -65,18 +65,6 @@
     [event]
         name=prestart
 
-        [set_variables]
-            name=factions
-            [value]
-                {multiplayer/factions/drakes-default.cfg}
-                {multiplayer/factions/knalgans-default.cfg}
-                {multiplayer/factions/loyalists-default.cfg}
-                {multiplayer/factions/northerners-default.cfg}
-                {multiplayer/factions/rebels-default.cfg}
-                {multiplayer/factions/undead-default.cfg}
-            [/value]
-        [/set_variables]
-
         [lua]
             code={./2p_Hornshark_Island_lua}
         [/lua]
@@ -93,7 +81,7 @@
         [switch]
             variable=p1_faction
             [case]
-                value=$factions.multiplayer_side[0].id
+                value=_ "Drakes"
 
                 [unit]
                     side=1
@@ -149,7 +137,7 @@
                 [/unit]
             [/case]
             [case]
-                value=$factions.multiplayer_side[1].id
+                value=_ "Knalgan Alliance"
 
                 [unit]
                     side=1
@@ -214,7 +202,7 @@
             [/case]
 
             [case]
-                value=$factions.multiplayer_side[2].id
+                value=_ "Loyalists"
 
                 [unit]
                     side=1
@@ -289,7 +277,7 @@
             [/case]
 
             [case]
-                value=$factions.multiplayer_side[3].id
+                value=_ "Northerners"
 
                 [unit]
                     side=1
@@ -343,7 +331,7 @@
             [/case]
 
             [case]
-                value=$factions.multiplayer_side[4].id
+                value=_ "Rebels"
 
                 [unit]
                     side=1
@@ -400,7 +388,7 @@
                 [/unit]
             [/case]
             [case]
-                value=$factions.multiplayer_side[5].id
+                value=_ "Drakes"
 
                 [unit]
                     x,y=23,3
@@ -553,7 +541,7 @@
         [switch]
             variable=p2_faction
             [case]
-                value=$factions.multiplayer_side[0].id
+                value=_ "Drakes"
 
                 [unit]
                     side=2
@@ -609,7 +597,7 @@
                 [/unit]
             [/case]
             [case]
-                value=$factions.multiplayer_side[1].id
+                value=_ "Knalgan Alliance"
 
                 [unit]
                     side=2
@@ -674,7 +662,7 @@
             [/case]
 
             [case]
-                value=$factions.multiplayer_side[2].id
+                value=_ "Loyalists"
 
                 [unit]
                     side=2
@@ -749,7 +737,7 @@
             [/case]
 
             [case]
-                value=$factions.multiplayer_side[3].id
+                value=_ "Northerners"
 
                 [unit]
                     side=2
@@ -803,7 +791,7 @@
             [/case]
 
             [case]
-                value=$factions.multiplayer_side[4].id
+                value=_ "Rebels"
 
                 [unit]
                     side=2
@@ -860,7 +848,7 @@
                 [/unit]
             [/case]
             [case]
-                value=$factions.multiplayer_side[5].id
+                value=_ "Undead"
 
                 [unit]
                     x,y=6,20

--- a/data/multiplayer/scenarios/2p_Hornshark_Island.cfg
+++ b/data/multiplayer/scenarios/2p_Hornshark_Island.cfg
@@ -388,7 +388,7 @@
                 [/unit]
             [/case]
             [case]
-                value=_ "Drakes"
+                value=_ "Undead"
 
                 [unit]
                     x,y=23,3

--- a/data/multiplayer/scenarios/2p_Hornshark_Island_lua
+++ b/data/multiplayer/scenarios/2p_Hornshark_Island_lua
@@ -1,40 +1,8 @@
 <<
-	local factions = wesnoth.get_variable("factions")
-	local function detect_faction(side_number)
-		local helper = wesnoth.require("lua/helper.lua")
-		for multiplayer_side in helper.child_range(factions, "multiplayer_side") do
-			local function recruits_match()
-				local count = 0
-				for searched in string.gmatch(multiplayer_side.recruit, "[^%s,][^,]*") do
-					count = count + 1
-					local found = false
-					for i, actual in ipairs(wesnoth.sides[side_number].recruit) do
-						if searched == actual then
-							found = true
-							break
-						end
-					end
-					if not found then return false end
-				end
-				return count == #wesnoth.sides[side_number].recruit
-			end
-			local function leader_matches()
-				local actual = wesnoth.get_units({ canrecruit = true, side = side_number })[1]
-
-				if actual then
-					for searched in string.gmatch(multiplayer_side.leader, "[^%s,][^,]*") do
-						if searched == actual.type then return true end
-					end
-				else
-					return false
-				end
-			end
-			if recruits_match() and leader_matches() then
-				wesnoth.set_variable("p" .. tostring(side_number) .. "_faction", multiplayer_side.id)
-				return
-			end
-		end
+local function detect_factions()
+	for i, side in ipairs(wesnoth.get_sides({})) do
+		wesnoth.set_variable("p" .. tostring(i) .. "_faction", side.faction_name)
 	end
-	detect_faction(1)
-	detect_faction(2)
+end
+detect_factions()
 >>

--- a/src/gui/dialogs/lua_interpreter.cpp
+++ b/src/gui/dialogs/lua_interpreter.cpp
@@ -321,7 +321,7 @@ public:
 #ifdef HAVE_HISTORY
 		// Do history expansions
 		char * cmd_cstr = new char [cmd.length()+1];
-		std::strcpy (cmd_cstr, cmd.c_str());
+		strcpy (cmd_cstr, cmd.c_str());
 
 		char * expansion;
 

--- a/src/scripting/lua_team.cpp
+++ b/src/scripting/lua_team.cpp
@@ -68,6 +68,7 @@ static int impl_side_get(lua_State *L)
 	return_string_attrib("flag_icon", t.flag_icon());
 	return_tstring_attrib("user_team_name", t.user_team_name());
 	return_string_attrib("team_name", t.team_name());
+        return_tstring_attrib("faction_name", t.faction_name());
 	return_string_attrib("color", t.color());
 	return_cstring_attrib("controller", t.controller().to_string().c_str());
 	return_string_attrib("defeat_condition", t.defeat_condition().to_string());
@@ -125,6 +126,7 @@ static int impl_side_set(lua_State *L)
 	modify_bool_attrib("carryover_add", t.set_carryover_add(value));
 	modify_bool_attrib("lost", t.set_lost(value));
 	modify_bool_attrib("persistent", t.set_persistent(value));
+        modify_tstring_attrib("faction_name", t.set_faction_name(value));
 
 	if (strcmp(m, "carryover_bonus") == 0) {
 		t.set_carryover_bonus(luaL_checknumber(L, 3));

--- a/src/team.cpp
+++ b/src/team.cpp
@@ -83,6 +83,7 @@ team::team_info::team_info() :
 	team_name(),
 	user_team_name(),
 	side_name(),
+	faction_name(),
 	save_id(),
 	current_player(),
 	countdown_time(),
@@ -122,6 +123,7 @@ void team::team_info::read(const config &cfg)
 	team_name = cfg["team_name"].str();
 	user_team_name = cfg["user_team_name"];
 	side_name = cfg["side_name"];
+	faction_name = cfg["faction_name"];
 	save_id = cfg["save_id"].str();
 	current_player = cfg["current_player"].str();
 	countdown_time = cfg["countdown_time"].str();
@@ -239,6 +241,7 @@ void team::team_info::write(config& cfg) const
 	cfg["team_name"] = team_name;
 	cfg["user_team_name"] = user_team_name;
 	cfg["side_name"] = side_name;
+	cfg["faction_name"] = faction_name;
 	cfg["save_id"] = save_id;
 	cfg["current_player"] = current_player;
 	cfg["flag"] = flag;
@@ -540,6 +543,11 @@ void team::change_team(const std::string &name, const t_string &user_name)
 	}
 
 	clear_caches();
+}
+
+void team::set_faction_name(const t_string &faction_name)
+{
+        info_.faction_name = faction_name;
 }
 
 void team::clear_caches(){

--- a/src/team.hpp
+++ b/src/team.hpp
@@ -118,6 +118,7 @@ private:
 		std::string team_name;
 		t_string user_team_name;
 		t_string side_name;
+		t_string faction_name;
 		std::string save_id;
 		// 'id' of the current player (not necessarily unique)
 		std::string current_player;
@@ -296,6 +297,9 @@ public:
 	const std::string& team_name() const { return info_.team_name; }
 	const t_string &user_team_name() const { return info_.user_team_name; }
 	void change_team(const std::string &name, const t_string &user_name);
+
+	const t_string &faction_name() const { return info_.faction_name; }
+	void  set_faction_name(const t_string &faction_name);
 
 	const std::string& flag() const { return info_.flag; }
 	const std::string& flag_icon() const { return info_.flag_icon; }


### PR DESCRIPTION
Hi there,

I added a possibility to access the multiplayer faction via Lua. This makes faction-based scenarios like Hornshark Island easier to determine the faction of a side.