### PR TITLE
Refactor of menus to remove old markup

### DIFF
--- a/src/controller_base.hpp
+++ b/src/controller_base.hpp
@@ -141,8 +141,9 @@ protected:
 	 */
 	virtual void process_keyup_event(const SDL_Event& event);
 
-	virtual void show_menu(const std::vector<std::string>& items_arg, int xloc, int yloc, bool context_menu, display& disp);
-	virtual void execute_action(const std::vector<std::string>& items_arg, int xloc, int yloc, bool context_menu);
+	virtual int show_menu(const std::vector<config>& items, SDL_Rect& where, bool context_menu, display& disp);
+	virtual std::vector<config> expand_menu(const std::vector<std::string>& items);
+	virtual void execute_action(const std::vector<std::string>& items, int xloc, int yloc, bool context_menu);
 
 	virtual bool in_context_menu(hotkey::HOTKEY_COMMAND command) const;
 
@@ -154,6 +155,8 @@ protected:
 	bool scroll_left_;
 	bool scroll_right_;
 	joystick_manager joystick_manager_;
+private:
+	void execute_menu_selection(const std::string& id, int index);
 };
 
 

--- a/src/editor/controller/editor_controller.hpp
+++ b/src/editor/controller/editor_controller.hpp
@@ -110,7 +110,8 @@ class editor_controller : public controller_base,
 		bool execute_command(const hotkey::hotkey_command& command, int index = -1, bool press=true) override;
 
 		/** controller_base override */
-		void show_menu(const std::vector<std::string>& items_arg, int xloc, int yloc, bool context_menu, display& disp) override;
+		int show_menu(const std::vector<config>& items, SDL_Rect& where, bool context_menu, display& disp) override;
+		std::vector<config> expand_menu(const std::vector<std::string>& items) override;
 
 		void show_help() override;
 		void status_table() override;
@@ -225,7 +226,10 @@ class editor_controller : public controller_base,
 		 */
 		void redo() override;
 
+		std::vector<config>::iterator set_active_menu(std::vector<config>& base_menu, const std::vector<config>& items, std::vector<config>::iterator base_pos, editor::menu_type type);
+
 		editor::menu_type active_menu_;
+		int active_menu_base_index_;
 
 		/** Reports object. Must be initialized before the gui_ */
 		const std::unique_ptr<reports> reports_;
@@ -236,6 +240,7 @@ class editor_controller : public controller_base,
 		/** Pre-defined time of day lighting settings for the settings dialog */
 		typedef std::map<std::string, std::pair<std::string ,std::vector<time_of_day> > > tods_map;
 		tods_map tods_;
+		std::vector<config> expand_schedules_menu(const std::string& id) const;
 
 		/* managers */
 	public:

--- a/src/editor/map/context_manager.cpp
+++ b/src/editor/map/context_manager.cpp
@@ -16,6 +16,7 @@
 #include "resources.hpp"
 #include "team.hpp"
 
+#include "config_assign.hpp"
 #include "context_manager.hpp"
 #include "display.hpp"
 #include "filesystem.hpp"
@@ -268,171 +269,119 @@ void context_manager::new_scenario_dialog()
 	}
 }
 
-void context_manager::expand_open_maps_menu(std::vector<std::string>& items)
+std::vector<config> context_manager::expand_open_maps_menu()
 {
-	for (unsigned int i = 0; i < items.size(); ++i) {
-		if (items[i] == "editor-switch-map") {
-			items.erase(items.begin() + i);
-			std::vector<std::string> contexts;
-			for (size_t mci = 0; mci < map_contexts_.size(); ++mci) {
-				std::string filename = map_contexts_[mci]->get_filename();
-				bool changed = map_contexts_[mci]->modified();
-				bool pure_map = map_contexts_[mci]->is_pure_map();
-				if (filename.empty()) {
-					if (pure_map)
-						filename = _("(New Map)");
-					else
-						filename = _("(New Scenario)");
-				}
-				std::string label = "[" + std::to_string(mci) + "] "
-					+ filename + (changed ? " [*]" : "");
-				if (map_contexts_[mci]->is_embedded()) {
-					label += " (E)";
-				}
-				contexts.push_back(label);
-			}
-			items.insert(items.begin() + i, contexts.begin(), contexts.end());
-			break;
+	std::vector<config> result;
+	for (size_t mci = 0; mci < map_contexts_.size(); ++mci) {
+		std::string filename = map_contexts_[mci]->get_filename();
+		bool changed = map_contexts_[mci]->modified();
+		bool pure_map = map_contexts_[mci]->is_pure_map();
+		if (filename.empty()) {
+			if (pure_map)
+				filename = _("(New Map)");
+			else
+				filename = _("(New Scenario)");
 		}
+		std::string label = "[" + std::to_string(mci) + "] "
+			+ filename + (changed ? " [*]" : "");
+		if (map_contexts_[mci]->is_embedded()) {
+			label += " (E)";
+		}
+		// Don't include the ID here, because that makes it not work.
+		// (The reason is that there's a dummy hotkey for this, so including the ID will attempt to execute that instead.)
+		result.push_back(config_of("label", label)("index", mci));
 	}
+	return result;
 }
 
-void context_manager::expand_load_mru_menu(std::vector<std::string>& items)
+std::vector<config> context_manager::expand_load_mru_menu()
 {
 	std::vector<std::string> mru = preferences::editor::recent_files();
-
-	for (unsigned int i = 0; i < items.size(); ++i) {
-		if (items[i] != "EDITOR-LOAD-MRU-PLACEHOLDER") {
-			continue;
-		}
-
-		items.erase(items.begin() + i);
-
-		if(mru.empty()) {
-			items.insert(items.begin() + i, _("No Recent Files"));
-			continue;
-		}
-
-		for (std::string& path : mru)
-		{
-			// TODO: add proper leading ellipsization instead, since otherwise
-			// it'll be impossible to tell apart files with identical names and
-			// different parent paths.
-			path = filesystem::base_name(path);
-		}
-
-		items.insert(items.begin() + i, mru.begin(), mru.end());
-		break;
+	std::vector<config> result;
+	if(mru.empty()) {
+		result.push_back(config_of("label", _("No Recent Files"))("id", "EDITOR-LOAD-MRU-PLACEHOLDER"));
+	} else {
+		std::transform(mru.begin(), mru.end(), std::back_inserter(result), [](const std::string& path){
+			return config_of("label", filesystem::base_name(path))("id", "EDITOR-LOAD-MRU-PLACEHOLDER");
+		});
 	}
-
+	return result;
 }
 
-void context_manager::expand_areas_menu(std::vector<std::string>& items)
+std::vector<config> context_manager::expand_areas_menu()
 {
 	tod_manager* tod = get_map_context().get_time_manager();
+	std::vector<config> result;
 
-	if (!tod)
-		return;
-	for (unsigned int i = 0; i < items.size(); ++i) {
-		if (items[i] == "editor-switch-area") {
-			items.erase(items.begin() + i);
-			std::vector<std::string> area_entries;
-
-			std::vector<std::string> area_ids =
-					tod->get_area_ids();
-
-			for (size_t mci = 0; mci < area_ids.size(); ++mci) {
-
-				const std::string& area = area_ids[mci];
-				std::stringstream label;
-				label << "[" << mci+1 << "] ";
-				label << (area.empty() ? _("(Unnamed Area)") : area);
-
-				if (mci == static_cast<size_t>(get_map_context().get_active_area())
-						&& tod->get_area_by_index(mci) != get_map_context().get_map().selection())
-					label << " [*]";
-
-				area_entries.push_back(label.str());
-			}
-
-			items.insert(items.begin() + i,
-					area_entries.begin(), area_entries.end());
-			break;
-		}
+	if (!tod) {
+		return result;
 	}
+
+	std::vector<std::string> area_ids = tod->get_area_ids();
+
+	for (size_t mci = 0; mci < area_ids.size(); ++mci) {
+
+		const std::string& area = area_ids[mci];
+		std::stringstream label;
+		label << "[" << mci+1 << "] ";
+		label << (area.empty() ? _("(Unnamed Area)") : area);
+
+		if (mci == static_cast<size_t>(get_map_context().get_active_area())
+				&& tod->get_area_by_index(mci) != get_map_context().get_map().selection())
+			label << " [*]";
+
+		result.push_back(config_of("label", label.str())("index", mci)("id", "editor-switch-area"));
+	}
+
+	return result;
 }
 
-void context_manager::expand_sides_menu(std::vector<std::string>& items)
+std::vector<config> context_manager::expand_sides_menu()
 {
-	for (unsigned int i = 0; i < items.size(); ++i) {
-		if (items[i] == "editor-switch-side") {
-			items.erase(items.begin() + i);
-			std::vector<std::string> contexts;
+	std::vector<config> result;
+	for (size_t mci = 0; mci < get_map_context().get_teams().size(); ++mci) {
 
-			for (size_t mci = 0; mci < get_map_context().get_teams().size(); ++mci) {
-
-				const team& t = get_map_context().get_teams()[mci];
-				const std::string& teamname = t.user_team_name();
-				std::stringstream label;
-				label << "[" << mci+1 << "] ";
-				label << (teamname.empty() ? _("(New Side)") : teamname);
-				contexts.push_back(label.str());
-			}
-
-			items.insert(items.begin() + i, contexts.begin(), contexts.end());
-			break;
-		}
+		const team& t = get_map_context().get_teams()[mci];
+		const std::string& teamname = t.user_team_name();
+		std::stringstream label;
+		label << "[" << mci+1 << "] ";
+		label << (teamname.empty() ? _("(New Side)") : teamname);
+		result.push_back(config_of("label", label.str())("index", mci)("id", "editor-switch-side"));
 	}
+
+	return result;
 }
 
-void context_manager::expand_time_menu(std::vector<std::string>& items)
+std::vector<config> context_manager::expand_time_menu()
 {
-	for (unsigned int i = 0; i < items.size(); ++i) {
-		if (items[i] == "editor-switch-time") {
-			items.erase(items.begin() + i);
-			std::vector<std::string> times;
+	tod_manager* tod_m = get_map_context().get_time_manager();
+	std::vector<config> result;
 
-			tod_manager* tod_m = get_map_context().get_time_manager();
-
-			assert(tod_m != nullptr);
-
-			for (const time_of_day& time : tod_m->times()) {
-
-				std::stringstream label;
-				if (!time.image.empty())
-					label << IMAGE_PREFIX << time.image << IMG_TEXT_SEPARATOR;
-				label << time.name;
-				times.push_back(label.str());
-			}
-
-			items.insert(items.begin() + i, times.begin(), times.end());
-			break;
-		}
+	if(!tod_m) {
+		return result;
 	}
+
+	for (const time_of_day& time : tod_m->times()) {
+		result.push_back(config_of("image", time.image)("details", time.name)("id", "editor-switch-time"));
+	}
+
+	return result;
 }
 
-void context_manager::expand_local_time_menu(std::vector<std::string>& items)
+std::vector<config> context_manager::expand_local_time_menu()
 {
-	for (unsigned int i = 0; i < items.size(); ++i) {
-		if (items[i] == "editor-assign-local-time") {
-			items.erase(items.begin() + i);
-			std::vector<std::string> times;
+	tod_manager* tod_m = get_map_context().get_time_manager();
+	std::vector<config> result;
 
-			tod_manager* tod_m = get_map_context().get_time_manager();
-
-			for (const time_of_day& time : tod_m->times(get_map_context().get_active_area())) {
-
-				std::stringstream label;
-				if (!time.image.empty())
-					label << IMAGE_PREFIX << time.image << IMG_TEXT_SEPARATOR;
-				label << time.name;
-				times.push_back(label.str());
-			}
-
-			items.insert(items.begin() + i, times.begin(), times.end());
-			break;
-		}
+	if(!tod_m) {
+		return result;
 	}
+
+	for (const time_of_day& time : tod_m->times(get_map_context().get_active_area())) {
+		result.push_back(config_of("image", time.image)("details", time.name)("id", "editor-assign-local-time"));
+	}
+
+	return result;
 }
 
 void context_manager::apply_mask_dialog()

--- a/src/editor/map/context_manager.hpp
+++ b/src/editor/map/context_manager.hpp
@@ -107,22 +107,22 @@ public:
 	void rename_area_dialog();
 
 	/** Menu expanding for open maps list */
-	void expand_open_maps_menu(std::vector<std::string>& items);
+	std::vector<config> expand_open_maps_menu();
 
 	/** Menu expanding for most recent loaded list */
-	void expand_load_mru_menu(std::vector<std::string>& items);
+	std::vector<config> expand_load_mru_menu();
 
 	/** Menu expanding for the map's player sides */
-	void expand_sides_menu(std::vector<std::string>& items);
+	std::vector<config> expand_sides_menu();
 
 	/** Menu expanding for the map's defined areas */
-	void expand_areas_menu(std::vector<std::string>& items);
+	std::vector<config> expand_areas_menu();
 
 	/** Menu expanding for the map's defined areas */
-	void expand_time_menu(std::vector<std::string>& items);
+	std::vector<config> expand_time_menu();
 
 	/** Menu expanding for the map's defined areas */
-	void expand_local_time_menu(std::vector<std::string>& items);
+	std::vector<config> expand_local_time_menu();
 
 	/** Display a load map dialog and process user input. */
 	void load_map_dialog(bool force_same_context = false);

--- a/src/editor/palette/common_palette.hpp
+++ b/src/editor/palette/common_palette.hpp
@@ -71,8 +71,8 @@ public:
 	virtual const std::vector<item_group>& get_groups() const = 0;
 
 	/** Menu expanding for palette group list */
-	virtual void expand_palette_groups_menu(std::vector<std::string>& items) = 0;
-	virtual void expand_palette_groups_menu(std::vector< std::pair< std::string, std::string> >& items) = 0;
+	virtual std::vector<config> expand_palette_groups_menu() = 0;
+	//virtual std::vector<config> expand_palette_groups_menu(const std::vector< std::pair< std::string, std::string> >& items) = 0;
 
     //item
 	virtual int num_items() = 0;

--- a/src/editor/palette/editor_palettes.cpp
+++ b/src/editor/palette/editor_palettes.cpp
@@ -16,6 +16,7 @@
 
 #include "editor_palettes.hpp"
 
+#include "config_assign.hpp"
 #include "gettext.hpp"
 #include "marked-up_text.hpp"
 #include "tooltips.hpp"
@@ -43,46 +44,39 @@ template sdl_handler_vector editor_palette<unit_type>::handler_members();
 template sdl_handler_vector editor_palette<overlay>::handler_members();
 
 template<class Item>
-void editor_palette<Item>::expand_palette_groups_menu(std::vector<std::string>& items)
+std::vector<config> editor_palette<Item>::expand_palette_groups_menu()
 {
-	for (unsigned int i = 0; i < items.size(); ++i) {
-		if (items[i] == "editor-palette-groups") {
-			items.erase(items.begin() + i);
+	std::vector<config> result;
+	const std::vector<item_group>& item_groups = get_groups();
 
-			std::vector<std::string> groups;
-			const std::vector<item_group>& item_groups = get_groups();
-
-			for (size_t mci = 0; mci < item_groups.size(); ++mci) {
-				std::string groupname = item_groups[mci].name;
-				if (groupname.empty()) {
-					groupname = _("(Unknown Group)");
-				}
-				std::stringstream str;
-				str << IMAGE_PREFIX << item_groups[mci].icon;
-				if (mci == active_group_index()) {
-
-					if (filesystem::file_exists(str.str() + "_30-pressed.png" ) ) {
-						str << "_30-pressed.png";
-					} else {
-						str << "_30.png~CS(70,70,0)";
-					}
-
-				} else {
-					str << "_30.png";
-				}
-				str << COLUMN_SEPARATOR << groupname;
-				groups.push_back(str.str());
-
-
-			}
-			items.insert(items.begin() + i, groups.begin(), groups.end());
-			break;
+	for (size_t mci = 0; mci < item_groups.size(); ++mci) {
+		std::string groupname = item_groups[mci].name;
+		if (groupname.empty()) {
+			groupname = _("(Unknown Group)");
 		}
+		// Don't include the ID here, because that makes it not work.
+		// (The reason is that there's a dummy hotkey for this, so including the ID will attempt to execute that instead.)
+		result.push_back(config_of("label", groupname)("index", mci));
+		std::stringstream str;
+		str << item_groups[mci].icon;
+		if (mci == active_group_index()) {
+
+			if (filesystem::file_exists(str.str() + "_30-pressed.png" ) ) {
+				str << "_30-pressed.png";
+			} else {
+				str << "_30.png~CS(70,70,0)";
+			}
+
+		} else {
+			str << "_30.png";
+		}
+		result.back()["icon"] = str.str();
 	}
+	return result;
 }
-template void editor_palette<t_translation::t_terrain>::expand_palette_groups_menu(std::vector<std::string>& items);
-template void editor_palette<unit_type>::expand_palette_groups_menu(std::vector<std::string>& items);
-template void editor_palette<overlay>::expand_palette_groups_menu(std::vector<std::string>& items);
+template std::vector<config> editor_palette<t_translation::t_terrain>::expand_palette_groups_menu();
+template std::vector<config> editor_palette<unit_type>::expand_palette_groups_menu();
+template std::vector<config> editor_palette<overlay>::expand_palette_groups_menu();
 
 template<class Item>
 bool editor_palette<Item>::scroll_up()
@@ -102,23 +96,23 @@ template bool editor_palette<t_translation::t_terrain>::scroll_up();
 template bool editor_palette<unit_type>::scroll_up();
 template bool editor_palette<overlay>::scroll_up();
 
-template<class Item>
-void editor_palette<Item>::expand_palette_groups_menu(std::vector< std::pair< std::string, std::string> >& items)
-{
-	const std::vector<item_group>& item_groups = get_groups();
-
-	for (size_t mci = 0; mci < item_groups.size(); ++mci) {
-		std::string groupname = item_groups[mci].name;
-		if (groupname.empty()) {
-			groupname = _("(Unknown Group)");
-		}
-		const std::string& img = item_groups[mci].icon;
-		items.push_back(std::pair<std::string, std::string>( img, groupname));
-	}
-}
-template void editor_palette<t_translation::t_terrain>::expand_palette_groups_menu(std::vector< std::pair< std::string, std::string> >& items);
-template void editor_palette<unit_type>::expand_palette_groups_menu(std::vector< std::pair< std::string, std::string> >& items);
-template void editor_palette<overlay>::expand_palette_groups_menu(std::vector< std::pair< std::string, std::string> >& items);
+//template<class Item>
+//void editor_palette<Item>::expand_palette_groups_menu(std::vector< std::pair< std::string, std::string> >& items)
+//{
+//	const std::vector<item_group>& item_groups = get_groups();
+//
+//	for (size_t mci = 0; mci < item_groups.size(); ++mci) {
+//		std::string groupname = item_groups[mci].name;
+//		if (groupname.empty()) {
+//			groupname = _("(Unknown Group)");
+//		}
+//		const std::string& img = item_groups[mci].icon;
+//		items.push_back(std::pair<std::string, std::string>( img, groupname));
+//	}
+//}
+//template void editor_palette<t_translation::t_terrain>::expand_palette_groups_menu(std::vector< std::pair< std::string, std::string> >& items);
+//template void editor_palette<unit_type>::expand_palette_groups_menu(std::vector< std::pair< std::string, std::string> >& items);
+//template void editor_palette<overlay>::expand_palette_groups_menu(std::vector< std::pair< std::string, std::string> >& items);
 
 template<class Item>
 bool editor_palette<Item>::can_scroll_up()

--- a/src/editor/palette/editor_palettes.hpp
+++ b/src/editor/palette/editor_palettes.hpp
@@ -63,8 +63,8 @@ public:
 	size_t start_num(void) override { return items_start_; }
 
 	/** Menu expanding for palette group list */
-	void expand_palette_groups_menu(std::vector< std::pair<std::string, std::string> >& items) override;
-	void expand_palette_groups_menu(std::vector<std::string>& items) override;
+	//std::vector<config> expand_palette_groups_menu(std::vector< std::pair<std::string, std::string> >& items) override;
+	std::vector<config> expand_palette_groups_menu() override;
 
 	void set_group(size_t index) override;
 //	int active_group();

--- a/src/editor/palette/empty_palette.hpp
+++ b/src/editor/palette/empty_palette.hpp
@@ -72,8 +72,8 @@ public:
 	virtual const std::vector<item_group>& get_groups() const override { return empty_; }
 
 	/** Menu expanding for palette group list */
-	virtual void expand_palette_groups_menu(std::vector< std::pair< std::string, std::string> >& /*items*/) override {}
-	virtual void expand_palette_groups_menu(std::vector< std::string> & /*items*/) override {}
+	//virtual void expand_palette_groups_menu(std::vector< std::pair< std::string, std::string> >& /*items*/) override {}
+	virtual std::vector<config> expand_palette_groups_menu() override { return std::vector<config>(); }
 
     //item
 	virtual int num_items() override {return 0;}

--- a/src/editor/palette/location_palette.hpp
+++ b/src/editor/palette/location_palette.hpp
@@ -40,8 +40,8 @@ public:
 	size_t start_num(void) override { return items_start_; }
 
 	/** Menu expanding for palette group list */
-	void expand_palette_groups_menu(std::vector< std::pair<std::string, std::string> >&) override {}
-	void expand_palette_groups_menu(std::vector<std::string>&) override {}
+	//void expand_palette_groups_menu(std::vector< std::pair<std::string, std::string> >&) override {}
+	std::vector<config> expand_palette_groups_menu() override { return std::vector<config>(); }
 
 	virtual void set_group(size_t /*index*/) override {}
 	virtual void next_group() override {}

--- a/src/gui/dialogs/drop_down_list.cpp
+++ b/src/gui/dialogs/drop_down_list.cpp
@@ -109,7 +109,11 @@ void tdrop_down_list::pre_show(twindow& window)
 
 void tdrop_down_list::post_show(twindow& window)
 {
-	selected_item_ = find_widget<tlistbox>(&window, "list", true).get_selected_row();
+	tlistbox& list = find_widget<tlistbox>(&window, "list", true);
+	selected_item_ = list.get_selected_row();
+	if(selected_item_ >= 0) {
+		selected_rect_ = list.get_row_grid(selected_item_)->get_rectangle();
+	}
 }
 
 } // namespace gui2

--- a/src/gui/dialogs/drop_down_list.hpp
+++ b/src/gui/dialogs/drop_down_list.hpp
@@ -33,6 +33,7 @@ public:
 	{
 	}
 	int selected_item() const { return selected_item_; }
+	SDL_Rect selected_item_rect() const { return selected_rect_; }
 private:
 	/// The screen location of the menu_button button that triggred this droplist.
 	/// Note: we don't adjust the location of this dialog to when resizing the window.
@@ -40,6 +41,7 @@ private:
 	SDL_Rect button_pos_;
 	std::vector<config> items_;
 	int selected_item_;
+	SDL_Rect selected_rect_;
 	bool use_markup_;
 	/** Inherited from tdialog, implemented by REGISTER_DIALOG. */
 	virtual const std::string& window_id() const;

--- a/src/hotkey/command_executor.hpp
+++ b/src/hotkey/command_executor.hpp
@@ -132,8 +132,8 @@ public:
 	// Returns a vector of images for a given menu.
 	std::vector<config> get_menu_images(display &, const std::vector<std::string>& items_arg);
 
-	virtual void show_menu(const std::vector<std::string>& items_arg, int xloc, int yloc, bool context_menu, display& gui);
-	void execute_action(const std::vector<std::string>& items_arg, int xloc, int yloc, bool context_menu, display& gui);
+	virtual int show_menu(const std::vector<config>& items, SDL_Rect& where, bool context_menu, display& gui);
+	void execute_action(const std::vector<std::string>& items, int xloc, int yloc, bool context_menu, display& gui);
 
 	virtual bool can_execute_command(const hotkey_command& command, int index=-1) const = 0;
 	virtual bool execute_command(const hotkey_command& command, int index=-1, bool press=true);

--- a/src/hotkey/hotkey_handler.hpp
+++ b/src/hotkey/hotkey_handler.hpp
@@ -57,14 +57,14 @@ private:
 	typedef std::shared_ptr<const game_events::wml_menu_item> const_item_ptr;
 
 	// Expand AUTOSAVES in the menu items, setting the real savenames.
-	void expand_autosaves(std::vector<std::string>& items);
+	std::vector<config> expand_autosaves();
 
 	std::vector<std::string> savenames_;
 
 	/**
 	 * Replaces "wml" in @a items with all active WML menu items for the current field.
 	 */
-	void expand_wml_commands(std::vector<std::string>& items);
+	std::vector<config> expand_wml_commands();
 	std::vector<const_item_ptr> wml_commands_;
 	int last_context_menu_x_;
 	int last_context_menu_y_;
@@ -125,7 +125,7 @@ public:
 	/** Check if a command can be executed. */
 	virtual bool can_execute_command(const hotkey::hotkey_command& command, int index=-1) const override;
 	virtual bool execute_command(const hotkey::hotkey_command& command, int index=-1, bool press=true) override;
-	void show_menu(const std::vector<std::string>& items_arg, int xloc, int yloc, bool context_menu, display& disp) override;
+	int show_menu(const std::vector<config>& items, SDL_Rect& where, bool context_menu, display& disp) override;
 
 	/**
 	 *  Determines whether the command should be in the context menu or not.

--- a/src/lua_jailbreak_exception.hpp
+++ b/src/lua_jailbreak_exception.hpp
@@ -72,7 +72,7 @@ private:
 	 *
 	 * @pre                       jailbreak_exception != nullptr
 	 */
-	virtual void execute() = 0;
+	NORETURN virtual void execute() = 0;
 };
 
 /**


### PR DESCRIPTION
Not quite finished yet (all the editor menus I tested work, but most in-game menus are currently unresponsive).

If anyone wishes to test the editor menus or review the code (which still needs to be cleaned up to remove commented stuff, etc), then feel free. I tested most of them, but couldn't test unit facing (since units can't be placed to access it) and skipped recent maps (in the file menu).
