### PR TITLE
Use info level

### DIFF
--- a/src/generators/cave_map_generator.cpp
+++ b/src/generators/cave_map_generator.cpp
@@ -99,7 +99,7 @@ cave_map_generator::cave_map_generator_job::cave_map_generator_job(const cave_ma
 {
 	uint32_t seed = randomseed.get_ptr() ? *randomseed.get_ptr() : seed_rng::next_seed();
 	rng_.seed(seed);
-	std::cerr << "creating random cave with seed:" << seed << std::endl;
+	LOG_NG << "creating random cave with seed: " << seed << '\n';
 	flipx_ = int(rng_() % 100) < params.flipx_chance_;
 	flipy_ = int(rng_() % 100) < params.flipy_chance_;
 


### PR DESCRIPTION
The cave map generator displays the seed on stderr. Move it to the logging system at 'info' level.