### PR TITLE
HttT S23 Fix bug: Unclear objective

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/23_Test_of_the_Clans.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/23_Test_of_the_Clans.cfg
@@ -44,7 +44,7 @@
             [/objective]
             [objective]
                 {BONUS_OBJECTIVE_CAPTION}
-                description= _ "Defeat all enemy leaders"
+                description= _ "Defeat enemy leaders"
                 condition=win
             [/objective]
             [objective]


### PR DESCRIPTION
The bonus is (1) recruit Knights and (2) the defeated leaders join you for the Battle for Wesnoth. You do not need to defeat all four for this.