### PR TITLE
Resolve sides in editor not having a proper side number (bug #25093)

### DIFF
--- a/changelog
+++ b/changelog
@@ -166,6 +166,8 @@ Version 1.13.5+dev:
      player opened and closed a menu.
    * Correct unit recall count in statistics when undoing a unit recall (bug #25060)
    * Add tip to recall units instead of recruiting them if costs exceed 20 gold (recruitment costs)
+   * Resolve sides in map editor not having a proper side number and subsequently
+     causing a crash upon editing (bug #25093)
 
 Version 1.13.5:
  * Campaigns:

--- a/src/editor/map/context_manager.cpp
+++ b/src/editor/map/context_manager.cpp
@@ -207,14 +207,17 @@ void context_manager::load_mru_item(unsigned int index, bool force_same_context 
 	load_map(mru[index], !force_same_context);
 }
 
-void context_manager::edit_side_dialog(int side)
+void context_manager::edit_side_dialog(int side_index)
 {
-	team& t = get_map_context().get_teams()[side];
+	team& t = get_map_context().get_teams()[side_index];
 
 	//TODO
 	//t.support()
 
 	editor_team_info team_info(t);
+
+	// The side number perhaps should have been set in map_context::new_side() but the design of team::team_info appears to be read-only.
+	team_info.side = side_index + 1;	// note team_info::side is supposed to be 1 to n, while side/team indexes are 0 to n-1
 
 	if(gui2::teditor_edit_side::execute(team_info, gui_.video())) {
 		get_map_context().set_side_setup(team_info);

--- a/src/editor/map/context_manager.hpp
+++ b/src/editor/map/context_manager.hpp
@@ -133,8 +133,8 @@ public:
 	/** Display a scenario edit dialog and process user input. */
 	void edit_scenario_dialog();
 
-	/** TODO */
-	void edit_side_dialog(int side);
+	/** Display a side edit dialog and process user input. */
+	void edit_side_dialog(int side_index);
 
 	/** Display a new map dialog and process user input. */
 	void new_map_dialog();


### PR DESCRIPTION
Regarding the method commentary in context_manager.hpp, these are the kind of comments which are (mostly) useless - well-written method names should obviate the need for an explanatory comment. However, I replaced the 'TODO' and followed existing convention in this case.

This resolves https://gna.org/bugs/?25093 by replicating missing behaviour from 1.12 branch, however @Vultraz mentioned that he has 'an idea' and 'will investigate later' (#wesnoth-dev - 2016-09-24 07:08 UTC), so this may not be the 'proper' way to go about resolving the bug.