### PR TITLE
The Hammer of Thursagan (THoT) Corrections

### DIFF
--- a/data/campaigns/The_Hammer_of_Thursagan/lua/spawns.lua
+++ b/data/campaigns/The_Hammer_of_Thursagan/lua/spawns.lua
@@ -1,6 +1,7 @@
 -- Used for the bandit spawns in scenario 5
 
 local helper = wesnoth.require "lua/helper.lua"
+local utils = wesnoth.require "lua/wml-utils.lua"
 local wml_actions = wesnoth.wml_actions
 local T = helper.set_wml_tag_metatable {}
 
@@ -11,16 +12,26 @@ function wml_actions.spawn_units(cfg)
 	local count = cfg.count or helper.wml_error("[spawn_units] missing required count= attribute.")
 	local side = cfg.side or helper.wml_error("[spawn_units] missing required side= attribute.")
 
+	local done = 0
 	for i=1,count do
 		local locs = wesnoth.get_locations({T["not"] { T.filter {} } , T["and"] { x = x, y = y, radius = 1 } })
 		if #locs == 0 then locs = wesnoth.get_locations({T["not"] { T.filter {} } , T["and"] { x = x, y = y, radius = 2 } }) end
 		if #locs == 0 then break end
+
+		done = done + 1
 
 		local unit_type = helper.rand(types)
 		local loc_i = helper.rand("1.."..#locs)
 
 		wml_actions.move_unit_fake({x = string.format("%d,%d", x, locs[loc_i][1]) , y = string.format("%d,%d", y, locs[loc_i][2]) , type = unit_type , side = side})
 		wesnoth.put_unit({ type = unit_type , side = side, random_traits = "yes", generate_name = "yes" , upkeep = "loyal" }, locs[loc_i][1], locs[loc_i][2])
+	end
+
+	if done > 0 then
+		for then_child in helper.child_range(cfg, "then") do
+			local action = utils.handle_event_commands(then_child, "conditional")
+			if action ~= "none" then return end
+		end
 	end
 end
 

--- a/data/campaigns/The_Hammer_of_Thursagan/lua/spawns.lua
+++ b/data/campaigns/The_Hammer_of_Thursagan/lua/spawns.lua
@@ -19,7 +19,7 @@ function wml_actions.spawn_units(cfg)
 		local loc_i = helper.rand("1.."..#locs)
 
 		wml_actions.move_unit_fake({x = string.format("%d,%d", x, locs[loc_i][1]) , y = string.format("%d,%d", y, locs[loc_i][2]) , type = unit_type , side = side})
-		wesnoth.put_unit(locs[loc_i][1], locs[loc_i][2], { type = unit_type , side = side, random_traits = "yes", generate_name = "yes" , upkeep = "loyal" })
+		wesnoth.put_unit({ type = unit_type , side = side, random_traits = "yes", generate_name = "yes" , upkeep = "loyal" }, locs[loc_i][1], locs[loc_i][2])
 	end
 end
 

--- a/data/campaigns/The_Hammer_of_Thursagan/lua/spawns.lua
+++ b/data/campaigns/The_Hammer_of_Thursagan/lua/spawns.lua
@@ -14,6 +14,7 @@ function wml_actions.spawn_units(cfg)
 	for i=1,count do
 		local locs = wesnoth.get_locations({T["not"] { T.filter {} } , T["and"] { x = x, y = y, radius = 1 } })
 		if #locs == 0 then locs = wesnoth.get_locations({T["not"] { T.filter {} } , T["and"] { x = x, y = y, radius = 2 } }) end
+		if #locs == 0 then break end
 
 		local unit_type = helper.rand(types)
 		local loc_i = helper.rand("1.."..#locs)

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg
@@ -197,6 +197,18 @@
             message= _ "Ye’re young and not tested... but ye have the rank, and ye’ve shown the wits to use it well. I have decided. You and Angarthing will fare to Kal Kartha together, as soon as may be, with the best men of your guard."
         [/message]
 
+        [modify_unit]
+            [filter]
+                id=Angarthing
+            [/filter]
+            side=1
+        [/modify_unit]
+
+        [move_unit]
+            id=Angarthing
+            to_x,to_y=13,12
+        [/move_unit]
+
         [message]
             speaker=Aiglondur
             message= _ "Aye, my Lord Hamel."
@@ -211,13 +223,6 @@
             speaker=Aiglondur
             message= _ "We must make haste; winter approaches, and travel over the mountains will soon grow dangerous."
         [/message]
-
-        [modify_unit]
-            [filter]
-                id=Angarthing
-            [/filter]
-            side=1
-        [/modify_unit]
 
         [unlock_view][/unlock_view]
 

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg
@@ -244,27 +244,20 @@
             id=Gothras
         [/filter]
 
-        [if]
-            [have_unit]
-                id=Marth-Tak
-            [/have_unit]
-            [then]
-                [message]
-                    speaker=Marth-Tak
-                    message= _ "My thanks, dwarves. These bandits might have hacked a bloody swathe through the Alliance’s tribes if we had not killed them here."
-                [/message]
+        [message]
+            speaker=Marth-Tak
+            message= _ "My thanks, dwarves. These bandits might have hacked a bloody swathe through the Alliance’s tribes if we had not killed them here."
+        [/message]
 
-                [message]
-                    speaker=Aiglondur
-                    message= _ "My thanks to you, for proving there are orcs I can fight alongside rather than against. But we cannot linger here to celebrate; we are journeying east."
-                [/message]
+        [message]
+            speaker=Aiglondur
+            message= _ "My thanks to you, for proving there are orcs I can fight alongside rather than against. But we cannot linger here to celebrate; we are journeying east."
+        [/message]
 
-                [message]
-                    speaker=Marth-Tak
-                    message= _ "East, eh? You won’t find many friends in that direction. Travel safely."
-                [/message]
-            [/then]
-        [/if]
+        [message]
+            speaker=Marth-Tak
+            message= _ "East, eh? You won’t find many friends in that direction. Travel safely."
+        [/message]
 
         [endlevel]
             result=victory

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/04_Troll_Bridge.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/04_Troll_Bridge.cfg
@@ -164,10 +164,6 @@
             message= _ "Hey! That troll was sitting on some treasure!"
         [/message]
 
-        {PLACE_IMAGE "items/gold-coins-small.png" 24 7} # On troll keep
-
-        [redraw][/redraw]
-
         {LOOT 200 1}
 
         [endlevel]

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Invaders.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Invaders.cfg
@@ -170,14 +170,6 @@
     [event]
         name=prestart
 
-        [role]
-            type=Dwarvish Steelclad,Dwarvish Thunderguard,Dwarvish Fighter,Dwarvish Thunderer
-            [not]
-                id=Aiglondur
-            [/not]
-            role=scout
-        [/role]
-
         {VARIABLE indigs_sighted 0}
 
         [objectives]
@@ -207,9 +199,22 @@
             id=Angarthing
         [/recall]
 
-        [recall]
+        [role]
+            type=Dwarvish Lord,Dwarvish Dragonguard,Dwarvish Steelclad,Dwarvish Thunderguard,Dwarvish Fighter,Dwarvish Thunderer
+            [not]
+                id=Aiglondur
+            [/not]
             role=scout
-        [/recall]
+            [auto_recall][/auto_recall]
+            [else]
+                [unit]
+                    side=1
+                    type=Dwarvish Fighter
+                    placement=leader
+                    role=scout
+                [/unit]
+            [/else]
+        [/role]
 
         {MODIFY_UNIT (side=1) facing ne}
     [/event]

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Invaders.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Invaders.cfg
@@ -170,8 +170,6 @@
     [event]
         name=prestart
 
-        {VARIABLE indigs_sighted 0}
-
         [objectives]
             side=1
             [objective]
@@ -260,6 +258,23 @@
     [/event]
 
     [event]
+        name=indigs_sighted
+        [filter]
+            side=1
+        [/filter]
+
+        [message]
+            speaker=unit
+            message= _ "The villagers are attacking us!"
+        [/message]
+
+        [message]
+            speaker=Aiglondur
+            message= _ "Aye, it’s still bandit country, right enough."
+        [/message]
+    [/event]
+
+    [event]
         name=capture
         first_time_only=no
         [filter]
@@ -301,48 +316,15 @@
             count=$indigs
             types=Footpad,Thief,Thug
             side=5
-        [/spawn_units]
-
-        # Perform appropriate notifications
-        [if]
-            [variable]
-                name=indigs
-                greater_than=0
-            [/variable]
             [then]
-                [message]
-                    speaker=unit
-                    message= _ "The villagers are attacking us!"
-                [/message]
-
-                [message]
-                    speaker=Aiglondur
-                    message= _ "Aye, it’s still bandit country, right enough."
-                    [show_if]
-                        [variable]
-                            name=indigs_sighted
-                            equals=0
-                        [/variable]
-                    [/show_if]
-                [/message]
-
-                {VARIABLE_OP indigs_sighted add 1}
-            [/then]
-            [elseif]
-                [variable]
+                [fire_event]
                     name=indigs_sighted
-                    greater_than=0
-                [/variable]
-                [then]
-                    [message]
-                        speaker=unit
-                        message= _ "No bandits in this village."
-                    [/message]
-
-                    [allow_undo][/allow_undo]
-                [/then]
-            [/elseif]
-        [/if]
+                    [primary_unit]
+                        x,y=$x1,$y1
+                    [/primary_unit]
+                [/fire_event]
+            [/then]
+        [/spawn_units]
 
         {CLEAR_VARIABLE indigs}
     [/event]
@@ -355,12 +337,6 @@
             bonus=yes
             {NEW_GOLD_CARRYOVER 40}
         [/endlevel]
-    [/event]
-
-    [event]
-        name=scenario_end
-
-        {CLEAR_VARIABLE indigs_sighted}
     [/event]
 
     {HERODEATH_AIGLONDUR}

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Invaders.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Invaders.cfg
@@ -375,7 +375,7 @@
             [/do]
         [/foreach]
 
-        {CLEAR_VARIABLE villages,village_var,done_shaun,indigs_sighted}
+        {CLEAR_VARIABLE villages,village_var,indigs_sighted}
     [/event]
 
     {HERODEATH_AIGLONDUR}

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Invaders.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Invaders.cfg
@@ -254,17 +254,6 @@
         [/message]
     [/event]
 
-    # Pop up random bandits village captures.
-    [event]
-        name=capture
-        first_time_only=no
-        [filter]
-            side=5
-        [/filter]
-
-        {CLEAR_VARIABLE cleared_$x1|_$y1|_village}
-    [/event]
-
     [event]
         name=capture
         first_time_only=no
@@ -275,12 +264,16 @@
         [/filter]
         [filter_condition]
             [variable]
-                name=cleared_$x1|_$y1|_village
-                boolean_not_equals=yes
+                name=owner_side
+                equals=0
             [/variable]
+            [or]
+                [variable]
+                    name=owner_side
+                    equals=5
+                [/variable]
+            [/or]
         [/filter_condition]
-
-        {VARIABLE cleared_$x1|_$y1|_village yes}
 
         # Compute the number of indigs that will pop up
         [if]
@@ -362,20 +355,7 @@
     [event]
         name=scenario_end
 
-        [store_villages]
-            variable=villages
-        [/store_villages]
-
-        [foreach]
-            array=villages
-            [do]
-                {VARIABLE_OP village_var value "village_$this_item.x|_$this_item.y|_cleared"}
-
-                {CLEAR_VARIABLE $village_var}
-            [/do]
-        [/foreach]
-
-        {CLEAR_VARIABLE villages,village_var,indigs_sighted}
+        {CLEAR_VARIABLE indigs_sighted}
     [/event]
 
     {HERODEATH_AIGLONDUR}

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/06_High_Pass.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/06_High_Pass.cfg
@@ -153,16 +153,16 @@
 
         [remove_shroud]
             side=1
-            x=29-31
-            y=10-12
+            x=29-31,30
+            y=11-12,10
         [/remove_shroud]
 
         {HIGHLIGHT_IMAGE 30 11 scenery/signpost.png ()}
 
         [place_shroud]
             side=1
-            x=29-31
-            y=10-12
+            x=29-31,30
+            y=11-12,10
         [/place_shroud]
 
         {WILDTHING 8 7}

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/06_High_Pass.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/06_High_Pass.cfg
@@ -113,6 +113,15 @@
                 description= _ "Death of Angarthing"
                 condition=lose
             [/objective]
+            [objective]
+                description = _ "Death of Ratheln"
+                condition=lose
+                [show_if]
+                    [have_unit]
+                        id=Ratheln
+                    [/have_unit]
+                [/show_if]
+            [/objective]
 
             {TURNS_RUN_OUT}
 
@@ -293,6 +302,8 @@
             speaker=Aiglondur
             message= _ "Aye. And I’d not leave anyone who had done my kin no harm stranded to starve."
         [/message]
+
+        [show_objectives][/show_objectives]
     [/event]
 
     # In this scenario only, losing Ratheln is fatal.

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/06_High_Pass.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/06_High_Pass.cfg
@@ -241,24 +241,19 @@
     [/event]
 
     [event]
-        name=moveto
+        name=enter_hex
         first_time_only=yes
         [filter]
             side=1
-            # Should be triggered regardless of how the Dwarves move through.
-            # It will look a little odd if they've all decided to slog through
-            # the mountains to the extreme north or south, but that is quite
-            # unlikely.
-            x=18-21
-            y=4-21
+            [filter_location]
+                # Should be triggered regardless of how the Dwarves move through.
+                # It will look a little odd if they've all decided to slog through
+                # the mountains to the extreme north or south, but that is quite
+                # unlikely.
+                x=18-21
+                y=0-21
+            [/filter_location]
         [/filter]
-        [filter_condition]
-            [not]
-                [have_unit]
-                    id=Ratheln
-                [/have_unit]
-            [/not]
-        [/filter_condition]
 
         [unit]
             side=1

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/06_High_Pass.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/06_High_Pass.cfg
@@ -365,13 +365,6 @@
             message= _ "Aye. But I’ve a grim feeling we might be going to discover that in person."
         [/message]
 
-        {UNMAKE_HERO Ratheln}
-
-        [unit_overlay]
-            id=Ratheln
-            image=misc/loyal-icon.png
-        [/unit_overlay]
-
         [endlevel]
             result=victory
             bonus=yes

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Mages_and_Drakes.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Mages_and_Drakes.cfg
@@ -124,6 +124,10 @@
                 description= _ "Death of Angarthing"
                 condition=lose
             [/objective]
+            [objective]
+                description= _ "Death of Ratheln"
+                condition=lose
+            [/objective]
 
             {TURNS_RUN_OUT}
 
@@ -253,6 +257,13 @@
                     id=Ratheln
                 [/kill]
 #else
+                {UNMAKE_HERO Ratheln}
+
+                [unit_overlay]
+                    id=Ratheln
+                    image=misc/loyal-icon.png
+                [/unit_overlay]
+
                 [message]
                     speaker=Ratheln
                     message= _ "Perrin, I owe these dwarves a debt; I think it is my duty to aid them in their journey. I’ll return with your apprentices as soon as I may."
@@ -296,4 +307,18 @@
     {HERODEATH_AIGLONDUR}
     {HERODEATH_ANGARTHING}
     {HERODEATH_RATHELN}
+
+    # In this scenario only, losing Ratheln is fatal.
+    # This avoids continuity problems in this scenario.
+    # His death comment comes from the macro, above.
+    [event]
+        name=die
+        [filter]
+            id=Ratheln
+        [/filter]
+
+        [endlevel]
+            result=defeat
+        [/endlevel]
+    [/event]
 [/scenario]

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Mages_and_Drakes.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Mages_and_Drakes.cfg
@@ -209,6 +209,10 @@
                     experience=40 # of 60
                     side=1
                     placement=leader
+                    {IS_LOYAL}
+                    [modifications]
+                        {TRAIT_LOYAL}
+                    [/modifications]
                 [/unit]
 #endif
                 [unit]
@@ -218,6 +222,10 @@
                     experience=40 # of 60
                     side=1
                     placement=leader
+                    {IS_LOYAL}
+                    [modifications]
+                        {TRAIT_LOYAL}
+                    [/modifications]
                 [/unit]
 
                 [message]

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Mages_and_Drakes.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Mages_and_Drakes.cfg
@@ -200,16 +200,6 @@
                 [/message]
 #endif
 
-                [message]
-                    speaker=Aiglondur
-                    message= _ "What sort of thing?"
-                [/message]
-
-                [message]
-                    speaker=Master Perrin
-                    message= _ "There is some great magic brewing. Something... evil. I feel its traces in the currents of the earth and air."
-                [/message]
-
 #ifdef EASY
                 [unit]
                     type=Mage
@@ -229,6 +219,16 @@
                     side=1
                     placement=leader
                 [/unit]
+
+                [message]
+                    speaker=Aiglondur
+                    message= _ "What sort of thing?"
+                [/message]
+
+                [message]
+                    speaker=Master Perrin
+                    message= _ "There is some great magic brewing. Something... evil. I feel its traces in the currents of the earth and air."
+                [/message]
 
 #ifdef HARD
                 [message]

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Mages_and_Drakes.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Mages_and_Drakes.cfg
@@ -237,11 +237,19 @@
                     type=Mage
                 [/allow_recruit]
 
+#ifdef EASY
                 [message]
                     speaker=narrator
-                    message= _ "The presence of Master Perrin’s journeymen gives you the ability to recruit mages."
+                    message= _ "The presence of Lorinne and Darchas gives you the ability to recruit mages."
                     image=wesnoth-icon.png
                 [/message]
+#else
+                [message]
+                    speaker=narrator
+                    message= _ "The presence of Darchas gives you the ability to recruit mages."
+                    image=wesnoth-icon.png
+                [/message]
+#endif
 
                 [message]
                     speaker=Aiglondur

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Mages_and_Drakes.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Mages_and_Drakes.cfg
@@ -232,6 +232,17 @@
                     [/modifications]
                 [/unit]
 
+                [allow_recruit]
+                    side=1
+                    type=Mage
+                [/allow_recruit]
+
+                [message]
+                    speaker=narrator
+                    message= _ "The presence of Master Perrin’s journeymen gives you the ability to recruit mages."
+                    image=wesnoth-icon.png
+                [/message]
+
                 [message]
                     speaker=Aiglondur
                     message= _ "What sort of thing?"

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Mages_and_Drakes.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Mages_and_Drakes.cfg
@@ -218,6 +218,7 @@
                     name= _ "Lorinne"
                     experience=40 # of 60
                     side=1
+                    placement=leader
                 [/unit]
 #endif
                 [unit]
@@ -226,6 +227,7 @@
                     name= _ "Darchas"
                     experience=40 # of 60
                     side=1
+                    placement=leader
                 [/unit]
 
 #ifdef HARD

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Mages_and_Drakes.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/07_Mages_and_Drakes.cfg
@@ -286,14 +286,14 @@
                     message= _ "You have your duty, as we have ours. Fare well."
                 [/message]
 
+                [kill]
+                    id=Ratheln
+                [/kill]
+
                 [message]
                     speaker=Angarthing
                     message= _ "I think we will regret Perrin’s passing. There is much he might have told us."
                 [/message]
-
-                [kill]
-                    id=Ratheln
-                [/kill]
             [/else]
         [/if]
 

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/08_Fear.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/08_Fear.cfg
@@ -35,6 +35,7 @@
         {CHARACTER_STATS_AIGLONDUR}
 
         fog=yes
+        share_vision=all
         facing=ne
     [/side]
 
@@ -96,6 +97,8 @@
     [side]
         # The local peasantry
         side=3
+        fog=yes
+        share_vision=all
         no_leader=yes
         hidden=yes
         team_name=northern_alliance
@@ -185,6 +188,7 @@
     [/event]
 
     [event]
+        id=capture_ollin
         name=capture
         first_time_only=yes
         [filter]
@@ -198,6 +202,45 @@
             side=3
             x,y=$x1,$y1
         [/unit]
+
+        [fire_event]
+            name=banishment
+        [/fire_event]
+    [/event]
+
+    [event]
+        id=sighted_ollin
+        name=sighted
+        [filter]
+            side=2
+        [/filter]
+        [filter_second]
+            side=1
+        [/filter_second]
+
+        [unit]
+            type=Peasant
+            id=Ollin
+            name= _ "Ollin"
+            side=3
+            x,y=22,14
+        [/unit]
+
+        [fire_event]
+            name=banishment
+        [/fire_event]
+    [/event]
+
+    [event]
+        name=banishment
+
+        [remove_event]
+            id=capture_ollin,sighted_ollin
+        [/remove_event]
+
+        [redraw]
+            clear_shroud=yes
+        [/redraw]
 
         [message]
             speaker=Ollin
@@ -225,7 +268,7 @@
         [/message]
 
         [modify_side]
-            side=1
+            side=1,3
             fog=no
         [/modify_side]
 

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/08_Fear.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/08_Fear.cfg
@@ -142,32 +142,10 @@
         {MODIFY_UNIT (side=1) facing ne}
     [/event]
 
+    {CONDITIONAL_MAGE_RECRUITING}
+
     [event]
         name=start
-
-        [message]
-            speaker=narrator
-            message= _ "The presence of Master Perrin’s journeymen gives you the ability to recruit mages."
-            image=wesnoth-icon.png
-            [show_if]
-                [have_unit]
-                    id=Darchas
-                    [or]
-                        id=Lorinne
-                    [/or]
-                [/have_unit]
-            [/show_if]
-        [/message]
-
-        # Try to enable mage recruitment. If it isn't appropriate,
-        # the code in CONDITIONAL_MAGE_RECRUITING will undo this step.
-
-        [allow_recruit]
-            side=1
-            type=Mage
-        [/allow_recruit]
-
-        {CONDITIONAL_MAGE_RECRUITING}
 
         [message]
             speaker=Angarthing

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/08_Fear.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/08_Fear.cfg
@@ -16,6 +16,11 @@
 
     {THOT_TRACK {JOURNEY_STAGE8}}
 
+    {PLACE_IMAGE ("scenery/village-human-burned1.png") 36 8}
+    {PLACE_IMAGE ("scenery/village-human-burned2.png") 33 13}
+    {PLACE_IMAGE ("scenery/village-human-burned3.png") 26 13}
+    {PLACE_IMAGE ("scenery/village-human-burned1.png") 30 16}
+
     # wmllint: validate-off
     [side]
         side=1
@@ -219,19 +224,6 @@
             message= _ "The masked dwarves. Killing, burning, kidnapping. Look..."
         [/message]
 
-#define PLACE_BURNED_VILLAGE X Y
-    {VARIABLE_OP bv rand "1,2,3,4"}
-
-    {PLACE_IMAGE ("scenery/village-human-burned" + $bv| + ".png") {X} {Y}}
-#enddef
-
-        {PLACE_BURNED_VILLAGE 36 8}
-        {PLACE_BURNED_VILLAGE 33 13}
-        {PLACE_BURNED_VILLAGE 26 13}
-        {PLACE_BURNED_VILLAGE 30 16}
-
-        {CLEAR_VARIABLE bv}
-
         [modify_side]
             side=1
             fog=no
@@ -370,4 +362,3 @@
 [/scenario]
 
 #undef MASKED_ULFSERKER
-#undef PLACE_BURNED_VILLAGE

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/08_Fear.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/08_Fear.cfg
@@ -176,16 +176,7 @@
         [/message]
     [/event]
 
-    # The Masked Dwarves are nameless, it's a part of their charm...
-    [event]
-        name=recruit
-        first_time_only=no
-        [filter]
-            side=2
-        [/filter]
-
-        {MODIFY_UNIT x,y=$x1,$y1 name ( _ "Masked Dwarf")}
-    [/event]
+    {RENAME_MASKED_DWARVES 2}
 
     [event]
         id=capture_ollin

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/09_Forbidden_Forest.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/09_Forbidden_Forest.cfg
@@ -35,79 +35,14 @@
     # wmllint: validate-on
 
     # This tells the elves not to venture onto the plains
-#define AVOID_LEAVING_FOREST
-    [avoid]
-        x,y=3-4,6
-    [/avoid]
-    [avoid]
-        x,y=3-4,7
-    [/avoid]
-    [avoid]
-        x,y=1-3,8-9
-    [/avoid]
-    [avoid]
-        x,y=1-5,10-11
-    [/avoid]
-    [avoid]
-        x,y=1-2,12-14
-    [/avoid]
-    [avoid]
-        x,y=1-3,15
-    [/avoid]
-    [avoid]
-        x,y=1-4,16-18
-    [/avoid]
-    [avoid]
-        x,y=1-3,19-21
-    [/avoid]
-    [avoid]
-        x,y=1-2,22-23
-    [/avoid]
-    [avoid]
-        x,y=1,24
-    [/avoid]
-    [avoid]
-        x,y=1-2,25-27
-    [/avoid]
-    [avoid]
-        x,y=1-2,32-33
-    [/avoid]
-
-    [avoid]
-        x,y=35-40,1
-    [/avoid]
-    [avoid]
-        x,y=36-40,2
-    [/avoid]
-    [avoid]
-        x,y=39-40,3-4
-    [/avoid]
-    [avoid]
-        x,y=40,5-6
-    [/avoid]
-    [avoid]
-        x,y=39-40,7-10
-    [/avoid]
-    [avoid]
-        x,y=40,11-12
-    [/avoid]
-    [avoid]
-        x,y=39-40,13
-    [/avoid]
-    [avoid]
-        x,y=38-40,14
-    [/avoid]
-    [avoid]
-        x,y=39-40,15-19
-    [/avoid]
-#enddef
 
     # Set up the Staff of Righteous Flame.
     # Tell the AIs not to step on it so we don't have to deal
     # with the case where a forest unit picks it up.
-#define AVOID_TEMPLE
+#define AVOID
     [avoid]
-        x,y=22,16
+        x=   0,   1,   2,    2,    2,   3,    3,  4,   4,    4,    5,22, 35, 36, 37,37, 38,38,   38,38, 39,  39,   39,   39,  40,   40,  41,   41
+        y=7-32,8-33,7-23,25-29,31-33,6-11,15-21,6-7,9-10,16-18,10-11,16,0-2,0-1,0-2,10,0-2, 9,13-14,24,0-4,7-10,13-19,22-27,0-19,21-26,0-19,22-27
     [/avoid]
 #enddef
 
@@ -131,8 +66,7 @@
             grouping=offensive
             passive_leader=yes
             recruitment_pattern=scout,fighter,mixed fighter,archer
-            {AVOID_TEMPLE}
-            {AVOID_LEAVING_FOREST}
+            {AVOID}
         [/ai]
     [/side]
 
@@ -156,8 +90,7 @@
             grouping=offensive
             passive_leader=yes
             recruitment_pattern=fighter,archer,mixed fighter,mixed fighter
-            {AVOID_TEMPLE}
-            {AVOID_LEAVING_FOREST}
+            {AVOID}
         [/ai]
     [/side]
 
@@ -182,7 +115,9 @@
             grouping=offensive
             passive_leader=yes
             recruitment_pattern=fighter
-            {AVOID_TEMPLE}
+            [avoid]
+                x,y=22,16
+            [/avoid]
         [/ai]
     [/side]
 
@@ -392,5 +327,4 @@
     {HERODEATH_RATHELN}
 [/scenario]
 
-#undef AVOID_LEAVING_FOREST
-#undef AVOID_TEMPLE
+#undef AVOID

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/09_Forbidden_Forest.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/09_Forbidden_Forest.cfg
@@ -238,10 +238,10 @@
         {MODIFY_UNIT (side=1) facing se}
     [/event]
 
+    {CONDITIONAL_MAGE_RECRUITING}
+
     [event]
         name=start
-
-        {CONDITIONAL_MAGE_RECRUITING}
 
         [delay]
             time=500

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Siege_of_Kal_Kartha.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Siege_of_Kal_Kartha.cfg
@@ -254,10 +254,10 @@
         {MODIFY_UNIT (side=1) facing ne}
     [/event]
 
+    {CONDITIONAL_MAGE_RECRUITING}
+
     [event]
         name=start
-
-        {CONDITIONAL_MAGE_RECRUITING}
 
         [message]
             speaker=Angarthing

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Siege_of_Kal_Kartha.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Siege_of_Kal_Kartha.cfg
@@ -205,6 +205,11 @@
 
     {STARTING_VILLAGES 2 5}
 
+    [label]
+        x,y=44,15
+        text= _ "West Gate"
+    [/label]
+
     [event]
         name=prestart
 

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Siege_of_Kal_Kartha.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Siege_of_Kal_Kartha.cfg
@@ -223,7 +223,7 @@
                 condition=lose
             [/objective]
             [objective]
-                description= _ "Death of West Gate commander"
+                description= _ "Death of Dulcatulos"
                 condition=lose
             [/objective]
 

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/11_The_Court_of_Karrag.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/11_The_Court_of_Karrag.cfg
@@ -249,6 +249,10 @@
             message= _ "The Law speaks. Against him with the eyes to see, no deception can hold. I AM A WITNESS!"
         [/message]
 
+        [scroll_to_unit]
+            id=Karrag
+        [/scroll_to_unit]
+
         [transform_unit]
             id=Karrag
             transform_to=Undead Dwarvish Rune Lord
@@ -264,6 +268,7 @@
 
         [message]
             speaker=Dulcatulos
+            scroll=no
             message= _ "No... no... it is horrible! My lord, how did you come to this?"
         [/message]
 
@@ -282,6 +287,8 @@
         # Put his mask back on so we don't have to deal with yet another unit type
         # for his maskless variation
         {MODIFY_UNIT (id=Karrag) variation none}
+
+        [redraw][/redraw]
 
         [message]
             speaker=narrator

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/11_The_Court_of_Karrag.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/11_The_Court_of_Karrag.cfg
@@ -174,6 +174,8 @@
         {MODIFY_UNIT (side=1) facing se}
     [/event]
 
+    {CONDITIONAL_MAGE_RECRUITING}
+
     [event]
         name=start
 

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/12_The_Underlevels.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/12_The_Underlevels.cfg
@@ -382,6 +382,7 @@
                 condition=lose
             [/objective]
 
+            {HAS_NO_TURN_LIMIT}
             {IS_LAST_SCENARIO}
         [/objectives]
 

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/12_The_Underlevels.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/12_The_Underlevels.cfg
@@ -1170,6 +1170,8 @@
         [/endlevel]
     [/event]
 
+    {RENAME_MASKED_DWARVES 3,4,5,8}
+
     {HERODEATH_AIGLONDUR}
     {HERODEATH_ANGARTHING}
     {HERODEATH_RATHELN}

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/12_The_Underlevels.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/12_The_Underlevels.cfg
@@ -400,10 +400,10 @@
         {MODIFY_UNIT (side=1) facing se}
     [/event]
 
+    {CONDITIONAL_MAGE_RECRUITING}
+
     [event]
         name=start
-
-        {CONDITIONAL_MAGE_RECRUITING}
 
         [message]
             speaker=Angarthing

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/13_Epilogue.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/13_Epilogue.cfg
@@ -206,6 +206,11 @@
 
         [hide_unit][/hide_unit]
 
+        [remove_item]
+            x=18,12,12
+            y=11,10,12
+        [/remove_item]
+
         {FADE_TO_BLACK_HOLD 500}
 
         [unlock_view][/unlock_view]

--- a/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Rune_Lord.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Rune_Lord.cfg
@@ -164,5 +164,10 @@
         variation_id=karrag-unmasked
         inherit=yes
         image=units/karrag-unmasked.png
+        [standing_anim]
+            [frame]
+                image=units/karrag-unmasked.png:100
+            [/frame]
+        [/standing_anim]
     [/variation]
 [/unit_type]

--- a/data/campaigns/The_Hammer_of_Thursagan/utils/macros.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/utils/macros.cfg
@@ -4,30 +4,55 @@
 Mage,Red Mage,White Mage,Arch Mage,Great Mage,Mage of Light,Silver Mage #enddef
 
 #define CONDITIONAL_MAGE_RECRUITING
-    [if]
-        [variable]
-            name=mage_disallow
-            boolean_equals=false
-        [/variable]
-        [not]
-            [have_unit]
-                side=1
-                type={MAGES}
-            [/have_unit]
-        [/not]
-        [then]
-            [message]
-                speaker=narrator
-                message= _ "Without magic users from Master Perrin’s academy in your party, you can no longer recruit new ones."
-                image=wesnoth-icon.png
-            [/message]
-            [disallow_recruit]
-                side=1
-                type=Mage
-            [/disallow_recruit]
-            {VARIABLE mage_disallow true}
-        [/then]
-    [/if]
+    [event]
+        name=die
+        first_time_only=no
+        [filter]
+            side=1
+            type_tree=Mage
+            [not]
+                id=Ratheln
+            [/not]
+            [filter_wml]
+                [modifications]
+                    [trait]
+                        id=loyal
+                    [/trait]
+                [/modifications]
+            [/filter_wml]
+        [/filter]
+
+        [if]
+            [not]
+                [have_unit]
+                    search_recall_list=yes
+                    side=1
+                    type_tree=Mage
+                    [not]
+                        id=Ratheln
+                    [/not]
+                    [filter_wml]
+                        [modifications]
+                            [trait]
+                                id=loyal
+                            [/trait]
+                        [/modifications]
+                    [/filter_wml]
+                [/have_unit]
+            [/not]
+            [then]
+                [message]
+                    speaker=narrator
+                    message= _ "Without magic users from Master Perrin’s academy in your party, you can no longer recruit new ones."
+                    image=wesnoth-icon.png
+                [/message]
+                [disallow_recruit]
+                    side=1
+                    type=Mage
+                [/disallow_recruit]
+            [/then]
+        [/if]
+    [/event]
 #enddef
 
 #define OBJ_STAFF_OF_RIGHTEOUS_FLAME X Y

--- a/data/campaigns/The_Hammer_of_Thursagan/utils/macros.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/utils/macros.cfg
@@ -60,6 +60,19 @@ Mage,Red Mage,White Mage,Arch Mage,Great Mage,Mage of Light,Silver Mage #enddef
 
     [event]
         name=moveto
+        [filter]
+            side=1
+            x,y={X},{Y}
+        [/filter]
+
+        [message]
+            speaker=unit
+            message= _ "There an altar in this temple, and a staff lies upon it."
+        [/message]
+    [/event]
+
+    [event]
+        name=moveto
         first_time_only=no
         [filter]
             side=1

--- a/data/campaigns/The_Hammer_of_Thursagan/utils/macros.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/utils/macros.cfg
@@ -1,8 +1,5 @@
 #textdomain wesnoth-thot
 
-#define MAGES
-Mage,Red Mage,White Mage,Arch Mage,Great Mage,Mage of Light,Silver Mage #enddef
-
 #define CONDITIONAL_MAGE_RECRUITING
     [event]
         name=die
@@ -88,7 +85,7 @@ Mage,Red Mage,White Mage,Arch Mage,Great Mage,Mage of Light,Silver Mage #enddef
             cannot_use_message= _ "Only a mage may wield this Staff."
             [filter]
                 side=1
-                type={MAGES}
+                type_tree=Mage
                 x,y=$x1,$y1
             [/filter]
 

--- a/data/campaigns/The_Hammer_of_Thursagan/utils/macros.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/utils/macros.cfg
@@ -170,3 +170,16 @@
         x,y={X},{Y}
     [/recall]
 #enddef
+
+#define RENAME_MASKED_DWARVES SIDE
+    # The Masked Dwarves are nameless, it's a part of their charm...
+    [event]
+        name=recruit
+        first_time_only=no
+        [filter]
+            side={SIDE}
+        [/filter]
+
+        {MODIFY_UNIT x,y=$x1,$y1 name ( _ "Masked Dwarf")}
+    [/event]
+#enddef


### PR DESCRIPTION
This completes my code-read and play-test of THoT.

Most changes were minor. The changes effecting game-play are:

The treatment of the Mages obtained from Master Perrin’s academy has been adjusted. The ability to recruit mages is now gained when they appear, and lost immediately upon the death of the last one rather than lingering until the start of the next scenario.

In S08 ('Fear') it was possible to meet the enemy without previously capturing a village and having Ollin appear. This rendered the closing scene difficult to understand. Now, meeting the enemy also triggers Ollin's appearance.

And the following other major changes were made:

The Lua function used to spawn indigenous units which appear when capturing villages during S05 ('Invaders') has been corrected, debugged and revised to reduce the [message] chatter.

The treatment of Ratheln has been adjusted to show him as a victory condition when appropriate, and to ensure he is available to deliver his lines.

**NOTE**

The final scene, S12 ('The Underlevels') has feedback which indicates a major problem with balance. I have made some minor corrections. Vultraz and/or Aeth have been talking about a major rework. So, I will be doing no more work on S12.