### PR TITLE
[role] always error on missing role=

### DIFF
--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -904,11 +904,7 @@ function wml_actions.role(cfg)
 	local filter = helper.shallow_literal(cfg)
 
 	if role == nil then
-		if helper.get_child("auto_recall") ~= nil then
-			role = ""
-		else
-			helper.wml_error("missing role= in [role]")
-		end
+		helper.wml_error("missing role= in [role]")
 	end
 
 	local types = {}


### PR DESCRIPTION
I changed my Felony Abuse of a Feature to use role="" to suppress the wml_error message.

It's best to always issue the error, even if we're going to auto_recall