### PR TITLE
Fix bug: Debug|Kill [have_unit] error

### DIFF
--- a/src/synced_commands.cpp
+++ b/src/synced_commands.cpp
@@ -518,6 +518,7 @@ SYNCED_COMMAND_HANDLER_FUNCTION(debug_kill, child, use_undo, /*show*/, /*error_h
 			unit_display::unit_die(loc, *i);
 		}
 		resources::screen->redraw_minimap();
+		i->set_hitpoints(0);
 		resources::controller->pump().fire("die", loc, loc);
 		if (i.valid()) {
 			resources::units->erase(i);


### PR DESCRIPTION
Set the killed units hit points to zero so [have_unit] does not find it.

This prevents adding [kill] to [event]name=die simply to support Debug|Kill.