### PR TITLE
An Orcish Incursion fixes

### DIFF
--- a/data/campaigns/An_Orcish_Incursion/scenarios/03_Wasteland.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/03_Wasteland.cfg
@@ -233,13 +233,7 @@
     [event]
         name=victory
 
-        [role]
-            race=elf
-            [not]
-                canrecruit=yes
-            [/not]
-            role=advisor
-        [/role]
+        {RECALL_ADVISOR}
 
         [message]
             role=advisor
@@ -320,13 +314,7 @@
     [event]
         name=time over
 
-        [role]
-            race=elf
-            [not]
-                canrecruit=yes
-            [/not]
-            role=advisor
-        [/role]
+        {PROMOTE_ADVISOR}
 
         [message]
             role=advisor

--- a/data/campaigns/An_Orcish_Incursion/scenarios/04_Valley_of_Trolls.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/04_Valley_of_Trolls.cfg
@@ -229,13 +229,7 @@
     [event]
         name=enemies defeated
 
-        [role]
-            race=elf
-            [not]
-                canrecruit=yes
-            [/not]
-            role=advisor
-        [/role]
+        {RECALL_ADVISOR}
 
         [message]
             role=advisor
@@ -283,13 +277,7 @@
             id=Erlornas
         [/filter]
 
-        [role]
-            race=elf
-            [not]
-                canrecruit=yes
-            [/not]
-            role=advisor
-        [/role]
+        {PROMOTE_ADVISOR}
 
         [message]
             speaker=second_unit
@@ -318,6 +306,7 @@
     [event]
         name=time over
 
+        {RECALL_ADVISOR}
         [message]
             role=advisor
             message= _ "We can’t get through, my Lord. These whelps are not individually very dangerous, but there are huge numbers of them."

--- a/data/campaigns/An_Orcish_Incursion/scenarios/06_A_Detour_through_the_Swamp.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/06_A_Detour_through_the_Swamp.cfg
@@ -94,17 +94,7 @@
             id=Linaera
         [/recall]
 
-        [role]
-            type="Red Mage,White Mage,Mage,Arch Mage,Silver Mage,Mage of Light,Great Mage"
-            [not]
-                canrecruit=yes
-            [/not]
-            role=mage
-        [/role]
-
-        [recall]
-            role=mage
-        [/recall]
+        {RECALL_MAGE}
 
         {MODIFY_UNIT (side=1) facing se}
     [/event]
@@ -121,13 +111,7 @@
     [event]
         name=enemies defeated
 
-        [role]
-            type="Red Mage,White Mage,Mage,Arch Mage,Silver Mage,Mage of Light,Great Mage"
-            [not]
-                canrecruit=yes
-            [/not]
-            role=mage
-        [/role]
+        {RECALL_MAGE}
 
         [message]
             speaker=Linaera

--- a/data/campaigns/An_Orcish_Incursion/scenarios/07_Showdown.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/07_Showdown.cfg
@@ -247,13 +247,7 @@
             side=2
         [/kill]
 
-        [role]
-            race=elf
-            [not]
-                canrecruit=yes
-            [/not]
-            role=advisor
-        [/role]
+        {RECALL_ADVISOR}
 
         [message]
             speaker=Erlornas

--- a/data/campaigns/An_Orcish_Incursion/utils/macros.cfg
+++ b/data/campaigns/An_Orcish_Incursion/utils/macros.cfg
@@ -9,44 +9,18 @@
 #enddef
 
 #define RECALL_ADVISOR
-    [if]
-        [have_unit]
-            side=1
-            role=advisor
-            search_recall_list=yes
-        [/have_unit]
-        [then]
-            # Recall an advisor if we have one to do so
-            [recall]
-                role=advisor
-            [/recall]
-        [/then]
-        [elseif]
-            # Else, make a new advisor from an elf unit
-            [have_unit]
-                side=1
-                race=elf
-                [not]
-                    canrecruit=yes
-                [/not]
-                search_recall_list=yes
-            [/have_unit]
-            [then]
-                [role]
-                    race=elf
-                    [not]
-                        canrecruit=yes
-                    [/not]
-                    role=advisor
-                [/role]
+    [role]
+        role=advisor
+        auto_recall=yes
+        search_recall_list=yes
 
-                [recall]
-                    role=advisor
-                [/recall]
-            [/then]
-        [/elseif]
+        side=1
+        race=elf
+        [not]
+            id=Erlornas
+        [/not]
+
         [else]
-            # If that fails too, make a brand new advisor
             [unit]
                 type=Elvish Fighter
                 side=1
@@ -55,5 +29,43 @@
                 placement=leader
             [/unit]
         [/else]
-    [/if]
+    [/role]
+#enddef
+
+#define PROMOTE_ADVISOR
+    [role]
+        role=advisor
+        auto_recall=no
+        search_recall_list=no
+
+        side=1
+        race=elf
+        [not]
+            id=Erlornas
+        [/not]
+    [/role]
+#enddef
+
+#define RECALL_MAGE
+    [role]
+        role=mage
+        auto_recall=yes
+        search_recall_list=yes
+
+        side=1
+        type="Great Mage,Mage of Light,Arch Mage,Silver Mage,White Mage,Red Mage,Mage"
+        [not]
+            id=Linaera
+        [/not]
+
+        [else]
+            [unit]
+                type=Mage
+                side=1
+                role=mage
+                animate=yes
+                placement=leader
+            [/unit]
+        [/else]
+    [/role]
 #enddef


### PR DESCRIPTION
With Zookeeper's and CelticMinstrel's changes to remove the on-screen warning about no unit for role, and add functionality to the [role] tag, this is my cleaned-up changes to An Orcish Incursion. It replaces my previous PR for that campaign. This patch set includes the following changes:

    S01     No changes

    S02     No changes

    S03  ** On victory, ensure a unit has the advisor role
         ** On time over, if needed, re-assign the advisor role to a unit on the board

    S04  ** On enemies defeated, ensure a unit has the advisor role
         ** On die (Erlornas), if needed, re-assign the advisor role to a unit on the board
         ** On time over, ensure a unit has the advisor role

    S05     No changes

    S06  ** During prestart, ensure a unit has the mage role
         ** On enemies defeated, ensure a unit has the mage role
    
    S07  ** On die (Rualsha), ensure a unit has the advisor role

    utils/macros

         ** Update RECALL_ADVISOR to use the new [rule] features
         ** Add PROMOTE_ADVISOR for cases where recall/recruit is not needed
         ** Add RECALL_MAGE to ensure a unit has the mage role, prefer higher level mages
        
** These are the important changes. They correct the conversational flow.

This is a unified patch set since cherry-picking would be as much work as doing it by-hand.