### PR TITLE
Fix bug: Crash loading replay

### DIFF
--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -138,6 +138,8 @@ bool loadgame::load_game_ingame()
 		}
 	}
 
+	load_data_.show_replay |= is_replay_save(load_data_.summary);
+
 	// Confirm the integrity of the file before throwing the exception.
 	// Use the summary in the save_index for this.
 	const config & summary = save_index_manager.get(load_data_.filename);


### PR DESCRIPTION
For reproduce: play a scene, when the next settles down use Menu|Load to load the replay just created for the previous scene.

gtgftd suggested this patch. Seems to work. PR to document change for review.