### PR TITLE
AOI: Fix WML no unit for role errors

### DIFF
--- a/data/campaigns/An_Orcish_Incursion/scenarios/01_Defend_the_Forest.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/01_Defend_the_Forest.cfg
@@ -184,7 +184,7 @@
         name=time over
 
         [message]
-            race=elf
+            {NOT_ERLORNAS}
             message= _ "It’s hopeless; we’ve tried everything, and they’re still coming back."
         [/message]
 
@@ -194,7 +194,7 @@
         [/message]
 
         [message]
-            speaker=Erlornas
+            {ERLORNAS_SPEAKS}
             message= _ "That cloud of dust on the horizon... flee! There’s more of the abominations heading this way! Fall back before we’re outnumbered and crushed."
         [/message]
 
@@ -218,7 +218,7 @@
         [/filter]
 
         [message]
-            speaker=Erlornas
+            {ERLORNAS_SPEAKS}
             message= _ "Ugh..."
         [/message]
 
@@ -228,15 +228,12 @@
         [/message]
 
         [message]
-            race=elf
-            [not]
-                id=Erlornas
-            [/not]
+            {NOT_ERLORNAS}
             message= _ "Lord!"
         [/message]
 
         [message]
-            speaker=Erlornas
+            {ERLORNAS_SPEAKS}
             message= _ "Take... command... Drive them... away."
         [/message]
 
@@ -266,7 +263,7 @@
         [/filter]
 
         [message]
-            speaker=Erlornas
+            {ERLORNAS_SPEAKS}
             message= _ "Rualsha? Hmm... What if... Assemble a war-party, we need to scout north!"
         [/message]
 

--- a/data/campaigns/An_Orcish_Incursion/scenarios/02_Assassins.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/02_Assassins.cfg
@@ -196,12 +196,12 @@
         [/filter]
 
         [message]
-            speaker=Erlornas
+            {ERLORNAS_SPEAKS}
             message= _ "This... ‘Rualsha’ again. We need to forge ahead; the answers we seek are not here. Perhaps we will find them further north."
         [/message]
 
         [message]
-            speaker=Erlornas
+            {ERLORNAS_SPEAKS}
             message= _ "Destroy this place and let the forest take the ruins. We don’t want any more undesirables to use it."
         [/message]
 

--- a/data/campaigns/An_Orcish_Incursion/scenarios/03_Wasteland.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/03_Wasteland.cfg
@@ -233,31 +233,23 @@
     [event]
         name=victory
 
-        [role]
-            race=elf
-            [not]
-                canrecruit=yes
-            [/not]
-            role=advisor
-        [/role]
-
         [message]
-            role=advisor
+            {NOT_ERLORNAS}
             message= _ "It’s done, lord. No-one escaped. No-one tried to escape. I’m... disturbed."
         [/message]
 
         [message]
-            speaker=Erlornas
+            {ERLORNAS_SPEAKS}
             message= _ "Good. But their disregard for self-preservation is astounding. As is their ferocity when defending what they claim as their own. Have the scouts found others this side of the hills?"
         [/message]
 
         [message]
-            role=advisor
+            {NOT_ERLORNAS}
             message= _ "No, lord. But trolls were spotted in the hills ahead. Do we really need to cross them to the north?"
         [/message]
 
         [message]
-            speaker=Erlornas
+            {ERLORNAS_SPEAKS}
             message= _ "Yes. The council has spoken to me through a dream-sending. They are troubled. Reinforcements have been sent after us, but we need to press on. Tell the men to rest, we’ll move out at dawn."
         [/message]
 
@@ -268,12 +260,12 @@
             [/variable]
             [then]
                 [message]
-                    role=advisor
+                    {NOT_ERLORNAS}
                     message= _ "What about the loot lord? We found supplies worth over a hundred gold in the camp."
                 [/message]
 
                 [message]
-                    speaker=Erlornas
+                    {ERLORNAS_SPEAKS}
                     message= _ "Distribute some among the men, save the rest for the road. This country is a wasteland now; we won’t find much forage on the march."
                 [/message]
             [/then]
@@ -290,12 +282,12 @@
             [/variable]
             [then]
                 [message]
-                    role=advisor
+                    {NOT_ERLORNAS}
                     message= _ "We found some supplies when searching the camp, but nothing much. What is to be done with them?"
                 [/message]
 
                 [message]
-                    speaker=Erlornas
+                    {ERLORNAS_SPEAKS}
                     message= _ "Save it for the march north. There is little to be found in this barren country."
                 [/message]
             [/then]
@@ -320,16 +312,8 @@
     [event]
         name=time over
 
-        [role]
-            race=elf
-            [not]
-                canrecruit=yes
-            [/not]
-            role=advisor
-        [/role]
-
         [message]
-            role=advisor
+            {NOT_ERLORNAS}
             message= _ "We can’t carry on Lord, the men are too tired. We have to fall back."
         [/message]
 

--- a/data/campaigns/An_Orcish_Incursion/scenarios/04_Valley_of_Trolls.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/04_Valley_of_Trolls.cfg
@@ -229,31 +229,23 @@
     [event]
         name=enemies defeated
 
-        [role]
-            race=elf
-            [not]
-                canrecruit=yes
-            [/not]
-            role=advisor
-        [/role]
-
         [message]
-            role=advisor
+            {NOT_ERLORNAS}
             message= _ "That was the last of the chieftains, lord. The lesser trolls seem to be retreating now."
         [/message]
 
         [message]
-            speaker=Erlornas
+            {ERLORNAS_SPEAKS}
             message= _ "It is well. Break camp and move everyone through the pass before they rally. We’ll rest a bit on the other side; we have earned it."
         [/message]
 
         [message]
-            role=advisor
+            {NOT_ERLORNAS}
             message= _ "At once. How much time do you think we have?"
         [/message]
 
         [message]
-            speaker=Erlornas
+            {ERLORNAS_SPEAKS}
             message= _ "A day, perhaps. We fought two clans today; they won’t take long to rally. We need to be gone from here by sunset next."
         [/message]
 
@@ -272,7 +264,7 @@
         [/filter]
 
         [message]
-            speaker=Erlornas
+            {ERLORNAS_SPEAKS}
             message= _ "We have slain a chieftain! Take heart! This battle is almost won!"
         [/message]
     [/event]
@@ -283,14 +275,6 @@
             id=Erlornas
         [/filter]
 
-        [role]
-            race=elf
-            [not]
-                canrecruit=yes
-            [/not]
-            role=advisor
-        [/role]
-
         [message]
             speaker=second_unit
             # wmllint: local spelling da
@@ -298,7 +282,7 @@
         [/message]
 
         [message]
-            role=advisor
+            {NOT_ERLORNAS}
             message= _ "No! This can’t be!"
         [/message]
 
@@ -319,22 +303,22 @@
         name=time over
 
         [message]
-            role=advisor
+            {NOT_ERLORNAS}
             message= _ "We can’t get through, my Lord. These whelps are not individually very dangerous, but there are huge numbers of them."
         [/message]
 
         [message]
-            speaker=Erlornas
+            {ERLORNAS_SPEAKS}
             message= _ "Four days of combat and nothing to show for it. How does it feel to you?"
         [/message]
 
         [message]
-            role=advisor
+            {NOT_ERLORNAS}
             message= _ "Terrible, my lord. Never in my life did I dream I’d be bested by mere trolls. What are your orders?"
         [/message]
 
         [message]
-            speaker=Erlornas
+            {ERLORNAS_SPEAKS}
             message= _ "Withdraw and make camp a safe distance from the hills. There is no further point in this fight. We’ll wait for reinforcements."
         [/message]
 

--- a/data/campaigns/An_Orcish_Incursion/scenarios/05_Linaera_the_Quick.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/05_Linaera_the_Quick.cfg
@@ -270,6 +270,28 @@
     [/event]
 
     [event]
+        name=time over
+        [message]
+            speaker=Erlornas
+            message= _ "There are so many of them!"
+        [/message]
+        [message]
+            speaker=Linaera
+            message= _ "And, look! More come, even as we speak!"
+        [/message]
+        [message]
+            speaker=narrator
+            image=wesnoth-icon.png
+            message= _ "The battle that ensued was bloody. The mages were utterly destroyed, and the elven losses were only the beginning of the mournful toll in a war that would rage for many years after."
+        [/message]
+        [message]
+            speaker=narrator
+            image=wesnoth-icon.png
+            message= _ "Erlornas' failure this day would haunt elven relations with humans forever more."
+        [/message]
+    [/event]
+
+    [event]
         name=enemies defeated
 
         [message]

--- a/data/campaigns/An_Orcish_Incursion/scenarios/06_A_Detour_through_the_Swamp.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/06_A_Detour_through_the_Swamp.cfg
@@ -96,7 +96,6 @@
 
         [if]
             [have_unit]
-                side=1
                 {LINAERA_APPRENTICE}
                 search_recall_list=yes
             [/have_unit]

--- a/data/campaigns/An_Orcish_Incursion/scenarios/06_A_Detour_through_the_Swamp.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/06_A_Detour_through_the_Swamp.cfg
@@ -94,17 +94,18 @@
             id=Linaera
         [/recall]
 
-        [role]
-            type="Red Mage,White Mage,Mage,Arch Mage,Silver Mage,Mage of Light,Great Mage"
-            [not]
-                canrecruit=yes
-            [/not]
-            role=mage
-        [/role]
-
-        [recall]
-            role=mage
-        [/recall]
+        [if]
+            [have_unit]
+                side=1
+                {LINAERA_APPRENTICE}
+                search_recall_list=yes
+            [/have_unit]
+            [then]
+                [recall]
+                    {LINAERA_APPRENTICE}
+                [/recall]
+            [/then]
+        [/if]
 
         {MODIFY_UNIT (side=1) facing se}
     [/event]
@@ -121,34 +122,53 @@
     [event]
         name=enemies defeated
 
-        [role]
-            type="Red Mage,White Mage,Mage,Arch Mage,Silver Mage,Mage of Light,Great Mage"
-            [not]
-                canrecruit=yes
-            [/not]
-            role=mage
-        [/role]
+        [if]
+            [have_unit]
+                {LINAERA_APPRENTICE}
+            [/have_unit]
+            [then]
+                [message]
+                    speaker=Linaera
+                    message= _ "Thank you, Erlornas... now I can return to my tower in peace. But I think some of my apprentices wish to follow you north in pursuit of the orcs."
+                [/message]
 
-        [message]
-            speaker=Linaera
-            message= _ "Thank you, Erlornas... now I can return to my tower in peace. But I think some of my apprentices wish to follow you north in pursuit of the orcs."
-        [/message]
+                [message]
+                    {LINAERA_APPRENTICE}
+                    message= _ "I have always wished to see elves, and now I have fought alongside them! May I please travel with you?"
+                [/message]
 
-        [message]
-            role=mage
-            message= _ "I have always wished to see elves, and now I have fought alongside them! May I please travel with you?"
-        [/message]
-
-        [message]
-            speaker=Erlornas
-            message= _ "Certainly... I shall be glad of your help."
-        [/message]
+                [message]
+                    speaker=Erlornas
+                    message= _ "Certainly... I shall be glad of your help."
+                [/message]
+            [/then]
+            [else]
+                [message]
+                    speaker=Linaera
+                    message= _ "Thank you, Erlornas... now I can return to my tower in peace."
+                [/message]
+            [/else]
+        [/if]
 
         [endlevel]
             result=victory
             bonus=yes
             {NEW_GOLD_CARRYOVER 40}
         [/endlevel]
+    [/event]
+
+    [event]
+        name=time over
+        [message]
+            speaker=narrator
+            image=wesnoth-icon.png
+            message= _ "One by one each member of the band was pulled down as more spirits appeared from the mist. None escaped while still living."
+        [/message]
+        [message]
+            speaker=narrator
+            image=wesnoth-icon.png
+            message= _ "The elves' war with the orcs would rage for many years, taking a mournful toll. But what became of Erlornas would forever remain a mystery."
+        [/message]
     [/event]
 
     {HERODEATH_ERLORNAS}

--- a/data/campaigns/An_Orcish_Incursion/scenarios/07_Showdown.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/07_Showdown.cfg
@@ -247,26 +247,18 @@
             side=2
         [/kill]
 
-        [role]
-            race=elf
-            [not]
-                canrecruit=yes
-            [/not]
-            role=advisor
-        [/role]
-
         [message]
-            speaker=Erlornas
+            {ERLORNAS_SPEAKS}
             message= _ "It grieves me to take life, even of a barbarian such as Rualsha."
         [/message]
 
         [message]
-            role=advisor
+            {NOT_ERLORNAS}
             message= _ "If the orcs press us, we shall need to become more accustomed to fighting."
         [/message]
 
         [message]
-            speaker=Erlornas
+            {ERLORNAS_SPEAKS}
             message= _ "I fear it will be so. We have won a first victory here, but dark times come upon its heels."
         [/message]
 
@@ -280,6 +272,41 @@
             carryover_report=no
             save=no
         [/endlevel]
+    [/event]
+
+    [event]
+        name=time over
+
+        [message]
+            {NOT_ERLORNAS}
+            message= _ "It’s hopeless; we’ve tried everything, and can not reach Rualsha."
+        [/message]
+
+        [message]
+            speaker=Rualsha
+            message= _ "Forward, you worthless worms! Look at them, they’re tired and afraid! You killed their will to fight, now go and finish the job!"
+        [/message]
+
+        [message]
+            speaker=narrator
+            image=wesnoth-icon.png
+            message= _ "Seemingly from nowhere, an arrow struck Erlornas dead."
+        [/message]
+
+        [message]
+            speaker=narrator
+            image=wesnoth-icon.png
+            message= _ "Of the ensuing events little is known, since much was lost in the chaos and confusion, but one thing is painfully sure: the orcsish invasion crushed the all elven resistance."
+        [/message]
+    [/event]
+
+    [event]
+        name=victory
+        [message]
+            speaker=narrator
+            image=wesnoth-icon.png
+            message= _ "With the defeat of Rualsha, the orcish invasion withered. For the elves, however, it only was a temporary reprieve for, soon, another warlord would appear in the north. But that is the story of the rise of Kalenz, as told in the Legend of Wesmere."
+        [/message]
     [/event]
 
     {HERODEATH_ERLORNAS}

--- a/data/campaigns/An_Orcish_Incursion/utils/macros.cfg
+++ b/data/campaigns/An_Orcish_Incursion/utils/macros.cfg
@@ -8,6 +8,30 @@
     [/note]
 #enddef
 
+#define LINAERA_APPRENTICE
+    side=1
+    type="Red Mage,White Mage,Mage,Arch Mage,Silver Mage,Mage of Light,Great Mage"
+    [not]
+        canrecruit=yes
+    [/not]
+#enddef
+
+#define NOT_ERLORNAS
+    side=1
+    [not]
+        id=Erlornas
+    [/not]
+#enddef
+
+#define ERLORNAS_SPEAKS
+    [show_if]
+        [have_unit]
+            {NOT_ERLORNAS}
+        [/have_unit]
+    [/show_if]
+    speaker=Erlornas
+#enddef
+
 #define RECALL_ADVISOR
     [if]
         [have_unit]


### PR DESCRIPTION
On playing AOI, I see WML errors on screen for several scenarios.

In most cases, these occur at the beginning of the scenario, where message should be displayed for an 'adviser' and no adviser can be found. For instance, if, at the end of the previous scenario, the recall list was empty an no units remain alive. In these cases, I replace the 'adviser' role, simply attributing the message to the eldest unit available.

A similar message appears in S06 where no apprentice mage can be recalled alongside Lenaera. Here, the fix is to simply avoid attempting the recall.

In fixing these errors, I noted a number of other edge conditions where, for example, Erlornas is delivering his half of a conversation but no unit exists to deliver the other half. In these cases, I suppressed Erlornas' half, as well.

This left some end-of-scenario conditions with no viable messages. Some scenarios simple omitted any messages on some end conditions. For these, I added narration so the player does not simply go from ending a turn to success or failure.
