### PR TITLE
[game_config]: new keys for logo

### DIFF
--- a/data/game_config.cfg
+++ b/data/game_config.cfg
@@ -57,6 +57,8 @@
     [images]
         game_title="maps/titlescreen.png"
         game_title_background="maps/background.jpg"
+        game_logo="misc/logo.png"
+        game_logo_background="misc/logo-bg.png"
 
         orb="misc/orb.png"
         energy="misc/bar-energy.png"

--- a/data/gui/window/title_screen.cfg
+++ b/data/gui/window/title_screen.cfg
@@ -319,7 +319,7 @@
 
 										[image]
 											id = "logo-bg"
-											label = "misc/logo-bg.png"
+											definition = "default"
 										[/image]
 
 									[/column]

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -83,6 +83,8 @@ namespace game_config
 	namespace images {
 	std::string game_title,
 			game_title_background,
+			game_logo,
+			game_logo_background,
 			// orbs and hp/xp bar
 			orb,
 			energy,
@@ -225,6 +227,8 @@ namespace game_config
 			using namespace game_config::images;
 			game_title = i["game_title"].str();
 			game_title_background = i["game_title_background"].str();
+			game_logo = i["game_logo"].str();
+			game_logo_background = i["game_logo_background"].str();
 
 			orb = i["orb"].str();
 			energy = i["energy"].str();

--- a/src/game_config.hpp
+++ b/src/game_config.hpp
@@ -85,6 +85,8 @@ namespace game_config
 	namespace images {
 	extern std::string game_title,
 			game_title_background,
+			game_logo,
+			game_logo_background,
 			// orbs and hp/xp bar
 			orb,
 			energy,

--- a/src/gui/dialogs/title_screen.cpp
+++ b/src/gui/dialogs/title_screen.cpp
@@ -110,8 +110,8 @@ namespace gui2
  * previous_tip & & button & m &
  *         The button show the previous tip of the day. $
  *
- * logo & & progress_bar & o &
- *         A progress bar to "animate" the Wesnoth logo. $
+ * logo & & image & o &
+ *         The Wesnoth logo. $
  *
  * revision_number & & control & o &
  *         A widget to show the version number when the version number is
@@ -336,7 +336,9 @@ void ttitle_screen::pre_show(twindow& window)
 	}
 
 	/***** Logo *****/
-	find_widget<timage>(&window, "logo", false).set_image("misc/logo.png");
+	find_widget<timage>(&window, "logo-bg", false).set_image(game_config::images::game_logo_background);
+
+	find_widget<timage>(&window, "logo", false).set_image(game_config::images::game_logo);
 
 	/***** About dialog button *****/
 	tbutton& about = find_widget<tbutton>(&window, "about", false);


### PR DESCRIPTION
remove hardcoded path for logo image
add 'game_logo' & 'game_logo_background' keys in [game_config]
this allows [core] authors to define their own game logo to appear on the title screen
this does not (yet) affect the loadscreen