### PR TITLE
Liberty fixes

### DIFF
--- a/data/campaigns/Liberty/scenarios/01_The_Raid.cfg
+++ b/data/campaigns/Liberty/scenarios/01_The_Raid.cfg
@@ -272,10 +272,12 @@
             side=2
         [/filter]
         [if]
-            [have_unit]
-                side=2
-            [/have_unit]
-            [else]
+            [not]
+                [have_unit]
+                    side=2
+                [/have_unit]
+            [/not]
+            [then]
                 {CLEAR_VARIABLE town_guards_awakened}
                 [if]
                     [variable]
@@ -310,7 +312,7 @@
                     bonus=yes
                     {NEW_GOLD_CARRYOVER 100}
                 [/endlevel]
-            [/else]
+            [/then]
         [/if]
     [/event]
 

--- a/data/campaigns/Liberty/scenarios/01_The_Raid.cfg
+++ b/data/campaigns/Liberty/scenarios/01_The_Raid.cfg
@@ -286,6 +286,7 @@
                     [/variable]
 
                     [then]
+                        {CLEAR_VARIABLE any_villagers_died}
                         [message]
                             speaker=Harper
                             message= _ "We are barely able to survive these orc raids. We lost two men last week, more today... yet Weldyn does nothing!"

--- a/data/campaigns/Liberty/scenarios/01_The_Raid.cfg
+++ b/data/campaigns/Liberty/scenarios/01_The_Raid.cfg
@@ -420,3 +420,6 @@
 
     {LIBERTY_DEATHS}
 [/scenario]
+
+#undef GOBLIN_RAIDER
+#undef DALLBEN_PEASANT

--- a/data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg
+++ b/data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg
@@ -245,10 +245,7 @@
         [role]
             type=Huntsman_Peasant,Ranger,Fugitive_Peasant,Highwayman_Peasant,Outlaw_Peasant,Trapper_Peasant,Bandit_Peasant,Footpad_Peasant,Poacher_Peasant,Thug_Peasant
             [not]
-                id=Harper
-            [/not]
-            [not]
-                id=Baldras
+                id=Harper,Baldras
             [/not]
             role=Advisor
         [/role]

--- a/data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg
+++ b/data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg
@@ -247,6 +247,9 @@
             [not]
                 id=Harper
             [/not]
+            [not]
+                id=Baldras
+            [/not]
             role=Advisor
         [/role]
 

--- a/data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg
+++ b/data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg
@@ -301,6 +301,7 @@
                 canrecruit=$stored_peasants[$i].canrecruit
                 overlays=$stored_peasants[$i].overlays
                 random_traits=$stored_peasants[$i].random_traits
+                role=$stored_peasants[$i].role
 
                 [insert_tag]
                     name=modifications

--- a/data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg
+++ b/data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg
@@ -243,7 +243,7 @@
         [/message]
 
         [role]
-            type=Fugitive_Peasant,Outlaw_Peasant,Huntsman_Peasant,Human Ranger,Trapper_Peasant,Poacher_Peasant,Thug_Peasant
+            type=Huntsman_Peasant,Ranger,Fugitive_Peasant,Highwayman_Peasant,Outlaw_Peasant,Trapper_Peasant,Bandit_Peasant,Footpad_Peasant,Poacher_Peasant,Thug_Peasant
             [not]
                 id=Harper
             [/not]

--- a/data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg
+++ b/data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg
@@ -155,10 +155,6 @@
         [recall]
             id=Harper
         [/recall]
-        [role]
-            type=Huntsman,Ranger,Fugitive,Highwayman,Outlaw,Trapper,Bandit,Footpad,Poacher,Thug
-            role=Advisor
-        [/role]
         [recall]
             role=Advisor
         [/recall]

--- a/data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg
+++ b/data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg
@@ -189,7 +189,7 @@
             message= _ "Well, it won’t be long until they report back to the local garrison with the details of your encounter."
         [/message]
         [message]
-            speaker=Advisor
+            role=Advisor
             message= _ "Then they’ll be back in force."
         [/message]
         [message]

--- a/data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg
+++ b/data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg
@@ -172,6 +172,7 @@
         [role]
             type=Huntsman,Ranger,Fugitive,Highwayman,Outlaw,Trapper,Bandit,Footpad,Poacher,Thug
             role=Advisor
+            auto_recall=yes
             [not]
                 id=Harper
             [/not]
@@ -179,9 +180,6 @@
                 id=Baldras
             [/not]
         [/role]
-        [recall]
-            role=Advisor
-        [/recall]
 
         [message]
             speaker=Lord Maddock

--- a/data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg
+++ b/data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg
@@ -170,7 +170,7 @@
             id=Harper
         [/recall]
         [role]
-            type=Outlaw,Trapper,Thug,Poacher,Footpad,Bandit
+            type=Huntsman,Ranger,Fugitive,Highwayman,Outlaw,Trapper,Bandit,Footpad,Poacher,Thug
             role=Advisor
         [/role]
         [recall]

--- a/data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg
+++ b/data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg
@@ -639,6 +639,7 @@
         [/message]
 
         {CLEAR_VARIABLE undead_transformation}
+        {CLEAR_VARIABLE temp}
 
         [endlevel]
             result=victory

--- a/data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg
+++ b/data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg
@@ -174,10 +174,7 @@
             role=Advisor
             auto_recall=yes
             [not]
-                id=Harper
-            [/not]
-            [not]
-                id=Baldras
+                id=Harper,Baldras
             [/not]
         [/role]
 

--- a/data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg
+++ b/data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg
@@ -172,6 +172,12 @@
         [role]
             type=Huntsman,Ranger,Fugitive,Highwayman,Outlaw,Trapper,Bandit,Footpad,Poacher,Thug
             role=Advisor
+            [not]
+                id=Harper
+            [/not]
+            [not]
+                id=Baldras
+            [/not]
         [/role]
         [recall]
             role=Advisor

--- a/data/campaigns/Liberty/scenarios/05_Hide_and_Seek.cfg
+++ b/data/campaigns/Liberty/scenarios/05_Hide_and_Seek.cfg
@@ -627,3 +627,5 @@
 
     {VILLAGE_BURNED}
 [/scenario]
+
+#undef SEEKER

--- a/data/campaigns/Liberty/scenarios/05_Hide_and_Seek.cfg
+++ b/data/campaigns/Liberty/scenarios/05_Hide_and_Seek.cfg
@@ -46,10 +46,10 @@
         side=2
         canrecruit=yes
         controller=ai
-        ai_algorithm=idle_ai
         user_team_name=_"Asheviere"
         team_name=bad_guys
         [ai]
+            ai_algorithm=idle_ai
             passive_leader=yes
         [/ai]
         shroud=no

--- a/data/campaigns/Liberty/scenarios/07_The_Hunters.cfg
+++ b/data/campaigns/Liberty/scenarios/07_The_Hunters.cfg
@@ -348,6 +348,8 @@
                     [/then]
                 [/if]
 
+                {CLEAR_VARIABLE stored_Archarel}
+
                 [endlevel]
                     result=victory
                     bonus=yes

--- a/data/campaigns/Liberty/scenarios/07_The_Hunters.cfg
+++ b/data/campaigns/Liberty/scenarios/07_The_Hunters.cfg
@@ -324,10 +324,12 @@
             side=2,3
         [/filter]
         [if]
-            [have_unit]
-                side=2,3
-            [/have_unit]
-            [else]
+            [not]
+                [have_unit]
+                    side=2,3
+                [/have_unit]
+            [/not]
+            [then]
                 [message]
                     speaker=Baldras
                     message= _ "What a bloody mess. We must attack Halstead next. If we wait, they will become invincible. If we can burn it to the ground before that happens, our people may have a chance. Rest well tonight, because tomorrow’s battle will decide the fate of our homes, our families, and our freedom."
@@ -351,7 +353,7 @@
                     bonus=yes
                     {NEW_GOLD_CARRYOVER 40}
                 [/endlevel]
-            [/else]
+            [/then]
         [/if]
     [/event]
 

--- a/data/campaigns/Liberty/scenarios/07_The_Hunters.cfg
+++ b/data/campaigns/Liberty/scenarios/07_The_Hunters.cfg
@@ -377,3 +377,5 @@
 
     {VILLAGE_BURNED}
 [/scenario]
+
+#undef TROOPER

--- a/data/campaigns/Liberty/scenarios/08_Glory.cfg
+++ b/data/campaigns/Liberty/scenarios/08_Glory.cfg
@@ -530,6 +530,9 @@
         [role]
             role=farseer
             type=Outlaw,Footpad,Bandit,Thug,Thief,Huntsman,Trapper,Poacher,Rogue Mage,Rogue,Shadow Mage
+            [not]
+                id=Baldras
+            [/not]
         [/role]
         [message]
             role=farseer

--- a/data/campaigns/Liberty/scenarios/08_Glory.cfg
+++ b/data/campaigns/Liberty/scenarios/08_Glory.cfg
@@ -327,8 +327,6 @@
 
         #Initialize the counter and switches
         {VARIABLE supports_destroyed 0}
-        {VARIABLE harper_dead 0}
-        {VARIABLE dommel_dead 0}
 
         #Set up the inside of the fortress just like we want it
         {PLACE_IMAGE scenery/trapdoor-closed.png 16 13}
@@ -894,6 +892,9 @@ Uu, Uu, Chr, Uh, Re, Uu, Uu, Uh, Uu, Chr, Chr
                                 time=2000
                             [/delay]
 
+                            {CLEAR_VARIABLE Helicrom_status}
+                            {CLEAR_VARIABLE supports_destroyed}
+
                             [endlevel]
                                 result=victory
                                 carryover_report=no
@@ -995,7 +996,6 @@ Uu, Uu, Chr, Uh, Re, Uu, Uu, Uh, Uu, Chr, Chr
             speaker=Baldras
             message= _ "But we are so close to the end. We must finish this. I am sorry you will not be able to enjoy our freedom. Goodbye, Harper."
         [/message]
-        {VARIABLE harper_dead 1}
     [/event]
     #
     # Deaths - Helicrom
@@ -1077,14 +1077,12 @@ Uu, Uu, Chr, Uh, Re, Uu, Uu, Uh, Uu, Chr, Chr
                     # wmllint: local spelling Uungh
                     message= _ "You... underestimate the... cruelty and ambition of your Queen... Uungh..."
                 [/message]
-                {VARIABLE dommel_dead 2}
             [/then]
             [else]
                 [message]
                     speaker=Baldras
                     message= _ "Small victory? Bah! Now we will raze this fortress and bury it in the earth from whence it came."
                 [/message]
-                {VARIABLE dommel_dead 1}
             [/else]
         [/if]
     [/event]

--- a/data/campaigns/Liberty/scenarios/08_Glory.cfg
+++ b/data/campaigns/Liberty/scenarios/08_Glory.cfg
@@ -1090,3 +1090,6 @@ Uu, Uu, Chr, Uh, Re, Uu, Uu, Uh, Uu, Chr, Chr
         [/if]
     [/event]
 [/scenario]
+
+#undef MOVETO_TRAPDOOR
+#undef BAD_CAVALRY

--- a/data/campaigns/Liberty/scenarios/08_Glory.cfg
+++ b/data/campaigns/Liberty/scenarios/08_Glory.cfg
@@ -169,7 +169,7 @@
             [/avoid]
         [/ai]
         [ai]
-            turns=7-FOREVER
+            turns=7-99999
             caution=0.1
             aggression=0.9
             scout_village_targeting=1
@@ -271,7 +271,7 @@
         [/ai]
 
         [ai]
-            turns=7-FOREVER
+            turns=7-99999
             aggression=0.6
             caution=0.6
             leader_value=0.5

--- a/data/campaigns/Liberty/utils/utils.cfg
+++ b/data/campaigns/Liberty/utils/utils.cfg
@@ -8,38 +8,6 @@
     [/capture_village]
 #enddef
 
-#
-# This one changes a unit from one type to another
-#
-
-#define CHG_TYPE FILTER VALUE ALIGN
-    [store_unit]
-        [filter]
-            {FILTER}
-        [/filter]
-
-        variable=chgtype_store
-        kill=yes
-    [/store_unit]
-
-    {FOREACH chgtype_store i}
-        [set_variable]
-            name=chgtype_store[$i].type
-            value={VALUE}
-        [/set_variable]
-        [set_variable]
-            name=chgtype_store[$i].alignment
-            value={ALIGN}
-        [/set_variable]
-
-        [unstore_unit]
-            variable=chgtype_store[$i]
-        [/unstore_unit]
-    {NEXT i}
-
-    {CLEAR_VARIABLE chgtype_store}
-#enddef
-
 #define OBJ_HOLY_ANKH X Y ID
     [event]
         name=moveto

--- a/data/campaigns/Liberty/utils/utils.cfg
+++ b/data/campaigns/Liberty/utils/utils.cfg
@@ -8,60 +8,6 @@
     [/capture_village]
 #enddef
 
-#define OBJ_HOLY_ANKH X Y ID
-    [event]
-        name=moveto
-        first_time_only=no
-        [filter]
-            x={X}
-            y={Y}
-            side=1
-        [/filter]
-        [object]
-            id={ID}
-            name= _ "Holy Ankh"
-            image=items/ankh-necklace.png
-            duration=scenario
-            description= _ "You find a hefty pendant on a strange and ominous looking altar. It glows brightly when you pick it up!"
-            cannot_use_message= _ "There is a strange altar here and a pendant on it. I don’t want to touch it."
-            [filter]
-                side=1
-                x,y={X},{Y}
-            [/filter]
-            [then]
-                [remove_item]
-                    x,y={X},{Y}
-                [/remove_item]
-            [/then]
-            [effect]
-                apply_to=new_attack
-                name=ankh
-                description= _ "holy ankh"
-                icon=attacks/lightbeam.png
-                type=arcane
-                range=ranged
-                [specials]
-                    {WEAPON_SPECIAL_MAGICAL}
-                [/specials]
-                damage=24
-                number=1
-            [/effect]
-
-            [effect]
-                apply_to=new_animation
-                [attack_anim]
-                    [filter_attack]
-                        name=ankh
-                    [/filter_attack]
-
-                    {MISSILE_FRAME_LIGHT_BEAM}
-                    {SOUND:HIT_AND_MISS {SOUND_LIST:HOLY} {SOUND_LIST:HOLY_MISS} -75}
-                [/attack_anim]
-            [/effect]
-        [/object]
-    [/event]
-#enddef
-
 #define LIBERTY_DEATHS
     [event]
         name=last breath


### PR DESCRIPTION
With Zookeeper's and CelticMinstrel's changes to remove the on-screen warning about no unit for role, and add functionality to the [role] tag, this is my cleaned-up changes to Liberty. It replaces my previous PR for this campaign. This patch set includes the following changes:

    S01     Use positive logic: [if] must have [then]
            Remove the artifact variable 'any_villagers_died'

    S02  ** Use a consistent type list for the Advisor role
         ** Baldras cannot be the Advisor
         ** Pass the Advisor role along to S03 when converting unit types

    S03  ** No need to search for the Advisor, S02 set it.
         ** Use role= for roles in [message], not speaker=

    S04  ** Use a consistent type list for the Advisor role
         ** Neither Harper nor Baldras may be the Advisor
            Remove the artifact variable 'temp'
            Use auto_recall for Advisor [role]

    S05  ** Misplaced attribute, move 'ai_algorithm=idle_ai' inside [ai] tag

    S06     No changes

    S07     Use positive logic: [if] must have [then]
            Remove the artifact variable 'stored_Archarel'

    S08  ** Baldras cannot be the 'farseer', this makes the converastion irrational
         ** No manifest constant 'FOREVER', use 99999 intead
            Remove unused variables 'harper_dead' and 'dommel_dead'
            Remove the artifact variables 'Helicrom_status' and 'supports_destroyed'

    utils/utils.cfg
            Remove unused macros 'CHG_TYPE' and 'OBJ_HOLY_ANKH'

 ** These are the important changes.
    They either correct crashes, errors and warnings on stderr, or the conversational flow.

Each change is a separate commit, should you choose to cherry-pick.
