### PR TITLE
reports: remove unused variable "str"

### DIFF
--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -1350,7 +1350,6 @@ REPORT_GENERATOR(terrain_info, rc)
 	if (terrain == t_translation::OFF_MAP_USER)
 		return config();
 
-	std::ostringstream str;
 	config cfg;
 
 	bool high_res = false;


### PR DESCRIPTION
Remove unused variable, probably a leftover from when the function was originally copied from another function.
Found with cppcheck.