### PR TITLE
HttT S20b Wose Assistance

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/20b_Underground_Channels.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/20b_Underground_Channels.cfg
@@ -26,10 +26,8 @@
                 condition=win
             [/objective]
             [objective]
-                # There’s no actual bonus to be gained yet...
                 [show_if]
-                    [not]
-                    [/not]
+                    {CHECK_VARIABLE met_wose yes}
                 [/show_if]
                 {BONUS_OBJECTIVE_CAPTION}
                 description= _ "Help the Wose fend off the undead attack"
@@ -265,5 +263,374 @@
             bonus=yes
             {NEW_GOLD_CARRYOVER 40}
         [/endlevel]
+    [/event]
+
+# This place was virtually empty, but there were notes indicating something more was intended.
+#
+# Sub-quest: help the wose with the undead (per original notes).
+# Requirements: the undead and wose leaders must still be alive
+# Start Trigger: first meeting with any wose
+# Success Trigger: the death of the undead leader at the hands of side 1; the wose leader must still be alive
+# Complication: other sides might kill the undead leader first.
+# Result: a book appears at (1,1)
+# Effect: taking the book grants movement cost 1 through forest, forest defense 70%, and ambush (like Elvish Ranger)
+# Only some units can read the book. Those who cannot: Delfador, Elves, Dwarves, Merfolk, Horsemen and Mages.
+#
+# I chose these effects because we're close to the end, the next scenario (S22) has some large forests but,
+# thereafter, there is not a lot of use for forest skills, since most of theterritory is open grasslands.
+# So these effects should not have too large an effect upon the remaining parts of the campaign.
+#
+# GL-2016JUL
+
+# Haralamdum is ancient, and his mind does not work well any more. He takes things very slowly and carefully, even for a Wose. He halts and pauses, often searching for something in his memory, using meaningless syllables to fill the gap. The syllables of his name come from the phrase he uses to mean "that is all" or "I am done" which he says often, usually out of frustration with how hasty everyone seems. Nobody alive knows his real name, and he has likely forgotten as well. Feel free to add, move, or remove pauses to break up, or even scatter, his train of thought. For inspiration, think of Asperger Syndrome.
+
+# For background references, see Delfador's Memoirs, scenario 8 ("Ur Thorodor").
+
+    [event]
+        name=prestart
+
+        {VARIABLE met_wose no}
+    [/event]
+
+    [event]
+        name=victory
+
+        {CLEAR_VARIABLE book_taken,met_wose}
+    [/event]
+
+    [event]
+        name=die
+        [filter]
+            id=Haralamdum
+        [/filter]
+
+        [message]
+            speaker=narrator
+            image="wesnoth-icon.png"
+            message= _ "From far in the distance comes the sound of branches snapping, followed by a long, hollow boom. The world goes silent for a moment."
+        [/message]
+
+        [message]
+            speaker=Kalenz
+            message= _ "Can you feel it? It is as if the entire forest is stunned! Something has happened and, I fear, not for the good."
+        [/message]
+    [/event]
+
+    [event]
+        name=die
+        [filter]
+            id=Muff Argulak
+        [/filter]
+
+        [message]
+            speaker=narrator
+            image="wesnoth-icon.png"
+            message= _ "A hollow screech echoes throughout the caverns. The air suddenly seems fresher and lighter."
+        [/message]
+
+        [if]
+            [not]
+                {CHECK_VARIABLE second_unit.side 1}
+            [/not]
+            [then]
+                [message]
+                    speaker=Delfador
+                    message= _ "Whatever that was, the world rejoices."
+                [/message]
+            [/then]
+        [/if]
+    [/event]
+
+    [event]
+        name=sighted
+        [filter]
+            side=4
+        [/filter]
+        [filter_second]
+            side=1
+        [/filter_second]
+        [filter_condition]
+            [have_unit]
+                id=Muff Argulak
+            [/have_unit]
+            [have_unit]
+                id=Haralamdum
+            [/have_unit]
+        [/filter_condition]
+
+        [if]
+            {CHECK_VARIABLE unit.id Haralamdum}
+            [then]
+                [message]
+                    speaker=second_unit
+                    message= _ "Greetings, Sir Wose. We seek the exit to these caverns."
+                [/message]
+                [message]
+                    speaker=unit
+                    message= _ "If ... hmm dum ... you could help rid us of these ... alam hurum ... infernal undead, I would be ... alam alam ... look to the north and east ... hmm ... most grateful. Har alam dum."
+                [/message]
+            [/then]
+            [else]
+
+                # Intentionally courtly and formal here as a counter-point to the rough going when talking to Haralamdum.
+
+                [message]
+                    speaker=unit
+                    message= _ "Well met, stranger."
+                [/message]
+                [message]
+                    speaker=second_unit
+                    message= _ "Well met, indeed. We seek the exit to these caverns."
+                [/message]
+                [message]
+                    speaker=unit
+                    message= _ "Then you should look to the north and east. But, if you would, might we ask your assistance."
+                [/message]
+                [message]
+                    speaker=second_unit
+                    message= _ "What aid might we offer?"
+                [/message]
+                [message]
+                    speaker=unit
+                    message= _ "If you would help rid these caverns of those infernal undead, the Ancient One would be most grateful."
+                [/message]
+                [message]
+                    speaker=second_unit
+                    message= _ "Ancient one?"
+                [/message]
+                [message]
+                    speaker=unit
+                    message= _ "Our elder. Called, by some, Haralamdum."
+                [/message]
+            [/else]
+        [/if]
+
+        {VARIABLE met_wose yes}
+        [show_objectives][/show_objectives]
+
+        [event]
+            name=die
+            [filter]
+                id=Haralamdum
+            [/filter]
+
+            {VARIABLE met_wose no}
+        [/event]
+
+        [event]
+            name=die
+            [filter]
+                id=Muff Argulak
+            [/filter]
+            [filter_second]
+                [not]
+                    side=1
+                [/not]
+            [/filter_second]
+
+            {VARIABLE met_wose no}
+        [/event]
+
+        [event]
+            name=die
+            [filter]
+                id=Muff Argulak
+            [/filter]
+            [filter_second]
+                side=1
+            [/filter_second]
+            [filter_condition]
+                {CHECK_VARIABLE met_wose yes}
+                [have_unit]
+                    id=Haralamdum
+                [/have_unit]
+            [/filter_condition]
+
+            [message]
+                speaker=Haralamdum
+
+                message= _ "Har hum har ... hmm ... well ... har alam dum ... good."
+            [/message]
+
+            [message]
+                speaker=Konrad
+                message= _ "Those undead will bother you no more, Sir Wose."
+            [/message]
+
+            [delay]
+                time=2000
+            [/delay]
+
+            [message]
+                speaker=Delfador
+                message= _ "We still must find the exit from these caverns, Konrad."
+            [/message]
+
+            [message]
+                speaker=Konrad
+                message= _ "Yes, Delfador. I'm afraid we must be going, Sir Wose."
+            [/message]
+
+            [message]
+                speaker=Haralamdum
+                message= _ "Well, I say ... hmm dum har ... young Master Delfador? Harum-alam-alam. So it is! Hmm hmm alam ... how is your head?"
+            [/message]
+
+            [message]
+                speaker=Delfador
+                message= _ "My head?"
+            [/message]
+
+            [message]
+                speaker=Haralamdum
+
+                # "just the other day" probably means a few decades ago. To Haralamdum, Ur Thorodor is a very young Wose ... a small, young twig on the end of a new branch of an ancient tree, who has not yet earned the honorific 'Ur'
+
+                message= _ "Just the other day ... hmm ... I was speaking with that twig ... alam ... alam dum ... Thorodor? Hmm ... yes ... hum ... he said you took a ... alam har ... nasty blow to the head ... hmm ... and he feared you were dead."
+            [/message]
+
+            [message]
+                speaker=Delfador
+
+                # Over 50 years ago, probably 52, to be more precise.
+
+                message= _ "That was many years ago, I'm afraid. Now, we really must be moving along ..."
+            [/message]
+
+            [message]
+                speaker=Haralamdum
+                message= _ "So hasty ... hmm ... there was something ..."
+            [/message]
+
+            [message]
+                speaker=Haralamdum
+                message= _ "Har dum ... oh, yes, the book."
+            [/message]
+
+            [message]
+                speaker=Delfador
+                message= _ "Book?"
+            [/message]
+
+            [message]
+                speaker=Haralamdum
+                message= _ "When you asked Thorodor for ... harum ... assistance? Hmm ... hmm ... He thought you meant the book ... har hmm ... but you had rushed off ... alam ... alam dum ... and died before he could tell you I have it."
+            [/message]
+
+            [message]
+                speaker=Delfador
+                message= _ "I remember no book."
+            [/message]
+
+            [message]
+                speaker=Haralamdum
+                message= _ "I am sure ... dum hum ... well, the head ... alam lum alam ... yes, it was somewhere around here ... hum dum da dum ... Thorodor thought it ... hmm ... quite important ... lum harum dum ... perhaps near my home stump?"
+            [/message]
+
+            [message]
+                speaker=Delfador
+                message= _ "I am sorry, I remember no book. Now, we really must be off."
+            [/message]
+
+            [message]
+                speaker=Haralamdum
+                message= _ "So hasty. Har alam dum."
+            [/message]
+
+            [message]
+                speaker=narrator
+                image="wesnoth-icon.png"
+                message= _ "The wose silently fade into the forest."
+            [/message]
+
+            [kill]
+                side=4
+            [/kill]
+
+            {PLACE_IMAGE items/book4.png 1 1}
+            {VARIABLE book_taken no}
+            {VARIABLE met_wose no}
+
+            [event]
+                name=moveto
+                first_time_only=no
+                [filter]
+                    side=1
+                    x,y=1,1
+                [/filter]
+
+                [if]
+                    [not]
+                        {CHECK_VARIABLE book_taken yes}
+                    [/not]
+                    [then]
+                        [message]
+                            speaker=narrator
+                            image="wesnoth-icon.png"
+                            message= _ "Should $unit.name| read the book?"
+                            [option]
+                                label= _ "Yes"
+                                [command]
+                                    [object]
+                                        id=wose_lore
+                                        name= _ "Wose Lore"
+                                        image="items/book4.png"
+                                        duration=forever
+                                        description= _ "This massive book is filled with the Lore and Legends of the Wose. Any who read it learn deeply of the ways of the twig and leaf, the tree and the forest."
+                                        cannot_use_message= _ "The book is filled with meaningless tales of sticks and leaves, and childish stories about trees and forest creatures."
+                                        [filter]
+                                            x,y=1,1
+                                            [not] # Elvish Rangers already know this
+                                                type_tree=Elvish Ranger
+                                            [/not]
+                                        [/filter]
+                                        [then]
+                                            {VARIABLE book_taken yes}
+                                            [remove_item]
+                                                x,y=1,1
+                                            [/remove_item]
+                                            [message]
+                                                speaker=narrator
+                                                image="wesnoth-icon.png"
+                                                message= _ "Upon finishing the book, $unit.name| has a much greater understanding of the forest, its nature and ways, and all the creatures within it. Unfortunately, as the last page was turned, the book crumbled to dust."
+                                            [/message]
+                                        [/then]
+                                        [effect]
+                                            apply_to=new_ability
+                                            [abilities]
+                                                {ABILITY_AMBUSH}
+                                            [/abilities]
+                                        [/effect]
+                                        [effect]
+                                            apply_to=defense
+                                            replace=yes
+                                            [defense]
+                                                forest=30
+                                            [/defense]
+                                        [/effect]
+                                        [effect]
+                                            apply_to=movement_costs
+                                            replace=yes
+                                            [movement_costs]
+                                                forest=1
+                                            [/movement_costs]
+                                        [/effect]
+                                    [/object]
+                                [/command]
+                            [/option]
+                            [option]
+                                label= _ "No"
+                                [command]
+                                    [allow_undo][/allow_undo]
+                                [/command]
+                            [/option]
+                        [/message]
+                    [/then]
+                    [else]
+                        [allow_undo][/allow_undo]
+                    [/else]
+                [/if]
+            [/event]
+        [/event]
     [/event]
 [/scenario]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/25_HttT_Epilogue.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/25_HttT_Epilogue.cfg
@@ -72,6 +72,7 @@
 #	- if you bring a merman to a section of deep water in The Lost General, you can rescue a trapped dwarf
 #	- if you keep your ally leader alive in The Lost General, he allows you to recruit Dwarvish Guardsmen
 #	- if you bring a merman to the start of the River Longlier, you will unlock a series of two bonus scenarios
+#	- if you help the wose in a bonus scenario you get a book which grants special powers to the reader
 #	- if you visit the Elvish great tree living on the Plains of Snow, you are given a magical flaming sword
 #	- if you kill one of the Death Knights in the Swamp of Dread, it will drop a strong piece of armor
 #	- if you kill all 4 of the Death Knights in the Swamp of Dread, it severely weakens the Lich, dropping its HP by half


### PR DESCRIPTION
This Pull Request is part of a series of corrections and improvements to the HttT ('Heir to the Throne') campaign.

When merging or testing, please be aware that a PR deeper in the hierarchy will have merge conflicts unless each higher PR has already been applied. If this presents a problem, contact me and I will re-factor the hierarchy as required. At present, the best options to contact me are either as comments on one of these pull requests, or by creating an Issue on my personal fork.

**Hierarchy**

    master
    |
    +-- GregoryLundberg:GL_HttT_general_improvements ( PR #730 )
        |
        +-- GregoryLundberg:GL_HttT_S05b_use_advisor ( PR #731 )
        |
        +-- GregoryLundberg:GL_HttT_S05b_randomize_temples ( PR #732 )
        |
        +-- GregoryLundberg:GL_HttT_S06_logical_thieves ( PR #733 )
        |
        +-- GregoryLundberg:GL_HttT_S07_ambushers_reduced ( PR #734 )
        |
        +-- GregoryLundberg:GL_HttT_S13_snow_detritus ( PR #735 )
        |
        +-- GregoryLundberg:GL_HttT_S20b_wose_assistance ( PR #736 )
        |
        +-- GregoryLundberg:GL_HttT_S22_gryphons_return ( PR #737 )

**GregoryLundberg:GL_HttT_general_improvements**
These are general improvements of my own. Each patch is fairly localized and should be easy to follow. Individual patches should be easy to cherry pick, if desired. The only complex patch is the last, which touches many files, and gets the debug command 'choose_level' working.

**GregoryLundberg:GL_HttT_S05b_use_advisor**
This implements a TODO item. It selects the advisor Konrad will have at the start of S06 ('The Siege of Elensefar') and uses that advisor for a comment, apparently coming from inside the ship, when it arrives.

**GregoryLundberg:GL_HttT_S05b_randomize_temples**
This implements a TODO item. It randomizes the temple contents.

**GregoryLundberg:GL_HttT_S06_logical_thieves**
This is an improvement of my own. It handles the Thieves' Guild in a more logical manner. Mainly, they will simply join forces in cases where Konrad has already passed the point where an offer of help makes sense.

**GregoryLundberg:GL_HttT_S07_ambushers_reduced**
This implements a TODO item. The number of ambushes reduces based upon the number of enemy leaders killed in S01 ('The Elves Besieged').

**GregoryLundberg:GL_HttT_S13_snow_detritus**
This implements a TODO item. It adds random snow on up to 1/3rd the non-snow tiles, based upon the snow coverage (that is, turns to completion) from S12 ('Northern Winter').

**GregoryLundberg:GL_HttT_S20b_wose_assistance**
This implements a TODO item. It adds a bonus sub-quest assisting the wose in dealing with the undead. The reward is a book which, when read, grants forest movement cost 1, forest defense 70%, and forest ambush (as with an Elvish Ranger). This reward was chosen because it offers some assistance in S22 ('Return to Wesnoth') and has limited, or no, use in the following scenarios.

**GregoryLundberg:GL_HttT_S22_gryphons_return**
This implements a TODO item. If Konrad did not injure or kill the gryphons in S10 ('Gryphon Mountain'), a flight of gryphons return to assist Konrad in S22 ('Return to Wesnoth'). Remember, for the gryphons to arrive, Konrad must have forgone their eggs and, therefore, has no Gryphon Riders. This lack of Gryphon Riders will be most felt in the final two scenario, and especially on the large, open plains of S23 ('The Test of the Clans').

**KNOWN BUGS**

Multiple-tile units with animation leave visual artifacts as they move. This is most noticeable with the Gryphons and Gryphon Riders as they move using move_unit_fake in S10 ('Gryphon Mountain'), S14 ('Plunging into Darkness') and S22 ('Return to Wesnoth'). The artifacts clear fairly quickly, and are all removed at the end of the movement.

The game engine appears to have memory-leak issues. When play-testing, after loading several dozen scenario, memory usage will have grown quite large. This can cause the system to begin to swap (if your system has swap space), which severely degrades performance. To work around the issue, I keep an eye on memory use and restart the engine when it approaches the limit.

There are a few remaining user-interface issues such as the popup messages sometimes not appearing.

**NOTES**

I have tested each fork to ensure no merge conflicts occur, provided the required upper-level forks have already been merged. I found no problems using simple merges. I did, however, run into problems with rebase. If you need to rebase after merging these forks and get merge conflicts, abort your rebase (git rebase --abort). In general, such merge conflicts occur because git can re-order the commits; but that re-ordering can be avoided, preventing merge conflicts, with an interactive rebase. Contact me if you need assistance using rebase.

The debug command choose_level works well, now. In general, when testing, you can switch from any scenario to any other. Internal state, such as which path you took from S04 ('The Bay of Pearls') .. S05a ('Muff Malal's Peninsula') or S05b ('The Isle of the Damned') .. or the amount of snow which fell in S12 ('Northern Winter') is maintained until you visit the scenario which sets the state. Thus, if you want to test with the various incarnations of Moremirmu in S09 ('The Valley of Death'), you simply need to use choose_level to jump to S05a or S05b, then jump back to S09 once you have the desired state.

The debug command next_level also works well. But, since there is no way to know if you used next_level command, it always advances to the default next level. At points where there is a branch, S04 ('The Bay of Pearls') and S18 ('A Choice Must Be Made'), you must either play through, or use the choose_level command if you do not want to follow the default choice.

When using the choose_level command, be aware that game state, such as your gold balance, and your recall list (including your Heros) is NOT CHANGED. This means, yes, it is possible to advance your Heros and jump to S01 ('The Elves Besieged') and have Konrad, Li'sar and Kalenz, along with a host of other L3 units, even Gryphon Riders or Gryphons, if you have always wanted to clear the board of those pesky orcs.

There are times when a Hero (generally Delfador or Li'sar) cannot be on the map, either for story purposes or because that Hero is already in that scenario. In these cases your Hero is saved and, if you are using choose_level to jump around, will be restored once you leave the area.

Similarly, there are times when a unit will join Konrad's forces. For example, Haldiel in S02 ('Blackwater Port'). If you already have Haldiel in your recall list and choose_level to jump to Blackwater Port, Haldiel will be removed from your recall list, and a new Haldiel will appear at the appropriate time. For those units which only appear depending upon your actions, they will only be removed from your recall list (or the map) should you take the action which causes their appearance.

**CHANGES**

_07AUG2016_

GL_unique_items has been merged to master.

Spelling and grammar corrections on this document and PR titles. Unfortunately, the typo in a branch name has to stay.

Spelling and grammar corrections on commit messages.

Removed underscores in custom event names 'home destroyed' and 'victory dance'.

Spelling and grammar corrections in commit 'HttT S20a Fix bug: El'rien might be dead'

Spelling and grammar corrections in commit 'HttT S20b Fix bug: Bona-Melodia may be dead'

Corrected filter for moving side in commit 'HttT S08 Adjust closing-in area'

Spelling and grammar corrections, and eliminated po comments in commit 'HttT S20b Wose assistance quest'

_08AUG2016_

Clean up [objectives] handling for commit 'HttT S10 Change objectives'

Clean up the hidden advisor to use a galleon unit instead of a shallow copy for commit 'HttT S05b Use an Advisor'

Moved lua inline, removing custom tag, for commit 'HttT S13 Add some random snow'

Clean up [objectives] handling for commit 'HttT S19c Fix bug: Wrong objectives'

_10AUG2016_

Sync to master v1.13.5+dev (6235e18-Clean) and re-tested

_11AUG2016_

Removed commit 'HttT S21 Fix bug: No save'

Sync to master v1.13.5+dev (cf4f488-Clean) and re-tested

Finally got commit 'HttT S05b Use an Advisor' working just the way I always envisioned

_12AUG2016_

Removed workaround commit for [object] issues on S08, S11 and S16.

Sync to master v1.13.5+dev (265e41d-Clean)

_12AUG2016_

GL_HttT_errors has been merged to master

Sync to master v1.13.5+dev (12f7107-Clean) and re-tested

_13AUG2016_

Cleanup since [hide_unit] now works for commit 'HttT S05b Use an Advisor'

Audited and corrected state variables for 'HttT Debug choose_level works'

Clean up [objectives] handling for commit 'HttT S20b Wose assistance quest'

Only leaders count for commit 'HttT S07 Ambushers reduced'

Changed the subject from you to the unit in commit 'HttT S19a Improve Flaming Sword'

Changed the subject from you to the unit in commit 'HttT S19b Improve Void Armor'

Sync to master v1.13.5+dev (3cc2d09-Clean) and re-tested

_19AUG2016_

Removed commit 'HttT S12 Added ambiance (fog)'

Updated commit 'HttT S19a Improve Flaming Sword' for typo and [message] big fixed

Updated commit 'HttT S14 Consistent objectives' for new {HAS_NO_TURN_LIMIT} macro

Sync to master v1.13.5+dev (7fab085-Clean) and re-tested

_30AUG2016_

Sync to master v1.13.5+dev (b24fdbc-Clean) and re-tested

_06SEP2016_

Updated commit 'HttT Debug choose_level works' removing macro RECALL_ELSE

Sync to master v1.13.5+dev (206096c-Clean) and re-tested

_10SEP2016_

Re-enabled Paladin to use Flaming Sword.

Switched to using unit for speaker when taking Void Armor to allow gender-specific messages.

Sync to master v1.13.5+dev (eb3e27b-Clean) (only tested for the changes)

_13SEP2016_

Removed [kill] before [unit] and cleaned up Li'sar changing sides for choose_level

Sync to master v1.13.5+dev (1af1932-Clean) and re-tested.
