### PR TITLE
Fix bug #24553: Prevent the display from drawing over the storyscreen.

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -467,6 +467,7 @@ void pump()
 				}
 				//make sure this runs in it's own scope.
 				{
+					flip_locker flip_lock(CVideo::get_singleton());
 					for( std::deque<context>::iterator i = event_contexts.begin() ; i != event_contexts.end(); ++i) {
 						const handler_list& event_handlers = (*i).handlers;
 						for(auto handler : event_handlers) {

--- a/src/storyscreen/render.cpp
+++ b/src/storyscreen/render.cpp
@@ -964,6 +964,8 @@ bool part_ui::handle_interface()
 
 part_ui::RESULT part_ui::show()
 {
+	update_locker locker(video_);
+
 	this->prepare_background();
 	this->prepare_geometry();
 	this->prepare_floating_images();

--- a/src/storyscreen/render.cpp
+++ b/src/storyscreen/render.cpp
@@ -366,6 +366,9 @@ bool part_ui::render_floating_images()
 				update_rect(old_ri.rect);
 			}
 		}
+		back_button_.set_dirty();
+		next_button_.set_dirty();
+		play_button_.set_dirty();
 
 		if (!skip_)
 		{
@@ -380,7 +383,6 @@ bool part_ui::render_floating_images()
 
 		++fi_n;
 	}
-
 	return true;
 #endif
 }


### PR DESCRIPTION
This also adds a call to stop flips during a full redraw as a consequence of a window event.