### PR TITLE
Mute the music when the game loses focus

### DIFF
--- a/data/gui/window/preferences/04_sound.cfg
+++ b/data/gui/window/preferences/04_sound.cfg
@@ -61,6 +61,40 @@
 	[/grid]
 #enddef
 
+#define _GUI_AUTO_MUTE_MUSIC_CHECKBOX
+	[row]
+		[column]
+			horizontal_grow = true
+			[grid]
+				[row]
+					[column]
+						{_GUI_PREFERENCES_CHECKBOX_ALIGN_SPACER}
+					[/column]
+
+					[column]
+						grow_factor = 0
+						border = "all"
+						border_size = 5
+						horizontal_grow = true
+
+						[toggle_button]
+							id = sound_toggle_stop_music_in_background
+							label = _ "Pause music on focus loss"
+							tooltip = _ "Pause the music when you switch to any other window"
+						[/toggle_button]
+					[/column]
+
+					[column]
+						grow_factor = 1
+						[spacer]
+						[/spacer]
+					[/column]
+				[/row]
+			[/grid]
+		[/column]
+	[/row]
+#enddef
+
 #define _GUI_PREFERENCES_SOUND_GRID
 	[row]
 		[column]
@@ -83,6 +117,8 @@
 			}
 		[/column]
 	[/row]
+
+	{_GUI_AUTO_MUTE_MUSIC_CHECKBOX}
 
 	[row]
 		[column]
@@ -121,4 +157,5 @@
 [/layer]
 
 #undef _GUI_PREFERENCES_SOUND_GRID
+#under _GUI_AUTO_MUTE_MUSIC_CHECKBOX
 #undef _GUI_SOUND_SLIDER_CONTROL

--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -112,6 +112,7 @@ game_launcher::game_launcher(const commandline_options& cmdline_opts, const char
 	main_event_context_(),
 	hotkey_manager_(),
 	music_thinker_(),
+	music_muter_(),
 	test_scenario_("test"),
 	screenshot_map_(),
 	screenshot_filename_(),

--- a/src/game_launcher.hpp
+++ b/src/game_launcher.hpp
@@ -114,6 +114,7 @@ private:
 	const events::event_context main_event_context_;
 	const hotkey::manager hotkey_manager_;
 	sound::music_thinker music_thinker_;
+	sound::music_muter music_muter_;
 
 	std::string test_scenario_;
 

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -622,6 +622,11 @@ void tpreferences::initialize_members(twindow& window)
 		music_on(), music_volume(),
 		bind_void(set_music, _1), set_music_volume, window);
 
+	setup_single_toggle("sound_toggle_stop_music_in_background",
+		stop_music_in_background(),
+		set_stop_music_in_background,
+		window);
+
 	/* TURN BELL */
 	setup_toggle_slider_pair("sound_toggle_bell", "sound_volume_bell",
 		turn_bell(), bell_volume(),

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -677,6 +677,16 @@ bool set_music(bool ison) {
 	return true;
 }
 
+bool stop_music_in_background()
+{
+	return get("stop_music_in_background", false);
+}
+
+void set_stop_music_in_background(bool ison)
+{
+	preferences::set("stop_music_in_background", ison);
+}
+
 namespace {
 	double scroll = 0.2;
 }

--- a/src/preferences.hpp
+++ b/src/preferences.hpp
@@ -121,6 +121,9 @@ namespace preferences {
 	int music_volume();
 	void set_music_volume(int vol);
 
+	bool stop_music_in_background();
+	void set_stop_music_in_background(bool ison);
+
 	bool turn_bell();
 	bool set_turn_bell(bool ison);
 

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -618,6 +618,30 @@ void music_thinker::process(events::pump_info &info) {
 	}
 }
 
+music_muter::music_muter() :
+	events::sdl_handler(false)
+{
+	join_global();
+}
+
+void music_muter::handle_window_event(const SDL_Event& event)
+{
+	if (preferences::music_on())
+	{
+		if (event.window.event == SDL_WINDOWEVENT_FOCUS_GAINED)
+		{
+			Mix_ResumeMusic();
+		}
+		else if (event.window.event == SDL_WINDOWEVENT_FOCUS_LOST)
+		{
+			if (Mix_PlayingMusic())
+			{
+				Mix_PauseMusic();
+			}
+		}
+	}
+}
+
 void commit_music_changes()
 {
 	played_before.clear();

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -626,7 +626,7 @@ music_muter::music_muter() :
 
 void music_muter::handle_window_event(const SDL_Event& event)
 {
-	if (preferences::music_on())
+	if (preferences::stop_music_in_background() && preferences::music_on())
 	{
 		if (event.window.event == SDL_WINDOWEVENT_FOCUS_GAINED)
 		{

--- a/src/sound.hpp
+++ b/src/sound.hpp
@@ -85,6 +85,14 @@ class music_thinker : public events::pump_monitor {
 	void process(events::pump_info &info);
 };
 
+// A class to mute music when the game is in background
+class music_muter : public events::sdl_handler {
+public:
+	music_muter();
+	void handle_event(const SDL_Event&) override {}
+	void handle_window_event(const SDL_Event& event) override;
+};
+
 // Save music playlist for snapshot
 void write_music_play_list(config& snapshot);
 


### PR DESCRIPTION
When I play any game, I tend to take a break once in a while: Alt-Tab out of the game and listen to some music for a while.

For that reason, it annoys me when a game continues to play music in background. In such a situation I either have to quit the game or mute it using the Windows volume mixer.

Wesnoth plays music in background, too.

This commit implements automatic muting of music on focus loss, and restarting it when Wesnoth regains focus.