### PR TITLE
HttT S13 Snow Detritus

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/12_Northern_Winter.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/12_Northern_Winter.cfg
@@ -423,6 +423,10 @@
     [event]
         name=victory
 
+        {VARIABLE_OP turn_limit sub 1}
+        {VARIABLE snowCoverage $turn_number}
+        {VARIABLE_OP snowCoverage sub 1}
+        {VARIABLE_OP snowCoverage divide $turn_limit}
         {CLEAR_VARIABLE turn_limit}
     [/event]
 

--- a/data/campaigns/Heir_To_The_Throne/scenarios/13_The_Dwarven_Doors.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/13_The_Dwarven_Doors.cfg
@@ -160,7 +160,60 @@
         #
         {VARIABLE_OP true_entrance_location rand "1..2"}
 
-        # TODO: manually add snow detritus
+        [lua]
+            code=<<
+-- The only parameter right now is the coverage (real 0.0 to 1.0, incl.)
+-- For prime-time use the filter terrain needs to come in and the convert
+-- table needs to be VERY complete. Or, rename this to morph_terrain and
+-- have the conversion table come in as an argument, too.
+
+local locations = wesnoth.get_locations{terrain = 'Ce,Ch,Chr,Co,Gd,Gd^Vc,Gd^Vh,Gd^Vo,Gll^Fp,Hhd,Hhd^Fp,Hhd^Vo,Ke,Khr,Ko,Md,Mm,Rd,Re,Re^Vo,Rr,Ww'}
+
+local coverage = wesnoth.get_variable("snowCoverage")
+if coverage == nil or coverage < 0 then
+    coverage = 0
+elseif coverage > 1 then
+    coverage = 1
+end
+local snowNeeded = (#locations * coverage) / 3
+-- Use 1/3rd of the coverage from Northern Winter. Spring is approaching. We need to watch
+-- this; if it adds too much snow, the player may not be able to make it to the exit in time.
+
+local convert = {
+    ['Ce'] = 'Cea',
+    ['Ch'] = 'Cha',
+    ['Chr'] = 'Cha',
+    ['Co'] = 'Coa',
+    ['Gd'] = 'Aa',
+    ['Gd^Vc'] = 'Aa^Vca',
+    ['Gd^Vh'] = 'Aa^Vha',
+    ['Gd^Vo'] = 'Aa^Voa',
+    ['Gll^Fp'] = 'Aa^Fpa',
+    ['Hhd'] = 'Ha',
+    ['Hhd^Fp'] = 'Ha^Fpa',
+    ['Hhd^Vo'] = 'Ha^Voa',
+    ['Ke'] = 'Kea',
+    ['Khr'] = 'Kha',
+    ['Ko'] = 'Koa',
+    ['Md'] = 'Ms',
+    ['Mm'] = 'Ms',
+    ['Rd'] = 'Aa',
+    ['Re'] = 'Aa',
+    ['Re^Vo'] = 'Aa^Voa',
+    ['Rr'] = 'Aa',
+    ['Ww'] = 'Ai'
+}
+
+local loopCounter
+for loopCounter = 1, snowNeeded do
+    local locationsIndex = wesnoth.random(#locations)
+    local coordinate = locations[locationsIndex]
+    local terrainCode = wesnoth.get_terrain(coordinate[1], coordinate[2])
+    wesnoth.set_terrain(coordinate[1], coordinate[2], (convert[terrainCode] or terrainCode))
+    table.remove(locations, locationsIndex)
+end
+            >>
+        [/lua]
     [/event]
 
     [event]


### PR DESCRIPTION
This Pull Request is part of a series of corrections and improvements to the HttT ('Heir to the Throne') campaign.

When merging or testing, please be aware that a PR deeper in the hierarchy will have merge conflicts unless each higher PR has already been applied. If this presents a problem, contact me and I will re-factor the hierarchy as required. At present, the best options to contact me are either as comments on one of these pull requests, or by creating an Issue on my personal fork.

**Hierarchy**

    master
    |
    +-- GregoryLundberg:GL_HttT_general_improvements ( PR #730 )
        |
        +-- GregoryLundberg:GL_HttT_S05b_use_advisor ( PR #731 )
        |
        +-- GregoryLundberg:GL_HttT_S05b_randomize_temples ( PR #732 )
        |
        +-- GregoryLundberg:GL_HttT_S06_logical_thieves ( PR #733 )
        |
        +-- GregoryLundberg:GL_HttT_S07_ambushers_reduced ( PR #734 )
        |
        +-- GregoryLundberg:GL_HttT_S13_snow_detritus ( PR #735 )
        |
        +-- GregoryLundberg:GL_HttT_S20b_wose_assistance ( PR #736 )
        |
        +-- GregoryLundberg:GL_HttT_S22_gryphons_return ( PR #737 )

**GregoryLundberg:GL_HttT_general_improvements**
These are general improvements of my own. Each patch is fairly localized and should be easy to follow. Individual patches should be easy to cherry pick, if desired. The only complex patch is the last, which touches many files, and gets the debug command 'choose_level' working.

**GregoryLundberg:GL_HttT_S05b_use_advisor**
This implements a TODO item. It selects the advisor Konrad will have at the start of S06 ('The Siege of Elensefar') and uses that advisor for a comment, apparently coming from inside the ship, when it arrives.

**GregoryLundberg:GL_HttT_S05b_randomize_temples**
This implements a TODO item. It randomizes the temple contents.

**GregoryLundberg:GL_HttT_S06_logical_thieves**
This is an improvement of my own. It handles the Thieves' Guild in a more logical manner. Mainly, they will simply join forces in cases where Konrad has already passed the point where an offer of help makes sense.

**GregoryLundberg:GL_HttT_S07_ambushers_reduced**
This implements a TODO item. The number of ambushes reduces based upon the number of enemy leaders killed in S01 ('The Elves Besieged').

**GregoryLundberg:GL_HttT_S13_snow_detritus**
This implements a TODO item. It adds random snow on up to 1/3rd the non-snow tiles, based upon the snow coverage (that is, turns to completion) from S12 ('Northern Winter').

**GregoryLundberg:GL_HttT_S20b_wose_assistance**
This implements a TODO item. It adds a bonus sub-quest assisting the wose in dealing with the undead. The reward is a book which, when read, grants forest movement cost 1, forest defense 70%, and forest ambush (as with an Elvish Ranger). This reward was chosen because it offers some assistance in S22 ('Return to Wesnoth') and has limited, or no, use in the following scenarios.

**GregoryLundberg:GL_HttT_S22_gryphons_return**
This implements a TODO item. If Konrad did not injure or kill the gryphons in S10 ('Gryphon Mountain'), a flight of gryphons return to assist Konrad in S22 ('Return to Wesnoth'). Remember, for the gryphons to arrive, Konrad must have forgone their eggs and, therefore, has no Gryphon Riders. This lack of Gryphon Riders will be most felt in the final two scenario, and especially on the large, open plains of S23 ('The Test of the Clans').

**KNOWN BUGS**

Multiple-tile units with animation leave visual artifacts as they move. This is most noticeable with the Gryphons and Gryphon Riders as they move using move_unit_fake in S10 ('Gryphon Mountain'), S14 ('Plunging into Darkness') and S22 ('Return to Wesnoth'). The artifacts clear fairly quickly, and are all removed at the end of the movement.

The game engine appears to have memory-leak issues. When play-testing, after loading several dozen scenario, memory usage will have grown quite large. This can cause the system to begin to swap (if your system has swap space), which severely degrades performance. To work around the issue, I keep an eye on memory use and restart the engine when it approaches the limit.

There are a few remaining user-interface issues such as the popup messages sometimes not appearing.

**NOTES**

I have tested each fork to ensure no merge conflicts occur, provided the required upper-level forks have already been merged. I found no problems using simple merges. I did, however, run into problems with rebase. If you need to rebase after merging these forks and get merge conflicts, abort your rebase (git rebase --abort). In general, such merge conflicts occur because git can re-order the commits; but that re-ordering can be avoided, preventing merge conflicts, with an interactive rebase. Contact me if you need assistance using rebase.

The debug command choose_level works well, now. In general, when testing, you can switch from any scenario to any other. Internal state, such as which path you took from S04 ('The Bay of Pearls') .. S05a ('Muff Malal's Peninsula') or S05b ('The Isle of the Damned') .. or the amount of snow which fell in S12 ('Northern Winter') is maintained until you visit the scenario which sets the state. Thus, if you want to test with the various incarnations of Moremirmu in S09 ('The Valley of Death'), you simply need to use choose_level to jump to S05a or S05b, then jump back to S09 once you have the desired state.

The debug command next_level also works well. But, since there is no way to know if you used next_level command, it always advances to the default next level. At points where there is a branch, S04 ('The Bay of Pearls') and S18 ('A Choice Must Be Made'), you must either play through, or use the choose_level command if you do not want to follow the default choice.

When using the choose_level command, be aware that game state, such as your gold balance, and your recall list (including your Heros) is NOT CHANGED. This means, yes, it is possible to advance your Heros and jump to S01 ('The Elves Besieged') and have Konrad, Li'sar and Kalenz, along with a host of other L3 units, even Gryphon Riders or Gryphons, if you have always wanted to clear the board of those pesky orcs.

There are times when a Hero (generally Delfador or Li'sar) cannot be on the map, either for story purposes or because that Hero is already in that scenario. In these cases your Hero is saved and, if you are using choose_level to jump around, will be restored once you leave the area.

Similarly, there are times when a unit will join Konrad's forces. For example, Haldiel in S02 ('Blackwater Port'). If you already have Haldiel in your recall list and choose_level to jump to Blackwater Port, Haldiel will be removed from your recall list, and a new Haldiel will appear at the appropriate time. For those units which only appear depending upon your actions, they will only be removed from your recall list (or the map) should you take the action which causes their appearance.

**CHANGES**

_07AUG2016_

GL_unique_items has been merged to master.

Spelling and grammar corrections on this document and PR titles. Unfortunately, the typo in a branch name has to stay.

Spelling and grammar corrections on commit messages.

Removed underscores in custom event names 'home destroyed' and 'victory dance'.

Spelling and grammar corrections in commit 'HttT S20a Fix bug: El'rien might be dead'

Spelling and grammar corrections in commit 'HttT S20b Fix bug: Bona-Melodia may be dead'

Corrected filter for moving side in commit 'HttT S08 Adjust closing-in area'

Spelling and grammar corrections, and eliminated po comments in commit 'HttT S20b Wose assistance quest'

_08AUG2016_

Clean up [objectives] handling for commit 'HttT S10 Change objectives'

Clean up the hidden advisor to use a galleon unit instead of a shallow copy for commit 'HttT S05b Use an Advisor'

Moved lua inline, removing custom tag, for commit 'HttT S13 Add some random snow'

Clean up [objectives] handling for commit 'HttT S19c Fix bug: Wrong objectives'

_10AUG2016_

Sync to master v1.13.5+dev (6235e18-Clean) and re-tested

_11AUG2016_

Removed commit 'HttT S21 Fix bug: No save'

Sync to master v1.13.5+dev (cf4f488-Clean) and re-tested

Finally got commit 'HttT S05b Use an Advisor' working just the way I always envisioned

_12AUG2016_

Removed workaround commit for [object] issues on S08, S11 and S16.

Sync to master v1.13.5+dev (265e41d-Clean)

_12AUG2016_

GL_HttT_errors has been merged to master

Sync to master v1.13.5+dev (12f7107-Clean) and re-tested

_13AUG2016_

Cleanup since [hide_unit] now works for commit 'HttT S05b Use an Advisor'

Audited and corrected state variables for 'HttT Debug choose_level works'

Clean up [objectives] handling for commit 'HttT S20b Wose assistance quest'

Only leaders count for commit 'HttT S07 Ambushers reduced'

Changed the subject from you to the unit in commit 'HttT S19a Improve Flaming Sword'

Changed the subject from you to the unit in commit 'HttT S19b Improve Void Armor'

Sync to master v1.13.5+dev (3cc2d09-Clean) and re-tested

_19AUG2016_

Removed commit 'HttT S12 Added ambiance (fog)'

Updated commit 'HttT S19a Improve Flaming Sword' for typo and [message] big fixed

Updated commit 'HttT S14 Consistent objectives' for new {HAS_NO_TURN_LIMIT} macro

Sync to master v1.13.5+dev (7fab085-Clean) and re-tested

_30AUG2016_

Sync to master v1.13.5+dev (b24fdbc-Clean) and re-tested

_06SEP2016_

Updated commit 'HttT Debug choose_level works' removing macro RECALL_ELSE

Sync to master v1.13.5+dev (206096c-Clean) and re-tested

_10SEP2016_

Re-enabled Paladin to use Flaming Sword.

Switched to using unit for speaker when taking Void Armor to allow gender-specific messages.

Sync to master v1.13.5+dev (eb3e27b-Clean) (only tested for the changes)

_13SEP2016_

Removed [kill] before [unit] and cleaned up Li'sar changing sides for choose_level

Sync to master v1.13.5+dev (1af1932-Clean) and re-tested.
