### PR TITLE
Improve move times for AI sides with many guardians

### DIFF
--- a/src/ai/default/ca_move_to_targets.cpp
+++ b/src/ai/default/ca_move_to_targets.cpp
@@ -157,8 +157,7 @@ void move_to_targets_phase::execute()
 		}
 
 		LOG_AI << "choosing move with " << targets.size() << " targets\n";
-		std::pair<map_location,map_location> move = choose_move(targets, get_srcdst(),
-								get_dstsrc(), get_enemy_dstsrc());
+		std::pair<map_location,map_location> move = choose_move(targets);
 		LOG_AI << "choose_move ends with " << targets.size() << " targets\n";
 
 		for(std::vector<target>::const_iterator ittg = targets.begin();
@@ -269,7 +268,7 @@ double move_to_targets_phase::rate_target(const target& tg, const unit_map::iter
 
 
 
-std::pair<map_location,map_location> move_to_targets_phase::choose_move(std::vector<target>& targets, const move_map& srcdst, const move_map& dstsrc, const move_map& enemy_dstsrc)
+std::pair<map_location,map_location> move_to_targets_phase::choose_move(std::vector<target>& targets)
 {
 	log_scope2(log_ai_testing_ca_move_to_targets, "choosing move");
 
@@ -305,6 +304,8 @@ std::pair<map_location,map_location> move_to_targets_phase::choose_move(std::vec
 	// and if its real value is better than other maximal values
 	// then we can skip them.
 
+	const move_map& dstsrc = get_dstsrc();
+	const move_map& enemy_dstsrc = get_enemy_dstsrc();
 	std::vector<rated_target> rated_targets;
 	for(std::vector<target>::iterator tg = targets.begin(); tg != targets.end(); ++tg) {
 		// passing a dummy route to have the maximal rating
@@ -431,6 +432,7 @@ std::pair<map_location,map_location> move_to_targets_phase::choose_move(std::vec
 
 	//if our target is a position to support, then we
 	//see if we can move to a position in support of this target
+	const move_map& srcdst = get_srcdst();
 	if(best_target->type == target::TYPE::SUPPORT) {
 		LOG_AI << "support...\n";
 

--- a/src/ai/default/ca_move_to_targets.cpp
+++ b/src/ai/default/ca_move_to_targets.cpp
@@ -278,7 +278,17 @@ std::pair<map_location,map_location> move_to_targets_phase::choose_move(std::vec
 
 	unit_map::iterator u;
 
-	//find the first eligible unit
+	//take care of all the guardians first
+	for(u = units_.begin(); u != units_.end(); ++u) {
+		if (!(u->side() != get_side() || (u->can_recruit() && !get_leader_ignores_keep()) || u->movement_left() <= 0 || u->incapacitated())) {
+			if (u->get_state("guardian")) {
+				LOG_AI << u->type_id() << " is guardian, staying still\n";
+				return std::make_pair(u->get_location(), u->get_location());
+			}
+		}
+	}
+
+	//now find the first eligible remaining unit
 	for(u = units_.begin(); u != units_.end(); ++u) {
 		if (!(u->side() != get_side() || (u->can_recruit() && !get_leader_ignores_keep()) || u->movement_left() <= 0 || u->incapacitated())) {
 			break;
@@ -288,12 +298,6 @@ std::pair<map_location,map_location> move_to_targets_phase::choose_move(std::vec
 	if(u == units_.end()) {
 		LOG_AI  << "no eligible units found\n";
 		return std::pair<map_location,map_location>();
-	}
-
-	//guardian units stay put
-	if (u->get_state("guardian")) {
-		LOG_AI << u->type_id() << " is guardian, staying still\n";
-		return std::make_pair(u->get_location(), u->get_location());
 	}
 
 	const pathfind::plain_route dummy_route;

--- a/src/ai/default/ca_move_to_targets.hpp
+++ b/src/ai/default/ca_move_to_targets.hpp
@@ -54,7 +54,7 @@ public:
 protected:
 	void access_points(const move_map& srcdst, const map_location& u, const map_location& dst, std::vector<map_location>& out);
 
-	std::pair<map_location,map_location> choose_move(std::vector<target>& targets, const move_map& srcdst, const move_map& dstsrc, const move_map& enemy_dstsrc);
+	std::pair<map_location,map_location> choose_move(std::vector<target>& targets);
 
 	double compare_groups(const std::set<map_location>& our_group, const std::set<map_location>& their_group, const std::vector<map_location>& battlefield) const;
 


### PR DESCRIPTION
This PR contains two changes which significantly improve AI move times for AI sides with many guardian units.  The first commit improves evaluation times for the guardian units themselves.  The second improves times for the other AI units.