### PR TITLE
Fix build with Visual Studio 2013

### DIFF
--- a/src/utils/context_free_grammar_generator.hpp
+++ b/src/utils/context_free_grammar_generator.hpp
@@ -21,6 +21,7 @@
 #include <map>
 #include <list>
 #include <vector>
+#include <cstdint>
 
 class context_free_grammar_generator : public name_generator
 {


### PR DESCRIPTION
I got these compiler errors when trying to build Wesnoth:

> 4>i:\battle for wesnoth\wesnoth\src\utils\context_free_grammar_generator.hpp(37): error C2061: syntax error : identifier 'uint32_t'
> 4>..\..\src\utils\context_free_grammar_generator.cpp(131): error C2511: 'std::string context_free_grammar_generator::print_nonterminal(const std::string &,uint32_t *,short) const' : overloaded member function not found in 'context_free_grammar_generator'
> 4>          i:\battle for wesnoth\wesnoth\src\utils\context_free_grammar_generator.hpp(25) : see declaration of 'context_free_grammar_generator'
> 4>..\..\src\utils\context_free_grammar_generator.cpp(133): error C2228: left of '.find' must have class/struct/union
> 4>..\..\src\utils\context_free_grammar_generator.cpp(134): error C2228: left of '.end' must have class/struct/union
> 4>..\..\src\utils\context_free_grammar_generator.cpp(148): error C2660: 'context_free_grammar_generator::print_nonterminal' : function does not take 3 arguments
> 4>..\..\src\utils\context_free_grammar_generator.cpp(159): error C2660: 'context_free_grammar_generator::print_nonterminal' : function does not take 3 arguments

To me, it looks like uint32_t is a different type in the header and the implementation file, and thus the compiler complains that the `print_nonterminal()` function (or more accurately, this particular overload) hasn't been declared.

Adding `#include <cstdint>` to the header fixes the issue.

I am using Visual Studio 2013.