### PR TITLE
terminal colored text extended to windows

### DIFF
--- a/utils/pywmlx/__init__.py
+++ b/utils/pywmlx/__init__.py
@@ -1,4 +1,5 @@
 from pywmlx.wmlerr import ansi_setEnabled
+from pywmlx.wmlerr import wincol_setEnabled
 from pywmlx.wmlerr import wmlerr
 from pywmlx.wmlerr import wmlwarn
 from pywmlx.wmlerr import set_warnall

--- a/utils/pywmlx/wmlerr.py
+++ b/utils/pywmlx/wmlerr.py
@@ -1,10 +1,36 @@
 import os
 import sys
 import warnings
+import ctypes
+import struct
 
-enabled_ansi_col = True
+enabled_text_col = True
 is_utest = False
 _warnall = False
+
+
+# these constants are used by the Win32 API
+FG_RED = 4
+FG_GREEN = 2
+FG_BLUE = 1
+FG_INTENSITY = 8
+BG_RED = 64
+BG_GREEN = 32
+BG_BLUE = 16
+BG_INTENSITY = 128
+STD_INPUT_HANDLE = -10
+STD_OUTPUT_HANDLE = -11
+STD_ERROR_HANDLE = -12
+
+# there are three ways to store the console's default status
+# the first requires to redefine the C structures used by the Win32 API
+# by using the ctypes.Structure class, and pass them by reference
+# by using ctypes.byref
+# the second requires to use ctypes.create_string_buffer
+# the third one just requires to create an empty bytes object
+# both of them must be able to contain exactly 22 bytes/characters
+# and you need to use the struct module to decode the values
+console_defaults = bytes(22)
 
 
 def wmlerr_debug():
@@ -14,9 +40,30 @@ def wmlerr_debug():
 
 
 def ansi_setEnabled(value):
-    global enabled_ansi_col
-    enabled_ansi_col = value
- 
+    global enabled_text_col
+    enabled_text_col = value
+
+
+
+def wincol_setEnabled(value):
+    global enabled_text_col
+    global handle
+    global default_console_status
+    global default_color
+    enabled_text_col = value
+    if sys.platform.startswith('win') and enabled_text_col:
+        # and now, let's start playing with the Win32 API
+        # first of all, we need to get a handle to the console output
+        handle = ctypes.windll.kernel32.GetStdHandle(STD_OUTPUT_HANDLE)
+        # and then we store the current console status
+        # to be able to reset the original color
+        ctypes.windll.kernel32.GetConsoleScreenBufferInfo(handle,
+                                                          console_defaults)
+        # by using struct.unpack_from, platform endianness is automatically
+        # handled
+        # this is why I'm using it, instead of a bitwise operation
+        default_color = struct.unpack_from("H", console_defaults, 8)[0]
+
 
 
 def warnall():
@@ -37,36 +84,57 @@ class WmlWarning(UserWarning):
 
 
 
-def print_wmlerr(message, iserr):
-    ansi_color = '\033[91;1m'  #red
-    errtype = "error:"
-    if iserr is False:
-        ansi_color = '\033[94m'  #blue
-        errtype = "warning:"
+def print_wmlerr(finfo, message, iserr):
+    # red if error, blue if warning
+    ansi_color = '\033[91;1m' if iserr else '\033[94m'
+    errtype = "error:" if iserr else "warning:"
     # now we have ascii_color and errtype values
-    # here we print the error/warning. 
-    # 1) On posix we write "error" in red and "warning" in blue
-    if os.name == "posix" and enabled_ansi_col is True:
-        msg = ansi_color + errtype + ' ' + message
-    # 2) On non-posix systems (ex. windows) we don't use colors
+    # here we print the error/warning.
+    # 1) On Windows, write "error" in red and "warning" in blue
+    #    by using the Win32 API (except if --no-text-colors is used)
+    if sys.platform.startswith('win') and enabled_text_col:
+        # a syntactic sugar to make lines shorter
+        kernel32 = ctypes.windll.kernel32
+        # first flush the stderr, otherwise colors might be changed in
+        # unpredictable ways
+        sys.stderr.flush()
+        if iserr:
+            kernel32.SetConsoleTextAttribute(handle, FG_RED | FG_INTENSITY)
+        else:
+            kernel32.SetConsoleTextAttribute(handle, FG_BLUE | FG_INTENSITY)
+        # then write the error type and continue on the same line
+        print(errtype + " ", end="", file=sys.stderr)
+        # flush again and write file name in yellow on the same line
+        sys.stderr.flush()
+        kernel32.SetConsoleTextAttribute(handle,
+                                         FG_RED | FG_GREEN | FG_INTENSITY)
+        print(finfo + ": ", end="", file=sys.stderr)
+        # then flush again, reset the color and finish writing
+        sys.stderr.flush()
+        ctypes.windll.kernel32.SetConsoleTextAttribute(handle, default_color)
+        print(message, file=sys.stderr)
+        # finally flush again for good measure
+        sys.stderr.flush()
+    # 2) On posix we write "error" in red and "warning" in blue
+    #    by using ansi escape codes (except if --no-text-colors is used)
+    elif os.name == "posix" and enabled_text_col:
+        msg = (ansi_color + errtype + ' \033[0m\033[93m' + finfo + 
+               ':\033[0m ' + message)
+        print(msg, file=sys.stderr)
+    # 3) On non-posix and non-windows system we don't use colors
+    #    (is it ever possible?).
+    #    If --no-text-colors option is used, than we don't use colors
+    #    regardless of OS.
     else:
-        msg = errtype + ' ' + message
-    print(msg, file=sys.stderr)
-    
-    
-    
-def dualcol_message(finfo, message):
-    if os.name == "posix" and enabled_ansi_col is True:
-        msg = '\033[0m\033[93m' + finfo + ':\033[0m ' + message
-    else:
-        msg = finfo + ': ' + message
-    return msg
-    
+        msg = errtype + ' ' + finfo + ': ' + message
+        print(msg, file=sys.stderr)
+
 
 
 def my_showwarning(message, category, filename, lineno, file=None, line=None):
     try:
-        print_wmlerr(message.args[0], False)
+        finfo, msg = message.args[0].split(": ", 1)
+        print_wmlerr(finfo, msg, False)
     except OSError:
         pass # the file (probably stderr) is invalid - this warning gets lost.
 
@@ -79,18 +147,15 @@ warnings.showwarning = my_showwarning
 def wmlerr(finfo, message, errtype=WmlError):
     if not is_utest:
         try:
-            msg = dualcol_message(finfo, message)
-            raise errtype(msg)
+            raise errtype(finfo + ": " + message)
         except errtype as err:
-            print_wmlerr(err.args[0], True)
+            print_wmlerr(finfo, message, True)
             sys.exit(1)
     else:
-        msg = dualcol_message(finfo, message)
-        raise errtype(msg)
+        raise errtype(finfo + ": " + message)
 
 
 
 def wmlwarn(finfo, message):
-    msg = dualcol_message(finfo, message)
-    warnings.warn(msg, WmlWarning)
+    warnings.warn(finfo + ": " + message, WmlWarning)
 

--- a/utils/wmlxgettext
+++ b/utils/wmlxgettext
@@ -8,6 +8,7 @@
 #                
 #
 # By Nobun, october 2015
+# Thanks to Elvish Hunter for writing code for coloring text under windows
 #
 #                              PURPOSE
 #
@@ -46,7 +47,7 @@ def commandline(args):
         usage='''wmlxgettext --domain=DOMAIN [--directory=START_PATH]
                    [--recursive] [--initialdomain=INITIALDOMAIN]
                    [--package-version=PACKAGE_VERSION]
-                   [--no-ansi-colors] [--fuzzy] [--warnall] [-o OUTPUT_FILE]
+                   [--no-text-colors] [--fuzzy] [--warnall] [-o OUTPUT_FILE]
                    FILE1 FILE2 ... FILEN'''
     )
     parser.add_argument(
@@ -91,15 +92,12 @@ def commandline(args):
               'help you to save a bit of time')
     )
     parser.add_argument(
-        '--no-ansi-colors',
+        '--no-text-colors',
         action='store_false',
         default=True,
-        dest='ansi_col',
+        dest='text_col',
         help=("By default warnings are displayed with colored text. You can "
-              "disable this feature using this flag.\n"
-              "This option doesn't have any effect on windows, since it "
-              "doesn't support ansi colors (on windows colors are ALWAYS"
-              ' disabled).')
+              "disable this feature using this flag.")
     )
     parser.add_argument(
         '--warnall',
@@ -137,7 +135,8 @@ def commandline(args):
 
 def main():
     args = commandline(sys.argv[1:])
-    pywmlx.ansi_setEnabled(args.ansi_col)
+    pywmlx.ansi_setEnabled(args.text_col)
+    pywmlx.wincol_setEnabled(args.text_col)
     pywmlx.set_warnall(args.warnall)
     startPath = os.path.realpath(os.path.normpath(args.start_path))
     sentlist = dict()


### PR DESCRIPTION
Thanks to Elvish Hunter, wmlxgettext now have colored text not only on posix system, but also on windows (I'm speaking about the text that appears on terminal).
I did some little changes from that original code.