### PR TITLE
Change most vector<bool> to dynamic_bitset

### DIFF
--- a/src/actions/vision.cpp
+++ b/src/actions/vision.cpp
@@ -35,6 +35,8 @@
 #include "team.hpp"
 #include "units/unit.hpp"
 
+#include <boost/dynamic_bitset.hpp>
+
 class unit_animation;
 
 static lg::log_domain log_engine("engine");
@@ -636,7 +638,8 @@ bool actor_sighted(const unit & target, const std::vector<int> * cache)
 	const map_location & target_loc = target.get_location();
 
 	// Determine the teams that (probably) should get events.
-	std::vector<bool> needs_event(teams_size, cache == nullptr);
+	boost::dynamic_bitset<> needs_event;
+	needs_event.resize(teams_size, cache == nullptr);
 	if ( cache != nullptr ) {
 		// Flag just the sides in the cache as needing events.
 		for (int side : *cache)

--- a/src/addon/manager_ui.cpp
+++ b/src/addon/manager_ui.cpp
@@ -42,6 +42,8 @@
 
 #include "addon/client.hpp"
 
+#include <boost/dynamic_bitset.hpp>
+
 static lg::log_domain log_config("config");
 static lg::log_domain log_network("network");
 static lg::log_domain log_filesystem("filesystem");
@@ -447,7 +449,7 @@ public:
 struct addons_filter_state
 {
 	std::string keywords;
-	std::vector<bool> types;
+	boost::dynamic_bitset<> types;
 	ADDON_STATUS_FILTER status;
 	// Yes, the sorting criterion and direction are part of the
 	// filter options since changing them requires rebuilding the
@@ -489,14 +491,14 @@ public:
 
 		dlg.show(video_);
 
-		const std::vector<bool> new_types = dlg.displayed_types();
+		const boost::dynamic_bitset<> new_types = dlg.displayed_types();
 		const ADDON_STATUS_FILTER new_status = dlg.displayed_status();
 		const ADDON_SORT new_sort = dlg.sort();
 		const ADDON_SORT_DIRECTION new_direction = dlg.direction();
 
 		assert(f_.types.size() == new_types.size());
 
-		if(std::equal(f_.types.begin(), f_.types.end(), new_types.begin()) && f_.status == new_status &&
+		if(f_.types == new_types && f_.status == new_status &&
 		   f_.sort == new_sort && f_.direction == new_direction) {
 			// Close the manager dialog only if the filter options changed.
 			return gui::CONTINUE_DIALOG;

--- a/src/game_initialization/multiplayer_lobby.hpp
+++ b/src/game_initialization/multiplayer_lobby.hpp
@@ -22,6 +22,8 @@
 #include "image.hpp"
 #include "serialization/string_utils.hpp"
 
+#include <boost/dynamic_bitset.hpp>
+
 class config;
 class video;
 class CVideo;
@@ -212,8 +214,8 @@ private:
 		lobby_sorter(const config& cfg);
 	};
 
-	std::vector<bool> game_vacant_slots_;
-	std::vector<bool> game_observers_;
+	boost::dynamic_bitset<> game_vacant_slots_;
+	boost::dynamic_bitset<> game_observers_;
 
 	gui::button observe_game_;
 	gui::button join_game_;

--- a/src/gui/dialogs/addon/filter_options.cpp
+++ b/src/gui/dialogs/addon/filter_options.cpp
@@ -30,6 +30,8 @@
 
 #include "utils/functional.hpp"
 
+#include <boost/dynamic_bitset.hpp>
+
 namespace
 {
 bool unchecked_bool_field_finder(gui2::twindow& window,
@@ -150,7 +152,7 @@ void taddon_filter_options::register_displayed_type_field(
 			register_bool(field_id, true, displayed_types_[addon_type]));
 }
 
-void taddon_filter_options::read_types_vector(const std::vector<bool>& v)
+void taddon_filter_options::read_types_vector(const boost::dynamic_bitset<>& v)
 {
 	for(size_t k = 0; k < displayed_types_.size(); ++k) {
 		// All unspecified types default to visible.

--- a/src/gui/dialogs/addon/filter_options.hpp
+++ b/src/gui/dialogs/addon/filter_options.hpp
@@ -22,6 +22,7 @@
 #include "addon/state.hpp"
 
 #include <array>
+#include <boost/dynamic_bitset.hpp>
 
 namespace gui2
 {
@@ -33,13 +34,12 @@ class taddon_filter_options : public tdialog
 public:
 	taddon_filter_options();
 
-	std::vector<bool> displayed_types() const
+	boost::dynamic_bitset<> displayed_types() const
 	{
-		return std::vector<bool>(displayed_types_.begin(),
-								 displayed_types_.end());
+		return boost::dynamic_bitset<>(displayed_types_.begin(), displayed_types_.end());
 	}
 
-	void set_displayed_types(const std::vector<bool>& types)
+	void set_displayed_types(const boost::dynamic_bitset<>& types)
 	{
 		read_types_vector(types);
 	}
@@ -92,7 +92,7 @@ private:
 	void register_displayed_type_field(const std::string& field_id,
 									   ADDON_TYPE addon_type);
 
-	void read_types_vector(const std::vector<bool>& v);
+	void read_types_vector(const boost::dynamic_bitset<>& v);
 
 	void toggle_all_displayed_types_button_callback(twindow& window);
 

--- a/src/gui/dialogs/addon/list.cpp
+++ b/src/gui/dialogs/addon/list.cpp
@@ -173,8 +173,7 @@ void taddon_list::on_filtertext_changed(ttext_* textbox, const std::string& text
 {
 	tlistbox& listbox = find_widget<tlistbox>(textbox->get_window(), "addons", true);
 	filter_transform filter(utils::split(text, ' '));
-	std::vector<bool> res;
-	res.reserve(cfg_.child_count("campaign"));
+	boost::dynamic_bitset<> res;
 	for(const auto& child : cfg_.child_range("campaign"))
 	{
 		res.push_back(filter(child));

--- a/src/gui/dialogs/game_load.cpp
+++ b/src/gui/dialogs/game_load.cpp
@@ -234,7 +234,7 @@ void tgame_load::filter_text_changed(ttext_* textbox, const std::string& text)
 		return;
 	last_words_ = words;
 
-	std::vector<bool> show_items(list.get_item_count(), true);
+	boost::dynamic_bitset<> show_items(list.get_item_count(), true);
 
 	if(!text.empty()) {
 		for(unsigned int i = 0; i < list.get_item_count(); i++) {

--- a/src/gui/dialogs/lobby/info.hpp
+++ b/src/gui/dialogs/lobby/info.hpp
@@ -17,6 +17,7 @@
 
 #include "config.hpp"
 #include "gui/dialogs/lobby/data.hpp"
+#include <boost/dynamic_bitset.hpp>
 class twesnothd_connection;
 /**
  * This class represents the collective information the client has
@@ -86,7 +87,7 @@ public:
 	{
 		return games_;
 	}
-	const std::vector<bool>& games_visibility() const
+	const boost::dynamic_bitset<>& games_visibility() const
 	{
 		return games_visibility_;
 	}
@@ -116,7 +117,7 @@ private:
 	std::map<std::string, chat_log> whispers_;
 	std::vector<game_filter_func> game_filters_;
 	bool game_filter_invert_;
-	std::vector<bool> games_visibility_;
+	boost::dynamic_bitset<> games_visibility_;
 	twesnothd_connection& wesnothd_connection_;
 };
 

--- a/src/gui/dialogs/multiplayer/mp_create_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.cpp
@@ -403,7 +403,7 @@ void tmp_create_game::on_filter_change(twindow& window, const std::string& id)
 
 	tlistbox& game_list = find_widget<tlistbox>(&window, "games_list", false);
 
-	std::vector<bool> filtered(game_list.get_item_count());
+	boost::dynamic_bitset<> filtered(game_list.get_item_count());
 	for(const size_t i : create_engine_.get_filtered_level_indices(create_engine_.current_level_type())) {
 		filtered[i] = true;
 	}

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -716,7 +716,7 @@ void tpreferences::post_build(twindow& window)
 		// recently selected row. Thus, if it returns i, this row was just selected.
 		// Otherwise, it must have been deselected.
 		bool show = hotkey_categories.get_selected_row() == int(i);
-		std::vector<bool> mask = hotkey_list.get_rows_shown();
+		boost::dynamic_bitset<> mask = hotkey_list.get_rows_shown();
 		for(size_t j = 0; j < visible_hotkeys_.size(); j++) {
 			if(visible_hotkeys_[j]->category == cat) {
 				mask[j] = show;

--- a/src/gui/dialogs/unit_create.cpp
+++ b/src/gui/dialogs/unit_create.cpp
@@ -43,6 +43,7 @@
 #include "units/types.hpp"
 
 #include "utils/functional.hpp"
+#include <boost/dynamic_bitset.hpp>
 
 static std::string last_chosen_type_id = "";
 static unit_race::GENDER last_gender = unit_race::MALE;
@@ -217,7 +218,7 @@ void tunit_create::filter_text_changed(ttext_* textbox, const std::string& text)
 		return;
 	last_words_ = words;
 
-	std::vector<bool> show_items(list.get_item_count(), true);
+	boost::dynamic_bitset<> show_items(list.get_item_count(), true);
 
 	if(!text.empty()) {
 		for(unsigned int i = 0; i < list.get_item_count(); i++) {

--- a/src/gui/dialogs/unit_recall.cpp
+++ b/src/gui/dialogs/unit_recall.cpp
@@ -45,6 +45,7 @@
 #include "units/ptr.hpp"
 
 #include "utils/functional.hpp"
+#include <boost/dynamic_bitset.hpp>
 
 static lg::log_domain log_display("display");
 #define LOG_DP LOG_STREAM(info, log_display)
@@ -340,7 +341,7 @@ void tunit_recall::filter_text_changed(ttext_* textbox, const std::string& text)
 		return;
 	last_words_ = words;
 
-	std::vector<bool> show_items(list.get_item_count(), true);
+	boost::dynamic_bitset<> show_items(list.get_item_count(), true);
 
 	if(!text.empty()) {
 		for(unsigned int i = 0; i < list.get_item_count(); i++) {

--- a/src/gui/widgets/list.cpp
+++ b/src/gui/widgets/list.cpp
@@ -201,7 +201,7 @@ void tlist::set_row_shown(const unsigned row, const bool shown)
 	}
 }
 
-void tlist::set_row_shown(const std::vector<bool>& shown)
+void tlist::set_row_shown(const boost::dynamic_bitset<>& shown)
 {
 	assert(generator_);
 	assert(shown.size() == get_item_count());

--- a/src/gui/widgets/list.hpp
+++ b/src/gui/widgets/list.hpp
@@ -20,6 +20,8 @@
 #include "gui/widgets/generator.hpp"
 #include "gui/widgets/scrollbar_container.hpp"
 
+#include <boost/dynamic_bitset.hpp>
+
 namespace gui2
 {
 
@@ -138,7 +140,7 @@ public:
 	 *                            be equal to the number of items in the
 	 *                            listbox.
 	 */
-	void set_row_shown(const std::vector<bool>& shown);
+	void set_row_shown(const boost::dynamic_bitset<>& shown);
 
 	/**
 	 * Returns the grid of the wanted row.

--- a/src/gui/widgets/listbox.cpp
+++ b/src/gui/widgets/listbox.cpp
@@ -180,7 +180,7 @@ void tlistbox::set_row_shown(const unsigned row, const bool shown)
 	}
 }
 
-void tlistbox::set_row_shown(const std::vector<bool>& shown)
+void tlistbox::set_row_shown(const boost::dynamic_bitset<>& shown)
 {
 	assert(generator_);
 	assert(shown.size() == get_item_count());
@@ -214,9 +214,9 @@ void tlistbox::set_row_shown(const std::vector<bool>& shown)
 	}
 }
 
-std::vector<bool> tlistbox::get_rows_shown() const
+boost::dynamic_bitset<> tlistbox::get_rows_shown() const
 {
-	std::vector<bool> shown;
+	boost::dynamic_bitset<> shown;
 	for(size_t i = 0; i < get_item_count(); i++) {
 		shown.push_back(generator_->get_item_shown(i));
 	}

--- a/src/gui/widgets/listbox.hpp
+++ b/src/gui/widgets/listbox.hpp
@@ -23,6 +23,8 @@
 #include "gui/core/widget_definition.hpp"
 #include "gui/core/window_builder.hpp"
 
+#include <boost/dynamic_bitset.hpp>
+
 namespace gui2
 {
 
@@ -140,14 +142,14 @@ public:
 	 *                            be equal to the number of items in the
 	 *                            listbox.
 	 */
-	void set_row_shown(const std::vector<bool>& shown);
+	void set_row_shown(const boost::dynamic_bitset<>& shown);
 
 	/**
 	 * Returns a list of visible rows
 	 *
 	 * @returns                   A mask indicating which rows are visible
 	 */
-	std::vector<bool> get_rows_shown() const;
+	boost::dynamic_bitset<> get_rows_shown() const;
 
 	bool any_rows_shown() const;
 

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -55,6 +55,7 @@
 #include "wesnothd_connection_error.hpp"
 #include "whiteboard/manager.hpp"
 #include "hotkey/hotkey_item.hpp"
+#include <boost/dynamic_bitset.hpp>
 
 static lg::log_domain log_aitesting("aitesting");
 #define LOG_AIT LOG_STREAM(info, log_aitesting)
@@ -190,7 +191,8 @@ void playsingle_controller::play_scenario_main_loop()
 			//    OOS if the undone action is in the snapshot of the saved
 			//    game (luckily this is never the case for autosaves).
 			//
-			std::vector<bool> local_players(gamestate().board_.teams().size(), true);
+			boost::dynamic_bitset<> local_players;
+			local_players.resize(gamestate().board_.teams().size(), true);
 			//Preserve side controllers, becasue we won't get the side controoller updates again when replaying.
 			for(size_t i = 0; i < local_players.size(); ++i) {
 				local_players[i] = gamestate().board_.teams()[i].is_local();

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -36,6 +36,7 @@
 
 #include <cassert>
 #include <ctime>
+#include <boost/dynamic_bitset.hpp>
 
 static void add_text(config &report, const std::string &text,
 	const std::string &tooltip, const std::string &help = "")
@@ -366,7 +367,7 @@ static config unit_abilities(const unit* u)
 	if (!u) return config();
 	config res;
 
-	std::vector<bool> active;
+	boost::dynamic_bitset<> active;
 	const std::vector<std::tuple<t_string,t_string,t_string> > &abilities = u->ability_tooltips(&active);
 	const size_t abilities_size = abilities.size();
 	for ( size_t i = 0; i != abilities_size; ++i )
@@ -799,7 +800,7 @@ static int attack_info(reports::context & rc, const attack_type &at, config &res
 	}
 
 	at.set_specials_context_for_listing();
-	std::vector<bool> active;
+	boost::dynamic_bitset<> active;
 	const std::vector<std::pair<t_string, t_string> > &specials = at.special_tooltips(&active);
 	const size_t specials_size = specials.size();
 	for ( size_t i = 0; i != specials_size; ++i )

--- a/src/team.cpp
+++ b/src/team.cpp
@@ -34,6 +34,7 @@
 #include "whiteboard/side_actions.hpp"
 #include "config_assign.hpp"
 #include "serialization/string_utils.hpp"
+#include <boost/dynamic_bitset.hpp>
 
 static lg::log_domain log_engine("engine");
 #define DBG_NG LOG_STREAM(debug, log_engine)
@@ -435,17 +436,15 @@ int team::minimum_recruit_price() const
 	return info_.minimum_recruit_price;
 }
 
-bool team::calculate_enemies(size_t index) const
+void team::calculate_enemies(size_t index) const
 {
 	if(!resources::gameboard || index >= resources::gameboard->teams().size()) {
-		return false;
+		return;
 	}
 
 	while(enemies_.size() <= index) {
 		enemies_.push_back(calculate_is_enemy(enemies_.size()));
 	}
-
-	return enemies_.back();
 }
 
 bool team::calculate_is_enemy(size_t index) const

--- a/src/team.hpp
+++ b/src/team.hpp
@@ -26,6 +26,7 @@
 #include <set>
 
 #include <stdint.h>
+#include <boost/dynamic_bitset.hpp>
 
 class game_data;
 class gamemap;
@@ -239,10 +240,13 @@ public:
 
 	bool is_enemy(int n) const {
 		const size_t index = size_t(n-1);
+		if(index >= enemies_.size()) {
+			calculate_enemies(index);
+		}
 		if(index < enemies_.size()) {
 			return enemies_[index];
 		} else {
-			return calculate_enemies(index);
+			return false;
 		}
 	}
 
@@ -414,9 +418,10 @@ private:
 	recall_list_manager recall_list_;
 	std::string last_recruit_;
 
-	bool calculate_enemies(size_t index) const;
+private:
+	void calculate_enemies(size_t index) const;
 	bool calculate_is_enemy(size_t index) const;
-	mutable std::vector<bool> enemies_;
+	mutable boost::dynamic_bitset<> enemies_;
 
 	mutable std::vector<const shroud_map*> ally_shroud_, ally_fog_;
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -28,6 +28,7 @@
 #include "units/filter.hpp"
 #include "units/map.hpp"
 #include "filter_context.hpp"
+#include <boost/dynamic_bitset.hpp>
 
 static lg::log_domain log_engine("engine");
 #define ERR_NG LOG_STREAM(err, log_engine)
@@ -257,7 +258,7 @@ namespace {
  *                     one and will indicate whether or not the corresponding
  *                     ability is active.
  */
-std::vector<std::tuple<t_string,t_string,t_string> > unit::ability_tooltips(std::vector<bool> *active_list) const
+std::vector<std::tuple<t_string, t_string, t_string> > unit::ability_tooltips(boost::dynamic_bitset<>* active_list) const
 {
 	std::vector<std::tuple<t_string,t_string,t_string> > res;
 	if ( active_list )
@@ -608,7 +609,7 @@ unit_ability_list attack_type::get_specials(const std::string& special) const
  * If the appropriate name is empty, the special is skipped.
  */
 std::vector<std::pair<t_string, t_string> > attack_type::special_tooltips(
-	std::vector<bool> *active_list) const
+	boost::dynamic_bitset<>* active_list) const
 {
 	//log_scope("special_tooltips");
 	std::vector<std::pair<t_string, t_string> > res;

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -24,6 +24,7 @@
 #include <boost/iterator/indirect_iterator.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
+#include <boost/dynamic_bitset_fwd.hpp>
 
 class unit_ability_list;
 
@@ -70,7 +71,7 @@ public:
 
 	bool get_special_bool(const std::string& special, bool simple_check=false) const;
 	unit_ability_list get_specials(const std::string& special) const;
-	std::vector<std::pair<t_string, t_string> > special_tooltips(std::vector<bool> *active_list=nullptr) const;
+	std::vector<std::pair<t_string, t_string> > special_tooltips(boost::dynamic_bitset<>* active_list = nullptr) const;
 	std::string weapon_specials(bool only_active=false, bool is_backstab=false) const;
 	void set_specials_context(const map_location& unit_loc, const map_location& other_loc,
 	                          bool attacking, const attack_type *other_attack) const;

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -51,6 +51,7 @@
 
 #include "utils/functional.hpp"
 #include <boost/function_output_iterator.hpp>
+#include <boost/dynamic_bitset.hpp>
 
 #ifdef _MSC_VER
 #pragma warning (push)
@@ -372,7 +373,7 @@ unit::unit(const config &cfg, bool use_traits, const vconfig* vcfg)
 	, attacks_left_(0)
 	, max_attacks_(0)
 	, states_()
-	, known_boolean_states_(known_boolean_state_names_.size(),false)
+	, known_boolean_states_()
 	, variables_()
 	, events_()
 	, filter_recall_()
@@ -660,7 +661,7 @@ unit::unit(const unit_type &u_type, int side, bool real_unit, unit_race::GENDER 
 	, attacks_left_(0)
 	, max_attacks_(0)
 	, states_()
-	, known_boolean_states_(known_boolean_state_names_.size(), false)
+	, known_boolean_states_()
 	, variables_()
 	, events_()
 	, filter_recall_()

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -17,8 +17,10 @@
 #ifndef UNIT_H_INCLUDED
 #define UNIT_H_INCLUDED
 
+#include <boost/dynamic_bitset_fwd.hpp>
 #include <boost/ptr_container/ptr_vector.hpp>
 #include <boost/variant.hpp>
+#include <bitset>
 
 #include "units/types.hpp"
 #include "units/ptr.hpp"
@@ -378,7 +380,7 @@ public:
 	unit_ability_list get_abilities(const std::string &tag_name) const
 	{ return get_abilities(tag_name, loc_); }
 	/** Tuple of: neutral ability name, gendered ability name, description */
-	std::vector<std::tuple<t_string,t_string,t_string> > ability_tooltips(std::vector<bool> *active_list=nullptr) const;
+	std::vector<std::tuple<t_string, t_string, t_string> > ability_tooltips(boost::dynamic_bitset<>* active_list = nullptr) const;
 	std::vector<std::string> get_ability_list() const;
 	bool has_ability_type(const std::string& ability) const;
 
@@ -477,7 +479,8 @@ private:
 	int max_attacks_;
 
 	std::set<std::string> states_;
-	std::vector<bool> known_boolean_states_;
+	// TODO: Somehow make a static const var for the 7 so that it can auto-update if new boolean states are ever added
+	std::bitset<7> known_boolean_states_;
 	static std::map<std::string, state_t> known_boolean_state_names_;
 	config variables_;
 	config events_;

--- a/src/whiteboard/manager.hpp
+++ b/src/whiteboard/manager.hpp
@@ -24,6 +24,7 @@
 #include "units/map.hpp"
 
 #include <boost/noncopyable.hpp>
+#include <boost/dynamic_bitset.hpp>
 
 class CKey;
 class team;
@@ -238,7 +239,7 @@ private:
 	std::vector<config> net_buffer_;
 
 	///team_plans_hidden_[i] = whether or not to hide actions from teams[i].
-	std::vector<bool> team_plans_hidden_;
+	boost::dynamic_bitset<> team_plans_hidden_;
 
 	///used to keep track of units owning planned moves for visual ghosting/unghosting
 	std::set<size_t> units_owning_moves_;

--- a/src/widgets/scrollpane.cpp
+++ b/src/widgets/scrollpane.cpp
@@ -19,6 +19,7 @@
 #include "global.hpp"
 
 #include <algorithm>
+#include <boost/dynamic_bitset.hpp>
 
 #include "widgets/scrollpane.hpp"
 
@@ -122,7 +123,7 @@ void scrollpane::scroll(unsigned int pos)
 void scrollpane::update_widget_positions()
 {
 	widget_map::iterator itor;
-	std::vector<bool> hidden(content_.size());
+	boost::dynamic_bitset<> hidden(content_.size());
 	int i = 0;
 	for(itor = content_.begin(); itor != content_.end(); ++itor) {
 		hidden[i++] = (itor->second.w->state_ == HIDDEN);


### PR DESCRIPTION
A few cases were skipped, most of which involved 2D bitsets (eg shroud) or uses that could not be easily translated (eg GUI1 multimenu).

In a few cases, code needed to be updated for the different API that the dynamic_bitset provides, but in most cases, this change is entirely transparent.

There are probably a few unnecessary dynamic_bitset.hpp includes.

One use of vector<bool> was replaced instead with std::bitset, since the dynamic size was not required.