### PR TITLE
Snub warnings

### DIFF
--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -181,14 +181,14 @@ game_launcher::game_launcher(const commandline_options& cmdline_opts, const char
 	{
 		jump_to_editor_ = true;
 		if (!cmdline_opts_.editor->empty())
-			load_data_.reset(new savegame::load_game_metadata{ *cmdline_opts_.editor });
+			load_data_.reset(new savegame::load_game_metadata{ *cmdline_opts_.editor, {}, {}, {}, {}, {}, {} });
 	}
 	if (cmdline_opts_.fps)
 		preferences::set_show_fps(true);
 	if (cmdline_opts_.fullscreen)
 		video().set_fullscreen(true);
 	if (cmdline_opts_.load)
-		load_data_.reset(new savegame::load_game_metadata{ *cmdline_opts_.load });
+		load_data_.reset(new savegame::load_game_metadata{ *cmdline_opts_.load, {}, {}, {}, {}, {}, {} });
 	if (cmdline_opts_.max_fps) {
 		int fps;
 		//FIXME: remove the next line once the weird util.cpp specialized template lexical_cast_default() linking issue is solved
@@ -540,7 +540,7 @@ int game_launcher::unit_test()
 	savegame::replay_savegame save(state_, compression::NONE);
 	save.save_game_automatic(video(), false, "unit_test_replay"); //false means don't check for overwrite
 
-	load_data_.reset(new savegame::load_game_metadata{ "unit_test_replay" , "", true, true, false });
+	load_data_.reset(new savegame::load_game_metadata{ "unit_test_replay" , "", true, true, false, {},{} });
 
 	if (!load_game()) {
 		std::cerr << "Failed to load the replay!" << std::endl;

--- a/src/hotkey/hotkey_handler.cpp
+++ b/src/hotkey/hotkey_handler.cpp
@@ -531,5 +531,5 @@ hotkey::ACTION_STATE play_controller::hotkey_handler::get_action_state(hotkey::H
 
 void play_controller::hotkey_handler::load_autosave(const std::string& filename)
 {
-	throw savegame::load_game_exception({ filename });
+	throw savegame::load_game_exception({ filename, {}, {}, {}, {}, {}, {} });
 }


### PR DESCRIPTION
Add some initializers to quiet GCC warnings about missing initializers.

This fixes the warnings on GCC, don't know what it does with other compilers.