### PR TITLE
Hacky fix for the flickering when a screen is fully redrawn.

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2721,7 +2721,9 @@ void display::draw(bool update,bool force) {
 
 	if (dirty_) {
 		dirty_ = false;
+		screen_.lock_flips(true);
 		redraw_everything();
+		screen_.lock_flips(false);
 		return;
 	}
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2720,10 +2720,9 @@ void display::draw(bool update,bool force) {
 	}
 
 	if (dirty_) {
+		flip_locker flip_lock(screen_);
 		dirty_ = false;
-		screen_.lock_flips(true);
 		redraw_everything();
-		screen_.lock_flips(false);
 		return;
 	}
 

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -471,7 +471,7 @@ void pump()
 			}
 			case DRAW_ALL_EVENT:
 			{
-				CVideo::get_singleton().lock_flips(true);
+				flip_locker flip_lock(CVideo::get_singleton());
 				/* iterate backwards as the most recent things will be at the top */
 				for( std::deque<context>::iterator i = event_contexts.begin() ; i != event_contexts.end(); ++i) {
 					const std::vector<sdl_handler*>& event_handlers = (*i).handlers;
@@ -479,8 +479,6 @@ void pump()
 						(*i1)->handle_event(event);
 					}
 				}
-				CVideo::get_singleton().lock_flips(false);
-				//CVideo::get_singleton().flip();
 				continue; //do not do further handling here
 			}
 

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -471,6 +471,7 @@ void pump()
 			}
 			case DRAW_ALL_EVENT:
 			{
+				CVideo::get_singleton().lock_flips(true);
 				/* iterate backwards as the most recent things will be at the top */
 				for( std::deque<context>::iterator i = event_contexts.begin() ; i != event_contexts.end(); ++i) {
 					const std::vector<sdl_handler*>& event_handlers = (*i).handlers;
@@ -478,6 +479,8 @@ void pump()
 						(*i1)->handle_event(event);
 					}
 				}
+				CVideo::get_singleton().lock_flips(false);
+				//CVideo::get_singleton().flip();
 				continue; //do not do further handling here
 			}
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -220,7 +220,8 @@ CVideo::CVideo(FAKE_TYPES type) :
 	mode_changed_(false),
 	fake_screen_(false),
 	help_string_(0),
-	updatesLocked_(0)
+	updatesLocked_(0),
+	flip_locked_(0)
 {
 	assert(!singleton_);
 	singleton_ = this;
@@ -495,7 +496,7 @@ void CVideo::delay(unsigned int milliseconds)
 
 void CVideo::flip()
 {
-	if(fake_screen_)
+	if(fake_screen_ || flip_locked_ > 0)
 		return;
 #ifdef SDL_GPU
 	assert(render_target_);
@@ -715,4 +716,12 @@ void CVideo::set_resolution(const unsigned width, const unsigned height)
 	// Change the config values.
 	preferences::_set_resolution(std::make_pair(width, height));
 	preferences::_set_maximized(false);
+}
+
+void CVideo::lock_flips(bool lock) {
+	if (lock) {
+		++flip_locked_;
+	} else {
+		--flip_locked_;
+	}
 }

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -209,6 +209,8 @@ public:
 	 */
 	std::vector<std::pair<int, int> > get_available_resolutions(const bool include_current = false);
 
+	void lock_flips(bool);
+
 private:
 	static CVideo* singleton_;
 
@@ -242,6 +244,7 @@ private:
 	int help_string_;
 
 	int updatesLocked_;
+	int flip_locked_;
 };
 
 //an object which will lock the display for the duration of its lifetime.

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -272,6 +272,21 @@ private:
 	bool unlock;
 };
 
+class flip_locker
+{
+public:
+	flip_locker(CVideo &video) : video_(video) {
+		video_.lock_flips(true);
+	}
+	~flip_locker() {
+		video_.lock_flips(false);
+	}
+
+private:
+	CVideo& video_;
+};
+
+
 namespace video2 {
 class draw_layering: public events::sdl_handler {
 protected:


### PR DESCRIPTION
The fix supresses the call to flip() while a full redrawn
is performed. The flip calls are instead deferred to
then next draw-cycle.