### PR TITLE
AToTB S02 Improve AI

### DIFF
--- a/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
@@ -178,6 +178,11 @@ Besides... I want my brother back."
         [ai]
             leader_ignores_keep=yes
             village_value=0
+
+            [modify_ai]
+                action=delete
+                path=stage[main_loop].candidate_action[villages]
+            [/modify_ai]
         [/ai]
 
 #ifdef EASY


### PR DESCRIPTION
This tells the AI for side 3 to ignore villages as candidate actions. This finishes the changes making side 3 move toward the player (side 1) without distraction.

I just learned of this, and tested it. Works great.