### PR TITLE
New features for [role]

### DIFF
--- a/changelog
+++ b/changelog
@@ -3,6 +3,11 @@ Version 1.13.5+dev:
    * Trait descriptions in the help are now generated. (This makes user-defined
      traits show up in the help as well.)
  * WML Engine:
+   * New attributes for [role]:
+     - search_recall_list=yes|no|only(default yes) controls where to look
+     - reassign=yes|no(default yes) if no, check for a unit and do not assign to another
+     - [auto_recall] sub-tag, if assigned to recall list, gives [recall] attributes (no SUF)
+     - [else] sub-tag, WML to execute if no unit found for the role
    * New help_text= key for [trait] to set the description displayed in the help.
 
 Version 1.13.5:

--- a/data/campaigns/An_Orcish_Incursion/utils/macros.cfg
+++ b/data/campaigns/An_Orcish_Incursion/utils/macros.cfg
@@ -11,7 +11,7 @@
 #define RECALL_ADVISOR
     [role]
         role=advisor
-        auto_recall=yes
+        [auto_recall][/auto_recall]
         search_recall_list=yes
 
         side=1
@@ -35,7 +35,6 @@
 #define PROMOTE_ADVISOR
     [role]
         role=advisor
-        auto_recall=no
         search_recall_list=no
 
         side=1
@@ -49,7 +48,7 @@
 #define RECALL_MAGE
     [role]
         role=mage
-        auto_recall=yes
+        [auto_recall][/auto_recall]
         search_recall_list=yes
 
         side=1

--- a/data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg
+++ b/data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg
@@ -172,7 +172,7 @@
         [role]
             type=Huntsman,Ranger,Fugitive,Highwayman,Outlaw,Trapper,Bandit,Footpad,Poacher,Thug
             role=Advisor
-            auto_recall=yes
+            [auto_recall][/auto_recall]
             [not]
                 id=Harper,Baldras
             [/not]

--- a/src/game_events/action_wml.cpp
+++ b/src/game_events/action_wml.cpp
@@ -426,6 +426,8 @@ WML_HANDLER_FUNCTION(move_units_fake,, cfg)
 }
 
 /// If we should recall units that match a certain description.
+// If you change attributes specific to [recall] (that is, not a Standard Unit Filter)
+// be sure to update data/lua/wml_tag, auto_recall feature for [role] to reflect your changes.
 WML_HANDLER_FUNCTION(recall,, cfg)
 {
 	LOG_NG << "recalling unit...\n";


### PR DESCRIPTION
This builds upon [CelticMinstrel's changes](https://github.com/wesnoth/wesnoth/commit/d4b8fec953ca81531d323774a39da90445dfd3d6) from a few days ago.

On code-reading, I see he made allowances to bypass searching the map. Also, he asked about whether a [role] would re-assign the role if a better match was found. On testing, I found, it did. As a result, I added the following new attributes for the [role] tag.

    search_map=yes|no (optional, default yes)
    reassign=yes|no (optional, default yes)

The search_map attribute determines whether units presently on the map should be considered for the role. Note that if both search_map and search_recall_list are specified as 'no' the [else] sub-tag always executes; if there also is no [else] tag the [role] tag does nothing at all. (These might be cases for wmllint to check for, someday.)

The reassign attribute determines whether, if a unit already has the role, the role should be re-assigned to a 'better' unit. Here, 'better' means either appears earlier in the listed types, or earlier in whatever the order happens to be in the list of units matching the filters.

Consider one use case: a map with a number of Mages and one Red Mage.

1) Use [role] in the normal way to assign role=MageAdvisor to the Red Mage using types="White Mage,Red Mage,Mage".

2) Advance some of the Mages to Red Mage, some to White Mage.

3) Use [role] with the same type list and reassign=no. The same Red Mage will still have the role MageAdvisor without regard to whether 'better' advisors might now be available.

4) Kill the Red Mage with the role MageAdvisor

4) Use [role] with the same type list and reassign=no. Now, there is no unit with the role, so it must be assigned. One of the White Mages will be selected.
