### PR TITLE
bugfix: wmlxgettext '--recursive'  option and symlinks

### DIFF
--- a/utils/pywmlx/autof.py
+++ b/utils/pywmlx/autof.py
@@ -11,7 +11,7 @@ def autoscan(pathdir):
             rx = re.compile(r'\.(cfg|lua)$', re.I)
             m = re.search(rx, name)
             if m:
-                value = os.path.join(root, name)
+                value = os.path.realpath(os.path.join(root, name))
                 value = value [ len(parentdir) +1 : ]
                 if os.name == "posix":
                     value = re.sub(r'^\/', '', value)


### PR DESCRIPTION
During a test I noticed that the pywmlx.autof.autoscan function could work (very) wrongly if the path contains a symlink somewhere.

The bug is now fixed, and autoscan work correctly also if the input path (with symlinks) and the real path (where symlinks are translated to actual path) differs.

This issue was strictly related to the '--recursive' option (wich makes the life easier for UMC authors :) )