### PR TITLE
Pentarctagon two portraits fix

### DIFF
--- a/data/gui/window/wml_message.cfg
+++ b/data/gui/window/wml_message.cfg
@@ -756,19 +756,6 @@ if(gamemap_width - (10 + ({__GUI_IMAGE_WIDTH})) > {MAX_TEXT_WIDTH}
 											[column]
 
 												[spacer]
-													width = "(
-if(gamemap_width - (10 + ({__GUI_IMAGE_WIDTH})) > {MAX_TEXT_WIDTH}
-, gamemap_width - (10 + ({__GUI_IMAGE_WIDTH}) + {MAX_TEXT_WIDTH})
-, 0
-))"
-													height = 75
-												[/spacer]
-
-											[/column]
-
-											[column]
-
-												[spacer]
 													# reserve place for the image and set a minimum height for the text
 													id = "image_place_holder"
 

--- a/data/lua/wml/message.lua
+++ b/data/lua/wml/message.lua
@@ -200,6 +200,9 @@ local function message_user_choice(cfg, speaker, options, text_input)
 		title = caption,
 		message = cfg.message,
 		portrait = image,
+		mirror = cfg.message,
+		second_portrait = cfg.second_image,
+		second_mirror = cfg.second_mirror,
 	}
 	
 	if speaker ~= nil then

--- a/data/lua/wml/message.lua
+++ b/data/lua/wml/message.lua
@@ -200,7 +200,7 @@ local function message_user_choice(cfg, speaker, options, text_input)
 		title = caption,
 		message = cfg.message,
 		portrait = image,
-		mirror = cfg.message,
+		mirror = cfg.mirror,
 		second_portrait = cfg.second_image,
 		second_mirror = cfg.second_mirror,
 	}


### PR DESCRIPTION
The implementation of [this] (https://gna.org/bugs/?12098) feature request resulted in the content of a message being [squished] (http://cubeupload.com/im/Pcxsvs.png).  The change to wml_message.cfg fixes that issue.

[With no text] (http://i.cubeupload.com/7GTS22.png)
[With text] (http://i.cubeupload.com/inCkod.png)
[With text and options] (http://i.cubeupload.com/ET1bjV.png)
[With text and text input] (http://i.cubeupload.com/C4q4po.png)
[With text, text input, and options] (http://i.cubeupload.com/7CkSRJ.png)

The change to message.lua then allows the [message] tag to display and mirror two portraits.