### PR TITLE
Allow explicit use of any CC license for UMC assets

### DIFF
--- a/src/campaign_server/campaign_server.cpp
+++ b/src/campaign_server/campaign_server.cpp
@@ -614,7 +614,7 @@ void server::handle_request_terms(const server::request& req)
 	}
 
 	LOG_CS << "sending terms " << req.addr << "\n";
-	send_message("All content within add-ons uploaded to this server must be licensed under the terms of the GNU General Public License (GPL), with the sole exception of artwork and audio explicitly denoted as released under a Creative Commons license either in a) a toplevel file named ART_LICENSE or b) a file with the same path as the asset with `.license` appended. By uploading content to this server, you certify that you have the right a) to release all included art and audio explicitly denoted with a Creative Commons license in the proscribed manner under that license, and b) to release all other included content under the terms of the GPL; and that you choose to do so.", req.sock);
+	send_message("All content within add-ons uploaded to this server must be licensed under the terms of the GNU General Public License (GPL), with the sole exception of artwork and audio explicitly denoted as released under a Creative Commons license either in a) a toplevel file named ART_LICENSE, e.g. `add-ons/My_Addon/ART_LICENSE`, or b) a file with the same path as the asset with `.license` appended, e.g. `add-ons/My_Addon/images/units/axeman.png.license`. By uploading content to this server, you certify that you have the right a) to release all included art and audio explicitly denoted with a Creative Commons license in the proscribed manner under that license, and b) to release all other included content under the terms of the GPL; and that you choose to do so.", req.sock);
 	LOG_CS << " Done\n";
 }
 

--- a/src/campaign_server/campaign_server.cpp
+++ b/src/campaign_server/campaign_server.cpp
@@ -614,7 +614,7 @@ void server::handle_request_terms(const server::request& req)
 	}
 
 	LOG_CS << "sending terms " << req.addr << "\n";
-	send_message("All add-ons uploaded to this server must be licensed under the terms of the GNU General Public License (GPL). By uploading content to this server, you certify that you have the right to place the content under the conditions of the GPL, and choose to do so.", req.sock);
+	send_message("All content within add-ons uploaded to this server not otherwise explicitly licensed must be licensed under the terms of the GNU General Public License (GPL). By uploading content to this server, you certify that you have the right a) to place all content not otherwise explicitly licensed under the conditions of the GPL and b) to release all explicitly licensed content for download on this server, and that you choose to do so.", req.sock);
 	LOG_CS << " Done\n";
 }
 

--- a/src/campaign_server/campaign_server.cpp
+++ b/src/campaign_server/campaign_server.cpp
@@ -614,7 +614,7 @@ void server::handle_request_terms(const server::request& req)
 	}
 
 	LOG_CS << "sending terms " << req.addr << "\n";
-	send_message("All content within add-ons uploaded to this server not otherwise explicitly licensed must be licensed under the terms of the GNU General Public License (GPL). By uploading content to this server, you certify that you have the right a) to place all content not otherwise explicitly licensed under the conditions of the GPL and b) to release all explicitly licensed content for download on this server, and that you choose to do so.", req.sock);
+	send_message("All content within add-ons uploaded to this server must be licensed under the terms of the GNU General Public License (GPL), with the sole exception of artwork and audio explicitly denoted as released under a Creative Commons license. By uploading content to this server, you certify that you have the right a) to release all included art and audio explicitly denoted with a Creative Commons license under that license, and b) to release all other included content under the terms of the GPL; and that you choose to do so.", req.sock);
 	LOG_CS << " Done\n";
 }
 

--- a/src/campaign_server/campaign_server.cpp
+++ b/src/campaign_server/campaign_server.cpp
@@ -614,7 +614,7 @@ void server::handle_request_terms(const server::request& req)
 	}
 
 	LOG_CS << "sending terms " << req.addr << "\n";
-	send_message("All content within add-ons uploaded to this server must be licensed under the terms of the GNU General Public License (GPL), with the sole exception of artwork and audio explicitly denoted as released under a Creative Commons license. By uploading content to this server, you certify that you have the right a) to release all included art and audio explicitly denoted with a Creative Commons license under that license, and b) to release all other included content under the terms of the GPL; and that you choose to do so.", req.sock);
+	send_message("All content within add-ons uploaded to this server must be licensed under the terms of the GNU General Public License (GPL), with the sole exception of artwork and audio explicitly denoted as released under a Creative Commons license either in a) a toplevel file named ART_LICENSE or b) a file with the same path as the asset with `.license` appended. By uploading content to this server, you certify that you have the right a) to release all included art and audio explicitly denoted with a Creative Commons license in the proscribed manner under that license, and b) to release all other included content under the terms of the GPL; and that you choose to do so.", req.sock);
 	LOG_CS << " Done\n";
 }
 


### PR DESCRIPTION
The mandatory use of the GPL for all things Wesnoth has long been a sticky point for contributors, especially those not contributing to core (i.e. creating UMC add-ons).  [Here](https://forums.wesnoth.org/viewtopic.php?f=2&t=42966&p=588491#p588491) are a few [examples](https://forums.wesnoth.org/viewtopic.php?f=6&t=42975&p=588173#p588173) of forum [discussion](https://forums.wesnoth.org/viewtopic.php?f=14&t=41454&p=579487#p579340), and [an explanation](http://shadowm.ai0867.net/blog/archives/54-Original-music-in-Wesnoth-content.html) of why the current state of affairs is not ideal.

There's been much talk about addressing the issue, but no action, and the only actual planned solution is to allow use of Creative Commons licensing, which still forces content creators to give up some rights beyond simple redistribution of the unified work. Some authors wishing to use non-GPL resources have gone so far as to [attempt to disanull the upload agreement by asserting licensing terms within the add-on itself](https://github.com/wescamp/A_New_Order-1.10/blob/master/A_New_Order/LICENSE.important.txt).

This PR seeks only to allow content authors to not agree to sign away all their work under the GPL, instead only requiring that they allow distribution through the official add-on server, while still maintaining current behavior for all content not explicitly licensed. Changing the default license is far beyond the scope of this PR. Any discussion of the exact text changes is welcomed.
