### PR TITLE
A Tale of Two Brothers fixes

### DIFF
--- a/data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg
@@ -315,8 +315,22 @@ Will he heed the call? I do not know if he has kept the amulet; we have not spok
         [/message]
 
         [role]
-            type=Spearman,Bowman,Horseman
             role=Reporter
+            side=1
+            type="Royal Guard,Halberdier,Master Bowman,Paladin,Grand Knight,Swordsman,Pikeman,Javelineer,Longbowman,Knight,Lancer,Spearman,Bowman,Horseman"
+            [not]
+                id=Arvith
+            [/not]
+            search_recall_list=no
+            [else]
+                [unit]
+                    type=Spearman
+                    side=1
+                    placement=leader
+                    generate_name=yes
+                    role=Reporter
+                [/unit]
+            [/else]
         [/role]
 
         [message]

--- a/data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg
@@ -163,14 +163,6 @@ Will he heed the call? I do not know if he has kept the amulet; we have not spok
     [event]
         name=prestart
 
-        [role]
-            type=Horseman
-            [not]
-                canrecruit=yes
-            [/not]
-            role=Mercenary
-        [/role]
-
         [objectives]
             side=1
             [objective]
@@ -261,6 +253,25 @@ Will he heed the call? I do not know if he has kept the amulet; we have not spok
             message= _ "Baran has not made his attack!"
         [/message]
 
+        [role]
+            role=Mercenary
+            side=1
+            type="Paladin,Grand Knight,Knight,Lancer,Horseman"
+            [not]
+                id=Arvith
+            [/not]
+            search_recall_list=no
+            [else]
+                [unit]
+                    type=Horseman
+                    side=1
+                    placement=leader
+                    generate_name=yes
+                    facing=ne
+                    role=Mercenary
+                [/unit]
+            [/else]
+        [/role]
         [message]
             role="Mercenary"
             message= _ "Could he have abandoned us?"

--- a/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
@@ -212,24 +212,14 @@ Besides... I want my brother back."
         [/terrain]
 #endif
 
-        [if]
-            [have_unit]
-                side=1
-                type=Paladin,Grand Knight,Knight,Lancer,Horseman
-                search_recall_list=yes
-            [/have_unit]
-
-            [then]
-                [role]
-                    type=Paladin,Grand Knight,Knight,Lancer,Horseman
-                    role=speaker
-                [/role]
-
-                [recall]
-                    role=speaker
-                [/recall]
-            [/then]
-
+        [role]
+            role=speaker
+            side=1
+            type="Paladin,Grand Knight,Knight,Lancer,Horseman"
+            [not]
+                id=Arvith
+            [/not]
+            auto_recall=yes
             [else]
                 [unit]
                     type=Horseman
@@ -240,7 +230,7 @@ Besides... I want my brother back."
                     role=speaker
                 [/unit]
             [/else]
-        [/if]
+        [/role]
     [/event]
 
     [event]

--- a/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
@@ -215,13 +215,13 @@ Besides... I want my brother back."
         [if]
             [have_unit]
                 side=1
-                type=Horseman
+                type=Paladin,Grand Knight,Knight,Lancer,Horseman
                 search_recall_list=yes
             [/have_unit]
 
             [then]
                 [role]
-                    type=Horseman
+                    type=Paladin,Grand Knight,Knight,Lancer,Horseman
                     role=speaker
                 [/role]
 

--- a/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
@@ -1,5 +1,27 @@
 #textdomain wesnoth-tb
 
+#define HORSEMAN_SPEAKER
+    [role]
+        role=speaker
+        side=1
+        type="Paladin,Grand Knight,Knight,Lancer,Horseman"
+        [not]
+            id=Arvith
+        [/not]
+        auto_recall=yes
+        [else]
+            [unit]
+                type=Horseman
+                side=1
+                placement=leader
+                generate_name=yes
+                facing=ne
+                role=speaker
+            [/unit]
+        [/else]
+    [/role]
+#enddef
+
 [scenario]
     id=02_The_Chase
     name= _ "The Chase"
@@ -212,25 +234,7 @@ Besides... I want my brother back."
         [/terrain]
 #endif
 
-        [role]
-            role=speaker
-            side=1
-            type="Paladin,Grand Knight,Knight,Lancer,Horseman"
-            [not]
-                id=Arvith
-            [/not]
-            auto_recall=yes
-            [else]
-                [unit]
-                    type=Horseman
-                    side=1
-                    placement=leader
-                    generate_name=yes
-                    facing=ne
-                    role=speaker
-                [/unit]
-            [/else]
-        [/role]
+        {HORSEMAN_SPEAKER}
     [/event]
 
     [event]
@@ -396,24 +400,6 @@ Besides... I want my brother back."
 
         {VARIABLE_OP second_password_number rand "1..4"}
 
-        [if]
-            [not]
-                [have_unit]
-                    role=speaker
-                [/have_unit]
-            [/not]
-
-            [then]
-                [role]
-                    side=1
-                    [not]
-                        id=Arvith
-                    [/not]
-                    role=speaker
-                [/role]
-            [/then]
-        [/if]
-
         [message]
             speaker=unit
             message= _ "Three days ride to the northeast, in a deserted castle. The passwords to the guards are $first_password_$first_password_number and $second_password_$second_password_number|."
@@ -424,6 +410,7 @@ Besides... I want my brother back."
             message= _ "Bind him and take him with us. If he has played us false, he will die."
         [/message]
 
+        {HORSEMAN_SPEAKER}
         [message]
             role=speaker
             message= _ "Captain, what are we riding into? I thought you wanted nothing to do with Baran any more, not since Toen Caric."
@@ -604,3 +591,5 @@ Besides... I want my brother back."
         [/endlevel]
     [/event]
 [/scenario]
+
+#undef HORSEMAN_SPEAKER

--- a/data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg
@@ -355,6 +355,12 @@ Yet for some reason I fear these brothers more. If Mordak were here it would be 
                 {VARIABLE delay_guards true}
             [/else]
         [/if]
+        {CLEAR_VARIABLE first_password_1}
+        {CLEAR_VARIABLE first_password_2}
+        {CLEAR_VARIABLE first_password_3}
+        {CLEAR_VARIABLE first_password_4}
+        {CLEAR_VARIABLE first_password_number}
+        {CLEAR_VARIABLE first_password_picked}
     [/event]
 
     [event]
@@ -534,6 +540,12 @@ Yet for some reason I fear these brothers more. If Mordak were here it would be 
                 [/message]
             [/else]
         [/if]
+        {CLEAR_VARIABLE second_password_1}
+        {CLEAR_VARIABLE second_password_2}
+        {CLEAR_VARIABLE second_password_3}
+        {CLEAR_VARIABLE second_password_4}
+        {CLEAR_VARIABLE second_password_number}
+        {CLEAR_VARIABLE second_password_picked}
 
         [message]
             speaker=Arvith

--- a/data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg
@@ -410,7 +410,7 @@ Yet for some reason I fear these brothers more. If Mordak were here it would be 
         name=new turn
         [filter_condition]
             [variable]
-                name=delayed_guards
+                name=delay_guards
                 boolean_equals=false
             [/variable]
             [variable]
@@ -419,7 +419,7 @@ Yet for some reason I fear these brothers more. If Mordak were here it would be 
             [/variable]
             [or]
                 [variable]
-                    name=delayed_guards
+                    name=delay_guards
                     boolean_equals=true
                 [/variable]
                 [variable]

--- a/data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg
@@ -428,6 +428,7 @@ Yet for some reason I fear these brothers more. If Mordak were here it would be 
                 [/variable]
             [/or]
         [/filter_condition]
+        {CLEAR_VARIABLE delay_guards}
 
         [unit]
             side=2


### PR DESCRIPTION
With Zookeeper's and CelticMinstrel's changes to remove the on-screen warning about no unit for role, and add functionality to the [role] tag, this is my cleaned-up changes to A Tale of Two Brothers. It replaces my previous PR for this campaign. This patch set includes the following changes:

    S01  ** For the Mercenary role:
                Do not assign the Mercenary role so early
                Allow advanced units to the role, but not Arvith
                Use the new [role] features:
                    Use search_recall_list=no to document on-board only (recall list is empty)
                    Use [role][else] to recruit a replacement Horseman if none live at the time

         ** For the Reporter role:
                Allow advanced units to the role, but not Arvith
                Use the new [role] features:
                    Use search_recall_list=no to document on-board only (recall list is empty)
                    Use [role][else] to recruit a replacement Spearman if none live at victory

    S02  ** For the speaker role:
                Use a local macro for this role.
                Allow advanced units to the role, but no Arvith
                Use the new [role] features:
                    Use auto_recall=yes to ensure a unit is on-board
                    Use [role][else] to recruit a replacement Horseman if none live at victory

    S03  ** Fix a typo which caused the second set of guards to appear too early
            Clear variables when no longer needed to prevent artifacts.
    
    S04     No changes

    S05     No changes

 ** These are the important changes.
    They either correct implementation errors, or the conversational flow.

The S03 patches can be cherry-picked. The S01 and S02 main patches may depend upon earlier changes in this patch set.