### PR TITLE
Modernize the MD5 hash calculation API

### DIFF
--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -23,9 +23,9 @@ namespace util {
 const std::string itoa64 = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" ;
 const std::string hash_prefix = "$H$";
 
-unsigned char* md5(const std::string& input) {
+std::array<uint8_t, 16> md5(const std::string& input) {
 	MD5 md5_worker;
-	md5_worker.update(const_cast<unsigned char*>(reinterpret_cast<const unsigned char*>(input.c_str())), input.size());
+	md5_worker.update(reinterpret_cast<const uint8_t*>(input.data()), input.size());
 	md5_worker.finalize();
 	return md5_worker.raw_digest();
 }
@@ -48,7 +48,7 @@ bool is_valid_hash(const std::string& hash) {
 	return true;
 }
 
-std::string encode_hash(unsigned char* input) {
+std::string encode_hash(const std::array<uint8_t, 16>& input) {
 	std::string encoded_hash;
 
 	unsigned int i = 0;
@@ -74,9 +74,9 @@ std::string encode_hash(unsigned char* input) {
 std::string create_hash(const std::string& password, const std::string& salt, int iteration_count) {
 	iteration_count = 1 << iteration_count;
 
-	unsigned char* output = md5(salt + password);
+	std::array<uint8_t, 16> output = md5(salt + password);
 	do {
-		output = md5(std::string(reinterpret_cast<char*>(output), reinterpret_cast<char*>(output) + 16).append(password));
+		output = md5(std::string(output.begin(), output.end()).append(password));
 	} while(--iteration_count);
 
 	return encode_hash(output);

--- a/src/hash.hpp
+++ b/src/hash.hpp
@@ -15,6 +15,8 @@
 #ifndef HASH_HPP_INCLUDED
 #define HASH_HPP_INCLUDED
 
+#include <array>
+#include <cstdint>
 #include <string>
 
 namespace util {
@@ -26,11 +28,11 @@ namespace util {
  *       the raw MD5 value, not a null-terminated string. Use encode_hash if
  *       you need the text representation instead.
  */
-unsigned char* md5(const std::string& input);
+std::array<uint8_t, 16> md5(const std::string& input);
 int get_iteration_count(const std::string& hash);
 std::string get_salt(const std::string& hash);
 bool is_valid_hash(const std::string& hash);
-std::string encode_hash(unsigned char* input);
+std::string encode_hash(const std::array<uint8_t, 16>& input);
 std::string create_hash(const std::string& password, const std::string& salt, int iteration_count =10);
 
 } // namespace util

--- a/src/md5.cpp
+++ b/src/md5.cpp
@@ -72,7 +72,7 @@ MD5::MD5()
 // operation, processing another message block, and updating the
 // context.
 
-void MD5::update (uint1 *input, uint4 input_length) {
+void MD5::update (const uint1* input, uint4 input_length) {
 
   uint4 input_index, buffer_index;
   uint4 buffer_space;                // how much space is left in buffer
@@ -156,17 +156,17 @@ void MD5::finalize (){
 }
 
 
-MD5::uint1 *MD5::raw_digest()
+std::array<uint8_t, 16> MD5::raw_digest()
 {
-  static uint1 s[16];
+  std::array<uint8_t, 16> s;
 
   if (!finalized){
     std::cerr << "MD5::raw_digest:  Can't get digest if you haven't "<<
       "finalized the digest!" <<std::endl;
-    return nullptr;
+    throw std::logic_error("MD5::raw_digest: attempted to obtain digest before finalizing it");
   }
 
-  memcpy(s, digest, 16);
+  memcpy(s.data(), digest, 16);
   return s;
 }
 
@@ -213,7 +213,7 @@ void MD5::init(){
 
 
 // MD5 basic transformation. Transforms state based on block.
-void MD5::transform (uint1 block[64]){
+void MD5::transform (const uint1 block[64]){
 
   uint4 a = state[0], b = state[1], c = state[2], d = state[3], x[16];
 
@@ -324,7 +324,7 @@ void MD5::encode (uint1 *output, uint4 *input, uint4 len) {
 
 // Decodes input (uint1) into output (UINT4). Assumes len is
 // a multiple of 4.
-void MD5::decode (uint4 *output, uint1 *input, uint4 len){
+void MD5::decode (uint4 *output, const uint1 *input, uint4 len){
 
   uint4 i, j;
 

--- a/src/md5.hpp
+++ b/src/md5.hpp
@@ -42,26 +42,27 @@ documentation and/or software.
 #ifndef MD5_HPP_INCLUDED
 #define MD5_HPP_INCLUDED
 
-#include <boost/cstdint.hpp>
+#include <array>
+#include <cstdint>
 
 class MD5 {
 
 public:
 // methods for controlled operation:
   MD5              ();  // simple initializer
-  void  update     (boost::uint8_t *input, boost::uint32_t input_length);
+  void  update     (const uint8_t* input, const uint32_t input_length);
   void  finalize   ();
 
 // methods to acquire finalized result
-  boost::uint8_t    *raw_digest ();  // digest as a 16-byte binary array
+  std::array<uint8_t, 16> raw_digest ();  // digest as a 16-byte binary array
 
 
 private:
 
 // first, some types:
-  typedef boost::uint32_t uint4;
-  typedef boost::uint16_t uint2;
-  typedef boost::uint8_t  uint1;
+  typedef uint32_t uint4;
+  typedef uint16_t uint2;
+  typedef uint8_t  uint1;
 
 // next, the private data:
   uint4 state[4];
@@ -72,11 +73,11 @@ private:
 
 // last, the private methods, mostly static:
   void init             ();                 // called by all constructors
-  void transform        (uint1 buffer[64]); // does the real update work.  Note
-                                            // that length is implied to be 64.
+  void transform        (const uint1 buffer[64]); // does the real update work.  Note
+                                                  // that length is implied to be 64.
 
   static void encode    (uint1 *dest, uint4 *src, uint4 length);
-  static void decode    (uint4 *dest, uint1 *src, uint4 length);
+  static void decode    (uint4 *dest, const uint1 *src, uint4 length);
 
   static inline uint4  rotate_left (uint4 x, uint4 n);
   static inline uint4  F           (uint4 x, uint4 y, uint4 z);


### PR DESCRIPTION
I modernized the MD5 calculation API to use `std::array` and `std::vector` instead of raw C arrays. This way, in particular, the length of the MD5 hash is shown right in the function signatures, and it's no longer possible to accidentally pass an incorrect length to `MD5::update()`.

The internal API of the MD5 class I left intact to the extent I could. I needed to add the `const` qualifier to a couple of function parameters, though.