### PR TITLE
objectives.lua show_turn_counter in white

### DIFF
--- a/data/lua/wml/objectives.lua
+++ b/data/lua/wml/objectives.lua
@@ -68,9 +68,9 @@ local function generate_objectives(cfg)
 
 				if turn_limit >= current_turn then
 					if turn_limit - current_turn + 1 > 1 then
-						turn_counter = "<small> " .. string.format(tostring(_"(%d turns left)"), turn_limit - current_turn + 1) .. "</small>"
+						turn_counter = "<span foreground='white'><small> " .. string.format(tostring(_"(%d turns left)"), turn_limit - current_turn + 1) .. "</small></span>"
 					else
-						turn_counter = "<small> " .. _"(this turn left)" .. "</small>"
+						turn_counter = "<span foreground='white'><small> " .. _"(this turn left)" .. "</small></span>"
 					end
 				end
 			end


### PR DESCRIPTION
This matches the style used for OBJECTIVE_FOOTNOTE and makes the turn count more apparent.

The turn count really is not part of the win/lose condition. The show_turn_counter option adds it as an informative footnote. Other such footnotes are created using OBJECTIVE_FOOTNOTE, which sets the color 'white'. This change makes the show_turn_counter footnote consistent with that macro.
