### PR TITLE
Add mode=replace to [modify_unit]

### DIFF
--- a/changelog
+++ b/changelog
@@ -3597,6 +3597,8 @@ Version 1.9.7:
    * Fixed bug #18000, #18099: Show a wrongly entered MP password and crash
      upon editing this text.
  * WML engine:
+   * added mode=replace to [modify_unit] to replace rather than merge unit subtags
+     (does not apply to object, trait, effect, or advancement)  
    * new attribute team_name= in SSFs
    * added [event][filter_side]<SSF keys> support
    * added support for inline SSF to [chat]

--- a/data/lua/wml/modify_unit.lua
+++ b/data/lua/wml/modify_unit.lua
@@ -5,9 +5,11 @@ local wml_actions = wesnoth.wml_actions
 function wml_actions.modify_unit(cfg)
 	local unit_variable = "LUA_modify_unit"
 
+	local replace_mode = cfg.mode == "replace"
+
 	local function handle_attributes(cfg, unit_path, toplevel)
 		for current_key, current_value in pairs(helper.shallow_parsed(cfg)) do
-			if type(current_value) ~= "table" and (not toplevel or current_key ~= "type") then
+			if type(current_value) ~= "table" and (not toplevel or (current_key ~= "type" and current_key ~= "mode")) then
 				wesnoth.set_variable(string.format("%s.%s", unit_path, current_key), current_value)
 			end
 		end
@@ -64,6 +66,9 @@ function wml_actions.modify_unit(cfg)
 					helper.wml_error("[modify_unit] had invalid [effect]apply_to value")
 				end
 			else
+				if replace_mode then
+					wesnoth.set_variable(string.format("%s.%s", unit_path, current_tag), {})
+				end
 				local tag_index = children_handled[current_tag] or 0
 				handle_child(current_table[2], string.format("%s.%s[%u]",
 					unit_path, current_tag, tag_index))


### PR DESCRIPTION
When specified, replace rather than merge the [unit] sub-tags. Does not effect [object], [trait], [effect] or [advancement].

For example:

    [modify_unit]
        [filter]
            id=Deoran
        [/filter]
        mode=replace

        [filter_recall]
            [not]
                id="Sir Gerrick"
            [/not]
        [/filter_recall]
    [/modify_unit]

will replace the current contents of [filter_recall] with the given contents. Without mode=replace, the contents would be appended to the previous contents.