### PR TITLE
Fix undefined behavior on destroying an event context

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -132,15 +132,15 @@ void context::set_focus(const sdl_handler* ptr)
 
 context::~context()
 {
-	if (!handlers.empty()) {
-		for (handler_list::iterator it = handlers.begin(); it != handlers.end(); ++it) {
-			if ((*it)->has_joined()) {
-				(*it)->has_joined_ = false;
-			}
-			if ((*it)->has_joined_global()) {
-				(*it)->has_joined_global_ = false;
-			}
-			it = handlers.erase(it);
+	for (sdl_handler* h : handlers)
+	{
+		if (h->has_joined())
+		{
+			h->has_joined_ = false;
+		}
+		if (h->has_joined_global())
+		{
+			h->has_joined_global_ = false;
 		}
 	}
 }


### PR DESCRIPTION
Quoting the corresponding messages in IRC:

> [19:49:36] \<JyrkiVesterinen\> FYI: the game crashed when I tried to open the Preferences dialog ingame. Looks related to the event context changes.
> [19:49:37] \<JyrkiVesterinen\> https://gist.github.com/jyrkive/3992782bfb0c7b6bea6f9dd2ac6b9dad
> [19:49:42] \<JyrkiVesterinen\> I'm investigating.
> [20:10:19] \<hk238\> :o
> [20:21:54] * stikonas (~gentoo@wesnoth/translator/stikonas) has quit IRC (Quit: Konversation terminated!)
> [20:30:50] \<JyrkiVesterinen\> All right, the problem is in the destructor of the context class.
> [20:30:51] \<JyrkiVesterinen\> https://github.com/wesnoth/wesnoth/blob/681322bf2935ce08e2526d92b842aad86302afe6/src/events.cpp#L133-L146
> [20:31:43] \<JyrkiVesterinen\> It performs "it = handlers.erase(it);" followed by "++it" in every iteration. It other words, it increments it twice.
> [20:32:24] \<JyrkiVesterinen\> If the number of handlers happens to be odd, the second increment increments the end iterator, which is undefined behavior.
> [20:32:46] \<JyrkiVesterinen\> Microsoft's debug CRT is guaranteed to crash in that situation, fortunately.
> [20:32:46] \<celticminstrel\> I think logically the ++it is not supposed to be there.
> [20:33:14] \<JyrkiVesterinen\> It doesn't make sense to manually remove the handlers from the list anyway.
> [20:33:16] \<celticminstrel\> Yeah, MSVC tends to be pretty good about crashing in these sorts of situations.
> [20:33:29] \<celticminstrel\> Hmm.
> [20:33:42] \<JyrkiVesterinen\> This is the destructor of the context class. The destructor of the list is just about to be executed, and that would clear the list for us.