### PR TITLE
Fix issues with tunnels when exit hex is occupied by an allied unit

### DIFF
--- a/src/actions/move.cpp
+++ b/src/actions/move.cpp
@@ -453,12 +453,6 @@ namespace { // Private helpers for move_unit()
 		if ( blocking_unit == resources::units->end() )
 			return false;
 
-		if ( !tiles_adjacent(hex, prev_hex) ) {
-			// Cannot teleport to an occupied hex.
-			teleport_failed_ = true;
-			return true;
-		}
-
 		if ( current_team_->is_enemy(blocking_unit->side()) ) {
 			// Trying to go through an enemy.
 			blocked_loc_ = hex;

--- a/src/pathfind/teleport.cpp
+++ b/src/pathfind/teleport.cpp
@@ -182,8 +182,20 @@ teleport_map::teleport_map(
 			locations.first.swap(filter_locs.first);
 			locations.second.swap(filter_locs.second);
 		}
-		std::string teleport_id = group.get_teleport_id();
 
+		if (!ignore_units) {
+			std::set<map_location>::iterator loc = locations.second.begin();
+			while(loc != locations.second.end()) {
+				const unit *v = resources::gameboard->get_visible_unit(*loc, viewing_team, see_all);
+				if (v) {
+					loc = locations.second.erase(loc);
+				} else {
+					++loc;
+				}
+			}
+		}
+
+		std::string teleport_id = group.get_teleport_id();
 		std::set<map_location>::iterator source_it = locations.first.begin();
 		for (; source_it != locations.first.end(); ++source_it ) {
 			if(teleport_map_.count(*source_it) == 0) {

--- a/src/pathfind/teleport.cpp
+++ b/src/pathfind/teleport.cpp
@@ -146,6 +146,10 @@ bool teleport_group::always_visible() const {
 	return cfg_["always_visible"].to_bool(false);
 }
 
+bool teleport_group::pass_allied_units() const {
+	return cfg_["pass_allied_units"].to_bool(false);
+}
+
 config teleport_group::to_config() const {
 	config retval = cfg_;
 	retval["saved"] = "yes";
@@ -183,7 +187,7 @@ teleport_map::teleport_map(
 			locations.second.swap(filter_locs.second);
 		}
 
-		if (!ignore_units) {
+		if (!group.pass_allied_units() && !ignore_units) {
 			std::set<map_location>::iterator loc = locations.second.begin();
 			while(loc != locations.second.end()) {
 				const unit *v = resources::gameboard->get_visible_unit(*loc, viewing_team, see_all);

--- a/src/pathfind/teleport.hpp
+++ b/src/pathfind/teleport.hpp
@@ -70,6 +70,11 @@ public:
 	 */
 	bool always_visible() const;
 
+	/*
+	 * Returns whether allied units on the exit hex can be passed.
+	 */
+	bool pass_allied_units() const;
+
 	/** Inherited from savegame_config. */
 	config to_config() const;
 


### PR DESCRIPTION
Previously, units on the tunnel exits blocked tunnels, but this was not checked until the move execution, resulting in inconsistencies between displayed and possible moves even without fog. It also caused such units effectively to act as ambushers. This PR removes these inconsistencies.

It also adds a new boolean parameter, pass_allied_units, to the [tunnel] tag, which lets the scenario designer choose whether units can move through allied units on the tunnel exit.