### PR TITLE
HttT General Improvements

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/01_The_Elves_Besieged.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/01_The_Elves_Besieged.cfg
@@ -25,6 +25,7 @@
 
     [event]
         name=prestart
+        {NEED_DELFADOR (x,y=19,23)}
         [objectives]
             side=1
             [objective]
@@ -76,21 +77,6 @@
         gold=100
         team_name=elves
         user_team_name=_"Rebels"
-        [unit]
-            id=Delfador
-            name= _ "Delfador"
-            unrenamable=yes
-            type=Elder Mage
-            profile=portraits/delfador-elvish.png
-            side=1
-            x=19
-            y=23
-            {IS_HERO}
-            [modifications]
-                {TRAIT_LOYAL}
-                {TRAIT_INTELLIGENT}
-            [/modifications]
-        [/unit]
         [ai]
             [goal]
                 name=target

--- a/data/campaigns/Heir_To_The_Throne/scenarios/02_Blackwater_Port.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/02_Blackwater_Port.cfg
@@ -152,9 +152,7 @@
             {IS_LOYAL}
         [/unit]
 
-        [recall]
-            id=Delfador
-        [/recall]
+        {NEED_DELFADOR placement=leader}
     [/event]
 
     [event]
@@ -358,6 +356,9 @@
             speaker=Mokolo Qimur
             message= _ "So many foul humans riding on horses! There is no way we can defeat them. Quick, we must make our escape!"
         [/message]
+        [fire_event]
+            name=victory dance
+        [/fire_event]
         [endlevel]
             result=victory
             bonus=no
@@ -503,6 +504,9 @@
         [/message]
 #endif
 
+        [fire_event]
+            name=victory dance
+        [/fire_event]
         [endlevel]
             result=victory
             bonus=yes
@@ -511,7 +515,7 @@
     [/event]
 
     [event]
-        name=victory
+        name=victory dance
         [message]
             speaker=Kaylan
             message= _ "Thank you for the help, friends. The ship should arrive soon, it will take you to Alduin."

--- a/data/campaigns/Heir_To_The_Throne/scenarios/02_Blackwater_Port.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/02_Blackwater_Port.cfg
@@ -224,6 +224,12 @@
             {DELFADOR_MENTORING_ELF}
             message= _ "Recruit troops wisely, Konrad, and remember that you can recall experienced units from past battles to help you fight again."
         [/message]
+        [move_unit_fake]
+            side=1
+            type=Horseman
+            x=15,16,23
+            y=27,27,24
+        [/move_unit_fake]
         [unit]
             id=Haldiel
             name= _ "Haldiel"
@@ -231,6 +237,7 @@
             x=23
             y=24
             side=1
+            facing=ne
             [modifications]
                 {TRAIT_LOYAL}
                 {TRAIT_STRONG}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/02_Blackwater_Port.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/02_Blackwater_Port.cfg
@@ -455,7 +455,8 @@
             name= _ "Simyr"
             x=35
             y=6
-            side=1
+            ai_special=guardian
+            side=2
             facing=sw
             [modifications]
                 {TRAIT_LOYAL}
@@ -473,6 +474,29 @@
             speaker=Kaylan
             message= _ "You have risked your life to defend our city. In return, I place one of my city’s finest defenders in your service. Simyr, step forward. I place your lance in the service of young prince Konrad here. May you help him restore order to the country."
         [/message]
+        [kill]
+            id=Simyr
+        [/kill]
+        [move_unit_fake]
+            side=2
+            type=Knight
+            x=33,29
+            y=5,7
+        [/move_unit_fake]
+        [unit]
+            type=Knight
+            id=Simyr
+            name= _ "Simyr"
+            x=29
+            y=7
+            side=1
+            facing=sw
+            [modifications]
+                {TRAIT_LOYAL}
+                {TRAIT_INTELLIGENT}
+            [/modifications]
+            {IS_LOYAL}
+        [/unit]
         [message]
             speaker=Simyr
             message= _ "It is my pleasure and honor to serve, my liege."

--- a/data/campaigns/Heir_To_The_Throne/scenarios/02_Blackwater_Port.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/02_Blackwater_Port.cfg
@@ -79,6 +79,8 @@
         profile=portraits/humans/grand-knight-2.png
 
         side=2
+        # Make Kaylan's TC teal, so it fits better with the portrait.
+        color=teal
         canrecruit=yes
         team_name=elves
         user_team_name=_"Rebels"
@@ -103,6 +105,7 @@
         name= _ "Mokolo Qimur"
         profile=portraits/orcs/grunt-2.png
         side=3
+        color=purple
         canrecruit=yes
         team_name=orcs
         user_team_name=_"Orcs"
@@ -121,9 +124,6 @@
         name=prestart
 
         {PLACE_IMAGE scenery/rock1.png 23 17}
-
-        # Make Kaylan's TC teal, so it fits better with the portrait.
-        {TEAM_COLOR_OVERRIDE id=Kaylan teal}
 
         [unit]
             type=Swordsman

--- a/data/campaigns/Heir_To_The_Throne/scenarios/03_The_Isle_of_Alduin.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/03_The_Isle_of_Alduin.cfg
@@ -111,6 +111,12 @@
 
         {PLACE_IMAGE scenery/rock3.png 25 30}
 
+        [disallow_recruit]
+            side=1
+            type=Mage
+        [/disallow_recruit]
+
+        {NEED_DELFADOR (x,y=26,12)}
         [store_unit]
             variable=konrad_store
             kill=yes
@@ -169,10 +175,6 @@
             x=31,26
             y=11,12
         [/move_unit_fake]
-
-        #set Delfador's position
-        {VARIABLE delfador_store.x 26}
-        {VARIABLE delfador_store.y 12}
 
         #show Delfador
         [unstore_unit]
@@ -346,13 +348,8 @@
                     message= _ "Caution, young prince. It is very difficult to train inexperienced magi in combat. When they fight on the front lines of battle, you must protect magi with stronger units else the enemy will make short work of them."
                 [/message]
 #endif
-                [allow_recruit]
-                    side=1
-                    type=Mage
-                [/allow_recruit]
             [/then]
         [/if]
-        {CLEAR_VARIABLE received_mages}
 
         [kill]
             id=Seimus
@@ -366,4 +363,15 @@
     [/event]
 
     {campaigns/Heir_To_The_Throne/utils/deaths.cfg}
+
+    [event]
+        name=victory
+
+        [allow_recruit]
+            side=1
+            type=Mage
+        [/allow_recruit]
+
+        {CLEAR_VARIABLE received_mages}
+    [/event]
 [/scenario]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/04_The_Bay_of_Pearls.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/04_The_Bay_of_Pearls.cfg
@@ -670,14 +670,21 @@
             {KONRAD_VARIATION_ELF glad}
             message= _ "At last, we have freed the mermen. Go back to the ocean and live in peace."
         [/message]
-        [role]
-            type=Merman Fighter,Merman Warrior,Merman Triton,Merman Hoplite
-            role=ThankfulMerman
-        [/role]
-        [message]
-            role=ThankfulMerman
-            message= _ "My lord! You may need the help of some of us who have skill in the sea in future. We would like to come with you and offer you help."
-        [/message]
+#define MERMAN_SPEAKS
+    [role]
+        role=ThankfulMerman
+        search_recall_list=no
+
+        type="Merman Triton,Merman Hoplite,Merman Javelineer,Merman Entangler,Mermaid Diviner,Mermaid Siren," +
+             "Merman Warrior,Merman Spearman,Merman Netcaster,Mermaid Priestess,Mermaid Enchantress," +
+             "Merman Fighter,Merman Hunter,Mermaid Initiate"
+    [/role]
+    [message]
+        role=ThankfulMerman
+        message= _ "My lord! You may need the help of some of us who have skill in the sea in future. We would like to come with you and offer you help."
+    [/message]
+#enddef
+        {MERMAN_SPEAKS}
         [message]
             speaker=narrator
             image="wesnoth-icon.png"
@@ -876,14 +883,7 @@
                         [kill]
                             id=Delfador
                         [/kill]
-                        [role]
-                            type=Merman Fighter,Merman Warrior,Merman Triton,Merman Hoplite
-                            role=ThankfulMerman
-                        [/role]
-                        [message]
-                            role=ThankfulMerman
-                            message= _ "My lord! You may need the help of some of us who have skill in the sea in future. We would like to come with you and offer you help."
-                        [/message]
+                        {MERMAN_SPEAKS}
                         [message]
                             speaker=narrator
                             image="wesnoth-icon.png"
@@ -908,14 +908,7 @@
                         [kill]
                             id=Delfador
                         [/kill]
-                        [role]
-                            type=Merman Fighter,Merman Warrior,Merman Triton,Merman Hoplite
-                            role=ThankfulMerman
-                        [/role]
-                        [message]
-                            role=ThankfulMerman
-                            message= _ "My lord! You may need the help of some of us who have skill in the sea in future. We would like to come with you and offer you help."
-                        [/message]
+                        {MERMAN_SPEAKS}
                         [message]
                             speaker=narrator
                             image="wesnoth-icon.png"
@@ -939,3 +932,5 @@
 
     {campaigns/Heir_To_The_Throne/utils/deaths.cfg}
 [/scenario]
+
+#undef MERMAN_SPEAKS

--- a/data/campaigns/Heir_To_The_Throne/scenarios/04_The_Bay_of_Pearls.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/04_The_Bay_of_Pearls.cfg
@@ -103,6 +103,10 @@
     [event]
         name=prestart
 
+        [disallow_recruit]
+            side=1
+            type=Merman Fighter,Merman Hunter,Mermaid Initiate
+        [/disallow_recruit]
         #
         # Grant an extra enchampment tile
         #
@@ -125,10 +129,7 @@
         [/terrain]
 #endif
 
-        [recall]
-            id=Delfador
-            show=no
-        [/recall]
+        {NEED_DELFADOR placement=leader}
 
         #the ship they came on.
         {PLACE_IMAGE "units/transport/galleon.png~RC(magenta>red)" 2 34}
@@ -215,14 +216,7 @@
             message= _ "Very well. Be careful!"
         [/message]
 
-        #Delfador leaves the party
-        [store_unit]
-            variable=delfador_store
-            kill=yes
-            [filter]
-                id=Delfador
-            [/filter]
-        [/store_unit]
+        {STORE_DELFADOR}
     [/event]
 
     #comic relief with Bugg becoming a 'sea orc'
@@ -710,13 +704,8 @@
             message= _ "Now where is Delfador? I hope he’s safe!"
         [/message]
 
-        [unstore_unit]
-            variable=delfador_store
-            x,y=31,11
-            find_vacant=yes
-        [/unstore_unit]
-        # Note: do NOT clear the variable, because Delfador needs to return
-        # again in SoE.
+        {RESTORE_DELFADOR}
+        {NEED_DELFADOR (x,y=31,11)}
 
         [message]
             speaker=Delfador
@@ -790,9 +779,6 @@
                         speaker=Delfador
                         message= _ "Safe journey to you, Konrad. Until we meet again!"
                     [/message]
-                    [kill]
-                        id=Delfador
-                    [/kill]
                     [endlevel]
                         result=victory
                         next_scenario=05a_Muff_Malals_Peninsula
@@ -808,9 +794,6 @@
                         speaker=Delfador
                         message= _ "Safe voyage to you then, Konrad. May the weather be fair."
                     [/message]
-                    [kill]
-                        id=Delfador
-                    [/kill]
                     [endlevel]
                         result=victory
                         next_scenario=05b_Isle_of_the_Damned
@@ -825,13 +808,8 @@
     [event]
         name=time over
 
-        [unstore_unit]
-            variable=delfador_store
-            x,y=31,11
-            find_vacant=yes
-        [/unstore_unit]
-        # Note: do NOT clear the variable, because Delfador needs to return
-        # again in SoE.
+        {RESTORE_DELFADOR}
+        {NEED_DELFADOR (x,y=31,11)}
 
         #if neither of the enemies is dead, automatically lose
         [if]
@@ -896,19 +874,6 @@
                             speaker=Delfador
                             message= _ "Since you have broken the orcs’ hegemony over the seas, going by ship would be safest. Sail along the coast, and you can land mere miles from Elensefar. Make haste!"
                         [/message]
-                        [kill]
-                            id=Delfador
-                        [/kill]
-                        {MERMAN_SPEAKS}
-                        [message]
-                            speaker=narrator
-                            image="wesnoth-icon.png"
-                            message= _ "You may now recruit the noble merfolk!"
-                        [/message]
-                        [allow_recruit]
-                            side=1
-                            type=Merman Fighter
-                        [/allow_recruit]
                         [endlevel]
                             result=victory
                             bonus=no
@@ -921,19 +886,6 @@
                             speaker=Delfador
                             message= _ "With the orcs controlling the seas, going by ship would not be safe. Travel by land, Elensefar is only six days’ march up the coast. Make haste!"
                         [/message]
-                        [kill]
-                            id=Delfador
-                        [/kill]
-                        {MERMAN_SPEAKS}
-                        [message]
-                            speaker=narrator
-                            image="wesnoth-icon.png"
-                            message= _ "You may now recruit the noble merfolk!"
-                        [/message]
-                        [allow_recruit]
-                            side=1
-                            type=Merman Fighter
-                        [/allow_recruit]
                         [endlevel]
                             result=victory
                             bonus=no
@@ -942,11 +894,28 @@
                         [/endlevel]
                     [/else]
                 [/if]
+                {MERMAN_SPEAKS}
+                [message]
+                    speaker=narrator
+                    image="wesnoth-icon.png"
+                    message= _ "You may now recruit the noble merfolk!"
+                [/message]
             [/else]
         [/if]
     [/event]
 
     {campaigns/Heir_To_The_Throne/utils/deaths.cfg}
+
+    [event]
+        name=victory
+
+        [allow_recruit]
+            side=1
+            type=Merman Fighter
+        [/allow_recruit]
+
+        {RESTORE_DELFADOR}
+    [/event]
 [/scenario]
 
 #undef MERMAN_SPEAKS

--- a/data/campaigns/Heir_To_The_Throne/scenarios/04_The_Bay_of_Pearls.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/04_The_Bay_of_Pearls.cfg
@@ -266,6 +266,14 @@
                 id=Bugg
             [/have_unit]
             [then]
+                [scroll_to_unit]
+                    id=Bugg
+                [/scroll_to_unit]
+
+                [delay]
+                    time=500
+                [/delay]
+
                 [store_unit]
                     variable=bugg_flip
                     [filter]
@@ -275,6 +283,9 @@
                 [/store_unit]
 
                 {NAMED_LOYAL_UNIT 2 (Sea Orc) $bugg_flip.x $bugg_flip.y (Bugg) ( _ "Bugg")}
+                [+unit]
+                    animate=yes
+                [/unit]
 
                 {CLEAR_VARIABLE bugg_flip}
 

--- a/data/campaigns/Heir_To_The_Throne/scenarios/04_The_Bay_of_Pearls.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/04_The_Bay_of_Pearls.cfg
@@ -749,8 +749,13 @@
         [/message]
 
         [role]
-            type=Elvish Champion,Elvish Marshal,Elvish Captain,Elvish Hero,Knight,Elvish Rider,Elvish Outrider,Paladin,Mage,White Mage,Red Mage,Elvish Fighter,Elvish Archer,Elvish Shaman,Horseman
             role=Supporter
+            search_recall_list=no
+
+            type="Elvish Sylph,Great Mage,"+
+                 "Elvish Marshal,Elvish Champion,Elvish Avenger,Elvish Sharpshooter,Elvish Shyde,Elvish Enchantress,Elvish Outrider,Paladin,Grand Knight,Mage of Light,Arch Mage,Silver Mage,"+
+                 "Elvish Captain,Elvish Hero,Elvish Ranger,Elvish Marksman,Elvish Druid,Elvish Sorceress,Elvish Rider,Knight,Lancer,White Mage,Red Mage,"+
+                 "Elvish Fighter,Elvish Archer,Elvish Shaman,Elvish Scout,Horseman,Mage"
         [/role]
         [message]
             role=Supporter

--- a/data/campaigns/Heir_To_The_Throne/scenarios/05a_Muff_Malal_Peninsula.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/05a_Muff_Malal_Peninsula.cfg
@@ -100,12 +100,25 @@
         {PLACE_IMAGE scenery/rock2.png 17 20}
 
         [role]
-            type=Elvish Champion,Elvish Marshal,Elvish Captain,Elvish Hero,Knight,Elvish Rider,Elvish Outrider,Paladin,Mage,White Mage,Red Mage
             role=Advisor
+            [auto_recall][/auto_recall]
+
+            type="Elvish Sylph,Great Mage," +
+                 "Elvish Marshal,Elvish Champion,Elvish Avenger,Elvish Sharpshooter,Elvish Shyde,Elvish Enchantress,Elvish Outrider,Paladin,Grand Knight,Mage of Light,Arch Mage,Silver Mage," +
+                 "Merman Triton,Merman Hoplite,Merman Javelineer,Merman Entangler,Mermaid Diviner,Mermaid Siren," +
+                 "Elvish Captain,Elvish Hero,Elvish Ranger,Elvish Marksman,Elvish Druid,Elvish Sorceress,Elvish Rider,Knight,Lancer,White Mage,Red Mage," +
+                 "Merman Warrior,Merman Spearman,Merman Netcaster,Mermaid Priestess,Mermaid Enchantress," +
+                 "Elvish Fighter,Elvish Archer,Elvish Shaman,Elvish Scout,Horseman,Mage," +
+                 "Merman Fighter,Merman Hunter,Mermaid Initiate"
+            [else]
+                [unit]
+                    side=1
+                    type=Elvish Fighter
+                    role=Advisor
+                    placement=leader
+                [/unit]
+            [/else]
         [/role]
-        [recall]
-            role=Advisor
-        [/recall]
     [/event]
 
     [event]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/05a_Muff_Malal_Peninsula.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/05a_Muff_Malal_Peninsula.cfg
@@ -85,16 +85,8 @@
     {STARTING_VILLAGES 2 30}
 
     [event]
-        name=start
-        #For Elensefar: where do we come from?
-        [set_variable]
-            name=path_muff_malal
-            value=yes
-        [/set_variable]
-    [/event]
-
-    [event]
         name=prestart
+        {VARIABLE via_isle_of_the_damned no}
 
         {PLACE_IMAGE scenery/signpost.png 8 2}
         {PLACE_IMAGE scenery/rock2.png 17 20}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/05a_Muff_Malal_Peninsula.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/05a_Muff_Malal_Peninsula.cfg
@@ -87,10 +87,12 @@
     [event]
         name=prestart
         {VARIABLE via_isle_of_the_damned no}
+        {CLEAR_VARIABLE moremirmu}
 
         {PLACE_IMAGE scenery/signpost.png 8 2}
         {PLACE_IMAGE scenery/rock2.png 17 20}
 
+        {STORE_DELFADOR}
         [role]
             role=Advisor
             [auto_recall][/auto_recall]
@@ -220,4 +222,10 @@
     [/event]
 
     {campaigns/Heir_To_The_Throne/utils/deaths.cfg}
+
+    [event]
+        name=victory
+
+        {RESTORE_DELFADOR}
+    [/event]
 [/scenario]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/05b_Isle_of_the_Damned.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/05b_Isle_of_the_Damned.cfg
@@ -106,6 +106,7 @@
 
     [event]
         name=prestart
+        {VARIABLE via_isle_of_the_damned yes}
 
         {PLACE_IMAGE scenery/temple1.png 11 13}
         {PLACE_IMAGE scenery/temple1.png 10 17}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/05b_Isle_of_the_Damned.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/05b_Isle_of_the_Damned.cfg
@@ -107,6 +107,7 @@
     [event]
         name=prestart
         {VARIABLE via_isle_of_the_damned yes}
+        {CLEAR_VARIABLE moremirmu}
 
         {PLACE_IMAGE scenery/temple1.png 11 13}
         {PLACE_IMAGE scenery/temple1.png 10 17}
@@ -134,6 +135,7 @@
             side=1
             type=Thug,Poacher,Footpad
         [/allow_recruit]
+        {STORE_DELFADOR}
 
         # Kill the recall list except for merfolk
         [store_unit]
@@ -149,15 +151,15 @@
                 [/not]
             [/filter]
         [/store_unit]
-    [/event]
-
-    [event]
-        name=start
 
         {NAMED_LOYAL_UNIT 1 (Merman Fighter) 27 12 (Kalba) ( _ "Kalba")}
         {NAMED_LOYAL_UNIT 1 (Merman Fighter) 31 14 (Gnaba) ( _ "Gnaba")}
         # wmllint: recognize Kalba
         # wmllint: recognize Gnaba
+    [/event]
+
+    [event]
+        name=start
 
         [message]
             speaker=Konrad
@@ -336,7 +338,7 @@
 #enddef
 
     [event]
-        name=start
+        name=prestart
 
         #
         # Determine the contents of the temples:
@@ -443,7 +445,6 @@
         [/message]
 
         {ISLE_GALLEON_ARRIVE}
-        {RESTORE_RECALL_LIST}
 
         [if]
             [variable]
@@ -462,40 +463,14 @@
             [/then]
         [/if]
 
-        [modify_side]
-            side=1
-            gold=$isle_damned_starting_gold
-        [/modify_side]
-
-        [message]
-            speaker=narrator
-            message= _ "You regain your lost troops and $isle_damned_starting_gold gold!"
-            image=wesnoth-icon.png
-        [/message]
-        {CLEAR_VARIABLE isle_damned_starting_gold}
-
-        [allow_recruit]
-            side=1
-            type=Elvish Fighter,Elvish Archer,Elvish Shaman,Elvish Scout,Mage,Horseman
-        [/allow_recruit]
-
-        [disallow_recruit]
-            side=1
-            type=Thug,Poacher,Footpad
-        [/disallow_recruit]
-
-        [endlevel]
-            result=victory
-            bonus=no
-            carryover_add=yes
-            carryover_percentage=100
-        [/endlevel]
+        [fire_event]
+            name=victory dance
+        [/fire_event]
     [/event]
 
     [event]
         name=time over
         {ISLE_GALLEON_ARRIVE}
-        {RESTORE_RECALL_LIST}
 
         # TODO: use an existing unit as the speaker, and maybe add the message
         # to the enemies defeated event too
@@ -518,6 +493,42 @@
                     speaker=Moremirmu
                     message= _ "Thank you for your assistance here brothers. I will stay to continue resisting the foul undead. May fate be with you in your noble quest, and may we meet again some day!"
                 [/message]
+            [/then]
+        [/if]
+
+        [fire_event]
+            name=victory dance
+        [/fire_event]
+    [/event]
+
+    [event]
+        name=victory dance
+
+        [message]
+            speaker=narrator
+            message= _ "You regain your lost troops and $isle_damned_starting_gold gold!"
+            image=wesnoth-icon.png
+        [/message]
+
+        [endlevel]
+            result=victory
+            bonus=no
+            carryover_add=yes
+            carryover_percentage=100
+        [/endlevel]
+    [/event]
+
+    [event]
+        name=victory
+
+        {RESTORE_RECALL_LIST}
+
+        [if]
+            [variable]
+                name=moremirmu
+                equals=1
+            [/variable]
+            [then]
                 [kill]
                     id=Moremirmu
                 [/kill]
@@ -529,11 +540,6 @@
             gold=$isle_damned_starting_gold
         [/modify_side]
 
-        [message]
-            speaker=narrator
-            message= _ "You regain your lost troops and $isle_damned_starting_gold gold!"
-            image=wesnoth-icon.png
-        [/message]
         {CLEAR_VARIABLE isle_damned_starting_gold}
 
         [allow_recruit]
@@ -546,12 +552,7 @@
             type=Thug,Poacher,Footpad
         [/disallow_recruit]
 
-        [endlevel]
-            result=victory
-            bonus=no
-            carryover_add=yes
-            carryover_percentage=100
-        [/endlevel]
+        {RESTORE_DELFADOR}
     [/event]
 
     {campaigns/Heir_To_The_Throne/utils/deaths.cfg}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/06_The_Siege_of_Elensefar.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/06_The_Siege_of_Elensefar.cfg
@@ -155,6 +155,17 @@
         {PLACE_IMAGE scenery/rock1.png 13 12}
         {PLACE_IMAGE scenery/rock2.png 25 28}
 
+        [disallow_recruit]
+            side=1
+            type=Thief
+        [/disallow_recruit]
+
+        {NEED_KALENZ (x,y=recall,recall)}
+        {NEED_DELFADOR (x,y=recall,recall)}
+
+        {STORE_DELFADOR}
+        {STORE_KALENZ}
+
 #define ADVISOR
         [role]
             role=Advisor
@@ -554,6 +565,10 @@
             message= _ "The party rested for three days, after which an old friend returned."
         [/message]
 
+        {VARIABLE delfador_store.profile "portraits/delfador.png"}
+        {RESTORE_DELFADOR}
+        {RESTORE_KALENZ}
+
         [move_unit_fake]
             type=Elder Mage
             side=1
@@ -561,33 +576,16 @@
             y=18,17,16
         [/move_unit_fake]
 
-        {VARIABLE delfador_store.x 24}
-        {VARIABLE delfador_store.y 16}
-        {VARIABLE delfador_store.profile "portraits/delfador.png"}
+        [recall]
+            id=Delfador
+            x,y=24,16
+            show=no
+        [/recall]
 
-        #show Delfador
-        [unstore_unit]
-            variable=delfador_store
-        [/unstore_unit]
-        {CLEAR_VARIABLE delfador_store}
-        [unit]
+        [recall]
             id=Kalenz
-            name= _ "Kalenz"
-            profile=portraits/kalenz.png
-            unrenamable=yes
-            type=Elvish Lord
-            x=22
-            y=16
-            side=1
-            {IS_HERO}
-            random_traits=no
-            [modifications]
-                {TRAIT_LOYAL}
-            [/modifications]
-        [/unit]
-
-        [redraw]
-        [/redraw]
+            x,y=22,16
+        [/recall]
 
         [message]
             speaker=Delfador
@@ -675,7 +673,6 @@
             message= _ "We cannot go to Wesmere, for Asheviere’s orcs have the approaches ringed about with steel; Kalenz and I barely escaped, and Chantal cannot get out. Until we are stronger, we must go where the orcs are not."
         [/message]
 
-        {CLEAR_VARIABLE thieves_ford}
         [endlevel]
             result=victory
             bonus=yes
@@ -748,6 +745,20 @@
     [/event]
 
     {campaigns/Heir_To_The_Throne/utils/deaths.cfg}
+
+    [event]
+        name=victory
+
+        {CLEAR_VARIABLE thieves_ford}
+
+        [allow_recruit]
+            side=1
+            type=Thief
+        [/allow_recruit]
+
+        {RESTORE_DELFADOR}
+        {RESTORE_KALENZ}
+    [/event]
 [/scenario]
 
 #undef ADVISOR

--- a/data/campaigns/Heir_To_The_Throne/scenarios/07_Crossroads.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/07_Crossroads.cfg
@@ -236,14 +236,6 @@
     [event]
         name=start
 
-        {MODIFY_UNIT id=Konrad profile "portraits/konrad-human.png"}
-
-        [recall]
-            id=Delfador
-        [/recall]
-        [recall]
-            id=Kalenz
-        [/recall]
         [message]
             speaker=Delfador
             message= _ "Here we come to the great cross-roads. We should go northeast."
@@ -260,6 +252,11 @@
 
     [event]
         name=prestart
+
+        {MODIFY_UNIT id=Konrad profile "portraits/konrad-human.png"}
+
+        {NEED_DELFADOR placement=leader}
+        {NEED_KALENZ placement=leader}
 
         # Here we set up an array that holds the possible ambusher unit types.
         # We do this instead of just using a random type when creating the
@@ -528,19 +525,15 @@ SE — Fort Tahn"
         [filter]
             id=Kojun Herolm
         [/filter]
+        [message]
+            speaker=Konrad
+            message= _ "Victory is ours, men. Let us proceed northeast!"
+        [/message]
         [endlevel]
             result=victory
             bonus=yes
             {NEW_GOLD_CARRYOVER 40}
         [/endlevel]
-    [/event]
-
-    [event]
-        name=victory
-        [message]
-            speaker=Konrad
-            message= _ "Victory is ours, men. Let us proceed northeast!"
-        [/message]
     [/event]
 
     {campaigns/Heir_To_The_Throne/utils/deaths.cfg}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/08_The_Princess_of_Wesnoth.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/08_The_Princess_of_Wesnoth.cfg
@@ -323,9 +323,16 @@
         name=moveto
         [filter]
             side=1
-            x=20-29
-            y=1-23
         [/filter]
+        [filter_condition]
+            [have_location]
+                x,y=$x1,$y2
+                [and]
+                    x,y=27,12
+                    radius=7
+                [/and]
+            [/have_location]
+        [/filter_condition]
 
         [if]
             [variable]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/08_The_Princess_of_Wesnoth.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/08_The_Princess_of_Wesnoth.cfg
@@ -143,12 +143,9 @@
 
         {PLACE_IMAGE scenery/mine-abandoned.png 4 41}
 
-        [recall]
-            id=Delfador
-        [/recall]
-        [recall]
-            id=Kalenz
-        [/recall]
+        {NEED_DELFADOR placement=leader}
+        {NEED_KALENZ placement=leader}
+        {STORE_LISAR}
         [role]
             role=Advisor
             [auto_recall][/auto_recall]
@@ -287,13 +284,19 @@
             message= _ "(Ha ha, little do they know just how many undead have wandered the northern road of late. Surely they are doomed!)"
         [/message]
 
-        {CLEAR_VARIABLE trap_sprung}
-
         [endlevel]
             result=victory
             bonus=yes
             {NEW_GOLD_CARRYOVER 40}
         [/endlevel]
+    [/event]
+
+    [event]
+        name=victory
+
+        {CLEAR_VARIABLE trap_sprung}
+
+        {RESTORE_LISAR}
     [/event]
 
 #define SECOND_WAVE

--- a/data/campaigns/Heir_To_The_Throne/scenarios/08_The_Princess_of_Wesnoth.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/08_The_Princess_of_Wesnoth.cfg
@@ -352,6 +352,15 @@
                     message= _ "I see that your forces draw near, impostor! I’ll not be defeated in my own backyard so easily... Come forth and attack, my loyal duelist!"
                 [/message]
 
+                [scroll_to]
+                    x=6
+                    y=40
+                [/scroll_to]
+
+                [delay]
+                    time=500
+                [/delay]
+
                 [sound]
                     name=dagger-swish.wav
                 [/sound]
@@ -364,11 +373,6 @@
                 [/move_unit_fake]
 
                 {NAMED_LOYAL_UNIT 2 (Duelist) 6 40 (Ronry) ( _ "Ronry")}
-
-                [scroll_to_unit]
-                    x=6
-                    y=40
-                [/scroll_to_unit]
 #ifdef NORMAL
                 {LOYAL_UNIT 2 (Fencer) 6 41}
 #endif

--- a/data/campaigns/Heir_To_The_Throne/scenarios/09_The_Valley_of_Death.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/09_The_Valley_of_Death.cfg
@@ -374,6 +374,9 @@
                 numerical_equals=1
             [/variable]
 
+            [have_unit]
+                id=Moremirmu
+            [/have_unit]
             [then]
                 [message]
                     speaker=Konrad

--- a/data/campaigns/Heir_To_The_Throne/scenarios/09_The_Valley_of_Death.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/09_The_Valley_of_Death.cfg
@@ -202,12 +202,8 @@
         {PLACE_IMAGE scenery/rock3.png 30 34}
         {PLACE_IMAGE scenery/rock4.png 37 39}
 
-        [recall]
-            id=Delfador
-        [/recall]
-        [recall]
-            id=Kalenz
-        [/recall]
+        {NEED_DELFADOR placement=leader}
+        {NEED_KALENZ placement=leader}
         [recall]
             id=Moremirmu
         [/recall]
@@ -331,6 +327,9 @@
             message= _ "Whew! That was a difficult battle, but they are retreating at last!"
         [/message]
 
+        [fire_event]
+            name=victory dance
+        [/fire_event]
         [endlevel]
             result=victory
             bonus=no
@@ -352,6 +351,9 @@
     [event]
         name=enemies defeated
 
+        [fire_event]
+            name=victory dance
+        [/fire_event]
         [endlevel]
             result=victory
             bonus=yes
@@ -360,7 +362,7 @@
     [/event]
 
     [event]
-        name=victory
+        name=victory dance
         [message]
             speaker=Delfador
             message= _ "Yes! We have fought them off!"
@@ -439,6 +441,10 @@
                 [/message]
             [/else]
         [/if]
+    [/event]
+
+    [event]
+        name=victory
 
         [if]
             [variable]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/10_Gryphon_Mountain.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/10_Gryphon_Mountain.cfg
@@ -18,6 +18,8 @@
 
     [event]
         name=prestart
+
+        {VARIABLE eggs_done no}
         [objectives]
             side=1
             [objective]
@@ -25,6 +27,9 @@
                 condition=win
             [/objective]
             [objective]
+                [show_if]
+                    {CHECK_VARIABLE eggs_done no}
+                [/show_if]
                 {BONUS_OBJECTIVE_CAPTION}
                 description= _ "Defeat the mother gryphon before the enemy does"+{OBJECTIVE_FOOTNOTE _"(special bonus)"}
                 condition=win
@@ -181,6 +186,7 @@
         [/set_variable]
         {REMOVE_IMAGE 13 16}
         {PLACE_IMAGE scenery/nest-empty.png 13 16}
+        {VARIABLE eggs_done yes}
     [/event]
 
     [event]
@@ -212,6 +218,7 @@
         {VARIABLE_OP gryphon_disposition sub 1}
         {REMOVE_IMAGE 13 16}
         {PLACE_IMAGE scenery/nest-empty.png 13 16}
+        {VARIABLE eggs_done yes}
     [/event]
     [event]
         name=attack
@@ -415,7 +422,7 @@
             message= _ "Let us continue onward!"
         [/message]
 
-        {CLEAR_VARIABLE gryphon_disposition}
+        {CLEAR_VARIABLE gryphon_disposition,eggs_done}
         [endlevel]
             result=victory
             bonus=yes

--- a/data/campaigns/Heir_To_The_Throne/scenarios/10_Gryphon_Mountain.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/10_Gryphon_Mountain.cfg
@@ -120,12 +120,9 @@
 
     [event]
         name=prestart
-        [recall]
-            id=Delfador
-        [/recall]
-        [recall]
-            id=Kalenz
-        [/recall]
+        {CLEAR_VARIABLE get_gryphons}
+        {NEED_DELFADOR placement=leader}
+        {NEED_KALENZ placement=leader}
 
         {NAMED_LOYAL_UNIT 3 (Sleeping Gryphon) 12 18 (Graak) ( _ "Graak")}
         {NAMED_LOYAL_UNIT 3 (Sleeping Gryphon) 16 16 (Grook) ( _ "Grook")}
@@ -422,12 +419,17 @@
             message= _ "Let us continue onward!"
         [/message]
 
-        {CLEAR_VARIABLE gryphon_disposition,eggs_done}
         [endlevel]
             result=victory
             bonus=yes
             {NEW_GOLD_CARRYOVER 40}
         [/endlevel]
+    [/event]
+
+    [event]
+        name=victory
+
+        {CLEAR_VARIABLE gryphon_disposition,eggs_done}
     [/event]
 
     # Sleeping Gryphons will counter if attacked, then wake up and

--- a/data/campaigns/Heir_To_The_Throne/scenarios/11_The_Ford_of_Abez.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/11_The_Ford_of_Abez.cfg
@@ -300,50 +300,84 @@
         [/set_variable]
     [/event]
 
-    #if the players marches over to Li'sar's keep, reinforcements appear
+    #if someone marches over to Li'sar's keep, reinforcements appear
     [event]
         name=moveto
         [filter]
-            side=1
-            x=0-16
-            y=23-34
+            [not]
+                side=2
+            [/not]
         [/filter]
+        [filter_condition]
+            [have_unit]
+                id="Li’sar"
+            [/have_unit]
+            [have_location]
+                x,y=$x1,$y1
+                [and]
+                    x,y=5,27
+                    radius=11
+                [/and]
+                [not]
+                    terrain="Wo,Ww"
+                [/not]
+            [/have_location]
+        [/filter_condition]
+        [message]
+            type=Royal Guard
+            message= _ "Stop! You shall not pass!"
+        [/message]
         {FORD_GUARD 1 29}
-        {FORD_GUARD 1 29}
-        {FORD_GUARD 1 29}
-        {FORD_GUARD 1 29}
-        {FORD_GUARD 1 29}
-        {FORD_GUARD 1 29}
-        {FORD_GUARD 1 29}
-        {FORD_GUARD 1 29}
-        {FORD_GUARD 1 29}
-        {FORD_GUARD 1 29}
+        {FORD_GUARD 1 27}
+        {FORD_GUARD 1 25}
+        {FORD_GUARD 7 24}
+        {FORD_GUARD 9 25}
+        {FORD_GUARD 9 27}
+        {FORD_GUARD 9 29}
+        {FORD_GUARD 7 30}
+        {FORD_GUARD 5 31}
+        {FORD_GUARD 3 30}
     [/event]
 
     #getting closer --> more reinforcements
     [event]
         name=moveto
         [filter]
-            side=1
-            x=2-9
-            y=24-30
+            [not]
+                side=2
+            [/not]
         [/filter]
+        [filter_condition]
+            [have_unit]
+                id="Li’sar"
+            [/have_unit]
+            [have_location]
+                x,y=$x1,$y1
+                [and]
+                    x,y=5,27
+                    radius=4
+                [/and]
+                [not]
+                    terrain="Wo,Ww"
+                [/not]
+            [/have_location]
+        [/filter_condition]
         [message]
             side=2
             [not]
                 id="Li'sar"
             [/not]
-            message= _ "Stop! You shall not pass! Quick, reinforcements, protect the Princess!"
+            message= _ "Quick, reinforcements, protect the Princess!"
         [/message]
-        {FORD_GUARD 1 27}
-        {FORD_GUARD 1 27}
-        {FORD_GUARD 1 27}
-        {FORD_GUARD 1 27}
-        {FORD_GUARD 1 27}
-        {FORD_GUARD 1 27}
+        {FORD_GUARD 5 25}
+        {FORD_GUARD 7 26}
+        {FORD_GUARD 7 28}
+        {FORD_GUARD 5 29}
+        {FORD_GUARD 3 28}
+        {FORD_GUARD 3 26}
     [/event]
 
-    #if the player dares attack Li'sar's escort, they are pounced on by
+    #if anyone dares attack Li'sar's escort, they are pounced on by
     #many Royal Guards
     [event]
         name=attack
@@ -352,14 +386,33 @@
         [/filter_second]
         [message]
             speaker=second_unit
-            message= _ "Stop! You shall not pass! Quick, reinforcements, protect the Princess!"
+            message= _ "Quick, reinforcements!"
         [/message]
-        {FORD_GUARD 5 27}
-        {FORD_GUARD 5 27}
-        {FORD_GUARD 5 27}
-        {FORD_GUARD 5 27}
-        {FORD_GUARD 5 27}
-        {FORD_GUARD 5 27}
+        {FORD_GUARD $x1 $y1}
+        {FORD_GUARD $x1 $y1}
+        {FORD_GUARD $x1 $y1}
+        {FORD_GUARD $x1 $y1}
+        {FORD_GUARD $x1 $y1}
+    [/event]
+
+    #Geez, talk about not taking a hint ...
+    [event]
+        name=attack
+        [filter_second]
+            id="Li'sar"
+        [/filter_second]
+        [message]
+            side=2
+            [not]
+                id="Li'sar"
+            [/not]
+            message= _ "Protect the Princess!"
+        [/message]
+        {FORD_GUARD $x1 $y1}
+        {FORD_GUARD $x1 $y1}
+        {FORD_GUARD $x1 $y1}
+        {FORD_GUARD $x1 $y1}
+        {FORD_GUARD $x1 $y1}
     [/event]
 
     # Defeating Li'sar just sends her away
@@ -368,6 +421,9 @@
         [filter]
             id="Li'sar"
         [/filter]
+        [filter_second]
+            side=1
+        [/filter_second]
         [message]
             speaker="Li'sar"
             {LISAR_VARIATION defeat}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/11_The_Ford_of_Abez.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/11_The_Ford_of_Abez.cfg
@@ -188,12 +188,9 @@
         {FORD_GUARD 3 27}
         {FORD_GUARD 4 28}
 
-        [recall]
-            id=Delfador
-        [/recall]
-        [recall]
-            id=Kalenz
-        [/recall]
+        {NEED_DELFADOR placement=leader}
+        {NEED_KALENZ placement=leader}
+        {STORE_LISAR}
     [/event]
 
     [event]
@@ -516,12 +513,18 @@
             [/then]
         [/if]
 
-        {CLEAR_VARIABLE lisar_still_here}
         [endlevel]
             result=victory
             bonus=yes
             {NEW_GOLD_CARRYOVER 40}
         [/endlevel]
+    [/event]
+
+    [event]
+        name=victory
+
+        {CLEAR_VARIABLE lisar_still_here}
+        {RESTORE_LISAR}
     [/event]
 
     {campaigns/Heir_To_The_Throne/utils/deaths.cfg}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/11_The_Ford_of_Abez.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/11_The_Ford_of_Abez.cfg
@@ -133,6 +133,7 @@
 
     [side]
         side=4
+        hidden=yes
         no_leader=yes
         team_name=creature
         user_team_name=_"Monsters"

--- a/data/campaigns/Heir_To_The_Throne/scenarios/12_Northern_Winter.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/12_Northern_Winter.cfg
@@ -168,12 +168,8 @@
                 [/unit]
             [/else]
         [/role]
-        [recall]
-            id=Delfador
-        [/recall]
-        [recall]
-            id=Kalenz
-        [/recall]
+        {NEED_DELFADOR placement=leader}
+        {NEED_KALENZ placement=leader}
     [/event]
 
     [event]
@@ -417,12 +413,17 @@
             [/else]
         [/if]
 
-        {CLEAR_VARIABLE turn_limit}
         [endlevel]
             result=victory
             bonus=yes
             {NEW_GOLD_CARRYOVER 40}
         [/endlevel]
+    [/event]
+
+    [event]
+        name=victory
+
+        {CLEAR_VARIABLE turn_limit}
     [/event]
 
     {campaigns/Heir_To_The_Throne/utils/deaths.cfg}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/13_The_Dwarven_Doors.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/13_The_Dwarven_Doors.cfg
@@ -236,13 +236,17 @@
         # If you have outlaws in your party, you have the chance to
         # find a special unit
         #
-        [role]
-            type=Footpad,Thug,Poacher,Outlaw,Trapper,Bandit,Fugitive,Ranger,Huntsman,Highwayman
-            role=Outlaw_Advisor
-        [/role]
         [recall]
-            role=Outlaw_Advisor
+            id=Delurin
         [/recall]
+        [role] # If Delurin was just recalled, this will select him.
+            role=Outlaw_Advisor
+            [auto_recall][/auto_recall]
+
+            type="Highwayman,Fugitive,Huntsman,Ranger," +
+                 "Bandit,Outlaw,Trapper," +
+                 "Thug,Footpad,Poacher"
+        [/role]
 
         [if]
             [have_unit]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/13_The_Dwarven_Doors.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/13_The_Dwarven_Doors.cfg
@@ -316,8 +316,15 @@
 
     [event]
         name=die
+        [filter]
+            side=2,3,4
+        [/filter]
         [filter_second]
-            id=Haldiel
+            side=1
+            id=Haldiel,Simyr
+            [or]
+                type=Paladin
+            [/or]
         [/filter_second]
         [message]
             speaker=second_unit

--- a/data/campaigns/Heir_To_The_Throne/scenarios/13_The_Dwarven_Doors.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/13_The_Dwarven_Doors.cfg
@@ -132,6 +132,7 @@
         side=5
         no_leader=yes
         controller=ai
+        hidden=yes
     [/side]
 
     {STARTING_VILLAGES 2 20}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/13_The_Dwarven_Doors.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/13_The_Dwarven_Doors.cfg
@@ -655,7 +655,23 @@
             message= _ "A monster was hiding in that lake!"
         [/message]
         [role]
-            type=Thief,Rogue,Mage,Elvish Shaman,Elvish Druid,Elvish Archer,Elvish Fighter,Elvish Captain,Elvish Marshal,Horseman,Elvish Lord
+            type="Thief," +
+                 "Poacher,Footpad,Thug," +
+                 "Horseman," +
+                 "Elvish Scout,Elvish Archer,Elvish Fighter," +
+                 "Fighter," +
+                 "Rogue," +
+                 "Trapper,Outlaw,Bandit," +
+                 "Lancer,Knight," +
+                 "Elvish Rider,Elvish Marksman,Elvish Ranger,Elvish Hero,Elvish Captain," +
+                 "Elvish Lord," +
+                 "Commander," +
+                 "Assassin," +
+                 "Ranger,Huntsman,Fugitive,Highwayman," +
+                 "Grand Knight,Paladin," +
+                 "Elvish Outrider,Elvish Sharpshooter,Elvish Avenger,Elvish Champion,Elvish Marshal," +
+                 "Elvish High Lord," +
+                 "Lord"
             role=whiner
         [/role]
         [message]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/13_The_Dwarven_Doors.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/13_The_Dwarven_Doors.cfg
@@ -164,13 +164,11 @@
     [/event]
 
     [event]
-        name=start
-        [recall]
-            id=Delfador
-        [/recall]
-        [recall]
-            id=Kalenz
-        [/recall]
+        name=prestart
+
+        {NEED_DELFADOR placement=leader}
+        {NEED_KALENZ placement=leader}
+        {STORE_LISAR}
         [recall]
             id=Haldiel
         [/recall]
@@ -193,9 +191,22 @@
                 [/unit]
             [/else]
         [/role]
+        [recall]
+            id=Delurin
+        [/recall]
+        [role] # If Delurin was just recalled, this will select him.
+            role=Outlaw_Advisor
+            [auto_recall][/auto_recall]
 
-        [redraw]
-        [/redraw]
+            type="Highwayman,Fugitive,Huntsman,Ranger," +
+                 "Bandit,Outlaw,Trapper," +
+                 "Thug,Footpad,Poacher"
+        [/role]
+    [/event]
+
+    [event]
+        name=start
+
         [message]
             speaker=Delfador
             message= _ "At last, this is the entrance to the dwarven tunnels."
@@ -237,18 +248,6 @@
         # If you have outlaws in your party, you have the chance to
         # find a special unit
         #
-        [recall]
-            id=Delurin
-        [/recall]
-        [role] # If Delurin was just recalled, this will select him.
-            role=Outlaw_Advisor
-            [auto_recall][/auto_recall]
-
-            type="Highwayman,Fugitive,Huntsman,Ranger," +
-                 "Bandit,Outlaw,Trapper," +
-                 "Thug,Footpad,Poacher"
-        [/role]
-
         [if]
             [have_unit]
                 role=Outlaw_Advisor
@@ -576,6 +575,9 @@
                     speaker=Konrad
                     message= _ "Pray that we live to see sunlight again."
                 [/message]
+                [fire_event]
+                    name=victory dance
+                [/fire_event]
                 [endlevel]
                     result=victory
                     bonus=yes
@@ -602,6 +604,9 @@
                     speaker=Konrad
                     message= _ "Pray that we live to see sunlight again."
                 [/message]
+                [fire_event]
+                    name=victory dance
+                [/fire_event]
                 [endlevel]
                     result=victory
                     bonus=yes
@@ -682,7 +687,7 @@
     [/event]
 
     [event]
-        name=victory
+        name=victory dance
 
         [message]
             speaker=narrator
@@ -704,9 +709,16 @@
             speaker="Li'sar"
             message= _ "Whew! We make our way through the dangerous fog of the mountains, and now there is all this chaos before us! Come on, men! We must make it to the caves that lie ahead of us!"
         [/message]
+    [/event]
+
+    [event]
+        name=victory
+
         {CLEAR_VARIABLE true_entrance_location}
         {CLEAR_VARIABLE outlaw_advisor_store}
         {CLEAR_VARIABLE outlaw_name}
+
+        {RESTORE_LISAR}
     [/event]
 
     {campaigns/Heir_To_The_Throne/utils/deaths.cfg}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/14_Plunging_Into_the_Darkness.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/14_Plunging_Into_the_Darkness.cfg
@@ -240,14 +240,13 @@
 
     [event]
         name=prestart
-        [recall]
-            id=Delfador
-            show=no
-        [/recall]
-        [recall]
-            id=Kalenz
-            show=no
-        [/recall]
+        {NEED_DELFADOR placement=leader}
+        {NEED_KALENZ placement=leader}
+
+        [disallow_recruit]
+            side=1
+            type=Gryphon Rider
+        [/disallow_recruit]
 
         [place_shroud]
             side=1
@@ -652,11 +651,6 @@
                     y=19,18,17,18,17,18,18,19,20,21,22,22,23,24,24,25,26
                 [/move_unit_fake]
 
-                [allow_recruit]
-                    side=1
-                    type=Gryphon Rider
-                [/allow_recruit]
-
                 [message]
                     speaker=narrator
                     image="wesnoth-icon.png"
@@ -675,12 +669,28 @@
             [/then]
         [/if]
 
-        {CLEAR_VARIABLE get_gryphons}
         [endlevel]
             result=victory
             bonus=no
             {NEW_GOLD_CARRYOVER 100}
         [/endlevel]
+    [/event]
+
+    [event]
+        name=victory
+
+        [if]
+            [variable]
+                name=get_gryphons
+                numerical_equals=1
+            [/variable]
+            [then]
+                [allow_recruit]
+                    side=1
+                    type=Gryphon Rider
+                [/allow_recruit]
+            [/then]
+        [/if]
     [/event]
 
     #a secret passage

--- a/data/campaigns/Heir_To_The_Throne/scenarios/14_Plunging_Into_the_Darkness.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/14_Plunging_Into_the_Darkness.cfg
@@ -65,6 +65,7 @@
     [side]
         side=2
         no_leader=yes
+        hidden=yes
         [ai]
             {ATTACK_DEPTH 4 5 5}
             aggression=1.0

--- a/data/campaigns/Heir_To_The_Throne/scenarios/14_Plunging_Into_the_Darkness.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/14_Plunging_Into_the_Darkness.cfg
@@ -37,6 +37,10 @@
                 description= _ "Death of Kalenz"
                 condition=lose
             [/objective]
+            [gold_carryover]
+                carryover_percentage=100
+            [/gold_carryover]
+            {HAS_NO_TURN_LIMIT}
         [/objectives]
     [/event]
 

--- a/data/campaigns/Heir_To_The_Throne/scenarios/15_The_Lost_General.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/15_The_Lost_General.cfg
@@ -116,13 +116,21 @@
     {PLACE_IMAGE scenery/whirlpool.png 7 23}
 
     [event]
+        name=prestart
+        {NEED_DELFADOR placement=leader}
+        {NEED_KALENZ placement=leader}
+        [allow_recruit]
+            side=1
+            type=Dwarvish Fighter,Dwarvish Thunderer
+        [/allow_recruit]
+        [disallow_recruit]
+            side=1
+            type=Dwarvish Guardsman
+        [/disallow_recruit]
+    [/event]
+
+    [event]
         name=start
-        [recall]
-            id=Delfador
-        [/recall]
-        [recall]
-            id=Kalenz
-        [/recall]
         [message]
             speaker=Delfador
             message= _ "We are now in the main dwarvish caverns."
@@ -131,10 +139,6 @@
             speaker=Delfador
             message= _ "Underground roads once led to the different parts of the complex, but now everything lies in ruins."
         [/message]
-        [allow_recruit]
-            side=1
-            type=Dwarvish Fighter,Dwarvish Thunderer
-        [/allow_recruit]
     [/event]
 
     [event]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/16_Hasty_Alliance.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/16_Hasty_Alliance.cfg
@@ -135,17 +135,16 @@
     [/side]
 
     [event]
+        name=prestart
+
+        {NEED_DELFADOR placement=leader}
+        {NEED_KALENZ placement=leader}
+        {NEED_LISAR (x,y=recall,recall)}
+        {STORE_LISAR}
+    [/event]
+
+    [event]
         name=start
-
-        [recall]
-            id=Delfador
-        [/recall]
-        [recall]
-            id=Kalenz
-        [/recall]
-
-        [redraw]
-        [/redraw]
 
         [message]
             speaker=Konrad
@@ -390,37 +389,30 @@
             message= _ "Thank you, Princess. Come, men. Let us find the Sceptre!"
         [/message]
 
-        [store_unit]
-            [filter]
-                id="Li'sar"
-            [/filter]
-
-            kill=yes
-            variable=stored_Lisar
-        [/store_unit]
-
-        [unit]
-            side=1
-            id="Li'sar"
-            name= _ "Li’sar"
-            unrenamable=yes
-            profile=portraits/lisar.png
-            type=$stored_Lisar.type
-            experience=$stored_Lisar.experience
-            {IS_HERO}
-            random_traits=no
-            [modifications]
-                {TRAIT_LOYAL}
-            [/modifications]
-        [/unit]
-
-        {CLEAR_VARIABLE stored_Lisar}
-
         [endlevel]
             result=victory
             bonus=yes
             {NEW_GOLD_CARRYOVER 40}
         [/endlevel]
+    [/event]
+
+    [event]
+        name=victory
+
+        [modify_unit]
+            [filter]
+                id="Li'sar"
+            [/filter]
+            side=1
+            canrecruit=no
+            {IS_HERO}
+            [modifications]
+                {TRAIT_LOYAL}
+            [/modifications]
+        [/modify_unit]
+
+        {CLEAR_VARIABLE stored_Lisar}
+
     [/event]
 
     #deaths.cfg only handles death of Li'sar is she’s on side '1', so handle

--- a/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
@@ -158,24 +158,19 @@
             [/event]
 
             [event]
-                name=start
+                name=prestart
                 #
                 # Initialize the lava growing effect
                 #
                 {NEXT_LAVA}
+                {CLEAR_VARIABLE sceptre}
+                {NEED_DELFADOR placement=leader}
+                {NEED_KALENZ placement=leader}
+                {NEED_LISAR placement=leader}
             [/event]
 
             [event]
                 name=start
-                [recall]
-                    id=Delfador
-                [/recall]
-                [recall]
-                    id=Kalenz
-                [/recall]
-                [recall]
-                    id="Li'sar"
-                [/recall]
                 [message]
                     speaker=Konrad
                     message= _ "The Sceptre must be getting close now! Where shall we go?"

--- a/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
@@ -57,6 +57,8 @@
 
             [event]
                 name=prestart
+
+                {VARIABLE moved_too_close false}
                 [objectives]
                     side=1
                     [objective]
@@ -88,6 +90,9 @@
                     [/gold_carryover]
 
                     [note]
+                        [show_if]
+                            {VARIABLE_CONDITIONAL moved_too_close boolean_equals false}
+                        [/show_if]
                         description= _ "If Delfador rests, he can concentrate on the location of the Sceptre of Fire."
                     [/note]
                 [/objectives]
@@ -150,8 +155,6 @@
                 [/foreach]
 
                 {CLEAR_VARIABLE adjacent_to_starting_loc}
-
-                {VARIABLE moved_too_close false}
             [/event]
 
             [event]
@@ -316,37 +319,6 @@
                     speaker=Delfador
                     message= _ "I sense we are quite near the Sceptre; in fact, we should be able to see it right about now..."
                 [/message]
-
-                [objectives]
-                    side=1
-                    [objective]
-                        description= _ "Capture the Sceptre of Fire with Konrad or Li’sar"
-                        condition=win
-                    [/objective]
-                    [objective]
-                        description= _ "Death of Konrad"
-                        condition=lose
-                    [/objective]
-                    [objective]
-                        description= _ "Death of Delfador"
-                        condition=lose
-                    [/objective]
-                    [objective]
-                        description= _ "Death of Li’sar"
-                        condition=lose
-                    [/objective]
-                    [objective]
-                        description= _ "Death of Kalenz"
-                        condition=lose
-                    [/objective]
-
-                    {TURNS_RUN_OUT}
-
-                    [gold_carryover]
-                        bonus=yes
-                        carryover_percentage=40
-                    [/gold_carryover]
-                [/objectives]
 
                 {VARIABLE moved_too_close true}
             [/event]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/18_A_Choice_Must_Be_Made.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/18_A_Choice_Must_Be_Made.cfg
@@ -151,19 +151,17 @@
     {STARTING_VILLAGES 3 8}
 
     [event]
-        name=start
+        name=prestart
 
         {VARIABLE dialog no}
 
-        [recall]
-            id=Delfador
-        [/recall]
-        [recall]
-            id="Li'sar"
-        [/recall]
-        [recall]
-            id=Kalenz
-        [/recall]
+        {NEED_DELFADOR placement=leader}
+        {NEED_LISAR placement=leader}
+        {NEED_KALENZ placement=leader}
+    [/event]
+
+    [event]
+        name=start
 
         [if]
             [variable]
@@ -380,7 +378,6 @@
                         role=merman-advisor
                         id=$unit.id
                     [/role]
-                    {CLEAR_VARIABLE dialog}
 
                     [endlevel]
                         next_scenario=19c_Cliffs_of_Thoria
@@ -413,8 +410,6 @@
             id=Urug-Telfar
         [/filter]
 
-        {CLEAR_VARIABLE dialog}
-
         [endlevel]
             next_scenario=19a_Snow_Plains
             result=victory
@@ -429,13 +424,17 @@
             id="Unan-Ka'tall"
         [/filter]
 
-        {CLEAR_VARIABLE dialog}
-
         [endlevel]
             next_scenario=19b_Swamp_Of_Dread
             result=victory
             bonus=yes
             {NEW_GOLD_CARRYOVER 40}
         [/endlevel]
+    [/event]
+
+    [event]
+        name=victory
+
+        {CLEAR_VARIABLE dialog}
     [/event]
 [/scenario]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/18_A_Choice_Must_Be_Made.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/18_A_Choice_Must_Be_Made.cfg
@@ -295,8 +295,8 @@
                 [/message]
                 [if]
                     [variable]
-                        name=path_muff_malal
-                        equals=yes
+                        name=via_isle_of_the_damned
+                        not_equals=yes
                     [/variable]
                     [then]
                         [message]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/18_A_Choice_Must_Be_Made.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/18_A_Choice_Must_Be_Made.cfg
@@ -376,6 +376,10 @@
             [option]
                 label= _ "Our need for speed outweighs the danger. With the Merfolk to help us, we will win through."
                 [command]
+                    [role]
+                        role=merman-advisor
+                        id=$unit.id
+                    [/role]
                     {CLEAR_VARIABLE dialog}
 
                     [endlevel]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/19a_Snow_Plains.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/19a_Snow_Plains.cfg
@@ -96,21 +96,20 @@
     {STARTING_VILLAGES 2 7}
 
     [event]
-        name=start
+        name=prestart
         #For Home of the Northern Elves: where do we come from?
         [set_variable]
             name=A_Choice_Was_Made
             value=a
         [/set_variable]
-        [recall]
-            id=Delfador
-        [/recall]
-        [recall]
-            id=Kalenz
-        [/recall]
-        [recall]
-            id="Li'sar"
-        [/recall]
+        {NEED_DELFADOR placement=leader}
+        {NEED_KALENZ placement=leader}
+        {NEED_LISAR placement=leader}
+    [/event]
+
+    [event]
+        name=start
+
         [message]
             speaker=Kalenz
             message= _ "These fields of snow were once the home of my people. We left here centuries ago. Legends say a great sword of fire was left behind."

--- a/data/campaigns/Heir_To_The_Throne/scenarios/19b_Swamp_Of_Dread.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/19b_Swamp_Of_Dread.cfg
@@ -181,22 +181,21 @@
     {STARTING_VILLAGES 6 7}
 
     [event]
-        name=start
+        name=prestart
 
         #For Home of the Northern Elves: where do we come from?
         [set_variable]
             name=A_Choice_Was_Made
             value=b
         [/set_variable]
-        [recall]
-            id=Delfador
-        [/recall]
-        [recall]
-            id="Li'sar"
-        [/recall]
-        [recall]
-            id=Kalenz
-        [/recall]
+        {NEED_DELFADOR placement=leader}
+        {NEED_LISAR placement=leader}
+        {NEED_KALENZ placement=leader}
+    [/event]
+
+    [event]
+        name=start
+
         [message]
             speaker=Delfador
             message= _ "This land is cursed. Liches have existed here for ages, luring adventurers and soldiers to their deaths and amassing great armies and fortunes."
@@ -384,15 +383,20 @@
             {KONRAD_VARIATION mad}
             message= _ "Enough! I can listen to no more of this. Princess, you may want to end your mother’s rule, but I will end her life as she ended the life of my father and my brothers. Asheviere’s masterwork of treachery will end, and it will end by my blade!"
         [/message]
-        {CLEAR_VARIABLE temp_armor_x}
-        {CLEAR_VARIABLE temp_armor_y}
-        {CLEAR_VARIABLE armor_taken}
-        {CLEAR_VARIABLE armored_knight,dk_kill_count}
         [endlevel]
             result=victory
             bonus=yes
             {NEW_GOLD_CARRYOVER 40}
         [/endlevel]
+    [/event]
+
+    [event]
+        name=victory
+
+        {CLEAR_VARIABLE temp_armor_x}
+        {CLEAR_VARIABLE temp_armor_y}
+        {CLEAR_VARIABLE armor_taken}
+        {CLEAR_VARIABLE armored_knight,dk_kill_count}
     [/event]
 [/scenario]
 

--- a/data/campaigns/Heir_To_The_Throne/scenarios/19c_Cliffs_of_Thoria.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/19c_Cliffs_of_Thoria.cfg
@@ -186,7 +186,7 @@
     [/side]
 
     [event]
-        name=start
+        name=prestart
         #For Home of the Northern Elves: where do we come from?
         #the position where we are - impassable mountains, looking for a way out
         #the sunk loyalist fleet with the flag of wesnoth
@@ -210,24 +210,14 @@
                 [/unit]
             [/else]
         [/role]
-        [recall]
-            id=Delfador
-        [/recall]
-        [recall]
-            id=Kalenz
-        [/recall]
-        [recall]
-            id="Li'sar"
-        [/recall]
+        {NEED_DELFADOR placement=leader}
+        {NEED_KALENZ placement=leader}
+        {NEED_LISAR placement=leader}
 
         {VARIABLE sergeant_sighted no}
         {VARIABLE waterfall_sighted no}
         {OBJ_TRIDENT_STORM 17 11 cot_stormtrident}
         {PLACE_IMAGE items/gohere.png 55 3}
-    [/event]
-
-    [event]
-        name=start
         [unit]
             type=Injured Sergeant
             side=4
@@ -245,6 +235,10 @@
                 poisoned=yes
             [/status]
         [/unit]
+    [/event]
+
+    [event]
+        name=start
         [message]
             speaker=narrator
             image=wesnoth-icon.png
@@ -426,7 +420,7 @@ Soooo... It is you who sent your subordinates to attack us. Now when we’ve des
     [/event]
 
     [event]
-        name=start
+        name=prestart
         [store_locations]
             terrain=*^V*    # wmllint: ignore
             [and]
@@ -451,7 +445,7 @@ Soooo... It is you who sent your subordinates to attack us. Now when we’ve des
     [/event]
 
     [event]
-        name=start
+        name=prestart
         [store_locations]
             terrain=*^V*    # wmllint: ignore
             [and]
@@ -943,7 +937,6 @@ Soooo... It is you who sent your subordinates to attack us. Now when we’ve des
                     speaker=Konrad
                     message= _ "Everybody inside..."
                 [/message]
-                {CLEAR_VARIABLE sergeant_sighted,waterfall_sighted,drake_bases}
                 [endlevel]
                     result=victory
                     bonus=yes
@@ -951,5 +944,11 @@ Soooo... It is you who sent your subordinates to attack us. Now when we’ve des
                 [/endlevel]
             [/then]
         [/if]
+    [/event]
+
+    [event]
+        name=victory
+
+        {CLEAR_VARIABLE sergeant_sighted,waterfall_sighted,drake_bases}
     [/event]
 [/scenario]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/19c_Cliffs_of_Thoria.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/19c_Cliffs_of_Thoria.cfg
@@ -161,6 +161,7 @@
         no_leader=yes
         controller=ai
         canrecruit=no
+        hidden=yes
         [ai]
             {ATTACK_DEPTH 5 5 6}
             [avoid]
@@ -176,6 +177,7 @@
         side=4
         no_leader=yes
         controller=ai
+        hidden=yes
         canrecruit=no
         team_name=elves
         user_team_name=_"Rebels"

--- a/data/campaigns/Heir_To_The_Throne/scenarios/19c_Cliffs_of_Thoria.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/19c_Cliffs_of_Thoria.cfg
@@ -294,7 +294,7 @@
             message= _ "Delfador is right. We must go on!"
         [/message]
         [delay]
-            time=5000
+            time=1000
         [/delay]
         [move_unit_fake]
             type=Armageddon Drake

--- a/data/campaigns/Heir_To_The_Throne/scenarios/19c_Cliffs_of_Thoria.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/19c_Cliffs_of_Thoria.cfg
@@ -195,11 +195,19 @@
         [/set_variable]
         [role]
             role=merman-advisor
-            type=Merman Triton,Merman Hoplite,Mermaid Diviner,Siren,Merman Javelineer,Merman Entangler,Merman Warrior,Mermaid Priestess,Mermaid Enchantress,Merman Spearman,Merman Netcaster,Merman Fighter,Mermaid Initiate,Merman Hunter
+            type="Merman Triton,Merman Hoplite,Merman Javelineer,Merman Entangler,Mermaid Diviner,Mermaid Siren," +
+                 "Merman Warrior,Merman Spearman,Merman Netcaster,Mermaid Priestess,Mermaid Enchantress," +
+                 "Merman Fighter,Merman Hunter,Mermaid Initiate"
+            reassign=no
+            [auto_recall][/auto_recall]
+            [else]
+                [unit]
+                    type=Merman Fighter
+                    role=merman-advisor
+                    placement=leader
+                [/unit]
+            [/else]
         [/role]
-        [recall]
-            role=merman-advisor
-        [/recall]
         [recall]
             id=Delfador
         [/recall]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/20a_North_Elves.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/20a_North_Elves.cfg
@@ -348,19 +348,13 @@
     [/event]
 
     [event]
-        name=start
+        name=prestart
         #
         # Allow the player to have some >6MP loyal units to compensate for the loss of recruiting
         #
-        [recall]
-            id=Delfador
-        [/recall]
-        [recall]
-            id=Kalenz
-        [/recall]
-        [recall]
-            id="Li'sar"
-        [/recall]
+        {NEED_DELFADOR placement=leader}
+        {NEED_KALENZ placement=leader}
+        {NEED_LISAR placement=leader}
         [recall]
             id=Haldiel
         [/recall]
@@ -375,6 +369,10 @@
         [/recall]
         [redraw]
         [/redraw]
+    [/event]
+
+    [event]
+        name=start
 
         [message]
             speaker=Kalenz
@@ -773,6 +771,9 @@
                 y= 1- 8, 9-14,   15,16-17,18-20,   21,22-25,26-28
             [/have_unit]
             [then]
+                [fire_event]
+                    name=victory dance
+                [/fire_event]
                 [endlevel]
                     result=victory
                     bonus=yes
@@ -799,6 +800,9 @@
                 y= 1- 8, 9-14,   15,16-17,18-20,   21,22-25,26-28
             [/have_unit]
             [then]
+                [fire_event]
+                    name=victory dance
+                [/fire_event]
                 [endlevel]
                     result=victory
                     bonus=yes
@@ -815,7 +819,7 @@
     [/event]
 
     [event]
-        name=victory
+        name=victory dance
         [if]
             [have_unit]
                 id="El'rien"

--- a/data/campaigns/Heir_To_The_Throne/scenarios/20b_Underground_Channels.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/20b_Underground_Channels.cfg
@@ -163,16 +163,14 @@
     [/side]
 
     [event]
+        name=prestart
+        {NEED_DELFADOR placement=leader}
+        {NEED_LISAR placement=leader}
+        {NEED_KALENZ placement=leader}
+    [/event]
+
+    [event]
         name=start
-        [recall]
-            id=Delfador
-        [/recall]
-        [recall]
-            id="Li'sar"
-        [/recall]
-        [recall]
-            id=Kalenz
-        [/recall]
         [message]
             speaker=narrator
             image=wesnoth-icon.png

--- a/data/campaigns/Heir_To_The_Throne/scenarios/21_Elven_Council.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/21_Elven_Council.cfg
@@ -53,7 +53,7 @@
     [/side]
 
     [event]
-        name=start
+        name=prestart
 
         [music]
             name=silvan_sanctuary.ogg
@@ -61,24 +61,9 @@
             append=no
         [/music]
 
-        [recall]
-            id=Delfador
-            x=10
-            y=13
-            show=no
-        [/recall]
-        [recall]
-            id=Kalenz
-            x=10
-            y=9
-            show=no
-        [/recall]
-        [recall]
-            id="Li'sar"
-            x=11
-            y=14
-            show=no
-        [/recall]
+        {NEED_DELFADOR (x,y=10,13)}
+        {NEED_KALENZ (x,y=10,9)}
+        {NEED_LISAR (x,y=11,14)}
         [unit]
             type=Elvish Champion
             x=11
@@ -104,8 +89,11 @@
             id=Everlore
             name= _ "Everlore"
         [/unit]
-        [redraw]
-        [/redraw]
+    [/event]
+
+    [event]
+        name=start
+
         [message]
             speaker=Uradredia
             message= _ "Greetings, and welcome to our capital. You should feel honored. It has been half a century — a generation in the way your race counts time — since any man has been considered Elf-friend enough to stand here in Elensiria."
@@ -305,7 +293,6 @@
             speaker=Parandra
             message= _ "Yes, rest. Your soldiers will be tended to and refreshed. We have made sure you will leave our protection with the resources to finish your journey."
         [/message]
-        {CLEAR_VARIABLE sceptre}
         [endlevel]
             result=victory
             bonus=no

--- a/data/campaigns/Heir_To_The_Throne/scenarios/22_Return_to_Wesnoth.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/22_Return_to_Wesnoth.cfg
@@ -160,19 +160,18 @@
     {STARTING_VILLAGES 4 10}
 
     [event]
-        name=start
+        name=prestart
 
         {PLACE_IMAGE scenery/rock1.png 16 26}
 
-        [recall]
-            id=Delfador
-        [/recall]
-        [recall]
-            id=Kalenz
-        [/recall]
-        [recall]
-            id="Li'sar"
-        [/recall]
+        {NEED_DELFADOR placement=leader}
+        {NEED_KALENZ placement=leader}
+        {NEED_LISAR placement=leader}
+    [/event]
+
+    [event]
+        name=start
+
         [message]
             speaker=Malatus
             message= _ "Halt! Who goes there?"

--- a/data/campaigns/Heir_To_The_Throne/scenarios/23_Test_of_the_Clans.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/23_Test_of_the_Clans.cfg
@@ -28,15 +28,14 @@
 #ifdef HARD
         {VARIABLE units_to_slay 50}
 #endif
-        [recall]
-            id=Delfador
-        [/recall]
-        [recall]
-            id=Kalenz
-        [/recall]
-        [recall]
-            id="Li'sar"
-        [/recall]
+        {CLEAR_VARIABLE clan_alric,clan_bayar,clan_daryn,clan_ruga}
+        {NEED_DELFADOR placement=leader}
+        {NEED_KALENZ placement=leader}
+        {NEED_LISAR placement=leader}
+        [disallow_recruit]
+            side=1
+            type=Knight
+        [/disallow_recruit]
         [objectives]
             side=1
             [objective]
@@ -466,13 +465,18 @@
         # wmllint: local spelling Elnar
         message= _ "We should not speak of it now. Instead come with me, Konrad and Li’sar, to the top of mount Elnar. To look at Weldyn. To make plans for the battle, and to talk."
     [/message]
-    {CLEAR_VARIABLE units_to_slay}
     [endlevel]
         result=victory
         bonus=yes
         {NEW_GOLD_CARRYOVER 40}
     [/endlevel]
 #enddef
+
+    [event]
+        name=victory
+
+        {CLEAR_VARIABLE units_to_slay}
+    [/event]
 
     [event]
         name=last breath

--- a/data/campaigns/Heir_To_The_Throne/scenarios/24_Battle_for_Wesnoth.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/24_Battle_for_Wesnoth.cfg
@@ -214,25 +214,20 @@
                 {NAMED_LOYAL_UNIT 1 (Grand Knight) 39 8 (Sir Alric) (_ "Sir Alric")}
             [/then]
         [/if]
-        {CLEAR_VARIABLE clan_alric,clan_bayar,clan_daryn,clan_ruga}
-    [/event]
 
-    [event]
-        name=start
-        [recall]
-            id=Delfador
-        [/recall]
-        [recall]
-            id=Kalenz
-        [/recall]
-        [recall]
-            id="Li'sar"
-        [/recall]
+        {NEED_DELFADOR placement=leader}
+        {NEED_KALENZ placement=leader}
+        {NEED_LISAR placement=leader}
         [role]
             type=Grand Knight
             side=1
             role=clanboss
         [/role]
+    [/event]
+
+    [event]
+        name=strart
+
         [message]
             speaker=Asheviere
             message= _ "So, these rebels come at last to face me, while most of my army is off fighting the fickle clans."

--- a/data/campaigns/Heir_To_The_Throne/utils/bigmap.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/bigmap.cfg
@@ -160,8 +160,8 @@
 #define JOURNEY_06_NEW
     [if]
         [variable]
-            name=path_muff_malal
-            equals=yes
+            name=via_isle_of_the_damned
+            not_equals=yes
         [/variable]
         [then]
             {JOURNEY_05A_OLD}
@@ -195,8 +195,8 @@
 #define JOURNEY_06_OLD
     [if]
         [variable]
-            name=path_muff_malal
-            equals=yes
+            name=via_isle_of_the_damned
+            not_equals=yes
         [/variable]
         [then]
             {JOURNEY_05A_OLD}
@@ -534,10 +534,12 @@
 #enddef
 
 #define JOURNEY_20A_NEW
-    [switch]
-        variable=A_Choice_Was_Made
-        [case]
-            value=a
+    [if]
+        [variable]
+            name=A_Choice_Was_Made
+            not_equals=b
+        [/variable]
+        [then]
             {JOURNEY_19A_OLD}
             {JOURNEY 909 183}
             {JOURNEY 920 192}
@@ -557,9 +559,8 @@
             {JOURNEY 1079 333}
             {JOURNEY 1095 336}
             {NEW_BATTLE 1110 338}
-        [/case]
-        [case]
-            value=b
+        [/then]
+        [else]
             {JOURNEY_19B_OLD}
             {JOURNEY 836 341}
             {JOURNEY 851 344}
@@ -580,15 +581,17 @@
             {JOURNEY 1080 346}
             {JOURNEY 1095 342}
             {NEW_BATTLE 1110 338}
-        [/case]
-    [/switch]
+        [/else]
+    [/if]
 #enddef
 
 #define JOURNEY_20A_OLD
-    [switch]
-        variable=A_Choice_Was_Made
-        [case]
-            value=a
+    [if]
+        [variable]
+            name=A_Choice_Was_Made
+            not_equals=b
+        [/variable]
+        [then]
             {JOURNEY_19A_OLD}
             {OLD_JOURNEY 909 183}
             {OLD_JOURNEY 920 192}
@@ -608,9 +611,8 @@
             {OLD_JOURNEY 1079 333}
             {OLD_JOURNEY 1095 336}
             {OLD_BATTLE 1110 338}
-        [/case]
-        [case]
-            value=b
+        [/then]
+        [else]
             {JOURNEY_19B_OLD}
             {OLD_JOURNEY 836 341}
             {OLD_JOURNEY 851 344}
@@ -631,8 +633,8 @@
             {OLD_JOURNEY 1080 346}
             {OLD_JOURNEY 1095 342}
             {OLD_BATTLE 1110 338}
-        [/case]
-    [/switch]
+        [/else]
+    [/if]
 #enddef
 
 #define JOURNEY_20B_NEW

--- a/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
@@ -219,9 +219,11 @@
                                         x,y={X},{Y}
                                     [/remove_item]
                                     [message]
-                                        speaker=narrator
+                                        speaker=$unit.id|
                                         image="wesnoth-icon.png"
-                                        message= _ "$unit.name| struggles to lift and don the heavy plate. Once worn, however, it is amazingly comfortable. $unit.name| feels an increased resistance to all physical damage!"
+                                        caption=""
+                                        male_message= _ "$unit.name| struggles to lift and don the heavy plate. Once worn, however, it is amazingly comfortable. He feels an increased resistance to all physical damage!"
+                                        female_message= _ "$unit.name| struggles to lift and don the heavy plate. Once worn, however, it is amazingly comfortable. She feels an increased resistance to all physical damage!"
                                     [/message]
                                     {VARIABLE armor_taken 1}
 

--- a/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
@@ -47,6 +47,36 @@
 #
 
 #define OBJ_SWORD_FIRE X Y ID
+
+    # Give a hint the first time a unit stops in a hex near the sword.
+    # There is a village right there, so that's probably when it will occur,
+    # but anywhere nearby will do.
+
+    [event]
+        name=moveto
+        [filter]
+            side=1
+        [/filter]
+        [filter_condition]
+            [have_location]
+                x,y=$x1,$y1
+                [and]
+                    x,y={X},{Y}
+                    radius=2
+                [/and]
+                [not]
+                    x,y={X},{Y}
+                [/not]
+            [/have_location]
+        [/filter_condition]
+
+        [message]
+            speaker=narrator
+            image="wesnoth-icon.png"
+            message="Nearby is a clearing with a huge tree standing alone in the center."
+        [/message]
+    [/event]
+
     [event]
         name=moveto
 
@@ -56,6 +86,11 @@
             y={Y}
         [/filter]
 
+        [message]
+            speaker=narrator
+            image="wesnoth-icon.png"
+            message= _ "A large tree stands alone in a clearing. Driven into the trunk is a huge sword with flames dancing along its blade. Stangely, while the trunk near the sword is blackened and scorched, the tree seems otherwise unaffected by the flames."
+        [/message]
         {PLACE_IMAGE items/flame-sword.png ({X}) ({Y})}
         {VARIABLE sword_taken 0}
         [event]
@@ -80,7 +115,7 @@
                 [message]
                     speaker=narrator
                     image="wesnoth-icon.png"
-                    message= _ "Do you want this unit to pick up the sword?"
+                    message= _ "Should $unit.name| attempt to pick up the sword?"
                     [option]
                         label= _ "Yes"
                         [command]
@@ -93,7 +128,7 @@
                                 description= _ "This massive blade was created centuries ago by long-forgotten elvish forgemasters, who imbued the bluish steel with an inner magical fire. Tongues of flame dance on the surface, giving the metal a flawless mirrored finish."
                                 cannot_use_message= _ "Only the leader of an army can wield this sword!"
                                 [filter]
-                                    type=Fighter,Commander,Lord,Princess,Battle Princess,Elvish Captain,Elvish Hero,Elvish Marshal,Elvish Champion,Paladin,Elvish Lord,Elvish High Lord
+                                    type=Fighter,Commander,Lord,Princess,Battle Princess,Elvish Captain,Elvish Hero,Elvish Marshal,Elvish Champion,Elvish Lord,Elvish High Lord
                                     x,y={X},{Y}
                                 [/filter]
                                 [then]
@@ -101,9 +136,11 @@
                                         x,y={X},{Y}
                                     [/remove_item]
                                     [message]
-                                        speaker=narrator
+                                        speaker=$unit.id|
                                         image="wesnoth-icon.png"
-                                        message= _ "As you place your hand around the glittering leather hilt, the sword roars to life! Strangely, you feel no heat once you pick it up, yet the grass at your feet bursts into flame as you test the heft of this mighty weapon."
+                                        caption=""
+                                        male_message= _ "As $unit.name| places his hand around the glittering leather hilt, the sword roars to life! Strangely, he feels no heat once he picks it up, yet the grass at his feet bursts into flame as he tests the heft of this mighty weapon."
+                                        female_message= _ "As $unit.name| places her hand around the glittering leather hilt, the sword roars to life! Strangely, she feels no heat once she picks it up, yet the grass at her feet bursts into flame as she tests the heft of this mighty weapon."
                                     [/message]
                                     {VARIABLE sword_taken 1}
                                 [/then]

--- a/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
@@ -73,7 +73,7 @@
         [message]
             speaker=narrator
             image="wesnoth-icon.png"
-            message="Nearby is a clearing with a huge tree standing alone in the center."
+            message= _ "Nearby is a clearing with a huge tree standing alone in the center."
         [/message]
     [/event]
 

--- a/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
@@ -688,3 +688,155 @@ fire:  +10%"
         equals={VALUE}
     [/variable]
 #enddef
+
+#define NEED_DELFADOR PLACEMENT
+    [unit]
+        id=Delfador
+        name= _ "Delfador"
+        profile=portraits/delfador-elvish.png
+        unrenamable=yes
+        type=Elder Mage
+        {PLACEMENT}
+        {IS_HERO}
+        [modifications]
+            {TRAIT_LOYAL}
+            {TRAIT_INTELLIGENT}
+        [/modifications]
+    [/unit]
+#enddef
+
+#define NEED_KALENZ PLACEMENT
+    [unit]
+        id=Kalenz
+        name= _ "Kalenz"
+        profile=portraits/kalenz.png
+        unrenamable=yes
+        type=Elvish Lord
+        {PLACEMENT}
+        {IS_HERO}
+        random_traits=no
+        [modifications]
+            {TRAIT_LOYAL}
+        [/modifications]
+    [/unit]
+#enddef
+
+#define NEED_LISAR PLACEMENT
+    [unit]
+        id="Li'sar"
+        name= _ "Li'sar"
+        profile=portraits/lisar.png
+        unrenamable=yes
+        type=Princess
+        {PLACEMENT}
+        {IS_HERO}
+        random_traits=no
+        [modifications]
+            {TRAIT_LOYAL}
+        [/modifications]
+    [/unit]
+#enddef
+
+#define STORE_DELFADOR
+    [if]
+        [have_unit]
+            id=Delfador
+            search_recall_list=yes
+        [/have_unit]
+        [then]
+            [store_unit]
+                [filter]
+                    id=Delfador
+                [/filter]
+                kill=yes
+                variable=delfador_store
+            [/store_unit]
+        [/then]
+    [/if]
+#enddef
+
+#define RESTORE_DELFADOR
+    [if]
+        [variable]
+            name=delfador_store.id
+            equals="Delfador"
+        [/variable]
+        [then]
+            [unstore_unit]
+                variable=delfador_store
+                x,y=recall,recall
+            [/unstore_unit]
+            {CLEAR_VARIABLE delfador_store}
+        [/then]
+    [/if]
+#enddef
+
+#define STORE_KALENZ
+    [if]
+        [have_unit]
+            id=Kalenz
+            search_recall_list=yes
+        [/have_unit]
+        [then]
+            [store_unit]
+                [filter]
+                    id=Kalenz
+                [/filter]
+                kill=yes
+                variable=kalenz_store
+            [/store_unit]
+        [/then]
+    [/if]
+#enddef
+
+#define RESTORE_KALENZ
+    [if]
+        [variable]
+            name=kalenz_store.id
+            equals="Kalenz"
+        [/variable]
+        [then]
+            [unstore_unit]
+                variable=kalenz_store
+                x,y=recall,recall
+            [/unstore_unit]
+            {CLEAR_VARIABLE kalenz_store}
+        [/then]
+    [/if]
+#enddef
+
+#define STORE_LISAR
+    [if]
+        [have_unit]
+            side=1
+            id="Li'sar"
+            search_recall_list=yes
+        [/have_unit]
+        [then]
+            [store_unit]
+                [filter]
+                    side=1
+                    id="Li'sar"
+                [/filter]
+                kill=yes
+                variable=lisar_store
+            [/store_unit]
+        [/then]
+    [/if]
+#enddef
+
+#define RESTORE_LISAR
+[if]
+    [variable]
+        name=lisar_store.id
+        equals="Li'sar"
+    [/variable]
+    [then]
+        [unstore_unit]
+            variable=lisar_store
+            x,y=recall,recall
+        [/unstore_unit]
+        {CLEAR_VARIABLE lisar_store}
+    [/then]
+[/if]
+#enddef

--- a/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
@@ -128,7 +128,7 @@
                                 description= _ "This massive blade was created centuries ago by long-forgotten elvish forgemasters, who imbued the bluish steel with an inner magical fire. Tongues of flame dance on the surface, giving the metal a flawless mirrored finish."
                                 cannot_use_message= _ "Only the leader of an army can wield this sword!"
                                 [filter]
-                                    type=Fighter,Commander,Lord,Princess,Battle Princess,Elvish Captain,Elvish Hero,Elvish Marshal,Elvish Champion,Elvish Lord,Elvish High Lord
+                                    type=Fighter,Commander,Lord,Princess,Battle Princess,Elvish Captain,Elvish Hero,Elvish Marshal,Elvish Champion,Paladin,Elvish Lord,Elvish High Lord
                                     x,y={X},{Y}
                                 [/filter]
                                 [then]
@@ -146,8 +146,7 @@
                                 [/then]
                                 [effect]
                                     apply_to=attack
-                                    range=melee #includes Li'sar's saber
-                                    type=blade #excludes Paladin's lance
+                                    name=sword,saber
                                     set_description= _ "flaming sword"
                                     set_icon=attacks/sword-flaming.png
                                     set_type=fire

--- a/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
@@ -199,7 +199,7 @@
                 [message]
                     speaker=narrator
                     image="wesnoth-icon.png"
-                    message= _ "Do you want this unit to pick up the armor?"
+                    message= _ "Should $unit.name| attempt to pick up the armor?"
                     [option]
                         label= _ "Yes"
                         [command]
@@ -222,7 +222,7 @@
                                     [message]
                                         speaker=narrator
                                         image="wesnoth-icon.png"
-                                        message= _ "You struggle to lift and don the heavy plate. Once worn, however, it is amazingly comfortable. You have increased resistance to all physical damage!"
+                                        message= _ "$unit.name| struggles to lift and don the heavy plate. Once worn, however, it is amazingly comfortable. $unit.name| feels an increased resistance to all physical damage!"
                                     [/message]
                                     {VARIABLE armor_taken 1}
 


### PR DESCRIPTION
This Pull Request is part of a series of corrections and improvements to the HttT ('Heir to the Throne') campaign.

When merging or testing, please be aware that a PR deeper in the hierarchy will have merge conflicts unless each higher PR has already been applied. If this presents a problem, contact me and I will re-factor the hierarchy as required. At present, the best options to contact me are either as comments on one of these pull requests, or by creating an Issue on my personal fork.

**Hierarchy**

    master
    |
    +-- GregoryLundberg:GL_HttT_general_improvements ( PR #730 )
        |
        +-- GregoryLundberg:GL_HttT_S05b_use_advisor ( PR #731 )
        |
        +-- GregoryLundberg:GL_HttT_S05b_randomize_temples ( PR #732 )
        |
        +-- GregoryLundberg:GL_HttT_S06_logical_thieves ( PR #733 )
        |
        +-- GregoryLundberg:GL_HttT_S07_ambushers_reduced ( PR #734 )
        |
        +-- GregoryLundberg:GL_HttT_S13_snow_detritus ( PR #735 )
        |
        +-- GregoryLundberg:GL_HttT_S20b_wose_assistance ( PR #736 )
        |
        +-- GregoryLundberg:GL_HttT_S22_gryphons_return ( PR #737 )

**GregoryLundberg:GL_HttT_general_improvements**
These are general improvements of my own. Each patch is fairly localized and should be easy to follow. Individual patches should be easy to cherry pick, if desired. The only complex patch is the last, which touches many files, and gets the debug command 'choose_level' working.

**GregoryLundberg:GL_HttT_S05b_use_advisor**
This implements a TODO item. It selects the advisor Konrad will have at the start of S06 ('The Siege of Elensefar') and uses that advisor for a comment, apparently coming from inside the ship, when it arrives.

**GregoryLundberg:GL_HttT_S05b_randomize_temples**
This implements a TODO item. It randomizes the temple contents.

**GregoryLundberg:GL_HttT_S06_logical_thieves**
This is an improvement of my own. It handles the Thieves' Guild in a more logical manner. Mainly, they will simply join forces in cases where Konrad has already passed the point where an offer of help makes sense.

**GregoryLundberg:GL_HttT_S07_ambushers_reduced**
This implements a TODO item. The number of ambushes reduces based upon the number of enemy leaders killed in S01 ('The Elves Besieged').

**GregoryLundberg:GL_HttT_S13_snow_detritus**
This implements a TODO item. It adds random snow on up to 1/3rd the non-snow tiles, based upon the snow coverage (that is, turns to completion) from S12 ('Northern Winter').

**GregoryLundberg:GL_HttT_S20b_wose_assistance**
This implements a TODO item. It adds a bonus sub-quest assisting the wose in dealing with the undead. The reward is a book which, when read, grants forest movement cost 1, forest defense 70%, and forest ambush (as with an Elvish Ranger). This reward was chosen because it offers some assistance in S22 ('Return to Wesnoth') and has limited, or no, use in the following scenarios.

**GregoryLundberg:GL_HttT_S22_gryphons_return**
This implements a TODO item. If Konrad did not injure or kill the gryphons in S10 ('Gryphon Mountain'), a flight of gryphons return to assist Konrad in S22 ('Return to Wesnoth'). Remember, for the gryphons to arrive, Konrad must have forgone their eggs and, therefore, has no Gryphon Riders. This lack of Gryphon Riders will be most felt in the final two scenario, and especially on the large, open plains of S23 ('The Test of the Clans').

**KNOWN BUGS**

Multiple-tile units with animation leave visual artifacts as they move. This is most noticeable with the Gryphons and Gryphon Riders as they move using move_unit_fake in S10 ('Gryphon Mountain'), S14 ('Plunging into Darkness') and S22 ('Return to Wesnoth'). The artifacts clear fairly quickly, and are all removed at the end of the movement.

The game engine appears to have memory-leak issues. When play-testing, after loading several dozen scenario, memory usage will have grown quite large. This can cause the system to begin to swap (if your system has swap space), which severely degrades performance. To work around the issue, I keep an eye on memory use and restart the engine when it approaches the limit.

There are a few remaining user-interface issues such as the popup messages sometimes not appearing.

**NOTES**

I have tested each fork to ensure no merge conflicts occur, provided the required upper-level forks have already been merged. I found no problems using simple merges. I did, however, run into problems with rebase. If you need to rebase after merging these forks and get merge conflicts, abort your rebase (git rebase --abort). In general, such merge conflicts occur because git can re-order the commits; but that re-ordering can be avoided, preventing merge conflicts, with an interactive rebase. Contact me if you need assistance using rebase.

The debug command choose_level works well, now. In general, when testing, you can switch from any scenario to any other. Internal state, such as which path you took from S04 ('The Bay of Pearls') .. S05a ('Muff Malal's Peninsula') or S05b ('The Isle of the Damned') .. or the amount of snow which fell in S12 ('Northern Winter') is maintained until you visit the scenario which sets the state. Thus, if you want to test with the various incarnations of Moremirmu in S09 ('The Valley of Death'), you simply need to use choose_level to jump to S05a or S05b, then jump back to S09 once you have the desired state.

The debug command next_level also works well. But, since there is no way to know if you used next_level command, it always advances to the default next level. At points where there is a branch, S04 ('The Bay of Pearls') and S18 ('A Choice Must Be Made'), you must either play through, or use the choose_level command if you do not want to follow the default choice.

When using the choose_level command, be aware that game state, such as your gold balance, and your recall list (including your Heros) is NOT CHANGED. This means, yes, it is possible to advance your Heros and jump to S01 ('The Elves Besieged') and have Konrad, Li'sar and Kalenz, along with a host of other L3 units, even Gryphon Riders or Gryphons, if you have always wanted to clear the board of those pesky orcs.

There are times when a Hero (generally Delfador or Li'sar) cannot be on the map, either for story purposes or because that Hero is already in that scenario. In these cases your Hero is saved and, if you are using choose_level to jump around, will be restored once you leave the area.

Similarly, there are times when a unit will join Konrad's forces. For example, Haldiel in S02 ('Blackwater Port'). If you already have Haldiel in your recall list and choose_level to jump to Blackwater Port, Haldiel will be removed from your recall list, and a new Haldiel will appear at the appropriate time. For those units which only appear depending upon your actions, they will only be removed from your recall list (or the map) should you take the action which causes their appearance.

**CHANGES**

_07AUG2016_

GL_unique_items has been merged to master.

Spelling and grammar corrections on this document and PR titles. Unfortunately, the typo in a branch name has to stay.

Spelling and grammar corrections on commit messages.

Removed underscores in custom event names 'home destroyed' and 'victory dance'.

Spelling and grammar corrections in commit 'HttT S20a Fix bug: El'rien might be dead'

Spelling and grammar corrections in commit 'HttT S20b Fix bug: Bona-Melodia may be dead'

Corrected filter for moving side in commit 'HttT S08 Adjust closing-in area'

Spelling and grammar corrections, and eliminated po comments in commit 'HttT S20b Wose assistance quest'

_08AUG2016_

Clean up [objectives] handling for commit 'HttT S10 Change objectives'

Clean up the hidden advisor to use a galleon unit instead of a shallow copy for commit 'HttT S05b Use an Advisor'

Moved lua inline, removing custom tag, for commit 'HttT S13 Add some random snow'

Clean up [objectives] handling for commit 'HttT S19c Fix bug: Wrong objectives'

_10AUG2016_

Sync to master v1.13.5+dev (6235e18-Clean) and re-tested

_11AUG2016_

Removed commit 'HttT S21 Fix bug: No save'

Sync to master v1.13.5+dev (cf4f488-Clean) and re-tested

Finally got commit 'HttT S05b Use an Advisor' working just the way I always envisioned

_12AUG2016_

Removed workaround commit for [object] issues on S08, S11 and S16.

Sync to master v1.13.5+dev (265e41d-Clean)

_12AUG2016_

GL_HttT_errors has been merged to master

Sync to master v1.13.5+dev (12f7107-Clean) and re-tested

_13AUG2016_

Cleanup since [hide_unit] now works for commit 'HttT S05b Use an Advisor'

Audited and corrected state variables for 'HttT Debug choose_level works'

Clean up [objectives] handling for commit 'HttT S20b Wose assistance quest'

Only leaders count for commit 'HttT S07 Ambushers reduced'

Changed the subject from you to the unit in commit 'HttT S19a Improve Flaming Sword'

Changed the subject from you to the unit in commit 'HttT S19b Improve Void Armor'

Sync to master v1.13.5+dev (3cc2d09-Clean) and re-tested

_19AUG2016_

Removed commit 'HttT S12 Added ambiance (fog)'

Updated commit 'HttT S19a Improve Flaming Sword' for typo and [message] big fixed

Updated commit 'HttT S14 Consistent objectives' for new {HAS_NO_TURN_LIMIT} macro

Sync to master v1.13.5+dev (7fab085-Clean) and re-tested

_30AUG2016_

Sync to master v1.13.5+dev (b24fdbc-Clean) and re-tested

_06SEP2016_

Updated commit 'HttT Debug choose_level works' removing macro RECALL_ELSE

Sync to master v1.13.5+dev (206096c-Clean) and re-tested

_10SEP2016_

Re-enabled Paladin to use Flaming Sword.

Switched to using unit for speaker when taking Void Armor to allow gender-specific messages.

Sync to master v1.13.5+dev (eb3e27b-Clean) (only tested for the changes)

_13SEP2016_

Removed [kill] before [unit] and cleaned up Li'sar changing sides for choose_level

Sync to master v1.13.5+dev (1af1932-Clean) and re-tested.
