### PR TITLE
AToTB Fix errors

### DIFF
--- a/data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg
@@ -163,14 +163,6 @@ Will he heed the call? I do not know if he has kept the amulet; we have not spok
     [event]
         name=prestart
 
-        [role]
-            type=Horseman
-            [not]
-                canrecruit=yes
-            [/not]
-            role=Mercenary
-        [/role]
-
         [objectives]
             side=1
             [objective]
@@ -261,6 +253,42 @@ Will he heed the call? I do not know if he has kept the amulet; we have not spok
             message= _ "Baran has not made his attack!"
         [/message]
 
+        [if]
+            [have_unit]
+                side=1
+                type=Horseman
+                [not]
+                    canrecruit=yes
+                [/not]
+            [/have_unit]
+            [then]
+                [role]
+                    side=1
+                    type=Horseman
+                    [not]
+                        canrecruit=yes
+                    [/not]
+                    role=Mercenary
+                [/role]
+            [/then]
+            [else]
+                [store_unit]
+                    variable=Arvith_store
+                    [filter]
+                        id=Arvith
+                    [/filter]
+                [/store_unit]
+                {NAMED_LOYAL_UNIT () Horseman 38 30 Helpin  (_ "Helpin")}
+                {MOVE_UNIT id=Helpin $Arvith_store.x $Arvith_store.y}
+                [clear_variable]
+                    name=Arvith_store
+                [/clear_variable]
+                [role]
+                    id=Helpin
+                    role=Mercenary
+                [/role]
+            [/else]
+        [/if]
         [message]
             role="Mercenary"
             message= _ "Could he have abandoned us?"
@@ -303,13 +331,20 @@ Will he heed the call? I do not know if he has kept the amulet; we have not spok
             message= _ "There’s nothing more to be had from this one; we will have to search for Baran ourselves!"
         [/message]
 
-        [role]
-            type=Spearman,Bowman,Horseman
-            role=Reporter
-        [/role]
+        [store_unit]
+            variable=Arvith_store
+            [filter]
+                id=Arvith
+            [/filter]
+        [/store_unit]
+        {NAMED_LOYAL_UNIT 1 Spearman 19 1 (Gareth) ( _ "Gareth")}
+        {MOVE_UNIT id=Gareth $Arvith_store.x $Arvith_store.y}
+        [clear_variable]
+            name=Arvith_store
+        [/clear_variable]
 
         [message]
-            role=Reporter
+            id=Gareth
             message= _ "Sir, our scouts report that Baran was seen captured and carried away further north!"
         [/message]
 
@@ -387,3 +422,5 @@ Will he heed the call? I do not know if he has kept the amulet; we have not spok
         [/endlevel]
     [/event]
 [/scenario]
+
+#undef GET_LEADER_XY

--- a/data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg
@@ -422,5 +422,3 @@ Will he heed the call? I do not know if he has kept the amulet; we have not spok
         [/endlevel]
     [/event]
 [/scenario]
-
-#undef GET_LEADER_XY

--- a/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
@@ -407,21 +407,67 @@ Besides... I want my brother back."
         {VARIABLE_OP second_password_number rand "1..4"}
 
         [if]
-            [not]
+            [have_unit]
+                role=speaker
+            [/have_unit]
+            [elseif]
                 [have_unit]
-                    role=speaker
-                [/have_unit]
-            [/not]
-
-            [then]
-                [role]
                     side=1
                     [not]
                         id=Arvith
                     [/not]
-                    role=speaker
-                [/role]
-            [/then]
+                [/have_unit]
+
+                [then]
+                    [role]
+                        side=1
+                        [not]
+                            id=Arvith
+                        [/not]
+                        role=speaker
+                    [/role]
+                [/then]
+            [/elseif]
+            [else]
+                [store_unit]
+                    variable=Arvith_store
+                    [filter]
+                        id=Arvith
+                    [/filter]
+                [/store_unit]
+                [if]
+                    [have_unit]
+                        side=1
+                        [not]
+                            id=Arvith
+                        [/not]
+                        search_recall_list=yes
+                    [/have_unit]
+                    [then]
+                        [role]
+                            side=1
+                            [not]
+                                id=Arvith
+                            [/not]
+                            role=speaker
+                        [/role]
+                        [recall]
+                            role=speaker
+                            x,y=19,$Arvith_store.y
+                        [/recall]
+                    [/then]
+                    [else]
+                        {NAMED_LOYAL_UNIT 1 Spearman 19 ($Arvith_store.y) (Harith) ( _ "Harith")}
+                        [+unit]
+                            role=speaker
+                        [/unit]
+                    [/else]
+                [/if]
+                {MOVE_UNIT role=speaker $Arvith_store.x $Arvith_store.y}
+                [clear_variable]
+                    name=Arvith_store
+                [/clear_variable]
+            [/else]
         [/if]
 
         [message]

--- a/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
@@ -407,43 +407,20 @@ Besides... I want my brother back."
         {VARIABLE_OP second_password_number rand "1..4"}
 
         [if]
-            [have_unit]
-                role=speaker
-            [/have_unit]
-            [elseif]
+            [not]
                 [have_unit]
-                    side=1
-                    [not]
-                        id=Arvith
-                    [/not]
+                    role=speaker
                 [/have_unit]
-
-                [then]
-                    [role]
-                        side=1
-                        [not]
-                            id=Arvith
-                        [/not]
-                        role=speaker
-                    [/role]
-                [/then]
-            [/elseif]
-            [else]
-                [store_unit]
-                    variable=Arvith_store
-                    [filter]
-                        id=Arvith
-                    [/filter]
-                [/store_unit]
+            [/not]
+            [then] # we do not already have a speaker
                 [if]
                     [have_unit]
                         side=1
                         [not]
                             id=Arvith
                         [/not]
-                        search_recall_list=yes
                     [/have_unit]
-                    [then]
+                    [then] # no speaker, but we do have a unit on the board
                         [role]
                             side=1
                             [not]
@@ -451,23 +428,49 @@ Besides... I want my brother back."
                             [/not]
                             role=speaker
                         [/role]
-                        [recall]
-                            role=speaker
-                            x,y=19,$Arvith_store.y
-                        [/recall]
                     [/then]
-                    [else]
-                        {NAMED_LOYAL_UNIT 1 Spearman 19 ($Arvith_store.y) (Harith) ( _ "Harith")}
-                        [+unit]
-                            role=speaker
-                        [/unit]
+                    [else] # no speaker and no units on the board
+                        [if]
+                            [have_unit]
+                                side=1
+                                [not]
+                                    id=Arvith
+                                [/not]
+                                search_recall_list=yes
+                            [/have_unit]
+                            [then] # no speaker or units, but someone to recall
+                                [role]
+                                    side=1
+                                    [not]
+                                        id=Arvith
+                                    [/not]
+                                    role=speaker
+                                [/role]
+                                [recall]
+                                    role=speaker
+                                    x,y=12,53
+                                [/recall]
+                            [/then]
+                            [else] # no speaker, no units, no recalls
+                                {NAMED_LOYAL_UNIT 1 Spearman 12 53 (Harith) ( _ "Harith")}
+                                [+unit]
+                                    role=speaker
+                                [/unit]
+                            [/else]
+                        [/if]
+                        [store_unit]
+                            variable=Arvith_store
+                            [filter]
+                                id=Arvith
+                            [/filter]
+                        [/store_unit]
+                        {MOVE_UNIT role=speaker $Arvith_store.x $Arvith_store.y}
+                        [clear_variable]
+                            name=Arvith_store
+                        [/clear_variable]
                     [/else]
                 [/if]
-                {MOVE_UNIT role=speaker $Arvith_store.x $Arvith_store.y}
-                [clear_variable]
-                    name=Arvith_store
-                [/clear_variable]
-            [/else]
+            [/then]
         [/if]
 
         [message]


### PR DESCRIPTION
S01 "Rooting Out a Mage"

On Mordok's last breath, a speaking part goes to one of the units on the board. Some of the units are not considered, nor are unit advancements. In addition, there may be no units other than our leader, Arvith. These errors result in the WML error "no unit for role" to appear on-screen. Improve the storyline a bit by not selecting for the role but, instead, creating a loyal spearman to run in from the north to deliver this line, avoiding the entire mess.

On turn 10 a mercenary horseman delivers a line. Originally, this role was assigned at the start. If that unit died, the line would be omitted, which interrupts the flow of the script. Instead, assign the role when the line is neeeded and, if no horsement survive to deliver the role, give the player a free loyal horseman to deliver the line. Have the horseman come running in from the south-east corner.

The above to changes create new translatable strings for the unit names. Since these should rarely actually be translated, this should not create an issue. For both, the units run into the scene and move to be adjacent to our leader, Arvith.

S02 "The Chase"

On the last breath of the Dark Adept, there are speaking lines for a unit. If these are skipped the script makes no sense. At the beginning a speaker was assigned. If that speaker has died, another unit on the board is assigned the role. But, if there are no other units, the WML error "no unit for role" appears on the screen. Fix this by bringing in a loyal named spearman to deliver the lines. Try from the recall list and, if none are there, create a new one. This new speaker runs in from the right side of the board to join the leader.

In relation to this change, sumplified the WML a bit as well by removing an unneeded [NOT] tag.

This change creates a new translable string for the new loyal spearman. Again, this should not be an issue.