### PR TITLE
HttT S07 Ambushers Reduced

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/01_The_Elves_Besieged.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/01_The_Elves_Besieged.cfg
@@ -25,6 +25,7 @@
 
     [event]
         name=prestart
+        {VARIABLE besieged_enemies_killed 0}
         {NEED_DELFADOR (x,y=19,23)}
         [objectives]
             side=1
@@ -568,6 +569,21 @@
             speaker=Delfador
             message= _ "There can be no looking back. We must go quickly!"
         [/message]
+    [/event]
+
+    [event]
+        name=die
+        first_time_only=no
+
+        [filter]
+            side=2,3,4
+            canrecruit=yes
+        [/filter]
+
+        [set_variable]
+            name=besieged_enemies_killed
+            add=1
+        [/set_variable]
     [/event]
 [/scenario]
 

--- a/data/campaigns/Heir_To_The_Throne/scenarios/07_Crossroads.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/07_Crossroads.cfg
@@ -375,30 +375,37 @@
 
         # Only the number of ambushers differs by difficulty here.
 
-#ifdef EASY
-        {ORC_AMBUSH_AREA 2 5-35 1-7 5}
-        {ORC_AMBUSH_AREA 2 9-24 8-15 5}
-        {ORC_AMBUSH_AREA 3 1-17 17-24 9}
-        {ORC_AMBUSH_AREA 3 18-25 16-23 5}
-        {ORC_AMBUSH_AREA 3 26-40 16-23 5}
-#endif
-#ifdef NORMAL
-        {ORC_AMBUSH_AREA 2 5-35 1-7 6}
-        {ORC_AMBUSH_AREA 2 9-24 8-15 6}
-        {ORC_AMBUSH_AREA 3 1-17 17-24 10}
-        {ORC_AMBUSH_AREA 3 18-25 16-23 6}
-        {ORC_AMBUSH_AREA 3 26-40 16-23 6}
-#endif
-#ifdef HARD
-        {ORC_AMBUSH_AREA 2 5-35 1-7 7}
-        {ORC_AMBUSH_AREA 2 9-24 8-15 7}
-        {ORC_AMBUSH_AREA 3 1-17 17-24 11}
-        {ORC_AMBUSH_AREA 3 18-25 16-23 7}
-        {ORC_AMBUSH_AREA 3 26-40 16-23 7}
-#endif
+        # Adjust for leaders killed in S01 ('The Elves Besieged')
+        # Reduce 25% for each. Note: implicit floor() due to loop
+        # GL-2016Aug
+        #
+        #             3  2  1  0 # killed
+        #
+        #      5 -->  1  2  3  5
+        #      6 -->  1  3  4  6
+        #      7 -->  1  3  5  7
+        #
+        #      9 -->  2  4  6  9
+        #     10 -->  2  5  7 10
+        #     11 -->  2  5  8 11
+        #
+        # Net result
+        #
+        #   Easy -->  6 12 18 29
+        # Normal -->  6 17 23 34
+        #   Hard -->  6 17 28 39
+
+        {VARIABLE small_number "$(((4 - $besieged_enemies_killed?0|) * {ON_DIFFICULTY 5 6 7}) / 4)"}
+        {VARIABLE large_number "$(((4 - $besieged_enemies_killed?0|) * {ON_DIFFICULTY 9 10 11}) / 4)"}
+
+        {ORC_AMBUSH_AREA 2 5-35 1-7 $small_number}
+        {ORC_AMBUSH_AREA 2 9-24 8-15 $small_number}
+        {ORC_AMBUSH_AREA 3 1-17 17-24 $large_number}
+        {ORC_AMBUSH_AREA 3 18-25 16-23 $small_number}
+        {ORC_AMBUSH_AREA 3 26-40 16-23 $small_number}
 
         {CLEAR_VARIABLE random_ambusher_type_table}
-        {CLEAR_VARIABLE random_ambusher_type_i}
+        {CLEAR_VARIABLE random_ambusher_type_i,small_number,large_number}
     [/event]
 
     [event]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/25_HttT_Epilogue.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/25_HttT_Epilogue.cfg
@@ -62,7 +62,7 @@
 #	Some are old, some are new, some are secret, and some are well-known
 #	Something counts as a hidden goodie if the effect is not advertised or must be discovered somehow
 #	The list doesn't include any of the "pop-up" monsters, which are at best annoying
-#	- if you defeat two or more leaders in Elves Besieged, the orcish army is weakened enough such that there are far fewer ambushes in Crossroads
+#	- if you defeat any leaders in Elves Besieged, the orcish army is weakened enough such that there are far fewer ambushes in Crossroads
 #	- if you completely liberate Blackwater Port on HARD, you are given a free knight
 #	- if you completely eliminate the undead presence on the Isle of the Damned, Moremirmu joins your party
 #	- if you do not completely eliminate the undead presence on the Isle of the Damned, Moremirmu returns to help you in the Valley of Death


### PR DESCRIPTION
This Pull Request is part of a series of corrections and improvements to the HttT ('Heir to the Throne') campaign.

When merging or testing, please be aware that a PR deeper in the hierarchy will have merge conflicts unless each higher PR has already been applied. If this presents a problem, contact me and I will re-factor the hierarchy as required. At present, the best options to contact me are either as comments on one of these pull requests, or by creating an Issue on my personal fork.

**Hierarchy**

    master
    |
    +-- GregoryLundberg:GL_HttT_general_improvements ( PR #730 )
        |
        +-- GregoryLundberg:GL_HttT_S05b_use_advisor ( PR #731 )
        |
        +-- GregoryLundberg:GL_HttT_S05b_randomize_temples ( PR #732 )
        |
        +-- GregoryLundberg:GL_HttT_S06_logical_thieves ( PR #733 )
        |
        +-- GregoryLundberg:GL_HttT_S07_ambushers_reduced ( PR #734 )
        |
        +-- GregoryLundberg:GL_HttT_S13_snow_detritus ( PR #735 )
        |
        +-- GregoryLundberg:GL_HttT_S20b_wose_assistance ( PR #736 )
        |
        +-- GregoryLundberg:GL_HttT_S22_gryphons_return ( PR #737 )

**GregoryLundberg:GL_HttT_general_improvements**
These are general improvements of my own. Each patch is fairly localized and should be easy to follow. Individual patches should be easy to cherry pick, if desired. The only complex patch is the last, which touches many files, and gets the debug command 'choose_level' working.

**GregoryLundberg:GL_HttT_S05b_use_advisor**
This implements a TODO item. It selects the advisor Konrad will have at the start of S06 ('The Siege of Elensefar') and uses that advisor for a comment, apparently coming from inside the ship, when it arrives.

**GregoryLundberg:GL_HttT_S05b_randomize_temples**
This implements a TODO item. It randomizes the temple contents.

**GregoryLundberg:GL_HttT_S06_logical_thieves**
This is an improvement of my own. It handles the Thieves' Guild in a more logical manner. Mainly, they will simply join forces in cases where Konrad has already passed the point where an offer of help makes sense.

**GregoryLundberg:GL_HttT_S07_ambushers_reduced**
This implements a TODO item. The number of ambushes reduces based upon the number of enemy leaders killed in S01 ('The Elves Besieged').

**GregoryLundberg:GL_HttT_S13_snow_detritus**
This implements a TODO item. It adds random snow on up to 1/3rd the non-snow tiles, based upon the snow coverage (that is, turns to completion) from S12 ('Northern Winter').

**GregoryLundberg:GL_HttT_S20b_wose_assistance**
This implements a TODO item. It adds a bonus sub-quest assisting the wose in dealing with the undead. The reward is a book which, when read, grants forest movement cost 1, forest defense 70%, and forest ambush (as with an Elvish Ranger). This reward was chosen because it offers some assistance in S22 ('Return to Wesnoth') and has limited, or no, use in the following scenarios.

**GregoryLundberg:GL_HttT_S22_gryphons_return**
This implements a TODO item. If Konrad did not injure or kill the gryphons in S10 ('Gryphon Mountain'), a flight of gryphons return to assist Konrad in S22 ('Return to Wesnoth'). Remember, for the gryphons to arrive, Konrad must have forgone their eggs and, therefore, has no Gryphon Riders. This lack of Gryphon Riders will be most felt in the final two scenario, and especially on the large, open plains of S23 ('The Test of the Clans').

**KNOWN BUGS**

Multiple-tile units with animation leave visual artifacts as they move. This is most noticeable with the Gryphons and Gryphon Riders as they move using move_unit_fake in S10 ('Gryphon Mountain'), S14 ('Plunging into Darkness') and S22 ('Return to Wesnoth'). The artifacts clear fairly quickly, and are all removed at the end of the movement.

The game engine appears to have memory-leak issues. When play-testing, after loading several dozen scenario, memory usage will have grown quite large. This can cause the system to begin to swap (if your system has swap space), which severely degrades performance. To work around the issue, I keep an eye on memory use and restart the engine when it approaches the limit.

There are a few remaining user-interface issues such as the popup messages sometimes not appearing.

**NOTES**

I have tested each fork to ensure no merge conflicts occur, provided the required upper-level forks have already been merged. I found no problems using simple merges. I did, however, run into problems with rebase. If you need to rebase after merging these forks and get merge conflicts, abort your rebase (git rebase --abort). In general, such merge conflicts occur because git can re-order the commits; but that re-ordering can be avoided, preventing merge conflicts, with an interactive rebase. Contact me if you need assistance using rebase.

The debug command choose_level works well, now. In general, when testing, you can switch from any scenario to any other. Internal state, such as which path you took from S04 ('The Bay of Pearls') .. S05a ('Muff Malal's Peninsula') or S05b ('The Isle of the Damned') .. or the amount of snow which fell in S12 ('Northern Winter') is maintained until you visit the scenario which sets the state. Thus, if you want to test with the various incarnations of Moremirmu in S09 ('The Valley of Death'), you simply need to use choose_level to jump to S05a or S05b, then jump back to S09 once you have the desired state.

The debug command next_level also works well. But, since there is no way to know if you used next_level command, it always advances to the default next level. At points where there is a branch, S04 ('The Bay of Pearls') and S18 ('A Choice Must Be Made'), you must either play through, or use the choose_level command if you do not want to follow the default choice.

When using the choose_level command, be aware that game state, such as your gold balance, and your recall list (including your Heros) is NOT CHANGED. This means, yes, it is possible to advance your Heros and jump to S01 ('The Elves Besieged') and have Konrad, Li'sar and Kalenz, along with a host of other L3 units, even Gryphon Riders or Gryphons, if you have always wanted to clear the board of those pesky orcs.

There are times when a Hero (generally Delfador or Li'sar) cannot be on the map, either for story purposes or because that Hero is already in that scenario. In these cases your Hero is saved and, if you are using choose_level to jump around, will be restored once you leave the area.

Similarly, there are times when a unit will join Konrad's forces. For example, Haldiel in S02 ('Blackwater Port'). If you already have Haldiel in your recall list and choose_level to jump to Blackwater Port, Haldiel will be removed from your recall list, and a new Haldiel will appear at the appropriate time. For those units which only appear depending upon your actions, they will only be removed from your recall list (or the map) should you take the action which causes their appearance.

**CHANGES**

_07AUG2016_

GL_unique_items has been merged to master.

Spelling and grammar corrections on this document and PR titles. Unfortunately, the typo in a branch name has to stay.

Spelling and grammar corrections on commit messages.

Removed underscores in custom event names 'home destroyed' and 'victory dance'.

Spelling and grammar corrections in commit 'HttT S20a Fix bug: El'rien might be dead'

Spelling and grammar corrections in commit 'HttT S20b Fix bug: Bona-Melodia may be dead'

Corrected filter for moving side in commit 'HttT S08 Adjust closing-in area'

Spelling and grammar corrections, and eliminated po comments in commit 'HttT S20b Wose assistance quest'

_08AUG2016_

Clean up [objectives] handling for commit 'HttT S10 Change objectives'

Clean up the hidden advisor to use a galleon unit instead of a shallow copy for commit 'HttT S05b Use an Advisor'

Moved lua inline, removing custom tag, for commit 'HttT S13 Add some random snow'

Clean up [objectives] handling for commit 'HttT S19c Fix bug: Wrong objectives'

_10AUG2016_

Sync to master v1.13.5+dev (6235e18-Clean) and re-tested

_11AUG2016_

Removed commit 'HttT S21 Fix bug: No save'

Sync to master v1.13.5+dev (cf4f488-Clean) and re-tested

Finally got commit 'HttT S05b Use an Advisor' working just the way I always envisioned

_12AUG2016_

Removed workaround commit for [object] issues on S08, S11 and S16.

Sync to master v1.13.5+dev (265e41d-Clean)

_12AUG2016_

GL_HttT_errors has been merged to master

Sync to master v1.13.5+dev (12f7107-Clean) and re-tested

_13AUG2016_

Cleanup since [hide_unit] now works for commit 'HttT S05b Use an Advisor'

Audited and corrected state variables for 'HttT Debug choose_level works'

Clean up [objectives] handling for commit 'HttT S20b Wose assistance quest'

Only leaders count for commit 'HttT S07 Ambushers reduced'

Changed the subject from you to the unit in commit 'HttT S19a Improve Flaming Sword'

Changed the subject from you to the unit in commit 'HttT S19b Improve Void Armor'

Sync to master v1.13.5+dev (3cc2d09-Clean) and re-tested

_19AUG2016_

Removed commit 'HttT S12 Added ambiance (fog)'

Updated commit 'HttT S19a Improve Flaming Sword' for typo and [message] big fixed

Updated commit 'HttT S14 Consistent objectives' for new {HAS_NO_TURN_LIMIT} macro

Sync to master v1.13.5+dev (7fab085-Clean) and re-tested

_30AUG2016_

Sync to master v1.13.5+dev (b24fdbc-Clean) and re-tested

_06SEP2016_

Updated commit 'HttT Debug choose_level works' removing macro RECALL_ELSE

Sync to master v1.13.5+dev (206096c-Clean) and re-tested

_10SEP2016_

Re-enabled Paladin to use Flaming Sword.

Switched to using unit for speaker when taking Void Armor to allow gender-specific messages.

Sync to master v1.13.5+dev (eb3e27b-Clean) (only tested for the changes)

_13SEP2016_

Removed [kill] before [unit] and cleaned up Li'sar changing sides for choose_level

Sync to master v1.13.5+dev (1af1932-Clean) and re-tested.
