### PR TITLE
Fix bug #23712: Mage of Light halo not drawing correctly

### DIFF
--- a/changelog
+++ b/changelog
@@ -26,6 +26,8 @@ Version 1.13.4+dev:
    * Various design improvements to GUI2 widgets
    * New simpler GUI2 loading screen
    * New colored cursor graphics
+   * Fixed Mage of Light halo appearing in the top-left corner of the screen
+     while the mage is moving (bug #23712).
    * Fixed Observers icon appearing behind other top bar items in MP games on
      horizontal UI resolutions < 1024 (bug #24455).
    * Fixed ToD schedule progress indicator appearing behind other top bar items

--- a/players_changelog
+++ b/players_changelog
@@ -14,6 +14,8 @@ Version 1.13.4+dev:
      Portuguese, RACV, Russian, Scottish Gaelic, Spanish.
 
  * User interface:
+   * Fixed Mage of Light halo appearing in the top-left corner of the screen
+     while the mage is moving (bug #23712).
    * Fixed Observers icon appearing behind other top bar items in MP games on
      horizontal UI resolutions < 1024 (bug #24455).
    * Fixed ToD schedule progress indicator appearing behind other top bar items

--- a/src/halo.cpp
+++ b/src/halo.cpp
@@ -48,6 +48,7 @@ public:
 	bool need_update() const { return images_.need_update(); }
 	bool does_change() const { return !images_.does_not_change(); }
 	bool on_location(const std::set<map_location>& locations) const;
+	bool location_not_known() const;
 
 	void add_overlay_location(std::set<map_location>& locations);
 private:
@@ -143,8 +144,8 @@ halo_impl::effect::effect(display * screen, int xpos, int ypos, const animated<i
 		const map_location& loc, ORIENTATION orientation, bool infinite) :
 	images_(img),
 	orientation_(orientation),
-	x_(xpos),
-	y_(ypos),
+	x_(0),
+	y_(0),
 	surf_(nullptr),
 	buffer_(nullptr),
 	rect_(sdl::empty_rect),
@@ -165,6 +166,7 @@ void halo_impl::effect::set_location(int x, int y)
 	int new_x = x - disp->get_location_x(map_location::ZERO());
 	int new_y = y - disp->get_location_y(map_location::ZERO());
 	if (new_x != x_ || new_y != y_) {
+		unrender();
 		x_ = new_x;
 		y_ = new_y;
 		buffer_.assign(nullptr);
@@ -219,7 +221,7 @@ bool halo_impl::effect::render()
 
 	// If rendered the first time, need to determine the area affected.
 	// If a halo changes size, it is not updated.
-	if(overlayed_hexes_.empty()) {
+	if(location_not_known()) {
 		display::rect_of_hexes hexes = disp->hexes_under_rect(rect);
 		display::rect_of_hexes::iterator i = hexes.begin(), end = hexes.end();
 		for (;i != end; ++i) {
@@ -292,6 +294,11 @@ bool halo_impl::effect::on_location(const std::set<map_location>& locations) con
 		}
 	}
 	return false;
+}
+
+bool halo_impl::effect::location_not_known() const
+{
+	return overlayed_hexes_.empty();
 }
 
 void halo_impl::effect::add_overlay_location(std::set<map_location>& locations)
@@ -396,7 +403,8 @@ void halo_impl::unrender(std::set<map_location> invalidated_locations)
 			// Test all haloes not yet in the set
 			// which match one of the locations
 			if(invalidated_haloes.find(itor->first) == invalidated_haloes.end() &&
-					itor->second.on_location(invalidated_locations)) {
+					(itor->second.location_not_known() ||
+					itor->second.on_location(invalidated_locations))) {
 
 				// If found, add all locations which the halo invalidates,
 				// and add it to the set

--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -161,7 +161,7 @@ void unit_drawer::redraw_unit (const unit & u) const
 
 	bool has_halo = ac.unit_halo_ && ac.unit_halo_->valid();
 	if(!has_halo && !u.image_halo().empty()) {
-		ac.unit_halo_ = halo_man.add(0, 0, u.image_halo()+u.TC_image_mods(), map_location(-1, -1));
+		ac.unit_halo_ = halo_man.add(x, y - height_adjust, u.image_halo()+u.TC_image_mods(), map_location(-1, -1));
 	}
 	if(has_halo && u.image_halo().empty()) {
 		halo_man.remove(ac.unit_halo_);


### PR DESCRIPTION
The bug was caused by overly aggressive performance optimizations.

When a unit is moving, it's replaced with a temporary unit. If the moving unit is a Mage of Light, its halo is recreated. The recreated halo is originally placed in the top-left corner of the screen (exactly the position where it actually stayed in practice).

The game attempts to correct the position of the halo on the next frame by calling `halo::manager::set_location()`, that eventually calls `halo_impl::effect::set_location()`. Since the overlayed hexes (`overlayed_hexes_`) aren't known after moving the halo, `set_location()` clears the list of overlayed hexes. The idea is that the overlayed hexes will be determined when the halo is drawn next time, in `halo_impl::effect::render()`.

`Halo_impl::render()` only draws invalidated haloes.

Haloes are invalidated in `halo_impl::unrender()`. It only invalidates haloes which overlay invalidated hexes.

But the list of overlayed hexes is empty because the halo hasn't been drawn in the correct position yet. Thus, the halo won't be invalidated, or later drawn. The result is a kind of deadlock: the halo is never drawn in the correct position because it's never invalidated, and it's never invalidated because it's never drawn in the correct position.

My new code detects the situation in `halo_impl::unrender()` and invalidates haloes whose positions are not known.