### PR TITLE
HAS_NO_TURN_LIMIT objectives macro

### DIFF
--- a/changelog
+++ b/changelog
@@ -18,6 +18,7 @@ Version 1.13.5+dev:
    * Fix game map sometimes showing and buttons sometimes not rendered properly in story screen (bug #24553)
    * Improved font rendering on Windows.
  * WML Engine:
+   * Added {HAS_NO_TURN_LIMIT} macro for objectives
    * New attributes for [message] with [option]
      - Added variable= to [message]: if specified, gives variable name to receive the [option] index (1..n) selected
        only used if any [option] appear

--- a/data/core/macros/objective-utils.cfg
+++ b/data/core/macros/objective-utils.cfg
@@ -48,3 +48,9 @@
         description="<b>" + _"This is the last scenario." + "</b>"
     [/note]
 #enddef
+
+#define HAS_NO_TURN_LIMIT
+    [note]
+        description= "<b>" + _"No turn limit" + "</b>"
+    [/note]
+#enddef


### PR DESCRIPTION
A convenience macro to add a standardized note to the objectives pointing out there is no turn limit.

I considered going through all the mainline scenario with turns=-1 and adding this, but decided it would be best to wait and change each, after consideration for each case, when reviewing them.