### PR TITLE
Add result variable to [message] tag

### DIFF
--- a/changelog
+++ b/changelog
@@ -18,6 +18,11 @@ Version 1.13.5+dev:
    * Fix game map sometimes showing and buttons sometimes not rendered properly in story screen (bug #24553)
    * Improved font rendering on Windows.
  * WML Engine:
+   * New attributes for [message] with [option]
+     - Added variable= to [message]: if specified, gives variable name to receive the [option] index (1..n) selected
+       only used if any [option] appear
+     - Added value= to [option]: if specified, gives value to store in variable instead of index number, only used
+       if variable= appears in [message]
    * New attributes for [role]:
      - search_recall_list=yes|no|only(default yes) controls where to look
      - reassign=yes|no(default yes) if no, check for a unit and do not assign to another

--- a/data/lua/wml/message.lua
+++ b/data/lua/wml/message.lua
@@ -287,6 +287,7 @@ function wesnoth.wml_actions.message(cfg)
 					description = option.description,
 					image = option.image,
 					default = option.default,
+					value = option.value
 				}
 				if option.message then
 					if not option.label then
@@ -389,6 +390,14 @@ function wesnoth.wml_actions.message(cfg)
 			log("invalid choice (" .. option_chosen .. ") was specified, choice 1 to " ..
 				#options .. " was expected", "debug")
 			return
+		end
+
+		if cfg.variable ~= nil then
+			if options[option_chosen].value == nil then
+				wesnoth.set_variable(cfg.variable, option_chosen)
+			else
+				wesnoth.set_variable(cfg.variable, options[option_chosen].value)
+			end
 		end
 
 		for i, cmd in ipairs(option_events[option_chosen]) do


### PR DESCRIPTION
If [message] includes one or more [option] choices, store the choice index in the result variable. If [option] has value=, use that instead of the index number.

Simple example of use:

    [message]
        variable=choice
        speaker=narrator
        message="Choose option 1 through 4"
        [option]
            label="Option 1"
            value="One"
        [/option]
        [option]
            label="Option 2"
        [/option]
        [option]
            label="Option 3"
            value="Tres"
        [/option]
        [option]
            label="Option 4"
        [/option]
    [/message]
    [message]
        speaker=narrator
        message="You chose option number $choice|"
    [/message]
    {CLEAR_VARIABLE choice}

In examining AToTB, there is a lot of work in [command] blocks which can be eliminated if we simply know which of 1..4 was chosen. I imagine this is not all that unusual a use case.