### PR TITLE
include ctime header for time_t

### DIFF
--- a/src/addon/info.hpp
+++ b/src/addon/info.hpp
@@ -19,6 +19,7 @@
 
 #include "addon/validation.hpp"
 
+#include <ctime>
 #include <set>
 #include <map>
 


### PR DESCRIPTION
Missing #include causes compilation error with clang++.