### PR TITLE
unit.cpp Fix bug: Ellipse is lost

### DIFF
--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -921,7 +921,9 @@ void unit::advance_to(const unit_type &u_type,
 		 set_usage(new_type.usage());
 	}
 	set_image_halo(new_type.halo());
-	set_image_ellipse(new_type.ellipse());
+	if (!new_type.ellipse().empty()) {
+		set_image_ellipse(new_type.ellipse());
+	}
 	generate_name_ &= new_type.generate_name();
 	abilities_ = new_type.abilities_cfg();
 	advancements_.clear();


### PR DESCRIPTION
When advancing or an object (say, the Scepter of Fire) selects a unit variation, the ellipse is lost. This causes a unit with {ISHERO} to convert to {ISLOYAL}, changing the hero ellipse to the default.

I consider this a Work In Process because I view the issue as symptomatic of a general error and would prefer someone better invested in the engine, and unit.cpp specifically, to review the code for other instances.

This problem was first noticed in HttT S17 when Li'sar obtains the Scepter of Fire. The Scepter operates by selecting a unit variation.

The problem was then confirmed to also effect any {ISHERO} unit who was not canrecruit and not at AMLA such as Kalenz when first able to advance in HttT S07 and confirmed with additional checks in other campaigns.

The problem was also confirmed to NOT exist in 1.12.5.

Examining the commit history indicates this probably resulted from a refactor back around Feb by @gfgtdf but this could not be confirmed (I got compile errors attempting to roll back and, so, gave up). But, using that as a clue, I attempted this patch and it appears to work in both the normal advancement case and the Scepter case selecting a unit variation.
