### PR TITLE
[option]message= deprecated, use label=

### DIFF
--- a/data/campaigns/Dead_Water/scenarios/03_Wolf_Coast.cfg
+++ b/data/campaigns/Dead_Water/scenarios/03_Wolf_Coast.cfg
@@ -303,7 +303,7 @@
         [message]
             speaker=$unit.id
             [option]
-                message= _ "That sounds great! I’ll take it."
+                label= _ "That sounds great! I’ll take it."
                 [command]
                     [set_variable]
                         name=get_trident
@@ -312,7 +312,7 @@
                 [/command]
             [/option]
             [option]
-                message= _ "That sounds frightening. Let someone else have it."
+                label= _ "That sounds frightening. Let someone else have it."
             [/option]
         [/message]
 
@@ -350,7 +350,7 @@
                             [message]
                                 speaker=$unit.id
                                 [option]
-                                    message= _ "Let me have that trident. I want to control lightning!"
+                                    label= _ "Let me have that trident. I want to control lightning!"
                                     [command]
                                         [set_variable]
                                             name=get_trident
@@ -359,7 +359,7 @@
                                     [/command]
                                 [/option]
                                 [option]
-                                    message= _ "I’ll just leave that trident where it is."
+                                    label= _ "I’ll just leave that trident where it is."
                                 [/option]
                             [/message]
                         [/then]

--- a/data/campaigns/Dead_Water/scenarios/05_Tirigaz.cfg
+++ b/data/campaigns/Dead_Water/scenarios/05_Tirigaz.cfg
@@ -664,7 +664,7 @@
                             speaker=Kai Krellis
                             message= _ "We have destroyed the undead."
                             [option]
-                                message= _ "Now maybe we can head west undisturbed."
+                                label= _ "Now maybe we can head west undisturbed."
                                 [command]
                                     [endlevel]
                                         result=victory
@@ -673,7 +673,7 @@
                                 [/command]
                             [/option]
                             [option]
-                                message= _ "This orc leader has not learned that threatening merfolk is a bad idea. We shall defeat him before we go."
+                                label= _ "This orc leader has not learned that threatening merfolk is a bad idea. We shall defeat him before we go."
                             [/option]
                         [/message]
                     [/else]

--- a/data/campaigns/Dead_Water/scenarios/10_The_Flaming_Sword.cfg
+++ b/data/campaigns/Dead_Water/scenarios/10_The_Flaming_Sword.cfg
@@ -959,7 +959,7 @@
         [message]
             speaker=unit
             [option]
-                message= _ "I’ll carry this sword and destroy undead with blasts of flame."
+                label= _ "I’ll carry this sword and destroy undead with blasts of flame."
                 [command]
                     [set_variable]
                         name=get_sword
@@ -968,7 +968,7 @@
                 [/command]
             [/option]
             [option]
-                message= _ "This sword is not right for me. Let someone else have it."
+                label= _ "This sword is not right for me. Let someone else have it."
             [/option]
         [/message]
 
@@ -1003,7 +1003,7 @@
                     [message]
                         speaker=unit
                         [option]
-                            message= _ "I’ll carry the sword."
+                            label= _ "I’ll carry the sword."
                             [command]
                                 [set_variable]
                                     name=get_sword
@@ -1012,7 +1012,7 @@
                             [/command]
                         [/option]
                         [option]
-                            message= _ "Let someone else have it."
+                            label= _ "Let someone else have it."
                         [/option]
                     [/message]
                     [if]

--- a/data/campaigns/Dead_Water/scenarios/12_Revenge.cfg
+++ b/data/campaigns/Dead_Water/scenarios/12_Revenge.cfg
@@ -826,7 +826,7 @@
         [message]
             speaker=$unit.id
             [option]
-                message= _ "That sounds great! I’ll take it."
+                label= _ "That sounds great! I’ll take it."
                 [command]
                     [set_variable]
                         name=get_necklace
@@ -835,7 +835,7 @@
                 [/command]
             [/option]
             [option]
-                message= _ "It doesn’t seem to have helped its previous owner. I don’t want it."
+                label= _ "It doesn’t seem to have helped its previous owner. I don’t want it."
             [/option]
         [/message]
 
@@ -872,7 +872,7 @@
                             [message]
                                 speaker=$unit.id
                                 [option]
-                                    message= _ "I would like my life force protected."
+                                    label= _ "I would like my life force protected."
                                     [command]
                                         [set_variable]
                                             name=get_necklace
@@ -881,7 +881,7 @@
                                     [/command]
                                 [/option]
                                 [option]
-                                    message= _ "My life force feels fine as it is."
+                                    label= _ "My life force feels fine as it is."
                                 [/option]
                             [/message]
                         [/then]

--- a/data/campaigns/Dead_Water/utils/items.cfg
+++ b/data/campaigns/Dead_Water/utils/items.cfg
@@ -207,7 +207,7 @@
                 [message]
                     speaker=Kai Krellis
                     [option]
-                        message= _ "We will let the bat have the ring. It will make him more helpful."
+                        label= _ "We will let the bat have the ring. It will make him more helpful."
                         [command]
                             [set_variable]
                                 name=get_ring
@@ -216,7 +216,7 @@
                         [/command]
                     [/option]
                     [option]
-                        message= _ "Someone take that off him before he hurts himself."
+                        label= _ "Someone take that off him before he hurts himself."
                     [/option]
                 [/message]
             [/then]
@@ -253,7 +253,7 @@
                 [message]
                     speaker=unit
                     [option]
-                        message= _ "I’ll take this ring, and you can rely on my strength."
+                        label= _ "I’ll take this ring, and you can rely on my strength."
                         [command]
                             [set_variable]
                                 name=get_ring
@@ -262,7 +262,7 @@
                         [/command]
                     [/option]
                     [option]
-                        message= _ "This thing makes me dizzy. Someone else can have it."
+                        label= _ "This thing makes me dizzy. Someone else can have it."
                     [/option]
                 [/message]
             [/else]

--- a/data/campaigns/Delfadors_Memoirs/scenarios/06_Swamps_of_Illuven.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/06_Swamps_of_Illuven.cfg
@@ -132,7 +132,7 @@
             speaker=Garrath
             message=_"Greetings, strangers! This swamp is dangerous... You wanna cross it, you’ll need protection — cost you only $fee gold!"
             [option]
-                message=_"Thanks very much. Here’s the gold..."
+                label=_"Thanks very much. Here’s the gold..."
                 [command]
                     {VARIABLE_OP fee multiply -1}
                     [gold]
@@ -180,7 +180,7 @@
                 [/command]
             [/option]
             [option]
-                message=_"No thanks — we’ll manage by ourselves..."
+                label=_"No thanks — we’ll manage by ourselves..."
                 [command]
                     [message]
                         speaker=Garrath

--- a/data/campaigns/Delfadors_Memoirs/scenarios/09_Houses_of_the_Undead.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/09_Houses_of_the_Undead.cfg
@@ -58,7 +58,7 @@
             speaker={STRING}
             message=_"Do you serve Iliah-Malal, living man?"
             [option]
-                message=_"Yes, I serve him."
+                label=_"Yes, I serve him."
                 [command]
                     [message]
                         speaker={STRING}
@@ -67,7 +67,7 @@
                 [/command]
             [/option]
             [option]
-                message=_"No, I do not."
+                label=_"No, I do not."
                 [command]
                     [message]
                         speaker={STRING}

--- a/data/campaigns/Eastern_Invasion/scenarios/04b_The_Undead_Border_Patrol.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/04b_The_Undead_Border_Patrol.cfg
@@ -197,7 +197,7 @@
             speaker=Gweddry
             message= _ "Hmm..."
             [option]
-                message= _ "I wish to destroy the evil before it can spread. East we go!"
+                label= _ "I wish to destroy the evil before it can spread. East we go!"
                 [command]
                     [message]
                         speaker=Dacyn
@@ -220,7 +220,7 @@
                 [/command]
             [/option]
             [option]
-                message= _ "You are right. It is foolish to go onward — we will turn back."
+                label= _ "You are right. It is foolish to go onward — we will turn back."
                 [command]
                     [message]
                         speaker=Mal-Skraat

--- a/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
@@ -246,7 +246,7 @@
             speaker=Gweddry
             message= _ "Hmm..."
             [option]
-                message= _ "Yes, blow it up."
+                label= _ "Yes, blow it up."
                 [command]
                     [message]
                         speaker=Engineer
@@ -314,7 +314,7 @@
                 [/command]
             [/option]
             [option]
-                message= _ "No, wait until later."
+                label= _ "No, wait until later."
                 [command]
                     [message]
                         speaker=Engineer

--- a/data/campaigns/Eastern_Invasion/scenarios/16_Weldyn_under_Attack.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/16_Weldyn_under_Attack.cfg
@@ -303,7 +303,7 @@
             speaker=Gweddry
             message= _ "I have. I think we should..."
             [option]
-                message= _ "challenge Mal-Ravanal to a duel."
+                label= _ "challenge Mal-Ravanal to a duel."
                 [command]
                     [message]
                         speaker=Dacyn
@@ -317,7 +317,7 @@
                 [/command]
             [/option]
             [option]
-                message= _ "try to isolate Mal-Ravanal in battle."
+                label= _ "try to isolate Mal-Ravanal in battle."
                 [command]
                     [message]
                         speaker=Owaec

--- a/data/campaigns/Heir_To_The_Throne/scenarios/04_The_Bay_of_Pearls.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/04_The_Bay_of_Pearls.cfg
@@ -761,7 +761,7 @@
             speaker=Delfador
             message= _ "It is north-west of here, a few leagues inland. There are two ways to go, by ship or on foot. Each has its own dangers. You must choose between them."
             [option]
-                message= _ "Ships? Ugh! I have been seasick for the last time. We shall walk!"
+                label= _ "Ships? Ugh! I have been seasick for the last time. We shall walk!"
                 [command]
                     [message]
                         speaker=Delfador
@@ -779,7 +779,7 @@
                 [/command]
             [/option]
             [option]
-                message= _ "Going by ship we may at least get a little rest for ourselves. By sea it is!"
+                label= _ "Going by ship we may at least get a little rest for ourselves. By sea it is!"
                 [command]
                     [message]
                         speaker=Delfador

--- a/data/campaigns/Heir_To_The_Throne/scenarios/06_The_Siege_of_Elensefar.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/06_The_Siege_of_Elensefar.cfg
@@ -293,7 +293,7 @@
             speaker=Konrad
             message= _ "Hmm... I have to consider this..."
             [option]
-                message= _ "Help us infiltrate the city. We can do the rest."
+                label= _ "Help us infiltrate the city. We can do the rest."
                 [command]
                     [message]
                         speaker=Reglok
@@ -310,7 +310,7 @@
                 [/command]
             [/option]
             [option]
-                message= _ "I want you to reinforce us once we break through their line."
+                label= _ "I want you to reinforce us once we break through their line."
                 [command]
                     [message]
                         speaker=Reglok

--- a/data/campaigns/Heir_To_The_Throne/scenarios/18_A_Choice_Must_Be_Made.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/18_A_Choice_Must_Be_Made.cfg
@@ -374,7 +374,7 @@
             speaker=Konrad
             message= _ "I say that..."
             [option]
-                message= _ "Our need for speed outweighs the danger. With the Merfolk to help us, we will win through."
+                label= _ "Our need for speed outweighs the danger. With the Merfolk to help us, we will win through."
                 [command]
                     {CLEAR_VARIABLE dialog}
 
@@ -387,7 +387,7 @@
                 [/command]
             [/option]
             [option]
-                message= _ "On second thought, perhaps we should choose a safer way to go."
+                label= _ "On second thought, perhaps we should choose a safer way to go."
                 [command]
                     [message]
                         speaker=unit

--- a/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
@@ -78,7 +78,7 @@
                     image="wesnoth-icon.png"
                     message= _ "Do you want this unit to pick up the sword?"
                     [option]
-                        message= _ "Yes"
+                        label= _ "Yes"
                         [command]
                             [object]
                                 id={ID}
@@ -120,7 +120,7 @@
                     [/option]
 
                     [option]
-                        message= _ "No"
+                        label= _ "No"
 
                         [command]
                             [allow_undo]
@@ -160,7 +160,7 @@
                     image="wesnoth-icon.png"
                     message= _ "Do you want this unit to pick up the armor?"
                     [option]
-                        message= _ "Yes"
+                        label= _ "Yes"
                         [command]
                             [object]
                                 id={ID}
@@ -230,7 +230,7 @@ fire:  +10%"
                         [/command]
                     [/option]
                     [option]
-                        message= _ "No"
+                        label= _ "No"
                     [/option]
                 [/message]
             [/then]

--- a/data/campaigns/Liberty/scenarios/06_The_Grey_Woods.cfg
+++ b/data/campaigns/Liberty/scenarios/06_The_Grey_Woods.cfg
@@ -347,7 +347,7 @@
                     speaker=Helicrom
                     message= _ "I leave it to you to decide."
                     [option]
-                        message= _ "I will take the gold. How does 500 sound?"
+                        label= _ "I will take the gold. How does 500 sound?"
                         [command]
                             [message]
                                 speaker=Helicrom
@@ -372,7 +372,7 @@
 
                     # Note: don't mess with the alignment in the next message key.
                     [option]
-                        message= _ "Send your men with us. They will be valuable help as we prepare for the assault from the Wesnoth army garrison."
+                        label= _ "Send your men with us. They will be valuable help as we prepare for the assault from the Wesnoth army garrison."
                         [command]
                             [message]
                                 speaker=Helicrom
@@ -391,7 +391,7 @@
                         [/command]
                     [/option]
                     [option]
-                        message= _ "I wish you to join us in battle against the Queen’s forces."
+                        label= _ "I wish you to join us in battle against the Queen’s forces."
                         [command]
                             [message]
                                 speaker=Helicrom

--- a/data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg
@@ -361,7 +361,7 @@
         #    speaker=Tallin
         #    message= _ "I... I..."
         #    [option]
-        #        message= _ "Die... you... little... dwarf... vermin!"
+        #        label= _ "Die... you... little... dwarf... vermin!"
         #        [command]
         #            [message]
         #                role=Supporter
@@ -465,7 +465,7 @@
         #        [/command]
         #    [/option]
         #    [option]
-        #        message= _ "(<i>Shakes head</i>) I reject your evil. Attack, men! Let us rid the good green world of this rotting filth!"
+        #        label= _ "(<i>Shakes head</i>) I reject your evil. Attack, men! Let us rid the good green world of this rotting filth!"
         #        [command]
         # NOTE: remove this message when the alt path is activated
         [message]

--- a/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
@@ -1329,7 +1329,7 @@
             image=items/staff.png
             message= _ "An elegantly carved sceptre rests at the bottom of the chest. Precious jewels glitter across its surface, and it exudes a great aura of power."
             [option]
-                message= _ "rod of justice^Take it"
+                label= _ "rod of justice^Take it"
                 [command]
                     [message]
                         speaker=unit
@@ -1447,7 +1447,7 @@
                 [/command]
             [/option]
             [option]
-                message= _ "rod of justice^Leave it"
+                label= _ "rod of justice^Leave it"
                 [command]
                     [allow_undo][/allow_undo]
                 [/command]
@@ -2193,7 +2193,7 @@
             speaker=unit
             message= _ "It looks like this is it. Here is the door to Malifor’s study. Are we all ready for this?"
             [option]
-                message= _ "Get those doors open!"
+                label= _ "Get those doors open!"
                 [command]
                     [sound]
                         name=gate-fall.ogg
@@ -2224,7 +2224,7 @@
                 [/command]
             [/option]
             [option]
-                message= _ "Just wait a sec."
+                label= _ "Just wait a sec."
                 [command]
                     [message]
                         speaker=unit
@@ -2263,7 +2263,7 @@
             speaker=unit
             message= _ "Nope. Should I open it?"
             [option]
-                message= _ "Go for it!"
+                label= _ "Go for it!"
                 [command]
                     {MODIFY_UNIT (x,y=$x1,$y1) facing se}
 
@@ -2303,7 +2303,7 @@
                 [/command]
             [/option]
             [option]
-                message= _ "Just wait a sec."
+                label= _ "Just wait a sec."
                 [command]
                     [message]
                         speaker=unit
@@ -2342,7 +2342,7 @@
             speaker=unit
             message= _ "Should I throw it?"
             [option]
-                message= _ "Go for it!"
+                label= _ "Go for it!"
                 [command]
                     [delay]
                         time=2000
@@ -2401,7 +2401,7 @@
                 [/command]
             [/option]
             [option]
-                message= _ "Just wait a sec."
+                label= _ "Just wait a sec."
                 [command]
                     [message]
                         speaker=unit

--- a/data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg
@@ -770,7 +770,7 @@
             speaker=Tallin
             message= _ "Hmmm, should we let the trolls run away or should we finish them now?"
             [option]
-                message= _ "Hey! Stand your ground, you cowards!"
+                label= _ "Hey! Stand your ground, you cowards!"
                 [command]
                     [message]
                         speaker=Bor
@@ -804,7 +804,7 @@
                 [/command]
             [/option]
             [option]
-                message= _ "Haha! Look at them run!"
+                label= _ "Haha! Look at them run!"
                 [command]
                     [endlevel]
                         result=victory
@@ -916,7 +916,7 @@
             speaker=Tallin
             message= _ "Hmmm, should we let the trolls run away or should we finish them now?"
             [option]
-                message= _ "Hey! Stand your ground, you cowards!"
+                label= _ "Hey! Stand your ground, you cowards!"
                 [command]
                     [message]
                         speaker=Bor
@@ -952,7 +952,7 @@
                 [/command]
             [/option]
             [option]
-                message= _ "Haha! Look at them run!"
+                label= _ "Haha! Look at them run!"
                 [command]
                     [endlevel]
                         result=victory

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg
@@ -228,7 +228,7 @@
             message= _ "Hmmm..."
 
             [option]
-                message= _ "If what you say is true, then there is no way our tribe can face such an army alone."
+                label= _ "If what you say is true, then there is no way our tribe can face such an army alone."
 
                 [command]
                     [message]
@@ -265,7 +265,7 @@
             [/option]
 
             [option]
-                message= _ "Bah, humans? No better than goblins. We’ll break them!"
+                label= _ "Bah, humans? No better than goblins. We’ll break them!"
 
                 [command]
                     [message]

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg
@@ -467,7 +467,7 @@
                             message=$unit_detonating_says
 
                             [option]
-                                message= _ "Let her blow!"
+                                label= _ "Let her blow!"
 
                                 [command]
                                     [message]
@@ -521,7 +521,7 @@
                             [/option]
 
                             [option]
-                                message= _ "Wait a moment."
+                                label= _ "Wait a moment."
 
                                 [command]
                                     [message]

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/02_The_Fall.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/02_The_Fall.cfg
@@ -291,7 +291,7 @@
             image=portraits/haldric-annoyed.png
 
             [option]
-                message= _ "I think that your skills may be useful. You may join us."
+                label= _ "I think that your skills may be useful. You may join us."
                 [command]
                     [message]
                         speaker=Wesfolk Leader
@@ -343,7 +343,7 @@
                 [/command]
             [/option]
             [option]
-                message= _ "Your word can’t be trusted. Prepare to meet your gods!"
+                label= _ "Your word can’t be trusted. Prepare to meet your gods!"
                 [command]
                     [message]
                         speaker=Wesfolk Leader

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/03_A_Harrowing_Escape.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/03_A_Harrowing_Escape.cfg
@@ -276,7 +276,7 @@ SW — The Midlands."
         message= _ "Now, should I go southeast on the river road, or southwest through the midlands? The river road crosses the Swamp of Esten, so I doubt that even orcs would go there. The Midlands were nice, but who knows what’s going on there now."
 
         [option]
-            message= _ "I think I’ll take the river road..."
+            label= _ "I think I’ll take the river road..."
             [command]
                 [message]
                     speaker=Lady Outlaw
@@ -298,7 +298,7 @@ SW — The Midlands."
             [/command]
         [/option]
         [option]
-            message= _ "We’ll go through the Midlands..."
+            label= _ "We’ll go through the Midlands..."
             [command]
                 [message]
                     speaker=Lady Outlaw

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/09_Fallen_Lich_Point.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/09_Fallen_Lich_Point.cfg
@@ -356,7 +356,7 @@
                             image=portraits/haldric-annoyed.png
 
                             [option]
-                                message= _ "I think I’ll say that magic phrase."
+                                label= _ "I think I’ll say that magic phrase."
 
                                 [command]
                                     [set_variable]
@@ -393,7 +393,7 @@
                             [/option]
 
                             [option]
-                                message= _ "I think I’ll wait a while before uttering any magic phrases."
+                                label= _ "I think I’ll wait a while before uttering any magic phrases."
 
                                 [command]
                                     [message]

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/16_The_Kalian.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/16_The_Kalian.cfg
@@ -143,7 +143,7 @@
 
 #define DRAGON
     [option]
-        message= _ "I think I’ll fight the dragon!"
+        label= _ "I think I’ll fight the dragon!"
 
         [show_if]
             [variable]
@@ -172,7 +172,7 @@
 
 #define BEACH
     [option]
-        message= _ "Let’s get those saurians and nagas on that beach!"
+        label= _ "Let’s get those saurians and nagas on that beach!"
 
         [show_if]
             [variable]
@@ -201,7 +201,7 @@
 
 #define HOLE
     [option]
-        message= _ "Let’s clear out that troll hole!"
+        label= _ "Let’s clear out that troll hole!"
 
         [show_if]
             [variable]
@@ -229,7 +229,7 @@
 
 #define ISLE
     [option]
-        message= _ "Let’s put those souls to rest on the cursed isle!"
+        label= _ "Let’s put those souls to rest on the cursed isle!"
 
         [show_if]
             [variable]

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/17a_The_Dragon.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/17a_The_Dragon.cfg
@@ -494,7 +494,7 @@
                     image=portraits/haldric-mad.png
 
                     [option]
-                        message= _ "Let’s get out of here!"
+                        label= _ "Let’s get out of here!"
                         [command]
                             [endlevel]
                                 result=victory
@@ -506,7 +506,7 @@
 
                     # TODO: prevent the time over defeat if this is chosen...
                     [option]
-                        message= _ "Let’s finish off the rest of these monsters!"
+                        label= _ "Let’s finish off the rest of these monsters!"
                     [/option]
                 [/message]
             [/then]

--- a/data/campaigns/The_South_Guard/scenarios/05_Choice_In_The_Fog.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/05_Choice_In_The_Fog.cfg
@@ -517,7 +517,7 @@
             speaker=Deoran
             message= _ "Hmm... I have to consider this... If I ally with the elves, I must fight the bandits, but if I ally with the bandits I will make enemies of the elves..."
             [option]
-                message= _ "Your crimes are too great. You will fall with the rest of the foul undead!"
+                label= _ "Your crimes are too great. You will fall with the rest of the foul undead!"
                 [command]
                     [music]
                         name=knolls.ogg
@@ -583,7 +583,7 @@
             [/option]
 
             [option]
-                message= _ "Very well. All men must unite against the undead."
+                label= _ "Very well. All men must unite against the undead."
                 [command]
                     [music]
                         name=knalgan_theme.ogg

--- a/data/campaigns/The_South_Guard/scenarios/07a_Into_the_Depths.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/07a_Into_the_Depths.cfg
@@ -454,7 +454,7 @@
             speaker=Deoran
             message= _ "What should we offer them for their help?"
             [option]
-                message= _ "We will give you $troll_help_cost gold pieces if you help us defeat the undead."
+                label= _ "We will give you $troll_help_cost gold pieces if you help us defeat the undead."
                 [command]
                     [store_side]
                         side=1
@@ -515,7 +515,7 @@
             [/option]
 
             [option]
-                message= _ "We will offer you freedom and a place in our lands."
+                label= _ "We will offer you freedom and a place in our lands."
                 [command]
                     [message]
                         speaker=Grek
@@ -611,7 +611,7 @@
                             [/variable]
                         [/show_if]
 
-                        message= _ "Here’s $troll_help_cost for your help against the undead."
+                        label= _ "Here’s $troll_help_cost for your help against the undead."
 
                         [command]
                             {TROLL_HELP}
@@ -619,7 +619,7 @@
                     [/option]
 
                     [option]
-                        message= _ "No, sorry."
+                        label= _ "No, sorry."
 
                         [command]
                             [allow_undo][/allow_undo]

--- a/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
@@ -484,7 +484,7 @@ Besides... I want my brother back."
             speaker=Arvith
             message= _ "It is my place to decide this."
             [option]
-                message= _ "Oh, all right then. Come along with us."
+                label= _ "Oh, all right then. Come along with us."
                 [command]
                     [message]
                         speaker=Brena
@@ -498,7 +498,7 @@ Besides... I want my brother back."
                 [/command]
             [/option]
             [option]
-                message= _ "I am sorry. We have not the time to spare."
+                label= _ "I am sorry. We have not the time to spare."
                 [command]
                     [message]
                         speaker=Brena

--- a/data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg
@@ -285,25 +285,25 @@ Yet for some reason I fear these brothers more. If Mordak were here it would be 
             speaker=Arvith
             message= _ "The password is"
             [option]
-                message= _ "$first_password_1|!"
+                label= _ "$first_password_1|!"
                 [command]
                     {VARIABLE first_password_picked "$first_password_1"}
                 [/command]
             [/option]
             [option]
-                message= _ "$first_password_2|!"
+                label= _ "$first_password_2|!"
                 [command]
                     {VARIABLE first_password_picked "$first_password_2"}
                 [/command]
             [/option]
             [option]
-                message= _ "$first_password_3|!"
+                label= _ "$first_password_3|!"
                 [command]
                     {VARIABLE first_password_picked "$first_password_3"}
                 [/command]
             [/option]
             [option]
-                message= _ "$first_password_4|!"
+                label= _ "$first_password_4|!"
                 [command]
                     {VARIABLE first_password_picked "$first_password_4"}
                 [/command]
@@ -482,25 +482,25 @@ Yet for some reason I fear these brothers more. If Mordak were here it would be 
             speaker=Arvith
             message= _ "Oh, of course. I had nearly forgotten."
             [option]
-                message= _ "$second_password_1|!"
+                label= _ "$second_password_1|!"
                 [command]
                     {VARIABLE second_password_picked "$second_password_1"}
                 [/command]
             [/option]
             [option]
-                message= _ "$second_password_2|!"
+                label= _ "$second_password_2|!"
                 [command]
                     {VARIABLE second_password_picked "$second_password_2"}
                 [/command]
             [/option]
             [option]
-                message= _ "$second_password_3|!"
+                label= _ "$second_password_3|!"
                 [command]
                     {VARIABLE second_password_picked "$second_password_3"}
                 [/command]
             [/option]
             [option]
-                message= _ "$second_password_4|!"
+                label= _ "$second_password_4|!"
                 [command]
                     {VARIABLE second_password_picked "$second_password_4"}
                 [/command]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg
@@ -482,7 +482,7 @@
 
                 message= _ "Should I take this ring?"
                 [option]
-                    message= _ "Yes, I’ll take it."
+                    label= _ "Yes, I’ll take it."
 
                     [command]
                         [object]
@@ -520,7 +520,7 @@
                 [/option]
 
                 [option]
-                    message= _ "No, I think someone else should wear it."
+                    label= _ "No, I think someone else should wear it."
 
                     [command]
                         [allow_undo]
@@ -1625,7 +1625,7 @@
 
                 message= _ "Should I take the holy water?"
                 [option]
-                    message= _ "Yes, I’ll take it."
+                    label= _ "Yes, I’ll take it."
 
                     [command]
                         [object]
@@ -1654,7 +1654,7 @@
                 [/option]
 
                 [option]
-                    message= _ "No, I think someone else should take it."
+                    label= _ "No, I think someone else should take it."
 
                     [command]
                         [allow_undo]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg
@@ -638,7 +638,7 @@
 
                 message= _ "Should I take this ring?"
                 [option]
-                    message= _ "Yes, I’ll take it."
+                    label= _ "Yes, I’ll take it."
 
                     [command]
                         [object]
@@ -671,7 +671,7 @@
                 [/option]
 
                 [option]
-                    message= _ "No, I think someone else should wear it."
+                    label= _ "No, I think someone else should wear it."
 
                     [command]
                         [allow_undo]
@@ -816,7 +816,7 @@
             speaker=unit
             message= _ "How odd. Someone has carved a crude fountain out of the stone at the end of the passage. The freezing water pours out into a large pool. At the bottom of the pool I can see a skeleton still gripping a sword. The blade seems to glow faintly blue. The pool isn’t very deep, I could easily wade in and pick it up. But someone else has carved a crude message in the wall. <i>“If you dare to take this blade here, your greatest fear will surely appear.”</i> It looks like a nice sword, but do I dare chance it?"
             [option]
-                message= _ "I fear no creature, I will take the blade!"
+                label= _ "I fear no creature, I will take the blade!"
                 [command]
                     [message]
                         speaker=unit
@@ -866,7 +866,7 @@
             [/option]
 
             [option]
-                message= _ "I don’t like the sound of this. I’m out of here."
+                label= _ "I don’t like the sound of this. I’m out of here."
             [/option]
         [/message]
     [/event]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg
@@ -1319,7 +1319,7 @@
             message= _ "But they both look evenly matched. Who should we ally with?"
 
             [option]
-                message= _ "Let’s aid the dwarves."
+                label= _ "Let’s aid the dwarves."
 
                 [command]
                     [set_variable]
@@ -1386,7 +1386,7 @@
             [/option]
 
             [option]
-                message= _ "Let’s aid the trolls."
+                label= _ "Let’s aid the trolls."
 
                 [command]
                     [set_variable]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg
@@ -1902,7 +1902,7 @@ _ "These undead trolls fight again in death as they did in life, except this tim
 
             message= _ "For a troll this is quite an ornate tomb. The coffin itself is quite impressive. Inside, the skeleton has crumbled to dust and there are a few colored stones and trinkets, but what really sticks out is this emerald wand. I don’t have much experience with magical items, but the asp with emerald eyes and large fangs carved around its shaft leave little doubt as to its power. We don’t normally tolerate using poison, but extreme circumstances call for extreme measures and I have a feeling we may find this useful before our journey is over."
             [option]
-                message= _ "It might be useful, I’ll take it."
+                label= _ "It might be useful, I’ll take it."
                 [command]
                     [event]
                         id=take_wand
@@ -1935,7 +1935,7 @@ _ "These undead trolls fight again in death as they did in life, except this tim
             [/option]
 
             [option]
-                message= _ "On second thought, it’s better to leave the dead in peace."
+                label= _ "On second thought, it’s better to leave the dead in peace."
 
                 [command]
                     [allow_undo]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
@@ -1667,7 +1667,7 @@
 
             message= _ "Based on the runes covering the walls this must be the tomb of some ancient dwarf. The tomb seems empty except for this ornate stone coffin. The skeleton inside the coffin has long since vanished into dust. All that’s left are a few ceremonial trinkets and this shining golden belt. Inscribed on this inside are the words: <i>“May you have the toughness to stay standing long after your enemies fall.”</i> Grave robbing is never a good thing to do, but this belt looks magical and its former owner certainly won’t miss it."
             [option]
-                message= _ "I fear no ghosts, I’ll take it."
+                label= _ "I fear no ghosts, I’ll take it."
                 [command]
                     [event]
                         id=take_belt
@@ -1711,7 +1711,7 @@
             [/option]
 
             [option]
-                message= _ "On second thought, it’s better to leave the dead in peace."
+                label= _ "On second thought, it’s better to leave the dead in peace."
 
                 [command]
                     [allow_undo]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg
@@ -591,7 +591,7 @@
 
             message= _ "Should I take this sword?"
             [option]
-                message= _ "Yes, I’ll take it."
+                label= _ "Yes, I’ll take it."
 
                 [command]
                     [object]
@@ -648,7 +648,7 @@
             [/option]
 
             [option]
-                message= _ "No, I think someone else should wield it."
+                label= _ "No, I think someone else should wield it."
 
                 [command]
                     [allow_undo]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg
@@ -584,7 +584,7 @@
 
             message= _ "Should I take this sword?"
             [option]
-                message= _ "Yes, I’ll take it."
+                label= _ "Yes, I’ll take it."
 
                 [command]
                     [object]
@@ -636,7 +636,7 @@
             [/option]
 
             [option]
-                message= _ "No, I think someone else should wield it."
+                label= _ "No, I think someone else should wield it."
 
                 [command]
                     [allow_undo]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
@@ -1969,7 +1969,7 @@
 
             message= _ "In the center of this circle is a huge creature, with surging muscles and bloodshot eyes. I would think it was just a very big man, except for the fine stitches that cover its entire body. In fact it seems to be composed of many body parts all sewn together. It seems to be floating asleep in the center of the glowing magical circle. I could scratch out part of the circle and break it, but I have no idea what the consequences would be. I’m not sure I want something with that kind of strength attacking me."
             [option]
-                message= _ "Break the circle"
+                label= _ "Break the circle"
                 [command]
                     [event]
                         id=break_circle
@@ -2034,7 +2034,7 @@
             [/option]
 
             [option]
-                message= _ "Leave that thing alone."
+                label= _ "Leave that thing alone."
 
                 [command]
                     [allow_undo]
@@ -2189,7 +2189,7 @@
 
             message= _ "What’s this? Hidden underneath the edge of the altar is an iron lever. It looks slightly rusted, but with some effort I could pull it. I have no idea what it will do, but we’re running out of options."
             [option]
-                message= _ "Pull the lever."
+                label= _ "Pull the lever."
                 [command]
                     [event]
                         id=pull_lever
@@ -2253,7 +2253,7 @@
             [/option]
 
             [option]
-                message= _ "Leave it alone."
+                label= _ "Leave it alone."
 
                 [command]
                     [allow_undo]

--- a/data/core/macros/ai_controller.cfg
+++ b/data/core/macros/ai_controller.cfg
@@ -448,7 +448,7 @@
                     [/ai]
 
                     [option]
-                        message= _ "Defend a location..."
+                        label= _ "Defend a location..."
 
                         [show_if]
                             [variable]

--- a/data/core/macros/items.cfg
+++ b/data/core/macros/items.cfg
@@ -21,7 +21,7 @@
             message= _ "You have come across a wishing well. What would you like to wish for?"
             image=scenery/well.png
             [option]
-                message= _ "A swift victory"
+                label= _ "A swift victory"
                 [command]
                     [gold]
                         amount=-1
@@ -35,7 +35,7 @@
             [/option]
 
             [option]
-                message= _ "Lots of gold"
+                label= _ "Lots of gold"
                 [command]
                     [gold]
                         side=$side_number
@@ -49,7 +49,7 @@
             [/option]
 
             [option]
-                message= _ "Peace throughout Wesnoth."
+                label= _ "Peace throughout Wesnoth."
                 [command]
                     [gold]
                         side=$side_number
@@ -63,7 +63,7 @@
             [/option]
 
             [option]
-                message= _ "Don’t make a wish."
+                label= _ "Don’t make a wish."
             [/option]
         [/message]
     [/event]
@@ -123,7 +123,7 @@
                     image={IMAGE}
 
                     [option]
-                        message={TAKE_IT_STRING}
+                        label={TAKE_IT_STRING}
 
                         [command]
                             {OBJECT_WML}
@@ -141,7 +141,7 @@
                     [/option]
 
                     [option]
-                        message={LEAVE_IT_STRING}
+                        label={LEAVE_IT_STRING}
 
                         [command]
                             [allow_undo]

--- a/data/multiplayer/scenarios/ANL_utils/ANL_help.cfg
+++ b/data/multiplayer/scenarios/ANL_utils/ANL_help.cfg
@@ -2,7 +2,7 @@
 
 #define ANL_RETURN_TO_MENU
     [option]
-        message= _ "Return to menu"
+        label= _ "Return to menu"
         [command]
             #[allow_undo]
             #[/allow_undo]
@@ -112,7 +112,7 @@
                         message= _ "Select a topic."
 
                         [option]
-                            message= _ "Done"
+                            label= _ "Done"
                             [command]
                                 [set_variable]
                                     name=finished_help
@@ -122,49 +122,49 @@
                         [/option]
 
                         [option]
-                            message="<span color='green'>" + _ "Peasants" + "</span>"
+                            label="<span color='green'>" + _ "Peasants" + "</span>"
                             [command]
                                 {ANL_HELP_PEASANTS}
                             [/command]
                         [/option]
 
                         [option]
-                            message="<span color='green'>" + _ "Mages" + "</span>"
+                            label="<span color='green'>" + _ "Mages" + "</span>"
                             [command]
                                 {ANL_HELP_MAGES}
                             [/command]
                         [/option]
 
                         [option]
-                            message="<span color='green'>" + _ "Farms" + "</span>"
+                            label="<span color='green'>" + _ "Farms" + "</span>"
                             [command]
                                 {ANL_HELP_FARMS}
                             [/command]
                         [/option]
 
                         [option]
-                            message="<span color='green'>" + _ "Villages" + "</span>"
+                            label="<span color='green'>" + _ "Villages" + "</span>"
                             [command]
                                 {ANL_HELP_VILLAGES}
                             [/command]
                         [/option]
 
                         [option]
-                            message="<span color='green'>" + _ "Mines" + "</span>"
+                            label="<span color='green'>" + _ "Mines" + "</span>"
                             [command]
                                 {ANL_HELP_MINES}
                             [/command]
                         [/option]
 
                         [option]
-                            message="<span color='green'>" + _ "Universities" + "</span>"
+                            label="<span color='green'>" + _ "Universities" + "</span>"
                             [command]
                                 {ANL_HELP_UNIVERSITIES}
                             [/command]
                         [/option]
 
                         [option]
-                            message="<span color='green'>" + _ "Diplomacy" + "</span>"
+                            label="<span color='green'>" + _ "Diplomacy" + "</span>"
                             [command]
                                 {ANL_HELP_DIPLOMACY}
                             [/command]

--- a/data/multiplayer/scenarios/ANL_utils/ANL_leader_options.cfg
+++ b/data/multiplayer/scenarios/ANL_utils/ANL_leader_options.cfg
@@ -25,7 +25,7 @@
 
 #define DONATE_FUNDS_OPTION TARGET_SIDE
     [option]
-        message= "<span color='green'>" + "$player_{TARGET_SIDE}.name" + "</span>" # wmllint: ignore no spellcheck
+        label= "<span color='green'>" + "$player_{TARGET_SIDE}.name" + "</span>" # wmllint: ignore no spellcheck
         [show_if]
             [variable]
                 name=leader.gold
@@ -72,7 +72,7 @@
 #define SHARE_FARMING_KNOWLEDGE_OPTION TARGET_SIDE
     [option]
         image = "items/flower4.png"
-        message = $diplo_msg[{TARGET_SIDE}].farming
+        label = $diplo_msg[{TARGET_SIDE}].farming
         [show_if]
             [variable]
                 name=player_$side_number|.farming.target
@@ -111,7 +111,7 @@
 #define SHARE_MINING_KNOWLEDGE_OPTION TARGET_SIDE
     [option]
         image = "items/gold-coins-small.png"
-        message = $diplo_msg[{TARGET_SIDE}].mining
+        label = $diplo_msg[{TARGET_SIDE}].mining
         [show_if]
             [variable]
                 name=player_$side_number|.mining.target
@@ -150,7 +150,7 @@
 #define SHARE_WARFARE_KNOWLEDGE_OPTION TARGET_SIDE
     [option]
         image = "wesnoth-icon.png"
-        message = $diplo_msg[{TARGET_SIDE}].warfare
+        label = $diplo_msg[{TARGET_SIDE}].warfare
         [show_if]
             [variable]
                 name=player_$side_number|.warfare.target
@@ -298,7 +298,7 @@ Share knowledge of warfare"
                         # Nothing
 
                         [option]
-                            message= _ "Nothing"
+                            label= _ "Nothing"
                             [command]
                                 [set_variable]
                                     name=finished_options
@@ -311,7 +311,7 @@ Share knowledge of warfare"
 
                         [option]
                             image = "items/gold-coins-small.png"
-                            message =  _ "<span color='green'>Donate Funds</span>
+                            label =  _ "<span color='green'>Donate Funds</span>
 Give 20 gold to another player"
                             [command]
                                 [set_variable]
@@ -333,7 +333,7 @@ Give 20 gold to another player"
                                             message= _ "Who will you donate funds to?"
 
                                             [option]
-                                                message= _ "Back"
+                                                label= _ "Back"
                                                 [command]
                                                     [set_variable]
                                                         name=finished_suboptions
@@ -356,7 +356,7 @@ Give 20 gold to another player"
 
                         [option]
                             image = "items/book4.png"
-                            message =  _ "<span color='green'>Share Knowledge</span>
+                            label =  _ "<span color='green'>Share Knowledge</span>
 Help an ally with their research"
                             [command]
                                 [set_variable]
@@ -378,7 +378,7 @@ Help an ally with their research"
                                             message= _ "Who will you share knowledge with?"
 
                                             [option]
-                                                message= _ "Back"
+                                                label= _ "Back"
                                                 [command]
                                                     [set_variable]
                                                         name=finished_suboptions
@@ -414,7 +414,7 @@ Help an ally with their research"
 
                         [option]
                             image = "units/dwarves/lord.png~TC(1,magenta)"
-                            message =  _ "<span color='green'>Negotiate with the Dwarves</span>
+                            label =  _ "<span color='green'>Negotiate with the Dwarves</span>
 Lets you recruit a Dwarvish unit
 Negotiation Progress: $player_$side_number|.leader_option_1.progress|/$player_$side_number|.leader_option_1.target"
                             [show_if]
@@ -470,7 +470,7 @@ Negotiation Progress: $player_$side_number|.leader_option_1.progress|/$player_$s
 
                         [option]
                             image = "units/elves-wood/marshal.png~TC(1,magenta)"
-                            message =  _ "<span color='green'>Negotiate with the Elves</span>
+                            label =  _ "<span color='green'>Negotiate with the Elves</span>
 Lets you recruit an Elvish unit
 Negotiation Progress: $player_$side_number|.leader_option_2.progress|/$player_$side_number|.leader_option_2.target"
                             [show_if]

--- a/data/multiplayer/scenarios/ANL_utils/ANL_research_options.cfg
+++ b/data/multiplayer/scenarios/ANL_utils/ANL_research_options.cfg
@@ -133,7 +133,7 @@ Our mines produce $player_$side_number|.mining.gold|g
                         # wmllint: display off
 
                         [option]
-                            message= _ "Continue as before"
+                            label= _ "Continue as before"
                             [command]
                                 [set_variable]
                                     name=finished_options
@@ -151,7 +151,7 @@ Our mines produce $player_$side_number|.mining.gold|g
 
                         [option]
                             image = "items/flower4.png"
-                            message = _ "<span color='green'>Agriculture</span>
+                            label = _ "<span color='green'>Agriculture</span>
 Farmers produce +1 gold
 Study Progress: $player_$side_number|.farming.progress|/$player_$side_number|.farming.target"
                             [command]
@@ -163,7 +163,7 @@ Study Progress: $player_$side_number|.farming.progress|/$player_$side_number|.fa
 
                         [option]
                             image = "items/gold-coins-small.png"
-                            message =  _ "<span color='green'>Mining</span>
+                            label =  _ "<span color='green'>Mining</span>
 Miners produce +1 gold
 Study Progress: $player_$side_number|.mining.progress|/$player_$side_number|.mining.target"
                             [command]
@@ -175,7 +175,7 @@ Study Progress: $player_$side_number|.mining.progress|/$player_$side_number|.min
 
                         [option]
                             image = "wesnoth-icon.png"
-                            message =  _ "<span color='green'>Warfare</span>
+                            label =  _ "<span color='green'>Warfare</span>
 Allows you to recruit a new type of unit
 Study Progress: $player_$side_number|.warfare.progress|/$player_$side_number|.warfare.target"
                             [show_if]

--- a/data/multiplayer/scenarios/ANL_utils/ANL_special_macros.cfg
+++ b/data/multiplayer/scenarios/ANL_utils/ANL_special_macros.cfg
@@ -128,7 +128,7 @@
 #define PICK_RECRUIT_OPTION UNIT_IMAGE UNIT_TYPE_STRING UNIT_TYPE_NAME_STRING VAR
     [option]
         image = {UNIT_IMAGE}
-        message = {UNIT_TYPE_NAME_STRING}
+        label = {UNIT_TYPE_NAME_STRING}
         [show_if]
             [variable]
                 name=player_$side_number|.{VAR}

--- a/data/multiplayer/scenarios/ANL_utils/ANL_worker_options.cfg
+++ b/data/multiplayer/scenarios/ANL_utils/ANL_worker_options.cfg
@@ -44,7 +44,7 @@
                         message= _ "What shall I do my liege?"
 
                         [option]
-                            message= _ "Nothing"
+                            label= _ "Nothing"
                             [command]
                                 [set_variable]
                                     name=finished
@@ -60,7 +60,7 @@
 
                         [option]
                             image = "terrain/grass/green6.png"
-                            message= "<span color='green'>" + _ "Plant Farm" + "</span>"
+                            label= "<span color='green'>" + _ "Plant Farm" + "</span>"
                             description = "<span size='small'>" + _ "Cost: 0g" + "</span>"
                             {ANL_SHOW_IF ("Peasant") "Re"}
                             [command]
@@ -79,7 +79,7 @@
 
                         [option]
                             image = "terrain/grass/green6.png"
-                            message = "<span color='green'>" + _ "Plant Farm" + "</span>"
+                            label = "<span color='green'>" + _ "Plant Farm" + "</span>"
                             description = "<span size='small'>" + _ "Cost: 0g" + "</span>"
                             {ANL_SHOW_IF ("Peasant") "Gg,Gs"}
                             [command]
@@ -95,7 +95,7 @@
 
                         [option]
                             image = "terrain/village/human-tile.png"
-                            message = "<span color='green'>" + _ "Build Village" + "</span>"
+                            label = "<span color='green'>" + _ "Build Village" + "</span>"
                             description = "<span size='small'>" + _ "Cost: 15g" + "</span>"
                             {ANL_SHOW_IF ("Peasant") "Gg,Gs"}
                             [command]
@@ -119,7 +119,7 @@
 
                         [option]
                             image = "terrain/castle/castle-tile.png"
-                            message = "<span color='green'>" + _ "Build Castle" + "</span>"
+                            label = "<span color='green'>" + _ "Build Castle" + "</span>"
                             description = "<span size='small'>" + _ "Cost: 6g" + "</span>"
                             {ANL_SHOW_IF ("Peasant") "Gg,Gs"}
                             [command]
@@ -142,7 +142,7 @@
 
                         [option]
                             image = "terrain/water/coast-tile.png"
-                            message = "<span color='green'>" + _ "Flood the Field" + "</span>"
+                            label = "<span color='green'>" + _ "Flood the Field" + "</span>"
                             description = "<span size='small'>" + _ "Cost: 4g" + "</span>"
                             {ANL_SHOW_IF ("Peasant") "Gg,Gs"}
                             [command]
@@ -167,7 +167,7 @@
 
                         [option]
                             image = "terrain/forest/pine-tile.png"
-                            message = "<span color='green'>" + _ "Plant Saplings" + "</span>"
+                            label = "<span color='green'>" + _ "Plant Saplings" + "</span>"
                             description = "<span size='small'>" + _ "Cost: 1g" + "</span>"
                             {ANL_SHOW_IF ("Peasant") "Gg,Gs"}
                             [command]
@@ -195,7 +195,7 @@
 
                         [option]
                             image = "terrain/grass/green6.png"
-                            message = "<span color='green'>" + _ "Chop Down Forest" + "</span>"
+                            label = "<span color='green'>" + _ "Chop Down Forest" + "</span>"
                             description = "<span size='small'>" + _ "Earns: 1g" + "</span>"
                             {ANL_SHOW_IF ("Peasant") "Gs^Fp,Gs^Ft,Aa^Fpa,Gg^Fet"}
                             [command]
@@ -251,7 +251,7 @@
 
                         [option]
                             image = "terrain/village/human-hills-tile.png"
-                            message = "<span color='green'>" + _ "Build Mine" + "</span>"
+                            label = "<span color='green'>" + _ "Build Mine" + "</span>"
                             description = "<span size='small'>" + _ "Cost: 25g" + "</span>"
                             {ANL_SHOW_IF ("Peasant") "Hh"}
                             [command]
@@ -278,7 +278,7 @@
 
                         [option]
                             image = "terrain/village/human-mountain-tile.png"
-                            message = "<span color='green'>" + _ "Build Mine" + "</span>"
+                            label = "<span color='green'>" + _ "Build Mine" + "</span>"
                             description = "<span size='small'>" + _ "Cost: 25g" + "</span>"
                             {ANL_SHOW_IF ("Peasant") "Mm"}
                             [command]
@@ -305,7 +305,7 @@
 
                         [option]
                             image = "terrain/water/ford.png"
-                            message = "<span color='green'>" + _ "Make a Ford" + "</span>"
+                            label = "<span color='green'>" + _ "Make a Ford" + "</span>"
                             description = "<span size='small'>" + _ "Cost: 3g" + "</span>"
                             {ANL_SHOW_IF ("Peasant") "Ww"}
                             [command]
@@ -333,7 +333,7 @@
 
                         [option]
                             image = "terrain/grass/green6.png"
-                            message = "<span color='green'>" + _ "Landfill" + "</span>"
+                            label = "<span color='green'>" + _ "Landfill" + "</span>"
                             description = "<span size='small'>" + _ "Cost: 5g" + "</span>"
                             {ANL_SHOW_IF ("Peasant") "Ww"}
                             [command]
@@ -364,7 +364,7 @@
 
                         [option]
                             image = "terrain/water/coast-tile.png"
-                            message = "<span color='green'>" + _ "Destroy the Ford" + "</span>"
+                            label = "<span color='green'>" + _ "Destroy the Ford" + "</span>"
                             description = "<span size='small'>" + _ "Cost: 0g" + "</span>"
                             {ANL_SHOW_IF ("Peasant") "Wwf"}
                             [command]
@@ -389,7 +389,7 @@
 
                         [option]
                             image = "terrain/grass/green6.png"
-                            message = "<span color='green'>" + _ "Landfill" + "</span>"
+                            label = "<span color='green'>" + _ "Landfill" + "</span>"
                             description = "<span size='small'>" + _ "Cost: 1g" + "</span>"
                             {ANL_SHOW_IF ("Peasant") "Wwf"}
                             [command]
@@ -420,7 +420,7 @@
 
                         [option]
                             image = "terrain/grass/green6.png"
-                            message = "<span color='green'>" + _ "Smash Cave Floor" + "</span>"
+                            label = "<span color='green'>" + _ "Smash Cave Floor" + "</span>"
                             description = "<span size='small'>" + _ "Cost: 2g" + "</span>"
                             {ANL_SHOW_IF ("Peasant") "Uu,Uu^Ii"}
                             [command]
@@ -445,7 +445,7 @@
 
                         [option]
                             image = "terrain/hills/regular2.png"
-                            message = "<span color='green'>" + _ "Smash Cave Floor" + "</span>"
+                            label = "<span color='green'>" + _ "Smash Cave Floor" + "</span>"
                             description = "<span size='small'>" + _ "Cost: 3g" + "</span>"
                             {ANL_SHOW_IF ("Peasant") "Uh,Uh^Ii"}
                             [command]
@@ -470,7 +470,7 @@
 
                         [option]
                             image = "terrain/cave/floor.png"
-                            message = "<span color='green'>" + _ "Harvest Mushrooms" + "</span>"
+                            label = "<span color='green'>" + _ "Harvest Mushrooms" + "</span>"
                             description = "<span size='small'>" + _ "Earns: 3g" + "</span>"
                             {ANL_SHOW_IF ("Peasant") "Uu^Uf"}
                             [command]
@@ -520,7 +520,7 @@
 
                         [option]
                             image = "terrain/castle/keep-tile.png"
-                            message = "<span color='green'>" + _ "Build a Keep" + "</span>"
+                            label = "<span color='green'>" + _ "Build a Keep" + "</span>"
                             description = "<span size='small'>" + _ "Cost: 6g" + "</span>"
                             {ANL_SHOW_IF ("Peasant") "Ch,Ce,Cv,Cud,Chr,Chw,Chs"}
                             [command]
@@ -546,7 +546,7 @@
 
                         [option]
                             image = "terrain/village/elven-tile.png"
-                            message = "<span color='green'>" + _ "Establish University" + "</span>"
+                            label = "<span color='green'>" + _ "Establish University" + "</span>"
                             description = "<span size='small'>" + _ "Cost: 7g" + "</span>"
                             {ANL_SHOW_IF ("Peasant") "Gg^Vh,Aa^Vha"}
                             [command]
@@ -573,7 +573,7 @@
 
                         [option]
                             image = "terrain/grass/green6.png"
-                            message = "<span color='green'>" + _ "Clear the Ground" + "</span>"
+                            label = "<span color='green'>" + _ "Clear the Ground" + "</span>"
                             description = "<span size='small'>" + _ "Cost: 0g" + "</span>"
                             {ANL_SHOW_IF ("Peasant") "Rd"}
                             [command]

--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -1778,10 +1778,10 @@ Also, 0..9 = $below_ten, one,two,three = $ascii and the bonus answer is $mixed."
                     speaker=narrator
                     message=Is this greeting really okay?
                     [option]
-                        message="Yes"
+                        label="Yes"
                     [/option]
                     [option]
-                        message="No"
+                        label="No"
                         [command]
                             [message]
                                 speaker=narrator
@@ -2136,7 +2136,7 @@ Also, 0..9 = $below_ten, one,two,three = $ascii and the bonus answer is $mixed."
             [/text_input]
 
             [option]
-                message="Parrot is in denial"
+                label="Parrot is in denial"
                 [command]
                     [message]
                         speaker=$parrot
@@ -2151,7 +2151,7 @@ Also, 0..9 = $below_ten, one,two,three = $ascii and the bonus answer is $mixed."
             [/option]
 
             [option]
-                message="Parrot accepted its fate"
+                label="Parrot accepted its fate"
             [/option]
         [/message]
 
@@ -2177,10 +2177,10 @@ Also, 0..9 = $below_ten, one,two,three = $ascii and the bonus answer is $mixed."
             speaker=unit
             message="Pick your drink"
             [option]
-                message="Soda"
+                label="Soda"
             [/option]
             [option]
-                message="Water"
+                label="Water"
                 [command]
                     [message]
                         speaker=narrator
@@ -2558,7 +2558,7 @@ For game purposes, the races group into factions; for example, orcs often cooper
                 speaker=narrator
                 message="What should we do with the number $number|?"
                 [option]
-                    message="Round it"
+                    label="Round it"
                     [command]
                         [message]
                             speaker=narrator
@@ -2584,7 +2584,7 @@ For game purposes, the races group into factions; for example, orcs often cooper
                     [/command]
                 [/option]
                 [option]
-                    message="Add something"
+                    label="Add something"
                     [command]
                         [message]
                             speaker=narrator
@@ -2605,7 +2605,7 @@ For game purposes, the races group into factions; for example, orcs often cooper
                     [/command]
                 [/option]
                 [option]
-                    message="Multiply"
+                    label="Multiply"
                     [command]
                         [message]
                             speaker=narrator
@@ -2626,7 +2626,7 @@ For game purposes, the races group into factions; for example, orcs often cooper
                     [/command]
                 [/option]
                 [option]
-                    message="Divide by something"
+                    label="Divide by something"
                     [command]
                         [message]
                             speaker=narrator
@@ -2647,7 +2647,7 @@ For game purposes, the races group into factions; for example, orcs often cooper
                     [/command]
                 [/option]
                 [option]
-                    message="Modulo"
+                    label="Modulo"
                     [command]
                         [message]
                             speaker=narrator
@@ -2668,7 +2668,7 @@ For game purposes, the races group into factions; for example, orcs often cooper
                     [/command]
                 [/option]
                 [option]
-                    message="ints&amp;floats"
+                    label="ints&amp;floats"
                     [command]
                         [set_variable]
                             name=int
@@ -3653,10 +3653,10 @@ unplagueable: $wml_unit.status.unplagueable"
                 id=statue
                 message="dynamic " + {TYPE} + " event ${VAR}|!"
                 [option]
-                    message="Continue!"
+                    label="Continue!"
                 [/option]
                 [option]
-                    message="Stop annoying me..."
+                    label="Stop annoying me..."
                     [command]
                         [set_variables]
                             name={VAR}
@@ -3754,55 +3754,55 @@ unplagueable: $wml_unit.status.unplagueable"
                     speaker=unit
                     message="What glamour should I cast upon our foe?"
                     [option]
-                        message="Flip around!"
+                        label="Flip around!"
                         [command]
                             {SHOW_IMAGE_PATH_TEST "FL(horiz,vert)"}
                         [/command]
                     [/option]
                     [option]
-                        message="Scale up"
+                        label="Scale up"
                         [command]
                             {SHOW_IMAGE_PATH_TEST "SCALE(200,200)"}
                         [/command]
                     [/option]
                     [option]
-                        message="Scale down"
+                        label="Scale down"
                         [command]
                             {SHOW_IMAGE_PATH_TEST "SCALE(40,40)"}
                         [/command]
                     [/option]
                     [option]
-                        message="Blur 3"
+                        label="Blur 3"
                         [command]
                             {SHOW_IMAGE_PATH_TEST "BL(3)"}
                         [/command]
                     [/option]
                     [option]
-                        message="More red!"
+                        label="More red!"
                         [command]
                             {SHOW_IMAGE_PATH_TEST "R(255)"}
                         [/command]
                     [/option]
                     [option]
-                        message="More green!"
+                        label="More green!"
                         [command]
                             {SHOW_IMAGE_PATH_TEST "G(255)"}
                         [/command]
                     [/option]
                     [option]
-                        message="More blue!"
+                        label="More blue!"
                         [command]
                             {SHOW_IMAGE_PATH_TEST "B(255)"}
                         [/command]
                     [/option]
                     [option]
-                        message="Black and white!"
+                        label="Black and white!"
                         [command]
                             {SHOW_IMAGE_PATH_TEST "GS()"}
                         [/command]
                     [/option]
                     [option]
-                        message="Other team"
+                        label="Other team"
                         [command]
                             {VARIABLE_OP team rand 1..9}
                             {SHOW_IMAGE_PATH_TEST "TC($team,magenta)"}
@@ -3810,7 +3810,7 @@ unplagueable: $wml_unit.status.unplagueable"
                         [/command]
                     [/option]
                     [option]
-                        message="And other team again"
+                        label="And other team again"
                         [command]
                             {VARIABLE_OP rc rand 1..9}
                             {SHOW_IMAGE_PATH_TEST "RC(magenta>$rc)"}
@@ -3818,13 +3818,13 @@ unplagueable: $wml_unit.status.unplagueable"
                         [/command]
                     [/option]
                     [option]
-                        message="Psychedellic!"
+                        label="Psychedellic!"
                         [command]
                             {SHOW_IMAGE_PATH_TEST "CROP(10,10,50,50)~CS(255,-40,100)~O(50%)~BL(2)~SCALE(125,125)"}
                         [/command]
                     [/option]
                     [option]
-                        message="Shrooms!"
+                        label="Shrooms!"
                         [command]
                             # Shutz, this sounds like some obscure CPU architecture's data registers
                             {VARIABLE_OP rc   rand 1..9}


### PR DESCRIPTION
According to the Wiki, since 1.13.2 message= is an alias for label=.

Using message= provokes a warning about it being deprecated.

This replaces message= with label= in the entire mainline (where it had not already been changed).