### PR TITLE
Tunnels: fix issues with vision

### DIFF
--- a/src/pathfind/teleport.cpp
+++ b/src/pathfind/teleport.cpp
@@ -163,7 +163,8 @@ teleport_map::teleport_map(
 		, const unit& u
 		, const team &viewing_team
 		, const bool see_all
-		, const bool ignore_units)
+		, const bool ignore_units
+		, const bool check_vision)
 	: teleport_map_()
 	, sources_()
 	, targets_()
@@ -187,7 +188,7 @@ teleport_map::teleport_map(
 			locations.second.swap(filter_locs.second);
 		}
 
-		if (!group.pass_allied_units() && !ignore_units) {
+		if (!group.pass_allied_units() && !ignore_units && !check_vision) {
 			std::set<map_location>::iterator loc = locations.second.begin();
 			while(loc != locations.second.end()) {
 				const unit *v = resources::gameboard->get_visible_unit(*loc, viewing_team, see_all);
@@ -248,7 +249,7 @@ void teleport_map::get_targets(std::set<map_location>& targets) const {
 
 const teleport_map get_teleport_locations(const unit &u,
 	const team &viewing_team,
-	bool see_all, bool ignore_units)
+	bool see_all, bool ignore_units, bool check_vision)
 {
 	std::vector<teleport_group> groups;
 
@@ -265,7 +266,7 @@ const teleport_map get_teleport_locations(const unit &u,
 	const std::vector<teleport_group>& global_groups = resources::tunnels->get();
 	groups.insert(groups.end(), global_groups.begin(), global_groups.end());
 
-	return teleport_map(groups, u, viewing_team, see_all, ignore_units);
+	return teleport_map(groups, u, viewing_team, see_all, ignore_units, check_vision);
 }
 
 manager::manager(const config &cfg) : tunnels_(), id_(cfg["next_teleport_group_id"].to_int(0)) {

--- a/src/pathfind/teleport.cpp
+++ b/src/pathfind/teleport.cpp
@@ -200,8 +200,13 @@ teleport_map::teleport_map(
 		if (!group.pass_allied_units() && !ignore_units && !check_vision) {
 			std::set<map_location>::iterator loc = locations.second.begin();
 			while(loc != locations.second.end()) {
-				const unit *v = resources::gameboard->get_visible_unit(*loc, viewing_team, see_all);
-				if (v) {
+				unit_map::iterator u;
+				if (see_all) {
+					u = resources::units->find(*loc);
+				} else {
+					u = resources::gameboard->find_visible_unit(*loc, viewing_team);
+				}
+				if (u != resources::units->end()) {
 					loc = locations.second.erase(loc);
 				} else {
 					++loc;

--- a/src/pathfind/teleport.cpp
+++ b/src/pathfind/teleport.cpp
@@ -150,6 +150,10 @@ bool teleport_group::pass_allied_units() const {
 	return cfg_["pass_allied_units"].to_bool(true);
 }
 
+bool teleport_group::allow_vision() const {
+	return cfg_["allow_vision"].to_bool(true);
+}
+
 config teleport_group::to_config() const {
 	config retval = cfg_;
 	retval["saved"] = "yes";
@@ -173,6 +177,11 @@ teleport_map::teleport_map(
 	for (const teleport_group& group : groups) {
 
 		teleport_pair locations;
+
+        if (check_vision && !group.allow_vision()) {
+        	continue;
+        }
+
 		group.get_teleport_pair(locations, u, ignore_units);
 		if (!see_all && !group.always_visible() && viewing_team.is_enemy(u.side())) {
 			teleport_pair filter_locs;

--- a/src/pathfind/teleport.cpp
+++ b/src/pathfind/teleport.cpp
@@ -178,9 +178,9 @@ teleport_map::teleport_map(
 
 		teleport_pair locations;
 
-        if (check_vision && !group.allow_vision()) {
-        	continue;
-        }
+		if (check_vision && !group.allow_vision()) {
+			continue;
+		}
 
 		group.get_teleport_pair(locations, u, ignore_units);
 		if (!see_all && !group.always_visible() && viewing_team.is_enemy(u.side())) {

--- a/src/pathfind/teleport.hpp
+++ b/src/pathfind/teleport.hpp
@@ -94,13 +94,15 @@ public:
 	 * @param viewing_team
 	 * @param see_all
 	 * @param ignore_units
+	 * @param check_vision
 	 */
 	teleport_map(
 			  const std::vector<teleport_group>& teleport_groups
 			, const unit& u
 			, const team &viewing_team
 			, const bool see_all
-			, const bool ignore_units);
+			, const bool ignore_units
+			, const bool check_vision);
 
 	/*
 	 * Constructs an empty teleport map.
@@ -140,10 +142,11 @@ private:
  * @param viewing_team		The team the player belongs to
  * @param see_all			Whether the teleport can be seen below shroud
  * @param ignore_units		Whether to ignore zoc and blocking by units
+ * @param check_vision		Whether to check vision as opposed to movement range
  * @returns a teleport_map
  */
 const teleport_map get_teleport_locations(const unit &u, const team &viewing_team,
-		bool see_all = false, bool ignore_units = false);
+		bool see_all = false, bool ignore_units = false, bool check_vision = false);
 
 class manager
 {

--- a/src/pathfind/teleport.hpp
+++ b/src/pathfind/teleport.hpp
@@ -75,6 +75,11 @@ public:
 	 */
 	bool pass_allied_units() const;
 
+	/*
+	 * Returns whether vision through tunnels is possible.
+	 */
+	bool allow_vision() const;
+
 	/** Inherited from savegame_config. */
 	config to_config() const;
 


### PR DESCRIPTION
I think this is ready for testing and merging now.

There are some remaining questions about what should happen when there is an invisible unit on the tunnel exit hex, either because it's an enemy ambusher or because vision is not shared with an allied side.  Should the unit be revealed through the tunnel?  Should a message be displayed on-screen?  Etc.  But those are general questions as to what the correct behavior should be and have nothing specific to do with this PR.