### PR TITLE
Improvements in the name and map generators

### DIFF
--- a/changelog
+++ b/changelog
@@ -155,7 +155,7 @@ Version 1.13.4+dev:
      and [deprecated_message] tags now use this.
    * New wesnoth.name_generator function builds a name generator and returns
      it as a callable userdata. Both the original Markov chain generator
-     and the new context free gramamr generator are supported
+     and the new context free grammar generator are supported
    * WML tables defined in Lua now accept string keys with array values
      (where "array" is a table whose keys are all integers). This joins
      the elements of the array with commas and produces a single string
@@ -279,6 +279,9 @@ Version 1.13.4+dev:
      * pair() function that produces a key-value pair suitable for
        passing to tomap() - this also means key-value pairs are now
        serializable (relevant in FormulaAI)
+   * Map generator engine:
+     * makes now use of the new context free grammar name generator
+     * ported name generation from english.cfg to [naming]
    * Bugfixes:
      * Dice operator is now synced (where possible)
      * Modulus (%) operator now works on decimal numbers

--- a/data/core/macros/names.cfg
+++ b/data/core/macros/names.cfg
@@ -248,8 +248,8 @@ suffix=men|drum|tor|num|lad|de|ak|lol|dum|tam|nur|dium|deum|bil|rook|relm|dium|n
 #enddef
 
 #define VILLAGE_NAMES
-    male_names= _ "Bal,Cam,Corn,Del,Earl,El,Fox,Fren,Gel,Hel,Hex,Hol,Hox,Il,Kin,Nam,Nes,New,Ol,Old,Olf,Oul,Ox,Rock,Rook,Sal,Sam,Sed,Sel,Sen,Sil,Tal,Water,Wet,York"
-    name_generator= _ <<
+    base_names= _ "Bal,Cam,Corn,Del,Earl,El,Fox,Fren,Gel,Hel,Hex,Hol,Hox,Il,Kin,Nam,Nes,New,Ol,Old,Olf,Oul,Ox,Rock,Rook,Sal,Sam,Sed,Sel,Sen,Sil,Tal,Water,Wet,York"
+    base_name_generator= _ <<
 main={prefix}{middle}{suffix}
 prefix=B|C|D|E|F|Fr|Wat|G|H|K|N|O|R|S|T|W|Y|Ro
 middle=a|e|o|u|i

--- a/data/english.cfg
+++ b/data/english.cfg
@@ -19,26 +19,6 @@ Night: +25% Damage"
 Day: −25% Damage
 Night: −25% Damage"
 
-    #naming of terrain features
-    bridge_name= _ "$name|’s Bridge,$name|’s Crossing"
-    road_name= _ "$name|’s Highway,$name|’s Pass,Path of $name"
-    river_name= _ "$name River,River $name"
-    forest_name= _ "$name Forest,$name|’s Forest"
-    lake_name= _ "$name Lake"
-    mountain_name= _ "$name|’s Peak,Mount $name"
-    swamp_name= _ "$name|’s Swamp,$name|marsh,$name|fen"
-    village_name= _ "$name|bury,$name|ham,$name|ton,$name|bury"
-    village_name_lake= _ "$name|harbor,$name|port,$lake|port,$lake|harbor"
-    village_name_river= _ "$name|ham,$name|ford,$name|cross,$river|ford,$river|cross,$name on river"
-    village_name_river_bridge= _ "$river|bridge,$river|bridge,$river|bridge,$name|ham,$name|bridge,$bridge|ham,$bridge|ton"
-    village_name_grassland= _ "$name|ham,$name|ton,$name|field"
-    village_name_forest= _ "$name|ham,$name|ton,$name|wood,$name Forest,$forest|wood,$forest|ham,$forest|ton"
-    village_name_hill= _ "$name|ham,$name|bury,$name|ton,$name|hill,$name|crest"
-    village_name_mountain= _ "$mountain|mont,$mountain|cliff,$mountain|bury,$mountain|ham"
-    village_name_mountain_anonymous= _ "$name|ham,$name|bury,$name|ton,$name|mont,$name|mont,$name|cliff,$name|cliff"
-    village_name_road= _ "$road|’s Rest,$road|’s Waypoint,$road|bury,$road|ham,$name|bury,$name|ham"
-    village_name_swamp= _ "$name|bury,$name|ham,$name|ton,$swamp|bury,$swamp|ham,$swamp|ton,"
-
     #ranges
     range_melee= _ "melee"
     range_ranged= _ "ranged"
@@ -51,3 +31,28 @@ Night: −25% Damage"
     type_cold= _ "cold"
     type_arcane= _ "arcane"
 [/language]
+
+#default naming of terrain features
+[naming]
+    bridge_name_generator= _ << main=$base{!}’s Bridge|$base{!}’s Crossing >>
+    road_name_generator= _ << main=$base{!}’s Highway|$base{!}’s Pass|Path of $base >>
+    river_name_generator= _ << main=$base River|River $base >>
+    forest_name_generator= _ << main=$base Forest|$base{!}’s Forest >>
+    lake_name_generator= _ << main=$base{!} Lake >>
+    mountain_name_generator= _ << main=$base{!}’s Peak|Mount $base >>
+    swamp_name_generator= _ << main=$base{!}’s Swamp|base{!}marsh|$base{!}fen >>
+[/naming]
+
+[village_naming]
+    name_generator= _ << main = $base{!}bury|$base{!}ham|$base{!}ton|$base{!}bury >>
+    lake_name_generator= _ << main=$base{!}harbor|$base{!}port|$lake{!}port|$lake{!}harbor >>
+    river_name_generator= _ << main=$base{!}ham|$base{!}ford|$base{!}cross|$river{!}ford|$river{!}cross|$base on $river >>
+    bridge_name_generator= _ << main=$river{!}bridge|$river{!}bridge|$river{!}bridge|$base{!}ham|$base{!}bridge|$bridge{!}ham|$bridge{!}ton >>
+    grassland_name_generator= _ << main=$base{!}ham|$base{!}ton|$base{!}field >>
+    forest_name_generator= _ << main=$base{!}ham|$base{!}ton|$base{!}wood|$base Forest|$forest{!}wood|$forest{!}ham|$forest{!}ton >>
+    hill_name_generator= _ << main=$base{!}ham|$base{!}bury|$base{!}ton|$base{!}hill|$base{!}crest >>
+    mountain_name_generator= _ << main=$mountain{!}mont|$mountain{!}cliff|$mountain{!}bury|$mountain{!}ham >>
+    mountain_anonymous_name_generator= _ << "main=$base{!}ham|$base{!}bury|$base{!}ton|$base{!}mont|$base{!}mont|$base{!}cliff|$base}cliff >>
+    road_name_generator= _ << main=$road{!}’s Rest|$road{!}’s Waypoint|$road{!}bury|$road{!}ham|$base{!}bury|$base{!}ham >>
+    swamp_name_generator= _ << main=$base{!}bury|$base{!}ham|$base}ton|$swamp{!}bury|$swamp{!}ham|$swamp{!}ton >>
+[/village_naming]

--- a/data/multiplayer/scenarios/Random_Scenario_Marsh.cfg
+++ b/data/multiplayer/scenarios/Random_Scenario_Marsh.cfg
@@ -210,6 +210,7 @@
         [/naming]
 
         [village_naming]
+        #village_name_generator= _ << main = {$base}heim|{$base}land|{$base}stett|{$base}dorf >>
             {VILLAGE_NAMES}
         [/village_naming]
     [/generator]

--- a/data/multiplayer/scenarios/Random_Scenario_Marsh.cfg
+++ b/data/multiplayer/scenarios/Random_Scenario_Marsh.cfg
@@ -210,7 +210,6 @@
         [/naming]
 
         [village_naming]
-        #village_name_generator= _ << main = {$base}heim|{$base}land|{$base}stett|{$base}dorf >>
             {VILLAGE_NAMES}
         [/village_naming]
     [/generator]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -986,6 +986,7 @@ set(wesnoth-main_SRC
 	utils/sha1.cpp
 	utils/context_free_grammar_generator.cpp
 	utils/markov_generator.cpp
+	utils/name_generator_factory.cpp
 	variable.cpp
 	variable_info.cpp
 	whiteboard/action.cpp

--- a/src/SConscript
+++ b/src/SConscript
@@ -558,6 +558,7 @@ wesnoth_sources = Split("""
     utils/sha1.cpp
     utils/context_free_grammar_generator.cpp
     utils/markov_generator.cpp
+    utils/name_generator_factory.cpp
     variable_info.cpp
     variable.cpp
     whiteboard/action.cpp

--- a/src/formula/string_utils.cpp
+++ b/src/formula/string_utils.cpp
@@ -27,21 +27,22 @@ static bool two_dots(char a, char b) { return a == '.' && b == '.'; }
 
 namespace utils {
 
+template <typename T>
 class string_map_variable_set : public variable_set
 {
 public:
-	string_map_variable_set(const string_map& map) : map_(map) {}
+	string_map_variable_set(const std::map<std::string,T>& map) : map_(map) {}
 
 	virtual config::attribute_value get_variable_const(const std::string &key) const
 	{
 		config::attribute_value val;
-		const string_map::const_iterator itor = map_.find(key);
+		const auto itor = map_.find(key);
 		if (itor != map_.end())
 			val = itor->second;
 		return val;
 	}
 private:
-	const string_map& map_;
+	const std::map<std::string,T>& map_;
 
 };
 }
@@ -213,7 +214,13 @@ namespace utils {
 
 std::string interpolate_variables_into_string(const std::string &str, const string_map * const symbols)
 {
-	string_map_variable_set set(*symbols);
+	auto set = string_map_variable_set<t_string>(*symbols);
+	return do_interpolation(str, set);
+}
+
+std::string interpolate_variables_into_string(const std::string &str, const std::map<std::string,std::string> * const symbols)
+{
+	auto set = string_map_variable_set<std::string>(*symbols);
 	return do_interpolation(str, set);
 }
 

--- a/src/formula/string_utils.hpp
+++ b/src/formula/string_utils.hpp
@@ -42,6 +42,7 @@ inline bool might_contain_variables(const std::string &str)
  * is nullptr, then game event variables will be used instead.
  */
 std::string interpolate_variables_into_string(const std::string &str, const string_map * const symbols);
+std::string interpolate_variables_into_string(const std::string &str, const std::map<std::string,std::string> * const symbols);
 std::string interpolate_variables_into_string(const std::string &str, const variable_set& variables);
 
 /**

--- a/src/generators/default_map_generator_job.cpp
+++ b/src/generators/default_map_generator_job.cpp
@@ -782,8 +782,6 @@ std::string default_map_generator_job::default_generate_map(size_t width, size_t
 
 	if(misc_labels != nullptr) {
 
-		/////TODO
-
 		name_generator_factory base_generator_factory{ naming, {"male", "base", "bridge", "road", "river", "forest", "lake", "mountain", "swamp"} };
 
 		naming.get_old_attribute("base_names", "male_names", "[naming]male_names= is deprecated, use base_names= instead");

--- a/src/generators/default_map_generator_job.hpp
+++ b/src/generators/default_map_generator_job.hpp
@@ -28,8 +28,8 @@ class unit_race;
 
 #include <boost/random.hpp>
 #include <boost/cstdint.hpp>
-#include <boost/smart_ptr/shared_ptr.hpp>
 #include <map>
+#include <memory>
 
 class default_map_generator_job
 {
@@ -44,7 +44,6 @@ public:
 								 bool roads_between_castles, std::map<map_location,std::string>* labels,
 								 const config& cfg);
 private:
-
 	typedef std::vector<std::vector<int> > height_map;
 	typedef t_translation::t_map terrain_map;
 
@@ -60,11 +59,9 @@ private:
 
 	bool generate_lake(t_translation::t_map& terrain, int x, int y, int lake_fall_off, std::set<map_location>& locs_touched);
 	map_location random_point_at_side(size_t width, size_t height);
-	std::string generate_name(boost::shared_ptr<name_generator>& name_generator, const std::string& id,
-		std::string* base_name=nullptr,
-		utils::string_map* additional_symbols=nullptr);
 
 	boost::random::mt19937 rng_;
+	const config& game_config_;
 
 };
 #endif

--- a/src/units/race.cpp
+++ b/src/units/race.cpp
@@ -24,8 +24,8 @@
 #include "log.hpp"
 #include "serialization/string_utils.hpp"
 #include "serialization/unicode_cast.hpp"
-#include "utils/markov_generator.hpp"
-#include "utils/context_free_grammar_generator.hpp"
+#include "utils/name_generator.hpp"
+#include "utils/name_generator_factory.hpp"
 
 /// Dummy race used when a race is not yet known.
 const unit_race unit_race::null_race;
@@ -79,6 +79,7 @@ unit_race::unit_race(const config& cfg) :
 		lg::wml_error() << "[race] '" << cfg["name"] << "' is missing a plural_name field.";
 		plural_name_ = (cfg["name"]);
 	}
+
 	// use "name" if "male_name" or "female_name" aren't available
 	name_[MALE] = cfg["male_name"];
 	if(name_[MALE].empty()) {
@@ -89,34 +90,11 @@ unit_race::unit_race(const config& cfg) :
 		name_[FEMALE] = (cfg["name"]);
 	}
 
-	config::attribute_value male_generator = cfg["male_name_generator"];
-	config::attribute_value female_generator = cfg["female_name_generator"];
-	if(male_generator.blank()) {
-		male_generator = cfg["name_generator"];
-	}
-	if(female_generator.blank()) {
-		female_generator = cfg["name_generator"];
-	}
+	name_generator_factory generator_factory = name_generator_factory(cfg, {"male", "female"});
 
-	if(!male_generator.blank()) {
-		name_generator_[MALE].reset(new context_free_grammar_generator(male_generator));
-		if(!name_generator_[MALE]->is_valid()) {
-			name_generator_[MALE].reset();
-		}
-	}
-	if(!female_generator.blank()) {
-		name_generator_[FEMALE].reset(new context_free_grammar_generator(female_generator));
-		if(!name_generator_[FEMALE]->is_valid()) {
-			name_generator_[FEMALE].reset();
-		}
-	}
-
-	int chain_size = cfg["markov_chain_size"].to_int(2);
-	if(!name_generator_[MALE]) {
-		name_generator_[MALE].reset(new markov_generator(utils::split(cfg["male_names"]), chain_size, 12));
-	}
-	if(!name_generator_[FEMALE]) {
-		name_generator_[FEMALE].reset(new markov_generator(utils::split(cfg["female_names"]), chain_size, 12));
+	for(int i=MALE; i<NUM_GENDERS; i++) {
+		GENDER gender = static_cast<GENDER>(i);
+		name_generator_[i] = generator_factory.get_name_generator(gender_string(gender));
 	}
 }
 

--- a/src/units/race.hpp
+++ b/src/units/race.hpp
@@ -17,7 +17,7 @@
 
 #include "config.hpp"
 #include "utils/name_generator.hpp"
-#include <boost/smart_ptr/shared_ptr.hpp>
+#include <memory>
 
 class unit_race
 {
@@ -59,7 +59,7 @@ private:
 	t_string plural_name_;
 	t_string description_;
 	unsigned int ntraits_;
-	boost::shared_ptr<name_generator> name_generator_[NUM_GENDERS];
+	std::shared_ptr<name_generator> name_generator_[NUM_GENDERS];
 
 	config::const_child_itors traits_;
 	config::const_child_itors topics_;

--- a/src/utils/context_free_grammar_generator.cpp
+++ b/src/utils/context_free_grammar_generator.cpp
@@ -40,7 +40,11 @@ context_free_grammar_generator::context_free_grammar_generator(const std::string
 	while (*reading != 0) {
 		if (*reading == '=') {
 			// Leading and trailing whitespace is not significant, but internal whitespace is
-			current = &nonterminals_[utils::strip(buf)];
+			std::string key = utils::strip(buf);
+			if(key == "!" || key =="(" || key == ")") {
+				throw name_generator_invalid_exception("[context_free_grammar_generator] Parsing error: nonterminals (, ! and ) may not be overridden");
+			}
+			current = &nonterminals_[key];
 			current->possibilities_.push_back(std::vector<std::string>());
 			filled = &current->possibilities_.back();
 			buf.clear();
@@ -64,10 +68,6 @@ context_free_grammar_generator::context_free_grammar_generator(const std::string
 		} else if (*reading == '\\' && reading[1] == 't') {
 			reading++;
 			buf.push_back('\t');
-		} else if (*reading == '$') {
-			if (!current) {
-				throw name_generator_invalid_exception("[context_free_grammar_generator] Parsing error: nonterminals may not contain the $ symbol");
-			} else buf.push_back(*reading);
 		} else {
 			if (*reading == '{') {
 				if (!filled) {
@@ -95,7 +95,7 @@ context_free_grammar_generator::context_free_grammar_generator(const std::map<st
 		std::string key = rule.first; // Need to do this because utils::strip is mutating
 		key = utils::strip(key);
 		if(key == "!" || key =="(" || key == ")") {
-			throw name_generator_invalid_exception("[context_free_grammar_generator] Parsing error: Nonterminals (, ! and ) may not be overridden");
+			throw name_generator_invalid_exception("[context_free_grammar_generator] Parsing error: nonterminals (, ! and ) may not be overridden");
 		}
 		std::string buf;
 		for(std::string str : rule.second) {

--- a/src/utils/context_free_grammar_generator.cpp
+++ b/src/utils/context_free_grammar_generator.cpp
@@ -30,8 +30,7 @@ context_free_grammar_generator::~context_free_grammar_generator()
 {
 }
 
-context_free_grammar_generator::context_free_grammar_generator(const std::string& source) :
-	initialized_(false)
+context_free_grammar_generator::context_free_grammar_generator(const std::string& source)
 {
 	const char* reading = source.c_str();
 	nonterminal* current = nullptr;
@@ -53,8 +52,7 @@ context_free_grammar_generator::context_free_grammar_generator(const std::string
 			buf.clear();
 		} else if (*reading == '|') {
 			if (!filled || !current) {
-				lg::wml_error() << "[context_free_grammar_generator] Parsing error: misplaced | symbol";
-				return;
+				throw  name_generator_invalid_exception("[context_free_grammar_generator] Parsing error: misplaced | symbol");
 			}
 			filled->push_back(buf);
 			current->possibilities_.push_back(std::vector<std::string>());
@@ -66,19 +64,21 @@ context_free_grammar_generator::context_free_grammar_generator(const std::string
 		} else if (*reading == '\\' && reading[1] == 't') {
 			reading++;
 			buf.push_back('\t');
+		} else if (*reading == '$') {
+			if (!current) {
+				throw name_generator_invalid_exception("[context_free_grammar_generator] Parsing error: nonterminals may not contain the $ symbol");
+			} else buf.push_back(*reading);
 		} else {
 			if (*reading == '{') {
 				if (!filled) {
-					lg::wml_error() << "[context_free_grammar_generator] Parsing error: misplaced { symbol";
-					return;
+					throw name_generator_invalid_exception("[context_free_grammar_generator] Parsing error: misplaced { symbol");
 				}
 				filled->push_back(buf);
 				buf.clear();
 			}
 			else if (*reading == '}') {
 				if (!filled) {
-					lg::wml_error() << "[context_free_grammar_generator] Parsing error: misplaced } symbol";
-					return;
+					throw  name_generator_invalid_exception("[context_free_grammar_generator] Parsing error: misplaced } symbol");
 				}
 				filled->push_back('{' + utils::strip(buf));
 				buf.clear();
@@ -87,16 +87,16 @@ context_free_grammar_generator::context_free_grammar_generator(const std::string
 		reading++;
 	}
 	if (filled) filled->push_back(buf);
-
-	initialized_ = true;
 }
 
-context_free_grammar_generator::context_free_grammar_generator(const std::map<std::string, std::vector<std::string>>& source) :
-	initialized_(false)
+context_free_grammar_generator::context_free_grammar_generator(const std::map<std::string, std::vector<std::string>>& source)
 {
 	for(auto rule : source) {
 		std::string key = rule.first; // Need to do this because utils::strip is mutating
 		key = utils::strip(key);
+		if(key == "!" || key =="(" || key == ")") {
+			throw name_generator_invalid_exception("[context_free_grammar_generator] Parsing error: Nonterminals (, ! and ) may not be overridden");
+		}
 		std::string buf;
 		for(std::string str : rule.second) {
 			nonterminals_[key].possibilities_.emplace_back();
@@ -105,17 +105,16 @@ context_free_grammar_generator::context_free_grammar_generator(const std::map<st
 			for(char c : str) {
 				if (c == '{') {
 					if (!filled) {
-						lg::wml_error() << "[context_free_grammar_generator] Parsing error: misplaced { symbol";
-						return;
+						throw  name_generator_invalid_exception("[context_free_grammar_generator] Parsing error: misplaced { symbol");
 					}
 					filled->push_back(buf);
 					buf.clear();
 				}
 				else if (c == '}') {
 					if (!filled) {
-						lg::wml_error() << "[context_free_grammar_generator] Parsing error: misplaced } symbol";
-						return;
+						throw  name_generator_invalid_exception("[context_free_grammar_generator] Parsing error: misplaced } symbol");
 					}
+					
 					filled->push_back('{' + utils::strip(buf));
 					buf.clear();
 				} else buf.push_back(c);
@@ -125,36 +124,51 @@ context_free_grammar_generator::context_free_grammar_generator(const std::map<st
 			}
 		}
 	}
-	initialized_ = true;
 }
 
 std::string context_free_grammar_generator::print_nonterminal(const std::string& name, uint32_t* seed, short seed_pos) const {
-	std::string result;
-	std::map<std::string, nonterminal>::const_iterator found = nonterminals_.find(name);
-	if (found == nonterminals_.end()) {
-		lg::wml_error() << "[context_free_grammar_generator] Warning: needed nonterminal " << name << " not defined";
-		return "!" + name;
+	if (name == "!") {
+		return "|";
 	}
-	const context_free_grammar_generator::nonterminal& got = found->second;
-	unsigned int picked = seed[seed_pos++] % got.possibilities_.size();
-	if (seed_pos >= seed_size) seed_pos = 0;
-	if (picked == got.last_) {
-		picked = seed[seed_pos++] % got.possibilities_.size();
+	else if (name == "(" ) {
+		return "{";
+	}
+	else if (name == ")" ) {
+		return "}";
+	}
+	else {
+		std::string result = "";
+
+		std::map<std::string,nonterminal>::const_iterator found = nonterminals_.find(name);
+		if (found == nonterminals_.end()) {
+			lg::wml_error() << "[context_free_grammar_generator] Warning: needed nonterminal" << name << " not defined";
+			return "!" + name;
+		}
+		const context_free_grammar_generator::nonterminal& got = found->second;
+		unsigned int picked = seed[seed_pos++] % got.possibilities_.size();
 		if (seed_pos >= seed_size) seed_pos = 0;
+		if (picked == got.last_) {
+			picked = seed[seed_pos++] % got.possibilities_.size();
+			if (seed_pos >= seed_size) seed_pos = 0;
+		}
+		got.last_ = picked;
+		const std::vector<std::string>& used = got.possibilities_[picked];
+		for (unsigned int i = 0; i < used.size(); i++) {
+			if (used[i][0] == '{') result += print_nonterminal(used[i].substr(1), seed, seed_pos);
+			else result += used[i];
+		}
+		return result;
 	}
-	got.last_ = picked;
-	const std::vector<std::string>& used = got.possibilities_[picked];
-	for (unsigned int i = 0; i < used.size(); i++) {
-		if (used[i][0] == '{') result += print_nonterminal(used[i].substr(1), seed, seed_pos);
-		else result += used[i];
-	}
-	return result;
 }
 
 std::string context_free_grammar_generator::generate() const {
 	uint32_t seed[seed_size];
+	init_seed(seed);
+	return print_nonterminal("main", seed, 0);
+}
+
+void context_free_grammar_generator::init_seed(uint32_t seed[]) const {
 	for (unsigned short int i = 0; i < seed_size; i++) {
 		seed[i] = random_new::generator->next_random();
 	}
-	return print_nonterminal("main", seed, 0);
 }

--- a/src/utils/context_free_grammar_generator.hpp
+++ b/src/utils/context_free_grammar_generator.hpp
@@ -17,8 +17,6 @@
 
 #include "utils/name_generator.hpp"
 
-#include <string>
-#include <map>
 #include <list>
 #include <vector>
 
@@ -32,9 +30,9 @@ private:
 		mutable unsigned int last_;
 	};
 
+	void init_seed(uint32_t seed[]) const;
 	std::map<std::string, nonterminal> nonterminals_;
-	bool initialized_;
-	std::string print_nonterminal(const std::string& name, uint32_t* seed, short int seed_pos) const;
+	std::string print_nonterminal(const std::string& name, uint32_t seed[], short int seed_pos) const;
 	static const short unsigned int seed_size = 20;
 
 public:
@@ -54,11 +52,6 @@ public:
 	std::string generate() const override;
 
 	~context_free_grammar_generator();
-
-	/** Checks if the object is initialized
-	 * @return if it is initialized
-	 */
-	bool is_valid() const override {return initialized_; }
 };
 
 #endif

--- a/src/utils/markov_generator.cpp
+++ b/src/utils/markov_generator.cpp
@@ -130,6 +130,7 @@ markov_generator::markov_generator(const std::vector<std::string>& items, size_t
 {
 }
 
+
 std::string markov_generator::generate() const
 {
 	ucs4::string name = markov_generate_name(prefixes_, chain_size_, max_len_);

--- a/src/utils/markov_generator.hpp
+++ b/src/utils/markov_generator.hpp
@@ -17,7 +17,6 @@
 
 #include "serialization/unicode_types.hpp"
 #include "utils/name_generator.hpp"
-#include <map>
 
 typedef std::map<ucs4::string, ucs4::string> markov_prefix_map;
 

--- a/src/utils/name_generator.hpp
+++ b/src/utils/name_generator.hpp
@@ -15,21 +15,37 @@
 #ifndef NAME_GENERATOR_HPP_INCLUDED
 #define NAME_GENERATOR_HPP_INCLUDED
 
+#include "global.hpp"
+#include <map>
 #include <string>
+#include "formula/string_utils.hpp"
+#include <exception>
+
+typedef std::map< std::string, t_string > string_map;
+
+class name_generator_invalid_exception : public std::exception {
+ public:
+  name_generator_invalid_exception(const char* errMessage):errMessage_(errMessage){}
+  const char* what() const throw() { return errMessage_; }
+ 
+ private:
+  const char* errMessage_;
+};
+
 
 class name_generator {
 public:
-	virtual std::string generate() const = 0;
-	virtual bool is_valid() const {return true;}
-	virtual ~name_generator() {}
+	std::string generate(const std::map<std::string,std::string>& variables) const { return utils::interpolate_variables_into_string(generate(), &variables); };
+	virtual std::string generate() const { return ""; };
+	name_generator() {};
+	virtual ~name_generator() {};
 };
 
 class proxy_name_generator : public name_generator {
 	const name_generator& base;
 public:
 	proxy_name_generator(const name_generator& b) : base(b) {}
-	std::string generate() const override {return base.generate();}
-	bool is_valid() const override {return base.is_valid();}
+	std::string generate() const override { return base.generate(); };
 };
 
 #endif

--- a/src/utils/name_generator_factory.cpp
+++ b/src/utils/name_generator_factory.cpp
@@ -1,0 +1,68 @@
+/*
+   Part of the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#include "global.hpp"
+#include "log.hpp"
+#include "serialization/string_utils.hpp"
+#include "utils/name_generator_factory.hpp"
+#include "utils/name_generator.hpp"
+#include "utils/context_free_grammar_generator.hpp"
+#include "utils/markov_generator.hpp"
+
+name_generator_factory::name_generator_factory(const config& config, std::vector<std::string> ids) : name_generators_() {
+	add_name_generator_from_config(config, "", "");
+
+	for (std::vector<std::string>::iterator it = std::begin(ids); it!=std::end(ids); it++) {
+		std::string id = *it;
+		add_name_generator_from_config(config, id, (id + "_"));
+	}
+};
+
+void name_generator_factory::add_name_generator_from_config(const config& config, const std::string id, const std::string prefix) {
+ 	std::string cfg_name 	= prefix + "name_generator";
+	std::string markov_name = prefix + "names";
+
+	if(config.has_attribute(cfg_name)) {
+		try {
+			name_generators_[id] = std::shared_ptr<name_generator>(new context_free_grammar_generator(config[cfg_name]));
+		}
+		catch (const name_generator_invalid_exception& ex) { lg::wml_error() << ex.what() << '\n'; }
+	}
+
+	if(config.has_attribute(markov_name)) {
+		config::attribute_value markov_name_list = config[markov_name];
+
+		if(!markov_name_list.blank()) {
+			name_generators_[id] = std::shared_ptr<name_generator>(new markov_generator(utils::split(markov_name_list), config["markov_chain_size"].to_int(2), 12));
+		}
+	}
+};
+
+std::shared_ptr<name_generator> name_generator_factory::get_name_generator() {
+	std::map<std::string, std::shared_ptr<name_generator>>::const_iterator it = name_generators_.find("");
+	if(it == name_generators_.end()) {
+		//create a dummy instance, which always returns the empty string
+		return std::shared_ptr<name_generator>(new name_generator( ));
+	}
+
+	return it->second;
+};
+
+std::shared_ptr<name_generator> name_generator_factory::get_name_generator(const std::string id) {
+	std::map<std::string, std::shared_ptr<name_generator>>::const_iterator it = name_generators_.find(id);
+	if(it == name_generators_.end()) {
+		return get_name_generator();
+	}
+
+	return it->second;
+};

--- a/src/utils/name_generator_factory.hpp
+++ b/src/utils/name_generator_factory.hpp
@@ -1,0 +1,59 @@
+/*
+   Copyright (C) 2016 by Marius Spix
+   Part of the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#ifndef NAME_GENERATOR_FACTORY_HPP_INCLUDED
+#define NAME_GENERATOR_FACTORY_HPP_INCLUDED
+
+#include "utils/name_generator.hpp"
+#include "config.hpp"
+#include <vector>
+#include <memory>
+
+class name_generator_factory
+{
+public:
+	/**
+	 * Creates a new name generator factory
+	 * @param config the WML data to be parsed for name generators
+	 * @param ids a list of generator ids, e.g. genders or terrain types
+	 */
+	name_generator_factory(const config& config, std::vector<std::string> ids);
+
+	/**
+	 * Gets the default name generator
+	 * @returns the default name generator
+	 */
+	std::shared_ptr<name_generator> get_name_generator();
+
+	/**
+	 * Gets a specific name generator or the default name generator, if the
+	 * specific name generator is not found.
+	 * @param name generator id, e.g. a gender or a terrain type
+	 * @returns a name generator
+	 */
+	std::shared_ptr<name_generator> get_name_generator(const std::string name);
+
+private:
+	std::map<std::string, std::shared_ptr<name_generator>> name_generators_;
+
+	/**
+	 * Determines a name generator from WML data
+	 * @param config the WML data to be parsed for name generators
+	 * @param the prefix to look for
+	 * @returns a name generator or nullptr if not found
+	 */
+	void add_name_generator_from_config(const config& config, const std::string id, const std::string prefix);
+};
+
+#endif


### PR DESCRIPTION
This commit contains several improvements in the name generator and map generator:
- factory class to simplify creation of name generators and removing dependencies from concrete name generator classes
- the `is_valid()` method has been replaced by an exception, because that is more meaningful than using a shared pointer to delete the object, if it is not valid
- the context-free grammar based name generator now supports variables
- the map generator now uses the new features of the cfg name generator
- the redundant wml tag `[village_naming]` has been removed
- village and terrain generating rules have been ported from`/data/english.cfg` to `/data/core/macros/names.cfg`