### PR TITLE
Liberty Fix WML unit not found for role

### DIFF
--- a/data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg
+++ b/data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg
@@ -242,16 +242,10 @@
             message= _ "We must tell the people of Delwyn about this."
         [/message]
 
-        [role]
-            type=Fugitive_Peasant,Outlaw_Peasant,Huntsman_Peasant,Human Ranger,Trapper_Peasant,Poacher_Peasant,Thug_Peasant
-            [not]
-                id=Harper
-            [/not]
-            role=Advisor
-        [/role]
+        {PROMOTE_ADVISOR Thug_Peasant}
 
         [message]
-            role=Advisor
+            role=advisor
             message= _ "That is true. We have always flown to their aid, and they to ours. This is something we should face together."
         [/message]
 

--- a/data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg
+++ b/data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg
@@ -242,7 +242,15 @@
             message= _ "We must tell the people of Delwyn about this."
         [/message]
 
-        {PROMOTE_ADVISOR Thug_Peasant}
+        {IF_HAVE_UNIT_SET_ROLE 1 advisor (
+            type="Huntsman_Peasant,Ranger,Fugitive_Peasant,Highwayman_Peasant,Outlaw_Peasant,Trapper_Peasant,Bandit_Peasant,Footpad_Peasant,Poacher_Peasant,Thug_Peasant"
+            [not]
+                id=Harper
+                [or]
+                    canrecruit=yes
+                [/or]
+            [/not]
+        )}
 
         [message]
             role=advisor
@@ -292,6 +300,7 @@
                 canrecruit=$stored_peasants[$i].canrecruit
                 overlays=$stored_peasants[$i].overlays
                 random_traits=$stored_peasants[$i].random_traits
+                role=$stored_peasants[$i].role
 
                 [insert_tag]
                     name=modifications

--- a/data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg
+++ b/data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg
@@ -155,7 +155,9 @@
         [recall]
             id=Harper
         [/recall]
-        {RECALL_ADVISOR Thug}
+        [recall]
+            role=advisor
+        [/recall]
 
         # This makes sure Baldras' portrait doesn't cover up Relana's sprite
         [scroll_to_unit]

--- a/data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg
+++ b/data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg
@@ -155,13 +155,7 @@
         [recall]
             id=Harper
         [/recall]
-        [role]
-            type=Huntsman,Ranger,Fugitive,Highwayman,Outlaw,Trapper,Bandit,Footpad,Poacher,Thug
-            role=Advisor
-        [/role]
-        [recall]
-            role=Advisor
-        [/recall]
+        {RECALL_ADVISOR Thug}
 
         # This makes sure Baldras' portrait doesn't cover up Relana's sprite
         [scroll_to_unit]
@@ -189,7 +183,7 @@
             message= _ "Well, it won’t be long until they report back to the local garrison with the details of your encounter."
         [/message]
         [message]
-            speaker=Advisor
+            role=advisor
             message= _ "Then they’ll be back in force."
         [/message]
         [message]

--- a/data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg
+++ b/data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg
@@ -169,7 +169,18 @@
         [recall]
             id=Harper
         [/recall]
-        {RECALL_ADVISOR Thug}
+        {IF_HAVE_UNIT_SET_ROLE 1 advisor (
+            type="Huntsman,Ranger,Fugitive,Highwayman,Outlaw,Trapper,Bandit,Footpad,Poacher,Thug"
+            [not]
+                id=Harper
+                [or]
+                    canrecruit=yes
+                [/or]
+            [/not]
+        )}
+        [recall]
+            role=advisor
+        [/recall]
 
         [message]
             speaker=Lord Maddock

--- a/data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg
+++ b/data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg
@@ -169,13 +169,7 @@
         [recall]
             id=Harper
         [/recall]
-        [role]
-            type=Outlaw,Trapper,Thug,Poacher,Footpad,Bandit
-            role=Advisor
-        [/role]
-        [recall]
-            role=Advisor
-        [/recall]
+        {RECALL_ADVISOR Thug}
 
         [message]
             speaker=Lord Maddock

--- a/data/campaigns/Liberty/scenarios/05_Hide_and_Seek.cfg
+++ b/data/campaigns/Liberty/scenarios/05_Hide_and_Seek.cfg
@@ -46,10 +46,10 @@
         side=2
         canrecruit=yes
         controller=ai
-        ai_algorithm=idle_ai
         user_team_name=_"Asheviere"
         team_name=bad_guys
         [ai]
+            ai_algorithm=idle_ai
             passive_leader=yes
         [/ai]
         shroud=no

--- a/data/campaigns/Liberty/scenarios/08_Glory.cfg
+++ b/data/campaigns/Liberty/scenarios/08_Glory.cfg
@@ -529,19 +529,19 @@
     #
     [event]
         name=turn 4
-        [role]
-            role=farseer
-            type=Outlaw,Footpad,Bandit,Thug,Thief,Huntsman,Trapper,Poacher,Rogue Mage,Rogue,Shadow Mage
-        [/role]
-        [message]
-            role=farseer
-            message= _ "Look in the distance... riders approach!"
-        [/message]
         [if]
             [have_unit]
-                role=farseer
+                type=Outlaw,Footpad,Bandit,Thug,Thief,Huntsman,Trapper,Poacher,Rogue Mage,Rogue,Shadow Mage
             [/have_unit]
             [then]
+                [role]
+                    role=farseer
+                    type=Outlaw,Footpad,Bandit,Thug,Thief,Huntsman,Trapper,Poacher,Rogue Mage,Rogue,Shadow Mage
+                [/role]
+                [message]
+                    role=farseer
+                    message= _ "Look in the distance... riders approach!"
+                [/message]
                 [message]
                     speaker=Baldras
                     message= _ "Who is it?"

--- a/data/campaigns/Liberty/scenarios/08_Glory.cfg
+++ b/data/campaigns/Liberty/scenarios/08_Glory.cfg
@@ -169,7 +169,7 @@
             [/avoid]
         [/ai]
         [ai]
-            turns=7-FOREVER
+            turns=7-99
             caution=0.1
             aggression=0.9
             scout_village_targeting=1
@@ -271,7 +271,7 @@
         [/ai]
 
         [ai]
-            turns=7-FOREVER
+            turns=7-99
             aggression=0.6
             caution=0.6
             leader_value=0.5

--- a/data/campaigns/Liberty/utils/utils.cfg
+++ b/data/campaigns/Liberty/utils/utils.cfg
@@ -168,24 +168,26 @@
 
 #define IF_HAVE_UNIT_SET_ROLE sideNumber roleName unitFilter
     [if]
-        [have_unit]
-            side={sideNumber}
-            role={roleName}
-            search_recall_list=yes
-        [/have_unit]
-        [elseif]
+        [not]
+            [have_unit]
+                side={sideNumber}
+                role={roleName}
+                search_recall_list=yes
+            [/have_unit]
+        [/not]
+        [and]
             [have_unit]
                 side={sideNumber}
                 {unitFilter}
                 search_recall_list=yes
             [/have_unit]
-            [then]
-                [role]
-                    side={sideNumber}
-                    role={roleName}
-                    {unitFilter}
-                [/role]
-            [/then]
-        [/elseif]
+        [/and]
+        [then]
+            [role]
+                side={sideNumber}
+                role={roleName}
+                {unitFilter}
+            [/role]
+        [/then]
     [/if]
 #enddef

--- a/data/campaigns/Liberty/utils/utils.cfg
+++ b/data/campaigns/Liberty/utils/utils.cfg
@@ -166,77 +166,26 @@
     [/event]
 #enddef
 
-#define CAN_ADVISE
-    side=1
-    [not]
-        id=Harper
-        [or]
-            canrecruit=yes
-        [/or]
-    [/not]
-#enddef
-
-#define PROMOTE_ADVISOR RECRUIT
+#define IF_HAVE_UNIT_SET_ROLE sideNumber roleName unitFilter
     [if]
         [have_unit]
-            side=1
-            role=advisor
-        [/have_unit]
-        [else]
-            [if]
-                [have_unit]
-                    {CAN_ADVISE}
-                [/have_unit]
-                [then]
-                    [role]
-                        {CAN_ADVISE}
-                        role=advisor
-                    [/role]
-                [/then]
-                [else]
-                    {RECALL_ADVISOR {RECRUIT}}
-                [/else]
-            [/if]
-        [/else]
-    [/if]
-#enddef
-
-#define RECALL_ADVISOR RECRUIT
-    [if]
-        [have_unit]
-            side=1
-            role=advisor
+            side={sideNumber}
+            role={roleName}
             search_recall_list=yes
         [/have_unit]
-        [then]
-            [recall]
-                role=advisor
-            [/recall]
-        [/then]
         [elseif]
             [have_unit]
-                {CAN_ADVISE}
+                side={sideNumber}
+                {unitFilter}
                 search_recall_list=yes
             [/have_unit]
             [then]
                 [role]
-                    {CAN_ADVISE}
-                    role=advisor
+                    side={sideNumber}
+                    role={roleName}
+                    {unitFilter}
                 [/role]
-
-                [recall]
-                    role=advisor
-                [/recall]
             [/then]
         [/elseif]
-        [else]
-            [unit]
-                type={RECRUIT}
-                side=1
-                role=advisor
-                animate=yes
-                placement=leader
-            [/unit]
-        [/else]
     [/if]
 #enddef

--- a/data/campaigns/Liberty/utils/utils.cfg
+++ b/data/campaigns/Liberty/utils/utils.cfg
@@ -165,3 +165,78 @@
         [/message]
     [/event]
 #enddef
+
+#define CAN_ADVISE
+    side=1
+    [not]
+        id=Harper
+        [or]
+            canrecruit=yes
+        [/or]
+    [/not]
+#enddef
+
+#define PROMOTE_ADVISOR RECRUIT
+    [if]
+        [have_unit]
+            side=1
+            role=advisor
+        [/have_unit]
+        [else]
+            [if]
+                [have_unit]
+                    {CAN_ADVISE}
+                [/have_unit]
+                [then]
+                    [role]
+                        {CAN_ADVISE}
+                        role=advisor
+                    [/role]
+                [/then]
+                [else]
+                    {RECALL_ADVISOR {RECRUIT}}
+                [/else]
+            [/if]
+        [/else]
+    [/if]
+#enddef
+
+#define RECALL_ADVISOR RECRUIT
+    [if]
+        [have_unit]
+            side=1
+            role=advisor
+            search_recall_list=yes
+        [/have_unit]
+        [then]
+            [recall]
+                role=advisor
+            [/recall]
+        [/then]
+        [elseif]
+            [have_unit]
+                {CAN_ADVISE}
+                search_recall_list=yes
+            [/have_unit]
+            [then]
+                [role]
+                    {CAN_ADVISE}
+                    role=advisor
+                [/role]
+
+                [recall]
+                    role=advisor
+                [/recall]
+            [/then]
+        [/elseif]
+        [else]
+            [unit]
+                type={RECRUIT}
+                side=1
+                role=advisor
+                animate=yes
+                placement=leader
+            [/unit]
+        [/else]
+    [/if]
+#enddef

--- a/data/campaigns/Liberty/utils/utils.cfg
+++ b/data/campaigns/Liberty/utils/utils.cfg
@@ -166,27 +166,27 @@
     [/event]
 #enddef
 
-#define IF_HAVE_UNIT_SET_ROLE sideNumber roleName unitFilter
+#define IF_HAVE_UNIT_SET_ROLE SIDENUMBER ROLENAME UNITFILTER
     [if]
         [not]
             [have_unit]
-                side={sideNumber}
-                role={roleName}
+                side={SIDENUMBER}
+                role={ROLENAME}
                 search_recall_list=yes
             [/have_unit]
         [/not]
         [and]
             [have_unit]
-                side={sideNumber}
-                {unitFilter}
+                side={SIDENUMBER}
+                {UNITFILTER}
                 search_recall_list=yes
             [/have_unit]
         [/and]
         [then]
             [role]
-                side={sideNumber}
-                role={roleName}
-                {unitFilter}
+                side={SIDENUMBER}
+                role={ROLENAME}
+                {UNITFILTER}
             [/role]
         [/then]
     [/if]


### PR DESCRIPTION
In 1.13.4+dev I noted WML errors in S02 through S04 when attempting to locate a unit for use as an advisor.

I moved the macros over from AOI for locating, promoting and recalling an advisor. For this campaign, the unit types dynamically change; so I added a paramter which specifies the unit type to recruit if no suitable unit could be found. For this, I chose Thug and Thug_Peasant.

As with AOI, these macros select the eldest unit from the board or, of none exist there, from the recall list. This is a slight change from the original: my change allows the Footpad_Peasant to be an advisor, the original omitted this unit as a possibility. I did this so I could simply select a unit which was not one of the two heros and not worry about the specific unit types.

I also changed "Advisor" to "advisor" to align with AOI.

In S03 a [message] used "speaker=Advisor" and never appeared as a result. I changes this to "role=advisor" to have the message appear now that there is reliably an advisor available to deliver the message.

Finally, while testing, I ran into a but in 1.13.4+dev having to do with string-to-integer conversion. This affected S08, only. I changed the word 'FOREVER' to specify '99' turns, instead, to work around this bug. Since the scenario should end on turn 48 (or earlier), that is effectively the same. I can add a revert patch to this PR if a fix appears in the master; but it should not matter if this is never reverted.