### PR TITLE
Fix bug [role] missing role=

### DIFF
--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -900,7 +900,7 @@ end
 function wml_actions.role(cfg)
 	-- role= and type= are handled differently than in other tags,
 	-- so we need to remove them from the filter
-	local role = cfg.role
+	local role = cfg.role or ""
 	local filter = helper.shallow_literal(cfg)
 
 	local types = {}


### PR DESCRIPTION
Missing role for [role] caused runtime errors. Do NOT report an error on this; using an empty string is intentional. It allows type-prioritized recalls!

"I want to recall the two highest-level bowmen and, if needed, will recruit them. They don't have a role, and won't need one later."

        [repeat]
            times=2
            [do]
                [role]
                    search_recall_list=only
                    type=Master Bowman,Longbowman,Bowman
                    [auto_recall][/auto_recall]
                    [else]
                        [unit]
                            placement=leader
                            side=1
                            type=Bowman
                        [/unit]
                    [/else]
                [/role]
            [/do]
        [/repeat]