### PR TITLE
DM S03 Fix WML unit not found for role

### DIFF
--- a/data/campaigns/Delfadors_Memoirs/scenarios/03_The_Road_to_Weldyn.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/03_The_Road_to_Weldyn.cfg
@@ -157,17 +157,9 @@
     #############################
     [event]
         name=turn 4
-        [if]
-            [have_unit]
-                type=Master Bowman,Longbowman,Bowman
-            [/have_unit]
-            [then]
-                [role]
-                    role=bowman_advisor
-                    type=Master Bowman,Longbowman,Bowman
-                [/role]
-            [/then]
-        [/if]
+        {OPTIONAL_ASSIGN_ROLE 1 bowman_advisor (
+            type={BOWMEN}
+        )}
         [message]
             role=bowman_advisor
             message=_"Beware! Night is falling — that’s when the orcs tend to attack!"
@@ -179,33 +171,15 @@
     #############################
     [event]
         name=victory
-        [if]
-            [have_unit]
-                role=bowman_advisor
-            [/have_unit]
-            [else]
-                [if]
-                    [have_unit]
-                        type=Master Bowman,Longbowman,Bowman
-                    [/have_unit]
-                    [then]
-                        [role]
-                            role=bowman_advisor
-                            type=Master Bowman,Longbowman,Bowman
-                        [/role]
-                    [/then]
-                    [else]
-                        [unit]
-                            type=Bowman
-                            side=1
-                            role=bowman_advisor
-                            animate=yes
-                            placement=leader
-                        [/unit]
-                    [/else]
-                [/if]
-            [/else]
-        [/if]
+        {DM_RECALL 1 bowman_advisor (
+            type={BOWMEN}
+        ) (
+            [unit]
+                type=Bowman
+                animate=yes
+                placement=leader
+            [/unit]
+        )}
         [message]
             role=bowman_advisor
             message=_"Thank you, Delfador, for helping to rid our land of those pestilent orcs. Your magic was more help than we looked for, and we are in your debt."

--- a/data/campaigns/Delfadors_Memoirs/scenarios/03_The_Road_to_Weldyn.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/03_The_Road_to_Weldyn.cfg
@@ -157,10 +157,17 @@
     #############################
     [event]
         name=turn 4
-        [role]
-            role=bowman_advisor
-            type=Master Bowman,Longbowman,Bowman
-        [/role]
+        [if]
+            [have_unit]
+                type=Master Bowman,Longbowman,Bowman
+            [/have_unit]
+            [then]
+                [role]
+                    role=bowman_advisor
+                    type=Master Bowman,Longbowman,Bowman
+                [/role]
+            [/then]
+        [/if]
         [message]
             role=bowman_advisor
             message=_"Beware! Night is falling — that’s when the orcs tend to attack!"
@@ -172,10 +179,33 @@
     #############################
     [event]
         name=victory
-        [role]
-            role=bowman_advisor
-            type=Master Bowman,Longbowman,Bowman
-        [/role]
+        [if]
+            [have_unit]
+                role=bowman_advisor
+            [/have_unit]
+            [else]
+                [if]
+                    [have_unit]
+                        type=Master Bowman,Longbowman,Bowman
+                    [/have_unit]
+                    [then]
+                        [role]
+                            role=bowman_advisor
+                            type=Master Bowman,Longbowman,Bowman
+                        [/role]
+                    [/then]
+                    [else]
+                        [unit]
+                            type=Bowman
+                            side=1
+                            role=bowman_advisor
+                            animate=yes
+                            placement=leader
+                        [/unit]
+                    [/else]
+                [/if]
+            [/else]
+        [/if]
         [message]
             role=bowman_advisor
             message=_"Thank you, Delfador, for helping to rid our land of those pestilent orcs. Your magic was more help than we looked for, and we are in your debt."

--- a/data/campaigns/Delfadors_Memoirs/scenarios/09_Houses_of_the_Undead.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/09_Houses_of_the_Undead.cfg
@@ -171,6 +171,12 @@
                 name=delf_has_staff
                 equals=true
             [/variable]
+            [or]
+                [variable]
+                    name=delf_has_staff
+                    equals=yes
+                [/variable]
+            [/or]
             [then]
                 {CLEAR_VARIABLE delf_has_staff}
                 [endlevel]

--- a/data/campaigns/Delfadors_Memoirs/scenarios/09_Houses_of_the_Undead.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/09_Houses_of_the_Undead.cfg
@@ -169,14 +169,8 @@
         [if]
             [variable]
                 name=delf_has_staff
-                equals=true
+                boolean_equals=true
             [/variable]
-            [or]
-                [variable]
-                    name=delf_has_staff
-                    equals=yes
-                [/variable]
-            [/or]
             [then]
                 {CLEAR_VARIABLE delf_has_staff}
                 [endlevel]

--- a/data/campaigns/Delfadors_Memoirs/scenarios/10_The_Gate_Between_Worlds.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/10_The_Gate_Between_Worlds.cfg
@@ -84,13 +84,30 @@
     [event]
         name=start
 
-        [role]
-            type=Ghost,Wraith,Shadow,Ghoul,Necrophage,Ghast
-            role=dead_sidekick
-        [/role]
-        [recall]
-            role=dead_sidekick
-        [/recall]
+        [if]
+            [have_unit]
+                type=Ghost,Wraith,Shadow,Ghoul,Necrophage,Ghast
+                search_recall_list=yes
+            [/have_unit]
+            [then]
+                [role]
+                    type=Ghost,Wraith,Shadow,Ghoul,Necrophage,Ghast
+                    role=dead_sidekick
+                [/role]
+                [recall]
+                    role=dead_sidekick
+                [/recall]
+            [/then]
+            [else]
+                [unit]
+                    type=Ghost
+                    side=1
+                    role=dead_sidekick
+                    animate=yes
+                    placement=leader
+                [/unit]
+            [/else]
+        [/if]
 
         [message]
             speaker=Iliah-Malal

--- a/data/campaigns/Delfadors_Memoirs/scenarios/10_The_Gate_Between_Worlds.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/10_The_Gate_Between_Worlds.cfg
@@ -84,30 +84,15 @@
     [event]
         name=start
 
-        [if]
-            [have_unit]
-                type=Ghost,Wraith,Shadow,Ghoul,Necrophage,Ghast
-                search_recall_list=yes
-            [/have_unit]
-            [then]
-                [role]
-                    type=Ghost,Wraith,Shadow,Ghoul,Necrophage,Ghast
-                    role=dead_sidekick
-                [/role]
-                [recall]
-                    role=dead_sidekick
-                [/recall]
-            [/then]
-            [else]
-                [unit]
-                    type=Ghost
-                    side=1
-                    role=dead_sidekick
-                    animate=yes
-                    placement=leader
-                [/unit]
-            [/else]
-        [/if]
+        {DM_RECALL 1 dead_sidekick (
+            type={UNDEAD}
+        ) (
+            [unit]
+                type=Ghost
+                animate=yes
+                placement=leader
+            [/unit]
+        )}
 
         [message]
             speaker=Iliah-Malal

--- a/data/campaigns/Delfadors_Memoirs/scenarios/12_Terror_at_the_Ford_of_Parthyn.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/12_Terror_at_the_Ford_of_Parthyn.cfg
@@ -565,6 +565,12 @@
         [/message]
 
         {SUBSUME_SIDE_AND_VILLAGES 5}
+        [modify_unit]
+            moves=$this_unit.max_moves
+            [filter]
+                id=Arpus
+            [/filter]
+        [/modify_unit]
     [/event]
 
     #################from here on

--- a/data/campaigns/Delfadors_Memoirs/scenarios/13_The_Return_of_Trouble.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/13_The_Return_of_Trouble.cfg
@@ -32,6 +32,7 @@
     # wmllint: recognize Kalenz
     # wmllint: validate-off
     [side]
+        id=DelfadorIsNotHere
         side=1
         no_leader=yes
         controller=human

--- a/data/campaigns/Delfadors_Memoirs/scenarios/14_Shadows.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/14_Shadows.cfg
@@ -25,6 +25,10 @@
     #wmllint: validate-off
     [side]
         {KALENZ}
+        controller=human
+        persistent=yes
+        save_id=Player
+        team_name=player
         # wmllint: recognize Kalenz
         recruit={ELVES}
         fog=yes

--- a/data/campaigns/Delfadors_Memoirs/scenarios/15_Save_the_King.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/15_Save_the_King.cfg
@@ -322,6 +322,12 @@
             message= _ "Thank you, friends. May we meet again in happier times. Now I must make haste, for I need to study the book and prepare for the battle with the undead."
         [/message]
 
+        [modify_unit]
+            moves=$this_unit.max_moves
+            [filter]
+                id=Kalenz
+            [/filter]
+        [/modify_unit]
         {ELVES_DEPART}
     [/event]
 

--- a/data/campaigns/Delfadors_Memoirs/scenarios/19_Showdown_in_the_Northern_Swamp.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/19_Showdown_in_the_Northern_Swamp.cfg
@@ -341,7 +341,7 @@
                             [have_unit]
                                 race=undead
                                 side=1
-                                count=2
+                                count=2-99999
                                 search_recall_list=yes
                             [/have_unit]
                         [/not]

--- a/data/campaigns/Delfadors_Memoirs/scenarios/20_Prince_of_Wesnoth.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/20_Prince_of_Wesnoth.cfg
@@ -43,6 +43,10 @@
     #wmllint: validate-off
     [side]
         {KALENZ}
+        controller=human
+        persistent=yes
+        save_id=Player
+        team_name=player
         canrecruit=yes
         # wmllint: recognize Kalenz
         recruit={ELVES}

--- a/data/campaigns/Delfadors_Memoirs/utils/characters.cfg
+++ b/data/campaigns/Delfadors_Memoirs/utils/characters.cfg
@@ -1,15 +1,11 @@
 #textdomain wesnoth-dm
 #define KALENZ
     id=Kalenz
-    save_id=Player
-    persistent=yes
     name= _"Kalenz"
     unrenamable=yes
     profile="portraits/kalenz.png"
     type=Elvish High Lord
     side=1
-    controller=human
-    team_name=player
     [modifications]
         {TRAIT_STRONG}
         {TRAIT_RESILIENT}

--- a/data/campaigns/Delfadors_Memoirs/utils/dm-macros.cfg
+++ b/data/campaigns/Delfadors_Memoirs/utils/dm-macros.cfg
@@ -5,22 +5,29 @@
 #enddef
 
 #define DWARVES
-Dwarvish Fighter,Dwarvish Thunderer,Dwarvish Ulfserker,Dwarvish Scout#enddef
+Dwarvish Fighter,Dwarvish Thunderer,Dwarvish Ulfserker,Dwarvish Scout
+#enddef
 
 #define DWARVES2
-Dwarvish Steelclad,Dwarvish Thunderguard,Dwarvish Berserker,Dwarvish Pathfinder#enddef
+Dwarvish Steelclad,Dwarvish Thunderguard,Dwarvish Berserker,Dwarvish Pathfinder
+#enddef
 
 #define ELVES
-Elvish Fighter,Elvish Archer,Elvish Scout,Elvish Shaman#enddef
+Elvish Fighter,Elvish Archer,Elvish Scout,Elvish Shaman
+#enddef
 
 #define ELVES2
-Elvish Hero,Elvish Captain,Elvish Ranger,Elvish Marksman,Elvish Rider,Elvish Druid,Elvish Sorceress#enddef
+Elvish Hero,Elvish Captain,Elvish Ranger,Elvish Marksman,Elvish Rider,Elvish Druid,Elvish Sorceress
+#enddef
 
 #define LOYALISTS
-Mage,Spearman,Horseman,Bowman#enddef
+Mage,Spearman,Horseman,Bowman
+#enddef
 
 #define BOWMEN
-Master Bowman,Longbowman,Bowman#enddef
+Master Bowman,Longbowman,Bowman
+#enddef
 
 #define UNDEAD
-Ghost,Wraith,Shadow,Ghoul,Necrophage,Ghast#enddef
+Ghost,Wraith,Shadow,Ghoul,Necrophage,Ghast
+#enddef

--- a/data/campaigns/Delfadors_Memoirs/utils/dm-macros.cfg
+++ b/data/campaigns/Delfadors_Memoirs/utils/dm-macros.cfg
@@ -5,29 +5,22 @@
 #enddef
 
 #define DWARVES
-Dwarvish Fighter,Dwarvish Thunderer,Dwarvish Ulfserker,Dwarvish Scout
-#enddef
+Dwarvish Fighter,Dwarvish Thunderer,Dwarvish Ulfserker,Dwarvish Scout#enddef
 
 #define DWARVES2
-Dwarvish Steelclad,Dwarvish Thunderguard,Dwarvish Berserker,Dwarvish Pathfinder
-#enddef
+Dwarvish Steelclad,Dwarvish Thunderguard,Dwarvish Berserker,Dwarvish Pathfinder#enddef
 
 #define ELVES
-Elvish Fighter,Elvish Archer,Elvish Scout,Elvish Shaman
-#enddef
+Elvish Fighter,Elvish Archer,Elvish Scout,Elvish Shaman#enddef
 
 #define ELVES2
-Elvish Hero,Elvish Captain,Elvish Ranger,Elvish Marksman,Elvish Rider,Elvish Druid,Elvish Sorceress
-#enddef
+Elvish Hero,Elvish Captain,Elvish Ranger,Elvish Marksman,Elvish Rider,Elvish Druid,Elvish Sorceress#enddef
 
 #define LOYALISTS
-Mage,Spearman,Horseman,Bowman
-#enddef
+Mage,Spearman,Horseman,Bowman#enddef
 
 #define BOWMEN
-Master Bowman,Longbowman,Bowman
-#enddef
+Master Bowman,Longbowman,Bowman#enddef
 
 #define UNDEAD
-Ghost,Wraith,Shadow,Ghoul,Necrophage,Ghast
-#enddef
+Ghost,Wraith,Shadow,Ghoul,Necrophage,Ghast#enddef

--- a/data/campaigns/Delfadors_Memoirs/utils/dm-macros.cfg
+++ b/data/campaigns/Delfadors_Memoirs/utils/dm-macros.cfg
@@ -18,3 +18,9 @@ Elvish Hero,Elvish Captain,Elvish Ranger,Elvish Marksman,Elvish Rider,Elvish Dru
 
 #define LOYALISTS
 Mage,Spearman,Horseman,Bowman#enddef
+
+#define BOWMEN
+Master Bowman,Longbowman,Bowman#enddef
+
+#define UNDEAD
+Ghost,Wraith,Shadow,Ghoul,Necrophage,Ghast#enddef

--- a/data/campaigns/Delfadors_Memoirs/utils/misc.cfg
+++ b/data/campaigns/Delfadors_Memoirs/utils/misc.cfg
@@ -154,42 +154,42 @@
 #
 # Otherwise, create a unit for the role and assign it to the side and role.
 
-#define DM_RECALL sideNumber roleName filterWML unitWML
+#define DM_RECALL SIDENUMBER ROLENAME FILTERWML UNITWML
     [if]
         [have_unit]
-            side={sideNumber}
-            role={roleName}
+            side={SIDENUMBER}
+            role={ROLENAME}
             search_recall_list=yes
         [/have_unit]
         [then]
             [recall]
-                side={sideNumber}
-                role={roleName}
+                side={SIDENUMBER}
+                role={ROLENAME}
             [/recall]
         [/then]
         [elseif]
             [have_unit]
-                side={sideNumber}
-                {filterWML}
+                side={SIDENUMBER}
+                {FILTERWML}
                 search_recall_list=yes
             [/have_unit]
             [then]
                 [role]
-                    side={sideNumber}
-                    {filterWML}
-                    role={roleName}
+                    side={SIDENUMBER}
+                    {FILTERWML}
+                    role={ROLENAME}
                 [/role]
                 [recall]
-                    side={sideNumber}
-                    role={roleName}
+                    side={SIDENUMBER}
+                    role={ROLENAME}
                 [/recall]
             [/then]
         [/elseif]
         [else]
-            {unitWML}
+            {UNITWML}
             [+unit]
-                side={sideNumber}
-                role={roleName}
+                side={SIDENUMBER}
+                role={ROLENAME}
             [/unit]
         [/else]
     [/if]
@@ -208,25 +208,25 @@
 # we do have a unit on the board which matches the filter,
 # assign the role to that unit.
 
-#define OPTIONAL_ASSIGN_ROLE sideNumber roleName filterWML
+#define OPTIONAL_ASSIGN_ROLE SIDENUMBER ROLENAME FILTERWML
     [if]
         [not]
             [have_unit]
-                side={sideNumber}
-                role={roleName}
+                side={SIDENUMBER}
+                role={ROLENAME}
             [/have_unit]
         [/not]
         [and]
             [have_unit]
-                side={sideNumber}
-                {filterWML}
+                side={SIDENUMBER}
+                {FILTERWML}
             [/have_unit]
         [/and]
         [then]
             [role]
-                side={sideNumber}
-                {filterWML}
-                role={roleName}
+                side={SIDENUMBER}
+                {FILTERWML}
+                role={ROLENAME}
             [/role]
         [/then]
     [/if]

--- a/data/campaigns/Delfadors_Memoirs/utils/misc.cfg
+++ b/data/campaigns/Delfadors_Memoirs/utils/misc.cfg
@@ -133,3 +133,101 @@
         blue=0
     [/color_adjust]
 #enddef
+
+
+
+# This is for times when we absolutely MUST have a unit on the
+# board with a given role. For example, when we need a speaker
+# for a message and omitting the message would cause the flow
+# of the conversation to jump or become unclear, or the message
+# imparts critical information to the player.
+#
+# If we have a unit with the role, then recall that unit.
+#
+# Note that only one unit should have the role.
+# So, if the unit is already on the board, the recall should silently fail.
+#
+# If we do not have a unit with the role, but we do have a unit matching the filter,
+# then assign the role to that unit and recall it.
+#
+# Again, if the unit is already on the board, the recall should silently fail.
+#
+# Otherwise, create a unit for the role and assign it to the side and role.
+
+#define DM_RECALL sideNumber roleName filterWML unitWML
+    [if]
+        [have_unit]
+            side={sideNumber}
+            role={roleName}
+            search_recall_list=yes
+        [/have_unit]
+        [then]
+            [recall]
+                side={sideNumber}
+                role={roleName}
+            [/recall]
+        [/then]
+        [elseif]
+            [have_unit]
+                side={sideNumber}
+                {filterWML}
+                search_recall_list=yes
+            [/have_unit]
+            [then]
+                [role]
+                    side={sideNumber}
+                    {filterWML}
+                    role={roleName}
+                [/role]
+                [recall]
+                    side={sideNumber}
+                    role={roleName}
+                [/recall]
+            [/then]
+        [/elseif]
+        [else]
+            {unitWML}
+            [+unit]
+                side={sideNumber}
+                role={roleName}
+            [/unit]
+        [/else]
+    [/if]
+#enddef
+
+
+
+# This is for times when we would like to have a unit on the
+# board with the given role but, if we do not, it is no great
+# harm. For example, we would like a unit to interject a
+# comment, but if it does not, the flow of the conversation
+# does not suffer, and the player does not lose valuable
+# information.
+#
+# If we don't have a unit on the board with the role, but
+# we do have a unit on the board which matches the filter,
+# assign the role to that unit.
+
+#define OPTIONAL_ASSIGN_ROLE sideNumber roleName filterWML
+    [if]
+        [not]
+            [have_unit]
+                side={sideNumber}
+                role={roleName}
+            [/have_unit]
+        [/not]
+        [and]
+            [have_unit]
+                side={sideNumber}
+                {filterWML}
+            [/have_unit]
+        [/and]
+        [then]
+            [role]
+                side={sideNumber}
+                {filterWML}
+                role={roleName}
+            [/role]
+        [/then]
+    [/if]
+#enddef


### PR DESCRIPTION
Turn 4: simply skip the message if there is no bowman

Victory: Use the same bowman as turn 4, promote one if not present, recruit one if none present at all.

AOI and Liberty used macros. But only needed once, here, so coded inline.