### PR TITLE
Fix GUI2 multiplayer tests

### DIFF
--- a/host-gui2.lua
+++ b/host-gui2.lua
@@ -69,9 +69,15 @@ local function plugin()
 
   context.create({})
 
+  while (info.name ~= "Multiplayer Staging") do
+    events, context, info = coroutine.yield()
+    idle_text("in " .. info.name .. " waiting for staging")
+  end
+
   ready = nil
   repeat
     events, context, info = coroutine.yield()
+    context.process_network({})
     for i,v in ipairs(events) do
       if v[1] == "chat" then
         std_print(events[i][2])

--- a/src/game_initialization/connect_engine.cpp
+++ b/src/game_initialization/connect_engine.cpp
@@ -759,6 +759,21 @@ std::pair<bool, bool> connect_engine::process_network_data(const config& data)
 	return result;
 }
 
+std::tuple<bool, bool, config> connect_engine::process_network_data()
+{
+	config data;
+	bool has_data = campaign_info_->wesnothd_connection.receive_data(data);
+	if (!has_data)
+	{
+		return std::make_tuple(false, false, data);
+	}
+	else
+	{
+		std::pair<bool, bool> ret = process_network_data(data);
+		return std::make_tuple(ret.first, ret.second, data);
+	}
+}
+
 int connect_engine::find_user_side_index_by_id(const std::string& id) const
 {
 	size_t i = 0;

--- a/src/game_initialization/connect_engine.hpp
+++ b/src/game_initialization/connect_engine.hpp
@@ -75,6 +75,10 @@ public:
 	// and second element whether to silently update UI.
 	std::pair<bool, bool> process_network_data(const config& data);
 
+	// First two elements are the same as above, the third is any data
+	// received from the server (or empty config if there isn't any new data).
+	std::tuple<bool, bool, config> process_network_data();
+
 	// Returns the side which is taken by a given user,
 	// or -1 if none was found.
 	int find_user_side_index_by_id(const std::string& id) const;

--- a/src/gui/dialogs/multiplayer/mp_staging.hpp
+++ b/src/gui/dialogs/multiplayer/mp_staging.hpp
@@ -28,6 +28,7 @@ class config;
 namespace gui2
 {
 
+class tchatbox;
 class ttoggle_button;
 class ttoggle_panel;
 class tslider;
@@ -51,6 +52,9 @@ private:
 	void post_show(twindow& window);
 
 	void sync_changes();
+
+	/** Clears asynchronous send and receive buffers and handles incoming data. */
+	void process_network(tchatbox& chat);
 
 	void on_controller_select(ng::side_engine& side, tgrid& row_grid);
 	void on_ai_select(ng::side_engine& side, tmenu_button& ai_menu);

--- a/src/gui/widgets/chatbox.cpp
+++ b/src/gui/widgets/chatbox.cpp
@@ -37,6 +37,7 @@
 #include "game_preferences.hpp"
 #include "lobby_preferences.hpp"
 #include "log.hpp"
+#include "scripting/plugins/manager.hpp"
 
 static lg::log_domain log_lobby("lobby");
 #define DBG_LB LOG_STREAM(debug, log_lobby)
@@ -701,6 +702,11 @@ void tchatbox::process_message(const ::config& data, bool whisper /*= false*/)
 
 		add_chat_room_message_received(room, sender, message);
 	}
+
+	// Notify plugins about the message
+	::config plugin_data = data;
+	plugin_data["whisper"] = whisper;
+	plugins_manager::get()->notify_event("chat", plugin_data);
 }
 
 bool tchatbox::process_network_data(const ::config& data)


### PR DESCRIPTION
These changes get the GUI2 multiplayer tests to pass. They broke when @Vultraz added the GUI2 MP staging dialog.

Instead of pushing directly, I made a PR about these changes because I'm unsure if having the test plugin explicitly tell the game to process incoming test data (host-gui2.lua:80) is anywhere near the right approach. Any thoughts, @Vultraz?