### PR TITLE
Improve the control reassignment dialog when a player leaves

### DIFF
--- a/changelog
+++ b/changelog
@@ -20,6 +20,8 @@ Version 1.13.4+dev:
      horizontal UI resolutions < 1024 (bug #24455).
    * Fixed ToD schedule progress indicator appearing behind other top bar items
      on vertical UI resolutions < 600.
+   * Improved the dialog for choosing what to do when a player leaves in
+     multiplayer.
  * WML engine:
    * Fix some issues with [foreach]
    * Fix some issues with backstab-like weapon specials

--- a/src/playturn.cpp
+++ b/src/playturn.cpp
@@ -291,12 +291,17 @@ turn_info::PROCESS_DATA_RESULT turn_info::process_network_data(const config& cfg
 			dlg.set_single_button(true);
 			dlg.show(resources::screen->video());
 			action = dlg.selected_index();
+
+			// If esc was pressed, default to replace with local player
+			if (action == -1) {
+				action = control_change_options + 1;
+			}
 		} else {
-			// In linger mode, always set leaving side to idle
+			// Always set leaving side to idle if in linger mode and there is no next scenario
 			action = 2;
 		}
 
-		if (action > -1 && action < control_change_options) {
+		if (action < control_change_options) {
 			// Grant control to selected ally
 			
 			{
@@ -343,11 +348,6 @@ turn_info::PROCESS_DATA_RESULT turn_info::process_network_data(const config& cfg
 					break;
 			}
 		}
-
-		//Lua code currently catches this exception if this function was called from lua code
-		// in that case network::error doesn't end the game.
-		// but at least he sees this error message.
-		throw network::error("Network Error: A player left and you pressed Escape.");
 	}
 
 	// The host has ended linger mode in a campaign -> enable the "End scenario" button

--- a/src/playturn.cpp
+++ b/src/playturn.cpp
@@ -296,7 +296,7 @@ turn_info::PROCESS_DATA_RESULT turn_info::process_network_data(const config& cfg
 			action = 2;
 		}
 
-		if (action < control_change_options) {
+		if (action > -1 && action < control_change_options) {
 			// Grant control to selected ally
 			
 			{

--- a/src/playturn.cpp
+++ b/src/playturn.cpp
@@ -292,9 +292,9 @@ turn_info::PROCESS_DATA_RESULT turn_info::process_network_data(const config& cfg
 			dlg.show(resources::screen->video());
 			action = dlg.selected_index();
 
-			// If esc was pressed, default to replace with local player
+			// If esc was pressed, default to setting side to idle
 			if (action == -1) {
-				action = control_change_options + 1;
+				action = control_change_options + 2;
 			}
 		} else {
 			// Always set leaving side to idle if in linger mode and there is no next scenario


### PR DESCRIPTION
This moves the options for giving control to an ally/observer to the top of the list, labels them more descriptively, and prevents the dialog from appearing during linger mode if there is no next scenario.

Old:
Replace with AI
Replace with local player
Set side to idle
Save and abort game
Replace with (observer1)
Replace with (observer2)
Replace with (ally1)
Replace with (ally2)

New:
Give control to their ally (ally1)
Give control to their ally (ally2)
Give control to observer (observer1)
Give control to observer (observer2)
Replace with AI
Replace with local player
Set side to idle
Save and abort game