### PR TITLE
give formatter an x-value conversion to std::string (C++11)

### DIFF
--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -58,9 +58,9 @@ std::string format_version(unsigned a, unsigned b, unsigned c)
 
 std::string format_version(const SDL_version& v)
 {
-	return (formatter() << unsigned(v.major) << '.'
-						<< unsigned(v.minor) << '.'
-						<< unsigned(v.patch)).str();
+	return formatter() << unsigned(v.major) << '.'
+			    		<< unsigned(v.minor) << '.'
+						<< unsigned(v.patch);
 }
 
 version_table_manager::version_table_manager()

--- a/src/commandline_options.cpp
+++ b/src/commandline_options.cpp
@@ -52,15 +52,15 @@ static void validate(boost::any& v, const std::vector<std::string>& values,
 }
 
 bad_commandline_resolution::bad_commandline_resolution(const std::string& resolution)
-	: error((formatter() << "Invalid resolution \"" << resolution
-						 << "\" (WIDTHxHEIGHT expected)").str())
+	: error(formatter() << "Invalid resolution \"" << resolution
+						 << "\" (WIDTHxHEIGHT expected)")
 {
 }
 
 bad_commandline_tuple::bad_commandline_tuple(const std::string& str,
 											 const std::string& expected_format)
-	: error((formatter() << "Invalid value set \"" << str
-						 << "\" (" << expected_format << " expected)").str())
+	: error(formatter() << "Invalid value set \"" << str
+						 << "\" (" << expected_format << " expected)")
 {
 }
 

--- a/src/desktop/version.cpp
+++ b/src/desktop/version.cpp
@@ -176,10 +176,10 @@ std::string os_version()
 		ERR_DU << "os_version: uname error (" << strerror(errno) << ")\n";
 	}
 
-	return (formatter() << u.sysname << ' '
+	return formatter() << u.sysname << ' '
 						<< u.release << ' '
 						<< u.version << ' '
-						<< u.machine).str();
+						<< u.machine;
 
 #elif defined(_WIN32)
 

--- a/src/formatter.hpp
+++ b/src/formatter.hpp
@@ -14,6 +14,7 @@
 #define FORMATTER_HPP_INCLUDED
 
 #include <sstream>
+#include <utility>
 
 /**
  * std::ostringstream wrapper.
@@ -28,6 +29,10 @@
  *  s.str();
  * This class corrects this shortcoming, allowing something like this:
  *  string result = (formatter() << "blah " << n << x << " blah").str();
+ *
+ * Actually, due to the ref qualified versions below, you can get away with this
+ *
+ *  string result = formatter() << "blah " << n << x << " blah";
  */
 class formatter
 {
@@ -38,14 +43,25 @@ public:
 	}
 
 	template<typename T>
-	formatter& operator<<(const T& o) {
+	formatter& operator<<(const T & o) & {
 		stream_ << o;
 		return *this;
 	}
 
+    template <typename T>
+    formatter && operator<<(const T & o) && {
+      stream_ << o;
+      return std::move(*this);
+    }
+
 	std::string str() {
 		return stream_.str();
 	}
+
+    // Implicit x-value conversion to string
+    operator std::string() && {
+        return stream_.str();
+    }
 
 private:
 	std::ostringstream stream_;

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -561,7 +561,7 @@ replay_savegame::replay_savegame(saved_game &gamestate, const compression::forma
 
 void replay_savegame::create_filename()
 {
-	set_filename((formatter() << gamestate().classification().label << " " << _("replay")).str());
+	set_filename(formatter() << gamestate().classification().label << " " << _("replay"));
 }
 
 void replay_savegame::write_game(config_writer &out) {


### PR DESCRIPTION
`formatter` is one of these classes that Dave has put into every project that he worked on it seems.

In wesnoth, the `formatter` class still has a copyright to "The Silvertree Project" which has long been defunct.

It's commonly used as

```c++
    string result = (formatter() << "blah " << n << x << " blah").str();
```

In [anura](https://github.com/anura-engine/anura/blob/trunk/src/formatter.hpp), Dave modified it to be more aggressive, by giving it an `operator std::string()` implicit conversion.

This allows a terser syntax:

```c++
    string result = formatter() << "blah " << n << x << " blah";
```

but it creates some room for compiler shenanigans. Usually programmers agree that implicit conversions like this are evil. But it's also pretty convenient.

In another project, I modified it as shown in this pull request, using C++11 features.

- Make a version of `operator <<` which works with r-value reference to the formatter.
- Make an `operator std::string` which is ref-qualified so that it can only work with an expiring value.

This basically means that a `formatter` instance which is a nameless temporary can be converted to `std::string`, but an `l-value` formatter is not so convertible, you would have to use `.str()`.

Typically, rvalue-references arise as return values from functions, temporaries, or as result of `std::move`. I never saw a function that returns `formatter`, its sort of not what this idiom is for. So I consider that this operator usually just avoids you having to add extra parens and write `str()` and isn't usually invoked otherwise, which is the intent.

It's debatable whether this is still evil or not, but I think it's somewhat more safe. I leave it to you to decide if its worth it. :-)