### PR TITLE
Monte Carlo damage calculation

### DIFF
--- a/changelog
+++ b/changelog
@@ -49,6 +49,15 @@ Version 1.13.4+dev:
      loggers activated in the gui print just like loggers activated in the 
      command line (i.e. messages appear in the console)
    * Fix bug #24762: Editor actions are out of sync after resizing.
+ * Performance:
+   * Added an advanced preference (Preferences -> Advanced ->
+     Allow damage calculation with Monte Carlo simulation) that, when enabled,
+     allows the damage calculation to operate by simulating a few thousand fights
+     instead of calculating exact probabilities of each outcome (when a heuristic
+     determines that it's probably faster). This method is inexact, but in very
+     complex battles (extremely high HP, drain, slow, berserk, etc.) it's
+     significantly faster than the default damage calculation method, and may be
+     necessary for acceptable performance.
  * WML engine:
    * Add color= attribute to [message].
    * Add [else], search_recall_list=, auto_recall= to [role]

--- a/changelog
+++ b/changelog
@@ -50,14 +50,11 @@ Version 1.13.4+dev:
      command line (i.e. messages appear in the console)
    * Fix bug #24762: Editor actions are out of sync after resizing.
  * Performance:
-   * Added an advanced preference (Preferences -> Advanced ->
-     Allow damage calculation with Monte Carlo simulation) that, when enabled,
-     allows the damage calculation to operate by simulating a few thousand fights
-     instead of calculating exact probabilities of each outcome (when a heuristic
-     determines that it's probably faster). This method is inexact, but in very
-     complex battles (extremely high HP, drain, slow, berserk, etc.) it's
-     significantly faster than the default damage calculation method, and may be
-     necessary for acceptable performance.
+   * When a heuristic determines that it's probably faster, the game predicts battle
+     outcome by simulating a few thousand fights instead of calculating exact
+     probabilities. This method is inexact, but in very complex battles (extremely
+     high HP, drain, slow, berserk, etc.) it's significantly faster than the default
+     damage calculation method.
  * WML engine:
    * Add color= attribute to [message].
    * Add [else], search_recall_list=, auto_recall= to [role]

--- a/data/advanced_preferences.cfg
+++ b/data/advanced_preferences.cfg
@@ -188,6 +188,14 @@
     type=custom
 [/advanced_preference]
 
+[advanced_preference]
+    field=damage_prediction_allow_monte_carlo_simulation
+    name= _ "Allow damage calculation with Monte Carlo simulation"
+    description= _ "Allow the damage calculation window to simulate fights instead of using exact probability calculations"
+    type=boolean
+    default=no
+[/advanced_preference]
+
 #ifdef __UNUSED__
 [advanced_preference]
     field=joystick_support_enabled

--- a/data/advanced_preferences.cfg
+++ b/data/advanced_preferences.cfg
@@ -193,7 +193,7 @@
     name= _ "Allow damage calculation with Monte Carlo simulation"
     description= _ "Allow the damage calculation window to simulate fights instead of using exact probability calculations"
     type=boolean
-    default=no
+    default=yes
 [/advanced_preference]
 
 #ifdef __UNUSED__

--- a/players_changelog
+++ b/players_changelog
@@ -33,14 +33,11 @@ Version 1.13.4+dev:
      when checked, only allows registered users to join the game
 
  * Performance:
-   * Added an advanced preference (Preferences -> Advanced ->
-     Allow damage calculation with Monte Carlo simulation) that, when enabled,
-     allows the damage calculation to operate by simulating a few thousand fights
-     instead of calculating exact probabilities of each outcome (when a heuristic
-     determines that it's probably faster). This method is inexact, but in very
-     complex battles (extremely high HP, drain, slow, berserk, etc.) it's
-     significantly faster than the default damage calculation method, and may be
-     necessary for acceptable performance.
+   * When a heuristic determines that it's probably faster, the game predicts battle
+     outcome by simulating a few thousand fights instead of calculating exact
+     probabilities. This method is inexact, but in very complex battles (extremely
+     high HP, drain, slow, berserk, etc.) it's significantly faster than the default
+     damage calculation method.
 
 Version 1.13.4:
  * Language and i18n:

--- a/players_changelog
+++ b/players_changelog
@@ -32,6 +32,16 @@ Version 1.13.4+dev:
    * Added "Registered users only" checkbox to multiplayer configuration dialog which 
      when checked, only allows registered users to join the game
 
+ * Performance:
+   * Added an advanced preference (Preferences -> Advanced ->
+     Allow damage calculation with Monte Carlo simulation) that, when enabled,
+     allows the damage calculation to operate by simulating a few thousand fights
+     instead of calculating exact probabilities of each outcome (when a heuristic
+     determines that it's probably faster). This method is inexact, but in very
+     complex battles (extremely high HP, drain, slow, berserk, etc.) it's
+     significantly faster than the default damage calculation method, and may be
+     necessary for acceptable performance.
+
 Version 1.13.4:
  * Language and i18n:
    * Updated translations: British English, Russian.

--- a/src/attack_prediction.cpp
+++ b/src/attack_prediction.cpp
@@ -1572,8 +1572,8 @@ unsigned int fight_complexity(unsigned int num_slices,
 {
 	return num_slices *
 		opp_num_slices *
-		(stats.slows || opp_stats.is_slowed) ? 2 : 1 *
-		(opp_stats.slows || stats.is_slowed) ? 2 : 1 *
+		((stats.slows || opp_stats.is_slowed) ? 2 : 1) *
+		((opp_stats.slows || stats.is_slowed) ? 2 : 1) *
 		stats.max_hp *
 		opp_stats.max_hp;
 }

--- a/src/attack_prediction.cpp
+++ b/src/attack_prediction.cpp
@@ -1280,7 +1280,7 @@ monte_carlo_combat_matrix::monte_carlo_combat_matrix(unsigned int a_max_hp, unsi
 	: combat_matrix(a_max_hp, b_max_hp, a_hp, b_hp, a_summary, b_summary, a_slows, b_slows,
 	a_damage, b_damage, a_slow_damage, b_slow_damage, a_drain_percent, b_drain_percent, a_drain_constant, b_drain_constant),
 
-	rounds_(rounds), a_hit_chance_(a_hit_chance), b_hit_chance_(b_hit_chance), a_split_(a_split), b_split_(b_split),
+	a_split_(a_split), b_split_(b_split), rounds_(rounds), a_hit_chance_(a_hit_chance), b_hit_chance_(b_hit_chance),
 	a_initially_slowed_chance_(a_initially_slowed_chance), b_initially_slowed_chance_(b_initially_slowed_chance)
 {
 	scale_probabilities(a_summary[0], a_initial_, 1.0 / (1.0 - a_initially_slowed_chance), a_hp);

--- a/src/attack_prediction.cpp
+++ b/src/attack_prediction.cpp
@@ -40,6 +40,7 @@
 
 #include "actions/attack.hpp"
 #include "game_config.hpp"
+#include "preferences.hpp"
 #include "random_new.hpp"
 #include <array>
 #include <cmath>
@@ -1986,7 +1987,8 @@ void combatant::fight(combatant &opp, bool levelup_considered)
 	const std::vector<combat_slice> opp_split = split_summary(opp.u_, opp.summary);
 
 	if (fight_complexity(split.size(), opp_split.size(), u_, opp.u_) >
-		MONTE_CARLO_SIMULATION_THRESHOLD)
+		MONTE_CARLO_SIMULATION_THRESHOLD &&
+		preferences::damage_prediction_allow_monte_carlo_simulation())
 	{
 		// A very complex fight. Use Monte Carlo simulation instead of exact
 		// probability calculations.

--- a/src/attack_prediction.hpp
+++ b/src/attack_prediction.hpp
@@ -35,6 +35,9 @@ struct combatant
 	/** Copy constructor */
 	combatant(const combatant &that, const battle_context_unit_stats &u);
 
+	combatant(const combatant &that) = delete;
+	combatant& operator=(const combatant &) = delete;
+
 	/** Simulate a fight!  Can be called multiple times for cumulative calculations. */
 	void fight(combatant &opponent, bool levelup_considered=true);
 
@@ -60,13 +63,6 @@ struct combatant
 #endif
 
 private:
-	combatant(const combatant &that);
-	combatant& operator=(const combatant &);
-
-	struct combat_slice;
-	/** Split the combat by number of attacks per combatant (for swarm). */
-	std::vector<combat_slice> split_summary() const;
-
 	const battle_context_unit_stats &u_;
 
 	/** Summary of matrix used to calculate last battle (unslowed & slowed).

--- a/src/attack_prediction.hpp
+++ b/src/attack_prediction.hpp
@@ -63,6 +63,8 @@ struct combatant
 #endif
 
 private:
+	static const unsigned int MONTE_CARLO_SIMULATION_THRESHOLD = 5000u;
+
 	const battle_context_unit_stats &u_;
 
 	/** Summary of matrix used to calculate last battle (unslowed & slowed).

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -1043,7 +1043,7 @@ void set_disable_loadingscreen_animation(bool value)
 
 bool damage_prediction_allow_monte_carlo_simulation()
 {
-	return get("damage_prediction_allow_monte_carlo_simulation", false);
+	return get("damage_prediction_allow_monte_carlo_simulation", true);
 }
 
 void set_damage_prediction_allow_monte_carlo_simulation(bool value)

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -1041,5 +1041,15 @@ void set_disable_loadingscreen_animation(bool value)
 	set("disable_loadingscreen_animation", value);
 }
 
+bool damage_prediction_allow_monte_carlo_simulation()
+{
+	return get("damage_prediction_allow_monte_carlo_simulation", false);
+}
+
+void set_damage_prediction_allow_monte_carlo_simulation(bool value)
+{
+	set("damage_prediction_allow_monte_carlo_simulation", value);
+}
+
 } // end namespace preferences
 

--- a/src/preferences.hpp
+++ b/src/preferences.hpp
@@ -263,6 +263,9 @@ namespace preferences {
 	bool disable_loadingscreen_animation();
 	void set_disable_loadingscreen_animation(bool value);
 
+	bool damage_prediction_allow_monte_carlo_simulation();
+	void set_damage_prediction_allow_monte_carlo_simulation(bool value);
+
 } // end namespace preferences
 
 #endif

--- a/src/random_new.cpp
+++ b/src/random_new.cpp
@@ -99,4 +99,29 @@ namespace random_new
 		assert(max >= 0);
 		return static_cast<int> (next_random() % (static_cast<uint32_t>(max)+1));
 	}
+
+	double rng::get_random_double()
+	{
+		uint64_t double_as_int = 0u;
+		/* Exponent. It's set to zero.
+		Exponent bias is 1023 in double precision, and therefore the value 1023
+		needs to be encoded. */
+		double_as_int |= static_cast<uint64_t>(1023) << 52;
+		/* Significand. A double-precision floating point number stores 52 significand bits.
+		The underlying RNG only gives us 32 bits, so we need to shift the bits 20 positions
+		to the left. The last 20 significand bits we can leave at zero, we don't need
+		the full 52 bits of randomness allowed by the double-precision format. */
+		double_as_int |= static_cast<uint64_t>(next_random()) << (52 - 32);
+		/* At this point, the exponent is zero. The significand, taking into account the
+		implicit leading one bit, is at least exactly one and at most almost two.
+		In other words, a reinterpret_cast<double*> gives us a number in the range [1, 2[.
+		Simply subtract one from that value and return it. */
+		return *reinterpret_cast<double*>(&double_as_int) - 1.0;
+	}
+
+	bool rng::get_random_bool(double probability)
+	{
+		assert(probability >= 0.0 && probability <= 1.0);
+		return get_random_double() < probability;
+	}
 }

--- a/src/random_new.hpp
+++ b/src/random_new.hpp
@@ -16,6 +16,7 @@
 
 #include <cstdlib> //needed for RAND_MAX
 #include <cstdint>
+#include <iterator> //needed for std::distance
 
 namespace random_new
 {

--- a/src/random_new.hpp
+++ b/src/random_new.hpp
@@ -15,9 +15,7 @@
 #define RANDOM_NEW_H_INCLUDED
 
 #include <cstdlib> //needed for RAND_MAX
-#include <boost/cstdint.hpp>
-
-using boost::uint32_t;
+#include <cstdint>
 
 namespace random_new
 {
@@ -49,6 +47,30 @@ namespace random_new
 		 */
 		int get_random_int(int min, int max)
 		{ return min + get_random_int_in_range_zero_to(max - min); }
+
+		/**
+		 * This helper method returns true with the probability supplied as a parameter.
+		 * @param probability	The probability of returning true, from 0 to 1.
+		 */
+		bool get_random_bool(double probability);
+
+		/**
+		 * This helper method returns a floating-point number in the range [0,1[.
+		 */
+		double get_random_double();
+
+		/**
+		 * This helper method selects a random element from a container of floating-point numbers.
+		 * Every number has a probability to be selected equal to the number itself
+		 * (e.g. a number of 0.1 is selected with a probability of 0.1). The sum of numbers
+		 * should be one.
+		 * @param first	Iterator to the beginning of the container
+		 * @param last	Iterator to the end of the container
+		 * @ret			The index of the selected number
+		 */
+		template <typename T>
+		unsigned int get_random_element(T first, T last);
+
 		static rng& default_instance();
 	protected:
 		virtual uint32_t next_random_impl() = 0;
@@ -68,5 +90,27 @@ namespace random_new
 		Outside a synced context this has the same effect as rand()
 	*/
 	extern rng* generator;
+
+	template <typename T>
+	unsigned int rng::get_random_element(T first, T last)
+	{
+		double target = get_random_double();
+		double sum = 0.0;
+		T it = first;
+		sum += *it;
+		while (sum <= target)
+		{
+			++it;
+			if (it != last)
+			{
+				sum += *it;
+			}
+			else
+			{
+				break;
+			}
+		}
+		return std::distance(first, it);
+	}
 }
 #endif


### PR DESCRIPTION
In short: I implemented the Monte Carlo damage calculation mode requested in https://wiki.wesnoth.org/NotSoEasyCoding#Add_a_new_damage_stats_calculation_mode_to_support_scenarios_with_extremely_high_stats . :+1: 

As explained in the wiki, the advantage of this mode is that its time requirement is almost fixed: the only things which can make it slower are the number of strikes and the berserk ability. I benchmarked the code using the built-in benchmark functionality (which simulates thousands of battles with hard-to-calculate units): the simulation takes, on average, four milliseconds per battle.

Also, like the wiki page requested, the Monte Carlo simulation mode is disabled by default. The player can enable it with an advanced preference.