### PR TITLE
Add test button to title screen in debug mode

### DIFF
--- a/data/_main.cfg
+++ b/data/_main.cfg
@@ -53,12 +53,29 @@
 [/textdomain]
 #endif
 
+# We do a little preprocesser buggery to make the test scenarios accessible
+# in debug mode, but excluding the unit test scenarios.
+#ifdef DEBUG
+#define TEST_SCENARIO
+#enddef
+#endif
+
 #ifdef TEST
+#ifndef TEST_SCENARIO
+#define TEST_SCENARIO
+#enddef
+#endif
+#endif
+
+#ifdef TEST_SCENARIO
 {scenario-test.cfg}
 {scenario-leaders.cfg}
 {scenario-movethrough.cfg}
 {ai/scenarios/}
 {ai/micro_ais/scenarios/}
+#endif
+
+#ifdef TEST
 #define DONT_RELOAD_CORE
 #enddef
 

--- a/data/gui/window/title_screen.cfg
+++ b/data/gui/window/title_screen.cfg
@@ -251,6 +251,7 @@ where
 			{_GUI_BUTTON "tutorial" _"Tutorial" _"Start a tutorial to familiarize yourself with the game"}
 			{_GUI_BUTTON "campaign" _"Campaigns" _"Start a new single player campaign"}
 			{_GUI_BUTTON "multiplayer" _"Multiplayer" _"Play multiplayer (hotseat, LAN, or Internet), or a single scenario against the AI"}
+			{_GUI_BUTTON "tests" _"Tests" _"Run a test scenario"}
 			{_GUI_BUTTON "load" _"Load" _"Load a saved game"}
 			{_GUI_BUTTON "addons" _"Add-ons" _"Download usermade campaigns, eras, or map packs"}
 			{_GUI_BUTTON "cores" _"Cores" _"Select the game core data"}

--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -465,6 +465,20 @@ bool game_launcher::init_lua_script()
 	return !error;
 }
 
+void game_launcher::set_test(const std::string& id)
+{
+	state_ = saved_game();
+	state_.classification().campaign_type = game_classification::CAMPAIGN_TYPE::TEST;
+	state_.classification().campaign_define = "TEST_SCENARIO";
+
+	state_.mp_settings().mp_era = "era_default";
+	state_.mp_settings().show_connect = false;
+
+	state_.set_carryover_sides_start(
+		config_of("next_scenario", id)
+	);
+}
+
 bool game_launcher::play_test()
 {
 	static bool first_time = true;
@@ -477,17 +491,8 @@ bool game_launcher::play_test()
 
 	first_time = false;
 
-	state_.classification().campaign_type = game_classification::CAMPAIGN_TYPE::TEST;
+	set_test(test_scenario_);
 	state_.classification().campaign_define = "TEST";
-
-	state_.mp_settings().mp_era = "era_default";
-	state_.mp_settings().show_connect = false;
-
-	state_.set_carryover_sides_start(
-		config_of("next_scenario", test_scenario_)
-	);
-
-
 
 	game_config_manager::get()->
 		load_game_config_for_game(state_.classification());

--- a/src/game_launcher.hpp
+++ b/src/game_launcher.hpp
@@ -71,6 +71,7 @@ public:
 	void clear_loaded_game();
 	bool load_game();
 	void set_tutorial();
+	void set_test(const std::string& id);
 
 	std::string jump_to_campaign_id() const;
 	bool new_campaign();

--- a/src/gui/dialogs/title_screen.cpp
+++ b/src/gui/dialogs/title_screen.cpp
@@ -32,7 +32,9 @@
 #include "gui/dialogs/game_version.hpp"
 #include "gui/dialogs/language_selection.hpp"
 #include "gui/dialogs/lua_interpreter.hpp"
+#include "game_config_manager.hpp"
 #include "gui/dialogs/message.hpp"
+#include "gui/dialogs/simple_item_selector.hpp"
 #include "gui/dialogs/multiplayer/mp_method_selection.hpp"
 #include "gui/dialogs/multiplayer/mp_host_game_prompt.hpp"
 //#define DEBUG_TOOLTIP
@@ -459,6 +461,28 @@ void title_screen::pre_show(window& win)
 	find_widget<button>(&win, "clock", false).set_visible(show_debug_clock_button
 		? widget::visibility::visible
 		: widget::visibility::invisible);
+
+	//
+	// Test scenarios
+	//	
+	if(!game_config::debug) {
+		find_widget<button>(&win, "tests", false).set_visible(window::visibility::invisible);
+	}
+	register_button(win, "tests", hotkey::HOTKEY_NULL, [this](window& w) {
+		std::vector<std::string> options;
+		for(const config &sc : game_config_manager::get()->game_config().child_range("test")) {
+			const std::string &id = sc["id"];
+			options.push_back(id);
+		}
+		std::sort(options.begin(), options.end());
+		gui2::dialogs::simple_item_selector dlg(_("Choose Test"), "", options);
+		dlg.show(game_.video());
+		int choice = dlg.selected_index();
+		if(choice >= 0) {
+			game_.set_test(options[choice]);
+			w.set_retval(LAUNCH_GAME);
+		}
+	});
 }
 
 void title_screen::on_resize(window& win)


### PR DESCRIPTION
This makes tests a little more accessible for the average user, I suspect (which might be particularly good for the AI test scenarios). On the other hand, the button will appear if you start a campaign, enable debug mode, and then exit. Maybe that's fine, not sure. There's no hotkey for this button, though that could easily be added later.
