### PR TITLE
Honor special locations in terrain mask

### DIFF
--- a/changelog
+++ b/changelog
@@ -44,6 +44,14 @@ Version 1.13.5+dev:
    * Fix issue with the title screen not redrawing when the window size or
      fullscreen setting changes with a dialog open over it.
  * WML Engine:
+   * Added ignore_special_locations=yes|no, default no, to [terrain_mask] to
+     ignore the special locations given in the mask, leaving all those on the
+     underlying map unchanged.
+   * [terrain_mask] starting locations and special locations are relative to
+     the mask. Existing names replace any in the underlying map regardless of
+     their location. Each name as a unique location; but a location may have
+     any number of names. While a map/mask can give only one name per location;
+     stacking masks allows multiple names. Names cannot be removed.
    * Added {HAS_NO_TURN_LIMIT} macro for objectives
    * New attributes for [message] with [option]
      * Added variable= to [message]: if specified, gives variable name to

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -325,13 +325,14 @@ void gamemap::overlay(const gamemap& m, const config& rules_cfg, int xpos, int y
 			}
 			else {
 				set_terrain(map_location(x2,y2), t);
-				if (false /*TODO: add overwrite special locs paramter*/) {
-					starting_positions_.right.erase(t_translation::coordinate(x2, y2));
-					for (auto& pair : m.starting_positions_.right.equal_range(t_translation::coordinate(x1, y1))) {
-						starting_positions_.insert(tstarting_positions::value_type(pair.second, t_translation::coordinate(x2, y2)));
-					}
-				}
 			}
+		}
+	}
+
+	if (!rules_cfg["ignore_special_locations"].to_bool(false)) {
+		for(auto& pair : m.starting_positions_.left) {
+			starting_positions_.left.erase(pair.first);
+			starting_positions_.insert(tstarting_positions::value_type(pair.first, t_translation::coordinate(pair.second.x + xpos, pair.second.y + ypos+ ((xpos & 1) && (pair.second.x & 1) ? 1 : 0))));
 		}
 	}
 }


### PR DESCRIPTION
Added overlay_special_locations=yes|no, default no, to [terrain_mask]. When yes, side starting locations and special locations marked in the mask replace those in the effected area of the underlying map by removing any from the underlying map, and applying only those given in the mask.