### PR TITLE
Fade out music on scenario start and on disabling it

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,7 +1,7 @@
 Version 1.13.5+dev:
  * Music and sound effects:
    * Added a preference to pause the music when the game loses focus.
-   * Now the storyscreen music fades out at the start of each scenario.
+   * Now the music fades out between scenarios.
  * Units:
    * Changed the sound for the melee attack of the
      Loyalist Bowman, Orcish Crossbowman and Orcish Slurbow.

--- a/changelog
+++ b/changelog
@@ -1,6 +1,7 @@
 Version 1.13.5+dev:
  * Music and sound effects:
    * Added a preference to pause the music when the game loses focus.
+   * Now the storyscreen music fades out at the start of each scenario.
  * Units:
    * Changed the sound for the melee attack of the
      Loyalist Bowman, Orcish Crossbowman and Orcish Slurbow.

--- a/data/core/macros/sound-utils.cfg
+++ b/data/core/macros/sound-utils.cfg
@@ -628,6 +628,7 @@
         [music]
             name={MUSIC}
             immediate=yes
+            ms_after=2000
         [/music]
     [/event]
 #enddef
@@ -661,6 +662,7 @@
             name={SCENARIO_MUSIC}
             immediate=yes
             append=no
+            ms_after=2000
         [/music]
     [/event]
 #enddef

--- a/players_changelog
+++ b/players_changelog
@@ -5,7 +5,7 @@ changelog: https://github.com/wesnoth/wesnoth/blob/master/changelog
 Version 1.13.5+dev:
  * Music and sound effects:
    * Added a preference to pause the music when the game loses focus.
-   * Now the storyscreen music fades out at the start of each scenario.
+   * Now the music fades out between scenarios.
  * Units:
    * Changed the sound for the melee attack of the
 	 Loyalist Bowman, Orcish Crossbowman and Orcish Slurbow.

--- a/players_changelog
+++ b/players_changelog
@@ -5,15 +5,16 @@ changelog: https://github.com/wesnoth/wesnoth/blob/master/changelog
 Version 1.13.5+dev:
  * Music and sound effects:
    * Added a preference to pause the music when the game loses focus.
+   * Now the storyscreen music fades out at the start of each scenario.
  * Units:
    * Changed the sound for the melee attack of the
 	 Loyalist Bowman, Orcish Crossbowman and Orcish Slurbow.
  * Performance:
-  * When a heuristic determines that it's probably faster, the game predicts battle
-    outcome by simulating a few thousand fights instead of calculating exact
-    probabilities. This method is inexact, but in very complex battles (extremely
-    high HP, drain, slow, berserk, etc.) it's significantly faster than the default
-    damage calculation method.
+   * When a heuristic determines that it's probably faster, the game predicts battle
+     outcome by simulating a few thousand fights instead of calculating exact
+     probabilities. This method is inexact, but in very complex battles (extremely
+     high HP, drain, slow, berserk, etc.) it's significantly faster than the default
+     damage calculation method.
 
 Version 1.13.5:
  * Campaigns:

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -307,14 +307,15 @@ LEVEL_RESULT playsingle_controller::play_scenario(const config& level)
 				("result", is_victory ? "victory" : "defeat")
 			));
 		// Play victory music once all victory events
-		// are finished, if we aren't observers.
+		// are finished, if we aren't observers and the
+		// carryover dialog isn't disabled.
 		//
 		// Some scenario authors may use 'continue'
 		// result for something that is not story-wise
 		// a victory, so let them use [music] tags
 		// instead should they want special music.
 		const std::string& end_music = is_victory ? select_victory_music() : select_defeat_music();
-		if(end_music.empty() != true) {
+		if((!is_victory || end_level.transient.carryover_report) && !end_music.empty()) {
 			sound::play_music_once(end_music);
 		}
 		persist_.end_transaction();
@@ -337,8 +338,6 @@ LEVEL_RESULT playsingle_controller::play_scenario(const config& level)
 			throw;
 		}
 	}
-
-	return LEVEL_RESULT::QUIT;
 }
 
 void playsingle_controller::play_idle_loop()

--- a/src/storyscreen/render.cpp
+++ b/src/storyscreen/render.cpp
@@ -25,6 +25,7 @@
 #include "storyscreen/part.hpp"
 #include "storyscreen/render.hpp"
 
+#include "config.hpp"
 #include "image.hpp"
 #include "language.hpp"
 #include "sdl/rect.hpp"
@@ -973,7 +974,12 @@ part_ui::RESULT part_ui::show()
 	this->prepare_floating_images();
 
 	if(p_.music().empty() != true) {
-		sound::play_music_repeatedly(p_.music());
+		config music_config;
+		music_config["name"] = p_.music();
+		music_config["ms_after"] = 2000;
+		music_config["immediate"] = true;
+
+		sound::play_music_config(music_config);
 	}
 
 	if(p_.sound().empty() != true) {


### PR DESCRIPTION
@Vultraz requested something like this in IRC.

> 20160730 12:44:41\< vultraz\> JyrkiVesterinen: I have a small task for you, if you're up to it: make it so music fades out (such as when you toggle it off, or a scenario ends) instead of stopping abruptly.

I implemented fading out when the player disables music in preferences. I also edited the SCENARIO_MUSIC and INTRO_AND_SCENARIO_MUSIC macros by turning on fade-out of previous music (i.e. the storyscreen music) when the scenario starts.

I assume that the "scenario ends" condition @Vultraz mentioned means the victory or defeat situation, when the game plays the victory/defeat music. I didn't implement fade-out of previous music in that situation because I *oppose* it. (I prefer the "abrupt" switch to the victory/defeat music.)