### PR TITLE
AOI Linaera should recruit Mages, not Elves

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,5 +1,7 @@
 Version 1.13.4+dev:
  * Campaigns:
+   * An Orcish Incursion:
+     * Linaera can recruit Mage, and cannot recruit Elves
    * Heir to the Throne:
      * Add journey tracks for 19c/20b path.
      * New sprites for Li'sar.

--- a/data/campaigns/An_Orcish_Incursion/scenarios/01_Defend_the_Forest.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/01_Defend_the_Forest.cfg
@@ -50,7 +50,7 @@
     [side]
         side=1
         controller=human
-        recruit="Elvish Archer,Elvish Fighter,Elvish Scout,Elvish Shaman"
+        extra_recruit="Elvish Archer,Elvish Fighter,Elvish Scout,Elvish Shaman"
         {GOLD 200 150 100}
         income=0
         team_name=Elves

--- a/data/campaigns/An_Orcish_Incursion/scenarios/01_Defend_the_Forest.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/01_Defend_the_Forest.cfg
@@ -50,7 +50,6 @@
     [side]
         side=1
         controller=human
-        extra_recruit="Elvish Archer,Elvish Fighter,Elvish Scout,Elvish Shaman"
         {GOLD 200 150 100}
         income=0
         team_name=Elves

--- a/data/campaigns/An_Orcish_Incursion/scenarios/02_Assassins.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/02_Assassins.cfg
@@ -36,7 +36,6 @@
     [side]
         side=1
         controller=human
-        recruit="Elvish Archer,Elvish Fighter,Elvish Scout,Elvish Shaman"
         type=Elvish Lord
         team_name=Elves
         user_team_name= _ "Elves"

--- a/data/campaigns/An_Orcish_Incursion/scenarios/03_Wasteland.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/03_Wasteland.cfg
@@ -44,7 +44,6 @@
     [side]
         side=1
         controller=human
-        recruit="Elvish Archer,Elvish Fighter,Elvish Scout,Elvish Shaman"
         {INCOME 12 9 9}
         team_name=Elves
         user_team_name= _ "Elves"

--- a/data/campaigns/An_Orcish_Incursion/scenarios/04_Valley_of_Trolls.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/04_Valley_of_Trolls.cfg
@@ -40,7 +40,6 @@
     [side]
         side=1
         controller=human
-        recruit="Elvish Archer,Elvish Fighter,Elvish Scout,Elvish Shaman"
         team_name=Elves
         user_team_name= _ "Elves"
         {FLAG_VARIANT wood-elvish}

--- a/data/campaigns/An_Orcish_Incursion/scenarios/05_Linaera_the_Quick.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/05_Linaera_the_Quick.cfg
@@ -93,7 +93,6 @@
         {CHARACTER_STATS_LINAERA}
 
         facing=nw
-        extra_recruit="Mage"
     [/side]
     # wmllint: validate-on
 

--- a/data/campaigns/An_Orcish_Incursion/scenarios/05_Linaera_the_Quick.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/05_Linaera_the_Quick.cfg
@@ -41,7 +41,6 @@
     [side]
         side=1
         controller=human
-        recruit="Elvish Archer,Elvish Fighter,Elvish Scout,Elvish Shaman"
         {GOLD 100 100 100}
         {INCOME 0 0 0}
         team_name=Elves
@@ -94,6 +93,7 @@
         {CHARACTER_STATS_LINAERA}
 
         facing=nw
+        extra_recruit="Mage"
     [/side]
     # wmllint: validate-on
 

--- a/data/campaigns/An_Orcish_Incursion/scenarios/06_A_Detour_through_the_Swamp.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/06_A_Detour_through_the_Swamp.cfg
@@ -24,7 +24,6 @@
     [side]
         side=1
         controller=human
-        recruit="Elvish Archer,Elvish Fighter,Elvish Scout,Elvish Shaman"
         team_name=Elves
         user_team_name= _ "Elves"
         {FLAG_VARIANT wood-elvish}

--- a/data/campaigns/An_Orcish_Incursion/scenarios/07_Showdown.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/07_Showdown.cfg
@@ -23,7 +23,6 @@
     [side]
         side=1
         controller=human
-        recruit="Elvish Archer,Elvish Fighter,Elvish Scout,Elvish Shaman"
         gold=100
         income=0
         team_name=Elves

--- a/data/campaigns/An_Orcish_Incursion/utils/characters.cfg
+++ b/data/campaigns/An_Orcish_Incursion/utils/characters.cfg
@@ -6,6 +6,7 @@
     name= _ "Erlornas"
     profile=portraits/erlornas.png
     canrecruit=yes
+    extra_recruit="Elvish Archer,Elvish Fighter,Elvish Scout,Elvish Shaman"
     unrenamable=yes
 #enddef
 
@@ -16,6 +17,7 @@
     profile=portraits/linaera.png
     gender=female
     canrecruit=yes
+    extra_recruit="Mage"
     unrenamable=yes
     [modifications]
         {TRAIT_LOYAL}


### PR DESCRIPTION
This seems more logical, plus it allows the player to recover from losing all their Mages in S06 and S07. Mages really help in S07.

Originally part of my fixes to AOI, separated since it's completely independent.

N.B. When testing you must start a fresh campaign for the changed recruitment lists to fully take effect. If you see Linaera recruiting Elves **AND** Mages, that's the reason.