### PR TITLE
AOI Fix WML unit not found for role

### DIFF
--- a/data/campaigns/An_Orcish_Incursion/scenarios/01_Defend_the_Forest.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/01_Defend_the_Forest.cfg
@@ -50,7 +50,7 @@
     [side]
         side=1
         controller=human
-        recruit="Elvish Archer,Elvish Fighter,Elvish Scout,Elvish Shaman"
+        extra_recruit="Elvish Archer,Elvish Fighter,Elvish Scout,Elvish Shaman"
         {GOLD 200 150 100}
         income=0
         team_name=Elves
@@ -183,8 +183,10 @@
     [event]
         name=time over
 
+        {PROMOTE_ADVISOR}
+
         [message]
-            race=elf
+            role=advisor
             message= _ "It’s hopeless; we’ve tried everything, and they’re still coming back."
         [/message]
 
@@ -217,6 +219,8 @@
             id=Erlornas
         [/filter]
 
+        {PROMOTE_ADVISOR}
+
         [message]
             speaker=Erlornas
             message= _ "Ugh..."
@@ -228,10 +232,7 @@
         [/message]
 
         [message]
-            race=elf
-            [not]
-                id=Erlornas
-            [/not]
+            role=advisor
             message= _ "Lord!"
         [/message]
 

--- a/data/campaigns/An_Orcish_Incursion/scenarios/02_Assassins.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/02_Assassins.cfg
@@ -36,7 +36,6 @@
     [side]
         side=1
         controller=human
-        recruit="Elvish Archer,Elvish Fighter,Elvish Scout,Elvish Shaman"
         type=Elvish Lord
         team_name=Elves
         user_team_name= _ "Elves"

--- a/data/campaigns/An_Orcish_Incursion/scenarios/03_Wasteland.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/03_Wasteland.cfg
@@ -44,7 +44,6 @@
     [side]
         side=1
         controller=human
-        recruit="Elvish Archer,Elvish Fighter,Elvish Scout,Elvish Shaman"
         {INCOME 12 9 9}
         team_name=Elves
         user_team_name= _ "Elves"
@@ -116,6 +115,8 @@
 
     [event]
         name=start
+
+        {PROMOTE_ADVISOR}
 
         [message]
             role=advisor
@@ -233,13 +234,7 @@
     [event]
         name=victory
 
-        [role]
-            race=elf
-            [not]
-                canrecruit=yes
-            [/not]
-            role=advisor
-        [/role]
+        {PROMOTE_ADVISOR}
 
         [message]
             role=advisor
@@ -320,13 +315,7 @@
     [event]
         name=time over
 
-        [role]
-            race=elf
-            [not]
-                canrecruit=yes
-            [/not]
-            role=advisor
-        [/role]
+        {PROMOTE_ADVISOR}
 
         [message]
             role=advisor

--- a/data/campaigns/An_Orcish_Incursion/scenarios/04_Valley_of_Trolls.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/04_Valley_of_Trolls.cfg
@@ -40,7 +40,6 @@
     [side]
         side=1
         controller=human
-        recruit="Elvish Archer,Elvish Fighter,Elvish Scout,Elvish Shaman"
         team_name=Elves
         user_team_name= _ "Elves"
         {FLAG_VARIANT wood-elvish}
@@ -229,13 +228,7 @@
     [event]
         name=enemies defeated
 
-        [role]
-            race=elf
-            [not]
-                canrecruit=yes
-            [/not]
-            role=advisor
-        [/role]
+        {PROMOTE_ADVISOR}
 
         [message]
             role=advisor
@@ -283,13 +276,7 @@
             id=Erlornas
         [/filter]
 
-        [role]
-            race=elf
-            [not]
-                canrecruit=yes
-            [/not]
-            role=advisor
-        [/role]
+        {PROMOTE_ADVISOR}
 
         [message]
             speaker=second_unit
@@ -317,6 +304,8 @@
 
     [event]
         name=time over
+
+        {PROMOTE_ADVISOR}
 
         [message]
             role=advisor

--- a/data/campaigns/An_Orcish_Incursion/scenarios/05_Linaera_the_Quick.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/05_Linaera_the_Quick.cfg
@@ -41,7 +41,6 @@
     [side]
         side=1
         controller=human
-        recruit="Elvish Archer,Elvish Fighter,Elvish Scout,Elvish Shaman"
         {GOLD 100 100 100}
         {INCOME 0 0 0}
         team_name=Elves
@@ -94,6 +93,7 @@
         {CHARACTER_STATS_LINAERA}
 
         facing=nw
+        extra_recruit="Mage"
     [/side]
     # wmllint: validate-on
 
@@ -211,14 +211,18 @@
             message= _ "Some time later..."
         [/message]
 
-        [teleport]
+        # TODO - Revert to [teleport]
+        # GAL 2016-07-02 Workaround since 1.13.4+dev [teleport] does not work.
+        # All we lose is the teleport animations but Linaera’s minions never had it
+        # (which always sorta bothered me).
+        [modify_unit]
             [filter]
                 id=Linaera
             [/filter]
 
-            x,y=16,17
-            animate=yes
-        [/teleport]
+            x=16
+            y=17
+        [/modify_unit]
 
         {LOYAL_UNIT 3 Mage 17 17}
         {FACING se}

--- a/data/campaigns/An_Orcish_Incursion/scenarios/05_Linaera_the_Quick.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/05_Linaera_the_Quick.cfg
@@ -211,18 +211,14 @@
             message= _ "Some time later..."
         [/message]
 
-        # TODO - Revert to [teleport]
-        # GAL 2016-07-02 Workaround since 1.13.4+dev [teleport] does not work.
-        # All we lose is the teleport animations but Linaera’s minions never had it
-        # (which always sorta bothered me).
-        [modify_unit]
+        [teleport]
             [filter]
                 id=Linaera
             [/filter]
 
-            x=16
-            y=17
-        [/modify_unit]
+            x,y=16,17
+            animate=yes
+        [/teleport]
 
         {LOYAL_UNIT 3 Mage 17 17}
         {FACING se}

--- a/data/campaigns/An_Orcish_Incursion/scenarios/06_A_Detour_through_the_Swamp.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/06_A_Detour_through_the_Swamp.cfg
@@ -24,7 +24,6 @@
     [side]
         side=1
         controller=human
-        recruit="Elvish Archer,Elvish Fighter,Elvish Scout,Elvish Shaman"
         team_name=Elves
         user_team_name= _ "Elves"
         {FLAG_VARIANT wood-elvish}
@@ -94,17 +93,7 @@
             id=Linaera
         [/recall]
 
-        [role]
-            type="Red Mage,White Mage,Mage,Arch Mage,Silver Mage,Mage of Light,Great Mage"
-            [not]
-                canrecruit=yes
-            [/not]
-            role=mage
-        [/role]
-
-        [recall]
-            role=mage
-        [/recall]
+        {RECALL_MAGE}
 
         {MODIFY_UNIT (side=1) facing se}
     [/event]
@@ -121,13 +110,7 @@
     [event]
         name=enemies defeated
 
-        [role]
-            type="Red Mage,White Mage,Mage,Arch Mage,Silver Mage,Mage of Light,Great Mage"
-            [not]
-                canrecruit=yes
-            [/not]
-            role=mage
-        [/role]
+        {PROMOTE_MAGE}
 
         [message]
             speaker=Linaera

--- a/data/campaigns/An_Orcish_Incursion/scenarios/07_Showdown.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/07_Showdown.cfg
@@ -23,7 +23,6 @@
     [side]
         side=1
         controller=human
-        recruit="Elvish Archer,Elvish Fighter,Elvish Scout,Elvish Shaman"
         gold=100
         income=0
         team_name=Elves
@@ -247,13 +246,7 @@
             side=2
         [/kill]
 
-        [role]
-            race=elf
-            [not]
-                canrecruit=yes
-            [/not]
-            role=advisor
-        [/role]
+        {PROMOTE_ADVISOR}
 
         [message]
             speaker=Erlornas

--- a/data/campaigns/An_Orcish_Incursion/utils/macros.cfg
+++ b/data/campaigns/An_Orcish_Incursion/utils/macros.cfg
@@ -24,137 +24,101 @@
     [/not]
 #enddef
 
-#define PROMOTE_MAGE
+#define PROMOTE sideNumber roleName filterWML recallWML
     [if]
-        [have_unit]
-            side=1
-            role=mage
-        [/have_unit]
-        [else]
+        [not]
+            [have_unit]
+                side={sideNumber}
+                role={roleName}
+            [/have_unit]
+        [/not]
+        [then]
             [if]
                 [have_unit]
-                    {IS_MAGE}
+                    side={sideNumber}
+                    {filterWML}
                 [/have_unit]
                 [then]
                     [role]
-                        {IS_MAGE}
-                        role=mage
+                        side={sideNumber}
+                        {filterWML}
+                        role={roleName}
                     [/role]
                 [/then]
                 [else]
-                    {RECALL_MAGE}
+                    {recallWML}
                 [/else]
             [/if]
-        [/else]
+        [/then]
     [/if]
+#enddef 
+
+#define PROMOTE_MAGE
+    {PROMOTE 1 mage {IS_MAGE} {RECALL_MAGE}}
 #enddef
 
 #define PROMOTE_ADVISOR
+    {PROMOTE 1 advisor {CAN_ADVISE} {RECALL_ADVISOR}}
+#enddef
+
+#define AOI_RECALL sideNumber roleName filterWML unitWML
     [if]
         [have_unit]
-            side=1
-            role=advisor
+            side={sideNumber}
+            role={roleName}
+            search_recall_list=yes
         [/have_unit]
+        [then]
+            [recall]
+                side={sideNumber}
+                role={roleName}
+            [/recall]
+        [/then]
+        [elseif]
+            [have_unit]
+                side={sideNumber}
+                {filterWML}
+                search_recall_list=yes
+            [/have_unit]
+            [then]
+                [role]
+                    side={sideNumber}
+                    {filterWML}
+                    role={roleName}
+                [/role]
+                [recall]
+                    side={sideNumber}
+                    role={roleName}
+                [/recall]
+            [/then]
+        [/elseif]
         [else]
-            [if]
-                [have_unit]
-                    {CAN_ADVISE}
-                [/have_unit]
-                [then]
-                    [role]
-                        {CAN_ADVISE}
-                        role=advisor
-                    [/role]
-                [/then]
-                [else]
-                    {RECALL_ADVISOR}
-                [/else]
-            [/if]
+            {unitWML}
+            [+unit]
+                role={roleName}
+            [/unit]
         [/else]
     [/if]
 #enddef
 
 #define RECALL_MAGE
-    [if]
-        [have_unit]
+    {AOI_RECALL 1 mage {IS_MAGE} (
+        [unit]
+            type=Mage
             side=1
-            role=mage
-            search_recall_list=yes
-        [/have_unit]
-        [then]
-            [recall]
-                side=1
-                role=mage
-            [/recall]
-        [/then]
-        [elseif]
-            [have_unit]
-                {IS_MAGE}
-                search_recall_list=yes
-            [/have_unit]
-            [then]
-                [role]
-                    {IS_MAGE}
-                    role=mage
-                [/role]
-
-                [recall]
-                    side=1
-                    role=mage
-                [/recall]
-            [/then]
-        [/elseif]
-        [else]
-            [unit]
-                type=Mage
-                side=1
-                role=mage
-                animate=yes
-                placement=leader
-            [/unit]
-        [/else]
-    [/if]
+            animate=yes
+            placement=leader
+        [/unit]
+    )}
 #enddef
 
 #define RECALL_ADVISOR
-    [if]
-        [have_unit]
+    {AOI_RECALL 1 advisor {CAN_ADVISE} (
+        [unit]
+            type=Elvish Fighter
             side=1
-            role=advisor
-            search_recall_list=yes
-        [/have_unit]
-        [then]
-            # Recall an advisor if we have one to do so
-            [recall]
-                role=advisor
-            [/recall]
-        [/then]
-        [elseif]
-            # Else, make a new advisor from an elf unit
-            [have_unit]
-                {CAN_ADVISE}
-                search_recall_list=yes
-            [/have_unit]
-            [then]
-                [role]
-                    {CAN_ADVISE}
-                    role=advisor
-                [/role]
-
-                [recall]
-                    role=advisor
-                [/recall]
-            [/then]
-        [/elseif]
-        [else]
-            # If that fails too, make a brand new advisor
-            [unit]
-                type=Elvish Fighter
-                side=1
-                role=advisor
-                animate=yes
-                placement=leader
-            [/unit]
-        [/else]
-    [/if]
+            animate=yes
+            placement=leader
+        [/unit]
+    )}
 #enddef

--- a/data/campaigns/An_Orcish_Incursion/utils/macros.cfg
+++ b/data/campaigns/An_Orcish_Incursion/utils/macros.cfg
@@ -26,13 +26,11 @@
 
 #define PROMOTE_MAGE
     [if]
-        [not]
-            [have_unit]
-                side=1
-                role=mage
-            [/have_unit]
-        [/not]
-        [then]
+        [have_unit]
+            side=1
+            role=mage
+        [/have_unit]
+        [else]
             [if]
                 [have_unit]
                     {IS_MAGE}
@@ -47,19 +45,17 @@
                     {RECALL_MAGE}
                 [/else]
             [/if]
-        [/then]
+        [/else]
     [/if]
 #enddef
 
 #define PROMOTE_ADVISOR
     [if]
-        [not]
-            [have_unit]
-                side=1
-                role=advisor
-            [/have_unit]
-        [/not]
-        [then]
+        [have_unit]
+            side=1
+            role=advisor
+        [/have_unit]
+        [else]
             [if]
                 [have_unit]
                     {CAN_ADVISE}
@@ -74,7 +70,7 @@
                     {RECALL_ADVISOR}
                 [/else]
             [/if]
-        [/then]
+        [/else]
     [/if]
 #enddef
 

--- a/data/campaigns/An_Orcish_Incursion/utils/macros.cfg
+++ b/data/campaigns/An_Orcish_Incursion/utils/macros.cfg
@@ -24,34 +24,34 @@
     [/not]
 #enddef
 
-#define PROMOTE sideNumber roleName filterWML recallWML
+#define PROMOTE SIDENUMBER ROLENAME FILTERWML RECALLWML
     [if]
         [not]
             [have_unit]
-                side={sideNumber}
-                role={roleName}
+                side={SIDENUMBER}
+                role={ROLENAME}
             [/have_unit]
         [/not]
         [then]
             [if]
                 [have_unit]
-                    side={sideNumber}
-                    {filterWML}
+                    side={SIDENUMBER}
+                    {FILTERWML}
                 [/have_unit]
                 [then]
                     [role]
-                        side={sideNumber}
-                        {filterWML}
-                        role={roleName}
+                        side={SIDENUMBER}
+                        {FILTERWML}
+                        role={ROLENAME}
                     [/role]
                 [/then]
                 [else]
-                    {recallWML}
+                    {RECALLWML}
                 [/else]
             [/if]
         [/then]
     [/if]
-#enddef 
+#enddef
 
 #define PROMOTE_MAGE
     {PROMOTE 1 mage {IS_MAGE} {RECALL_MAGE}}
@@ -61,41 +61,41 @@
     {PROMOTE 1 advisor {CAN_ADVISE} {RECALL_ADVISOR}}
 #enddef
 
-#define AOI_RECALL sideNumber roleName filterWML unitWML
+#define AOI_RECALL SIDENUMBER ROLENAME FILTERWML UNITWML
     [if]
         [have_unit]
-            side={sideNumber}
-            role={roleName}
+            side={SIDENUMBER}
+            role={ROLENAME}
             search_recall_list=yes
         [/have_unit]
         [then]
             [recall]
-                side={sideNumber}
-                role={roleName}
+                side={SIDENUMBER}
+                role={ROLENAME}
             [/recall]
         [/then]
         [elseif]
             [have_unit]
-                side={sideNumber}
-                {filterWML}
+                side={SIDENUMBER}
+                {FILTERWML}
                 search_recall_list=yes
             [/have_unit]
             [then]
                 [role]
-                    side={sideNumber}
-                    {filterWML}
-                    role={roleName}
+                    side={SIDENUMBER}
+                    {FILTERWML}
+                    role={ROLENAME}
                 [/role]
                 [recall]
-                    side={sideNumber}
-                    role={roleName}
+                    side={SIDENUMBER}
+                    role={ROLENAME}
                 [/recall]
             [/then]
         [/elseif]
         [else]
-            {unitWML}
+            {UNITWML}
             [+unit]
-                role={roleName}
+                role={ROLENAME}
             [/unit]
         [/else]
     [/if]

--- a/data/campaigns/An_Orcish_Incursion/utils/macros.cfg
+++ b/data/campaigns/An_Orcish_Incursion/utils/macros.cfg
@@ -8,6 +8,118 @@
     [/note]
 #enddef
 
+#define IS_MAGE
+    side=1
+    type="Red Mage,White Mage,Mage,Arch Mage,Silver Mage,Mage of Light,Great Mage"
+    [not]
+        canrecruit=yes
+    [/not]
+#enddef
+
+#define CAN_ADVISE
+    side=1
+    race=elf
+    [not]
+        canrecruit=yes
+    [/not]
+#enddef
+
+#define PROMOTE_MAGE
+    [if]
+        [not]
+            [have_unit]
+                side=1
+                role=mage
+            [/have_unit]
+        [/not]
+        [then]
+            [if]
+                [have_unit]
+                    {IS_MAGE}
+                [/have_unit]
+                [then]
+                    [role]
+                        {IS_MAGE}
+                        role=mage
+                    [/role]
+                [/then]
+                [else]
+                    {RECALL_MAGE}
+                [/else]
+            [/if]
+        [/then]
+    [/if]
+#enddef
+
+#define PROMOTE_ADVISOR
+    [if]
+        [not]
+            [have_unit]
+                side=1
+                role=advisor
+            [/have_unit]
+        [/not]
+        [then]
+            [if]
+                [have_unit]
+                    {CAN_ADVISE}
+                [/have_unit]
+                [then]
+                    [role]
+                        {CAN_ADVISE}
+                        role=advisor
+                    [/role]
+                [/then]
+                [else]
+                    {RECALL_ADVISOR}
+                [/else]
+            [/if]
+        [/then]
+    [/if]
+#enddef
+
+#define RECALL_MAGE
+    [if]
+        [have_unit]
+            side=1
+            role=mage
+            search_recall_list=yes
+        [/have_unit]
+        [then]
+            [recall]
+                side=1
+                role=mage
+            [/recall]
+        [/then]
+        [elseif]
+            [have_unit]
+                {IS_MAGE}
+                search_recall_list=yes
+            [/have_unit]
+            [then]
+                [role]
+                    {IS_MAGE}
+                    role=mage
+                [/role]
+
+                [recall]
+                    side=1
+                    role=mage
+                [/recall]
+            [/then]
+        [/elseif]
+        [else]
+            [unit]
+                type=Mage
+                side=1
+                role=mage
+                animate=yes
+                placement=leader
+            [/unit]
+        [/else]
+    [/if]
+#enddef
+
 #define RECALL_ADVISOR
     [if]
         [have_unit]
@@ -24,19 +136,12 @@
         [elseif]
             # Else, make a new advisor from an elf unit
             [have_unit]
-                side=1
-                race=elf
-                [not]
-                    canrecruit=yes
-                [/not]
+                {CAN_ADVISE}
                 search_recall_list=yes
             [/have_unit]
             [then]
                 [role]
-                    race=elf
-                    [not]
-                        canrecruit=yes
-                    [/not]
+                    {CAN_ADVISE}
                     role=advisor
                 [/role]
 


### PR DESCRIPTION
My original goal was simply to suggest Linaera should be able to recruit Mage instead of using Erlornas' recruit list. But, in 1.13.4+dev, I hit some bugs which were not in 1.12. So, this is an omnibus which fixes those bugs.

One of those WML bugs was in S06 on victory where Linaera's student wants to speak but there is no surviving student. The fix for the advisor was to promote, recall or recruit. So that was what I did here. But, if Linaera can recruit here, why not let her recruit all the time? So fixing the bugs seems to lead to my original intention of allowing the player to use Linaera to recruit Mages, anyway.

1) In S05, using 1.13.4+dev, [teleport] for Linaera silently fails. Use [modify_unit] instead as a workaround. Added a TODO comment as a reminder to revert this. But it may be better if all four units (Linaera and her three student Mages) used the teleport arrival animation .. simultaneously, if possible .. I just don't know how to do this.

2) Traditionally, Linaera uses Erlornas' recruit list. Give each leader their own recruit list. Allow Linaera to recruit only Mage

3) Fix the WML unit not found for role errors when the advisor recalled (or recruited) at the beginning of the scenario does not make it to the end. Promote a surviving unit as the new advisor. If no units survive, recall or recruit one.

4) In cases where the advisor was not used, messages at the end of a scenario would be silently dropped. Change those messages to the advisor and promote one, if needed.

5) In S01, time over event, Erlornas would always be the eldest surviving elf. The intent appears to be that another elf deliver the message of hopelessness. So change this to the advisor. This aligns the time over here to be more like that in other scenarios, where used.