### PR TITLE
Fix bug #24234: Add Boost 1.60.0 support to unit tests

### DIFF
--- a/changelog
+++ b/changelog
@@ -16,6 +16,7 @@ Version 1.12.5+dev:
    * Fixed possible assertion failues in mp.
    * Fixed false positive OOS messages in replay when replaying games from an older
      wesnoth version..
+   * Fixed unit test compilation against Boost 1.60 and later (bug #24234).
 
 Version 1.12.5:
  * Campaigns:

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -16,10 +16,18 @@
 
 
 #define BOOST_TEST_MODULE wesnoth unit tests master suite
+
+#include <boost/version.hpp>
+
 #include <boost/test/unit_test.hpp>
 #include <boost/test/unit_test_monitor.hpp>
+#if BOOST_VERSION >= 106000
+#include <boost/test/unit_test_parameters.hpp>
+#else
 #include <boost/test/detail/unit_test_parameters.hpp>
+#endif
 #include <boost/test/results_reporter.hpp>
+
 
 #include <fstream>
 
@@ -80,6 +88,15 @@ struct wesnoth_global_fixture {
 
 
 		// Set more report as default
+#if BOOST_VERSION >= 106000
+		if (boost::unit_test::runtime_config::get<boost::unit_test::log_level>(boost::unit_test::runtime_config::LOG_LEVEL) == boost::unit_test::invalid_log_level)
+			boost::unit_test::unit_test_log.set_threshold_level( boost::unit_test::log_messages );
+		if (boost::unit_test::runtime_config::get<boost::unit_test::report_level>(boost::unit_test::runtime_config::REPORT_LEVEL) == boost::unit_test::INV_REPORT_LEVEL)
+			boost::unit_test::results_reporter::set_level(boost::unit_test::SHORT_REPORT);
+		boost::unit_test::unit_test_monitor.register_exception_translator<game::error>(&exception_translator_game);
+		boost::unit_test::unit_test_monitor.register_exception_translator<network::error>(&exception_translator_network);
+		boost::unit_test::unit_test_monitor.register_exception_translator<config::error>(&exception_translator_config);
+#else
 		if (boost::unit_test::runtime_config::log_level() == boost::unit_test::invalid_log_level)
 			boost::unit_test::unit_test_log.set_threshold_level( boost::unit_test::log_messages );
 		if (boost::unit_test::runtime_config::report_level() == boost::unit_test::INV_REPORT_LEVEL)
@@ -87,6 +104,7 @@ struct wesnoth_global_fixture {
 		boost::unit_test::unit_test_monitor.register_exception_translator<game::error>(&exception_translator_game);
 		boost::unit_test::unit_test_monitor.register_exception_translator<network::error>(&exception_translator_network);
 		boost::unit_test::unit_test_monitor.register_exception_translator<config::error>(&exception_translator_config);
+#endif
 	}
 	~wesnoth_global_fixture()
 	{
@@ -94,7 +112,7 @@ struct wesnoth_global_fixture {
 	}
 };
 
-BOOST_GLOBAL_FIXTURE(wesnoth_global_fixture)
+BOOST_GLOBAL_FIXTURE(wesnoth_global_fixture);
 
 /*
  * This is a main compilation unit for the test program.

--- a/src/tests/test_mp_connect.cpp
+++ b/src/tests/test_mp_connect.cpp
@@ -121,8 +121,8 @@ static mp::side_engine* create_mp_side_engine(const config& defaults,
 
 /* Tests */
 
-BOOST_GLOBAL_FIXTURE( mp_connect_fixture )
-BOOST_AUTO_TEST_SUITE( mp_connect )
+BOOST_GLOBAL_FIXTURE( mp_connect_fixture );
+BOOST_AUTO_TEST_SUITE( mp_connect );
 
 
 BOOST_AUTO_TEST_CASE( flg_map_settings )

--- a/src/tests/utils/auto_parameterized.hpp
+++ b/src/tests/utils/auto_parameterized.hpp
@@ -15,8 +15,14 @@
 #ifndef TESTS_UTILS_AUTO_PARAMETERIZED_HPP_INCLUDED
 #define TESTS_UTILS_AUTO_PARAMETERIZED_HPP_INCLUDED
 
+#include <boost/version.hpp>
+
 #include <boost/test/unit_test_suite.hpp>
 #include <boost/test/parameterized_test.hpp>
+
+#if BOOST_VERSION >= 106000
+#include <boost/test/tree/auto_registration.hpp>
+#endif
 
 namespace test_utils {
 
@@ -24,6 +30,7 @@ namespace test_utils {
 #define BOOST_AUTO_TU_REGISTRAR BOOST_AUTO_TC_REGISTRAR
 #endif
 
+#if BOOST_VERSION >= 106000
 #define WESNOTH_PARAMETERIZED_TEST_CASE( test_name, type_name, values, param_name )   \
 struct test_name : public BOOST_AUTO_TEST_CASE_FIXTURE                  \
 { void test_method(const type_name&); };                                \
@@ -39,12 +46,37 @@ static void BOOST_AUTO_TC_INVOKER( test_name )(const type_name& param_name ) \
 struct BOOST_AUTO_TC_UNIQUE_ID( test_name ) {};                         \
                                                                         \
 BOOST_AUTO_TU_REGISTRAR( test_name )( \
-		boost::unit_test::make_test_case(&BOOST_AUTO_TC_INVOKER( test_name ),      \
-			BOOST_TEST_STRINGIZE( test_name ),\
-			BOOST_JOIN(test_name, _begin), BOOST_JOIN(test_name, _end)));		\
+				     boost::unit_test::make_test_case(&BOOST_AUTO_TC_INVOKER( test_name ), \
+								      BOOST_TEST_STRINGIZE( test_name ), \
+								      BOOST_TEST_STRINGIZE(__FILE__), __LINE__, \
+								      BOOST_JOIN(test_name, _begin), BOOST_JOIN(test_name, _end)), \
+				     boost::unit_test::decorator::collector::instance()); \
                                                                        \
 void test_name::test_method(const type_name& param_name)                \
 /**/
+#else
+#define WESNOTH_PARAMETERIZED_TEST_CASE( test_name, type_name, values, param_name )   \
+struct test_name : public BOOST_AUTO_TEST_CASE_FIXTURE                  \
+{ void test_method(const type_name&); };                                \
+\
+type_name* BOOST_JOIN(test_name, _begin) = &values[0];    \
+type_name* BOOST_JOIN(test_name, _end) = BOOST_JOIN(test_name, _begin) + (sizeof(values)/sizeof(values[0])); \
+static void BOOST_AUTO_TC_INVOKER( test_name )(const type_name& param_name ) \
+{ \
+	test_name t;                                                        \
+    t.test_method(param_name);       \
+}                                                                       \
+                                                                        \
+struct BOOST_AUTO_TC_UNIQUE_ID( test_name ) {};                         \
+                                                                        \
+BOOST_AUTO_TU_REGISTRAR( test_name )( \
+				     boost::unit_test::make_test_case(&BOOST_AUTO_TC_INVOKER( test_name ), \
+								      BOOST_TEST_STRINGIZE( test_name ), \
+								      BOOST_JOIN(test_name, _begin), BOOST_JOIN(test_name, _end))); \
+                                                                       \
+void test_name::test_method(const type_name& param_name)                \
+/**/
+#endif
 
 }
 #endif


### PR DESCRIPTION
This backports Aginor's commit ff29581baa74dbc6ce1923e1352f4fd6d423a67d from master to 1.12 to solve compiler errors found when trying to build Wesnoth 1.12's unit tests against Boost 1.60.