### PR TITLE
Allow screen resolution to change in fullscreen (Bug #24583)

### DIFF
--- a/changelog
+++ b/changelog
@@ -38,6 +38,7 @@ Version 1.13.5+dev:
      than the default are installed
    * Redesigned game dropdown/context menu appearance
    * New categories bar in hotkey preferences allows you to filter hotkeys
+   * Screen resolution while in fullscreen possible again (bug #24583)
  * WML Engine:
    * Added {HAS_NO_TURN_LIMIT} macro for objectives
    * New attributes for [message] with [option]

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -340,7 +340,7 @@ void tpreferences::post_build(twindow& window)
 	tmenu_button& res_list = find_widget<tmenu_button>(&window, "resolution_set", false);
 
 	res_list.set_use_markup(true);
-	res_list.set_active(!fullscreen());
+	res_list.set_active(true);
 
 	set_resolution_list(res_list, window.video());
 
@@ -1016,7 +1016,6 @@ void tpreferences::fullscreen_toggle_callback(twindow& window)
 	tmenu_button& res_list = find_widget<tmenu_button>(&window, "resolution_set", false);
 
 	set_resolution_list(res_list, window.video());
-	res_list.set_active(!ison);
 }
 
 void tpreferences::handle_res_select(twindow& window)

--- a/src/sdl/window.cpp
+++ b/src/sdl/window.cpp
@@ -93,7 +93,7 @@ void twindow::restore()
 
 void twindow::full_screen()
 {
-	SDL_SetWindowFullscreen(window_, SDL_WINDOW_FULLSCREEN_DESKTOP);
+	SDL_SetWindowFullscreen(window_, SDL_WINDOW_FULLSCREEN);
 }
 
 void twindow::fill(Uint8 r, Uint8 g, Uint8 b, Uint8 a)

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -404,7 +404,7 @@ bool CVideo::init_window()
 	video_flags = get_flags(video_flags);
 
 	if (preferences::fullscreen()) {
-		video_flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+		video_flags |= SDL_WINDOW_FULLSCREEN;
 	} else if (preferences::maximized()) {
 		video_flags |= SDL_WINDOW_MAXIMIZED;
 	}
@@ -451,9 +451,11 @@ void CVideo::setMode(int x, int y, const MODE_EVENT mode)
 			break;
 
 		case TO_RES:
-			window->restore();
 			window->set_size(x, y);
-			window->center();
+			if (!isFullScreen()) {
+				window->restore();
+				window->center();
+			}
 			break;
 	}
 
@@ -542,8 +544,8 @@ Uint8 CVideo::window_state()
 	if (flags & SDL_WINDOW_MAXIMIZED) {
 		state |= SDL_WINDOW_MAXIMIZED;
 	}
-	if (flags & SDL_WINDOW_FULLSCREEN_DESKTOP) {
-		state |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+	if (flags & SDL_WINDOW_FULLSCREEN) {
+		state |= SDL_WINDOW_FULLSCREEN;
 	}
 	return state;
 }
@@ -619,7 +621,7 @@ std::pair<int,int> CVideo::current_resolution()
 }
 
 bool CVideo::isFullScreen() const {
-	return (window->get_flags() & SDL_WINDOW_FULLSCREEN_DESKTOP) != 0;
+	return (window->get_flags() & SDL_WINDOW_FULLSCREEN) != 0;
 }
 
 


### PR DESCRIPTION
When support was added for SDL2, the UI did not allow the screen resolution to change while in full screen. Here I restore this functionality by changing the full screen flag instead of the flag used that makes the full screen take on the desktop resolution.

https://gna.org/bugs/?24583