### PR TITLE
wmlxgettext: added support for plural forms (used on lua files)

### DIFF
--- a/utils/pywmlx/nodemanip.py
+++ b/utils/pywmlx/nodemanip.py
@@ -61,9 +61,6 @@ def newnode(tagname):
     if tagname == "[lua]":
         nodes.append( pos.WmlNode(fileref, fileno, 
                                   tagname, autowml=False) )
-    # elif tagname == "":
-    # self.nodes.append( WmlNode(self.fileref, self.fileno, 
-    #                            "[unknown]", False) )
     else:
         nodes.append( pos.WmlNode(fileref, fileno, 
                                   tagname, autowml=True) )

--- a/utils/pywmlx/nodemanip.py
+++ b/utils/pywmlx/nodemanip.py
@@ -100,14 +100,15 @@ def closenode(closetag, mydict, lineno):
 
 
 def addNodeSentence(sentence, *, ismultiline, lineno, lineno_sub,
-                    override, addition):
+                    override, addition, plural=None):
     global nodes
     if nodes is None:
         nodes = [pos.WmlNode(fileref=fileref, fileno=fileno, 
                               tagname="", autowml=False)]
     nodes[-1].add_sentence(sentence, ismultiline=ismultiline, 
                            lineno=lineno, lineno_sub=lineno_sub,
-                           override=override, addition=addition)
+                           override=override, addition=addition,
+                           plural=plural)
 
 
 def addWmlInfo(info):

--- a/utils/pywmlx/postring.py
+++ b/utils/pywmlx/postring.py
@@ -3,9 +3,9 @@ import re
 
 
 # PoCommentedStringPL represents a 'plural' form of a PoCommentedString or a
-# WmlNode. Currently PoCommentedStringPL is currently used only within 
-# PoCommentedString, becouse translation plural forms, in wesnoth, are
-# currently supported only on lua code
+# WmlNode. Currently PoCommentedStringPL is actually used only within 
+# PoCommentedString 
+# (until wesnoth supports plural forms only on lua code)
 class PoCommentedStringPL:
     def __init__(self, value, *, ismultiline=False):
         self.value = value

--- a/utils/pywmlx/postring.py
+++ b/utils/pywmlx/postring.py
@@ -1,7 +1,11 @@
 import re
 
-# remember... I ised PoCommentedStringML instead of PoCommentedStringML... don't know if something remained in other files
 
+
+# PoCommentedStringPL represents a 'plural' form of a PoCommentedString or a
+# WmlNode. Currently PoCommentedStringPL is currently used only within 
+# PoCommentedString, becouse translation plural forms, in wesnoth, are
+# currently supported only on lua code
 class PoCommentedStringPL:
     def __init__(self, value, *, ismultiline=False):
         self.value = value
@@ -23,7 +27,7 @@ class PoCommentedString:
             self.plural = plural
         
     def set_plural(self, plural_value, *, ismultiline=False):
-        # add_plural is a safe way to add a plural form into a sentence
+        # set_plural is a safe way to add a plural form into a sentence
         # if plural form is still stored, no plural form is added
         if self.plural is None:
             self.plural = PoCommentedStringPL(plural_value, ismultiline)
@@ -41,7 +45,7 @@ class PoCommentedString:
         self.finfos += commented_string.finfos
         self.update_orderid(commented_string.orderid)
         # update plural value only if current sentence actually don't have
-        # a plural form and only if the 
+        # a plural form
         if self.plural is None and isinstance(commented_string.plural,
                                               PoCommentedStringPL):
             self.plural = commented_string.plural
@@ -73,7 +77,7 @@ class PoCommentedString:
             print('msgstr[1] ""', file=filebuf)
 
 
-# Also nodesentence use PoCommentedStringPL for 'plural' parameter
+# WmlNodeSentence use PoCommentedStringPL for 'plural' parameter
 class WmlNodeSentence:
     def __init__(self, sentence, *, ismultiline, lineno, lineno_sub=0,
                  plural=None, override=None, addition=None):

--- a/utils/pywmlx/state/lua_states.py
+++ b/utils/pywmlx/state/lua_states.py
@@ -304,7 +304,6 @@ class LuaPlIdle1:
                     # PendingLuaString.plural to None
                     if status == 'wait_plural':
                         pywmlx.state.machine._pending_luastring.plural = None
-                    # when parenthenthesis
                     xline = xline [ realmatch.end(): ]
                     return (xline, 'lua_idle')
             else:
@@ -320,7 +319,7 @@ class LuaPlIdle1:
                 
         else:
             # You can find a new line rigthly after _ (. In this case, we will
-            # continue
+            # continue to search a string into the next line
             return (None, 'lua_plidle1')
 
 

--- a/utils/pywmlx/state/lua_states.py
+++ b/utils/pywmlx/state/lua_states.py
@@ -77,7 +77,7 @@ class LuaCommentState:
 
 class LuaStr00:
     def __init__(self):
-        self.regex = re.compile(r'.*?\s+_\s*\(')
+        self.regex = re.compile(r'((?:_)|(?:.*?\s+_))\s*\(')
         self.iffail = 'lua_str01'
     
     def run(self, xline, lineno, match):

--- a/utils/pywmlx/state/lua_states.py
+++ b/utils/pywmlx/state/lua_states.py
@@ -77,7 +77,7 @@ class LuaCommentState:
 
 class LuaStr00:
     def __init__(self):
-        self.regex = re.compile(r'.*?_\s*\(')
+        self.regex = re.compile(r'.*?\s+_\s*\(')
         self.iffail = 'lua_str01'
     
     def run(self, xline, lineno, match):

--- a/utils/pywmlx/state/lua_states.py
+++ b/utils/pywmlx/state/lua_states.py
@@ -2,6 +2,7 @@ import re
 import pywmlx.state.machine
 from pywmlx.state.state import State
 from pywmlx.wmlerr import wmlwarn
+from pywmlx.wmlerr import wmlerr
 
 
 
@@ -66,11 +67,29 @@ class LuaCheckpoState:
 class LuaCommentState:
     def __init__(self):
         self.regex = re.compile(r'\s*--.+')
-        self.iffail = 'lua_str01'
+        self.iffail = 'lua_str00'
     
     def run(self, xline, lineno, match):
         xline = None
         return (xline, 'lua_idle')
+
+
+
+class LuaStr00:
+    def __init__(self):
+        self.regex = re.compile(r'.*?_\s*\(')
+        self.iffail = 'lua_str01'
+    
+    def run(self, xline, lineno, match):
+        xline = xline [ match.end(): ]
+        pywmlx.state.machine._pending_luastring = None
+        pywmlx.state.machine._pending_luastring = (
+            pywmlx.state.machine.PendingLuaString( 
+                lineno, 'lua_plural', '', False,
+                True, 0, pywmlx.state.machine.PendingPlural()
+            )
+        )
+        return (xline, 'lua_plidle1')
 
 
 
@@ -237,6 +256,408 @@ class LuaStr30:
         return (xline, _nextstate)
 
 
+#-----------------------------------------------------------------------------
+# 2.  LUA PLURAL
+#-----------------------------------------------------------------------------
+# Lua plural will manage _ ("sentence", "plural_form", number) syntax
+#     when _ ( was found on LuaStr00 (fake lua string) 
+#     this case will treat also _ ("translatable_string") without plural form.
+#------------------------------------------------------------------------------
+
+#.....................
+#  2.1 Plural Idle States
+#.....................
+# Unlike Standard states, here we have multiple idle states, one for every
+# situations.
+# In this way we surely add more states, but every state can be easier to
+# develop, maintain and test, and it is less error-prone
+#.....................
+
+# Plural Idle 1:
+#  When argument 1 or 2 is expected
+#  Here we expect " ' or a [ wich will say us what kind of string we will add.
+class LuaPlIdle1:
+    def __init__(self):
+        self.regex = None
+        self.iffail = None
+        
+    def run(self, xline, lineno, match):
+        status = pywmlx.state.machine._pending_luastring.plural.status
+        realmatch = re.match(r'\s*(\S)', xline)
+        if realmatch:
+            _nextstate = 'lua_idle'
+            if realmatch.group(1) == '"':
+                _nextstate = 'lua_pl01'
+            elif realmatch.group(1) == "'":
+                _nextstate = 'lua_pl02'
+            elif realmatch.group(1) == '[':
+                _nextstate = 'lua_pl03'
+            elif realmatch.group(1) == ')':
+                if status == 'wait_string':
+                    finfo = pywmlx.nodemanip.fileref + ":" + str(lineno)
+                    errmsg = ("first argument of function '_ (...)' must be a "
+                              "string")
+                    wmlerr(finfo, errmsg)
+                else:
+                    # if parenthesis is closed rightly after first argument
+                    # this is not a plural form. So we set 
+                    # PendingLuaString.plural to None
+                    if status == 'wait_plural':
+                        pywmlx.state.machine._pending_luastring.plural = None
+                    # when parenthenthesis
+                    xline = xline [ realmatch.end(): ]
+                    return (xline, 'lua_idle')
+            else:
+                # this should never happen. But if the first value after _ (
+                # does not start with a string marker, than wmlxgettext will
+                # finish with an error
+                finfo = pywmlx.nodemanip.fileref + ":" + str(lineno)
+                errmsg = "first argument of function '_ (...)' must be a string"
+                wmlerr(finfo, errmsg)
+            xline = xline [ realmatch.end(): ]
+            xline = realmatch.group(1) + xline
+            return (xline, _nextstate)
+                
+        else:
+            # You can find a new line rigthly after _ (. In this case, we will
+            # continue
+            return (None, 'lua_plidle1')
+
+
+
+# Plural Idle 2:
+#  Between argument 1 and 2, when a comma is expected
+class LuaPlIdle2:
+    def __init__(self):
+        self.regex = None
+        self.iffail = None
+    
+    def run(self, xline, lineno, match):
+        realmatch = re.match(r'\s*,', xline)
+        if realmatch:
+            xline = xline [ realmatch.end(): ]
+            return (xline, 'lua_plidle1')
+        else:
+            pywmlx.state.machine._pending_luastring.plural = None
+            return (xline, 'lua_plidle3')
+
+
+
+# Plural Idle 3:
+#  Argument 1 and 2 still stored in memory. We wait only for final parenthesis
+class LuaPlIdle3:
+    def __init__(self):
+        self.regex = None
+        self.iffail = None
+        
+    def run(self, xline, lineno, match):
+        realmatch = re.match(r'.*?\)', xline)
+        if realmatch:
+            xline = xline [ realmatch.end(): ]
+            return (xline, 'lua_idle')
+        else:
+            return (None, 'lua_plidle3')
+
+
+
+#.....................
+#  2.2 Plural States - Actual strings
+#.....................
+# Those states works, more or less, like LuaStrXX
+#.....................
+
+
+
+class LuaPl01:
+    def __init__(self):
+        rx = r'"((?:\\"|[^"])*)("?)'
+        self.regex = re.compile(rx)
+        # 'lua_bug' is not an actual state. The regexp here should always match.
+        #           setting 'iffail' to a non-existing 'lua_bug' state will
+        #           allow us to raise an error
+        self.iffail = 'lua_bug'
+    
+    def run(self, xline, lineno, match):
+        status = pywmlx.state.machine._pending_luastring.plural.status
+        if status == 'wait_string':
+            _nextstate = 'lua_plidle2'
+            # we must fix values for luatype (wich is used later by 
+            #                                 PendingLuaString.store() )
+            # and ismultiline
+            pywmlx.state.machine._pending_luastring.luatype = 'luastr1'
+            if match.group(2) == '':
+                pywmlx.state.machine._pending_luastring.ismultiline = True
+                _nextstate = 'lua_pl10'
+                xline = None
+            else:
+                xline = xline [ match.end(): ]
+                pywmlx.state.machine._pending_luastring.plural.status = (
+                    'wait_plural'
+                )
+            # write first line of 'string' on PendingLuaString
+            pywmlx.state.machine._pending_luastring.luastring = match.group(1)
+            return (xline, _nextstate)
+        else:
+            _nextstate = 'lua_plidle3'
+            # we must fix values for plural.pluraltype
+            # and plural.ismultiline
+            pywmlx.state.machine._pending_luastring.plural.pluraltype = 1
+            if match.group(2) == '':
+                pywmlx.state.machine._pending_luastring.plural.ismultiline = True
+                _nextstate = 'lua_pl10'
+                xline = None
+            else:
+                xline = xline [ match.end(): ]
+                pywmlx.state.machine._pending_luastring.plural.status = (
+                    'wait_close'
+                )
+            # write first line of 'plural' on PendingLuaString
+            pywmlx.state.machine._pending_luastring.plural.string = (
+                match.group(1)
+            )
+            return (xline, _nextstate)
+
+
+
+class LuaPl02:
+    def __init__(self):
+        rx = r"'((?:\\'|[^'])*)('?)"
+        self.regex = re.compile(rx)
+        # 'lua_bug' is not an actual state. The regexp here should always match.
+        #           setting 'iffail' to a non-existing 'lua_bug' state will
+        #           allow us to raise an error
+        self.iffail = 'lua_bug'
+    
+    def run(self, xline, lineno, match):
+        status = pywmlx.state.machine._pending_luastring.plural.status
+        if status == 'wait_string':
+            _nextstate = 'lua_plidle2'
+            # we must fix values for luatype (wich is used later by 
+            #                                 PendingLuaString.store() )
+            # and ismultiline
+            pywmlx.state.machine._pending_luastring.luatype = 'luastr2'
+            if match.group(2) == '':
+                pywmlx.state.machine._pending_luastring.ismultiline = True
+                _nextstate = 'lua_pl20'
+                xline = None
+            else:
+                xline = xline [ match.end(): ]
+                pywmlx.state.machine._pending_luastring.plural.status = (
+                    'wait_plural'
+                )
+            # write first line of 'string' on PendingLuaString
+            pywmlx.state.machine._pending_luastring.luastring = match.group(1)
+            return (xline, _nextstate)
+        else:
+            _nextstate = 'lua_plidle3'
+            # we must fix values for plural.pluraltype
+            # and plural.ismultiline
+            pywmlx.state.machine._pending_luastring.plural.pluraltype = 2
+            if match.group(2) == '':
+                pywmlx.state.machine._pending_luastring.plural.ismultiline = True
+                _nextstate = 'lua_pl20'
+                xline = None
+            else:
+                xline = xline [ match.end(): ]
+                pywmlx.state.machine._pending_luastring.plural.status = (
+                    'wait_close'
+                )
+            # write first line of 'plural' on PendingLuaString
+            pywmlx.state.machine._pending_luastring.plural.string = (
+                match.group(1)
+            )
+            return (xline, _nextstate)
+
+
+
+class LuaPl03:
+    def __init__(self):
+        rx = r'\[(=*)\[(.*?)]\1]'
+        self.regex = re.compile(rx)
+        self.iffail = 'lua_pl03o'
+    
+    def run(self, xline, lineno, match):
+        status = pywmlx.state.machine._pending_luastring.plural.status
+        xline = xline [ match.end(): ]
+        _nextstate = 'lua_plidle2'
+        if status == 'wait_string':
+            _nextstate = 'lua_plidle2'
+            # we must fix values for luatype (wich is used later by 
+            #                                 PendingLuaString.store() )
+            pywmlx.state.machine._pending_luastring.luatype = 'luastr3'
+            # storing string into PendingLuaString
+            pywmlx.state.machine._pending_luastring.luastring = (
+                match.group(2)
+            )
+            pywmlx.state.machine._pending_luastring.plural.status = (
+                'wait_plural'
+            )
+        else:
+            _nextstate = 'lua_plidle3'
+            # we must fix values for plural.pluraltype
+            pywmlx.state.machine._pending_luastring.plural.pluraltype = 2
+            # storing plural.string into PendingLuaString
+            pywmlx.state.machine._pending_luastring.plural.string = (
+                match.group(2)
+            )
+            pywmlx.state.machine._pending_luastring.plural.status = (
+                'wait_close'
+            )
+        return (xline, _nextstate)
+
+
+
+class LuaPl03o:
+    def __init__(self):
+        rx = r'\[(=*)\[(.*)'
+        self.regex = re.compile(rx)
+        self.iffail = 'lua_bug'
+    
+    def run(self, xline, lineno, match):
+        status = pywmlx.state.machine._pending_luastring.plural.status
+        xline = None
+        if status == 'wait_string':
+            pywmlx.state.machine._pending_luastring.ismultiline = True
+            pywmlx.state.machine._pending_luastring.luatype = 'luastr3'
+            pywmlx.state.machine._pending_luastring.luastring = (
+                match.group(2)
+            )
+            pywmlx.state.machine._pending_luastring.numequals = (
+                len(match.group(1))
+            )
+        else:
+            pywmlx.state.machine._pending_luastring.plural.ismultiline = True
+            pywmlx.state.machine._pending_luastring.plural.pluraltype = 3
+            pywmlx.state.machine._pending_luastring.plural.string = (
+                match.group(2)
+            )
+            pywmlx.state.machine._pending_luastring.plural.numequals = (
+                len(match.group(1))
+            )
+        return (xline, 'lua_pl30')
+
+
+
+# well... the regex will always be true on this state, so iffail will never
+# be executed
+class LuaPl10:
+    def __init__(self):
+        self.regex = re.compile(r'((?:\\"|[^"])*)("?)')
+        self.iffail = 'lua_pl10'
+        
+    def run(self, xline, lineno, match):
+        status = pywmlx.state.machine._pending_luastring.plural.status
+        _nextstate = 'lua_pl10'
+        if status == 'wait_string':
+            pywmlx.state.machine._pending_luastring.addline( match.group(1) )
+        else:
+            pywmlx.state.machine_pending_luastring.plural.addline( 
+                match.group(1) 
+            )
+        if match.group(2) == '"':
+            xline = xline [ match.end(): ]
+            if status == 'wait_string':
+                _nextstate = 'lua_plidle2'
+                pywmlx.state.machine_pending_luastring.plural.status = (
+                    'wait_plural'
+                )
+            else:
+                _nextstate = 'lua_plidle3'
+                pywmlx.state.machine_pending_luastring.plural.status = (
+                    'wait_close'
+                )
+        else:
+            xline = None
+        return (xline, _nextstate)
+
+
+
+# well... the regex will always be true on this state, so iffail will never
+# be executed
+class LuaPl20:
+    def __init__(self):
+        self.regex = re.compile(r"((?:\\'|[^'])*)('?)")
+        self.iffail = 'lua_pl20'
+        
+    def run(self, xline, lineno, match):
+        status = pywmlx.state.machine._pending_luastring.plural.status
+        _nextstate = 'lua_pl20'
+        if status == 'wait_string':
+            pywmlx.state.machine._pending_luastring.addline( match.group(1) )
+        else:
+            pywmlx.state.machine_pending_luastring.plural.addline( 
+                match.group(1) 
+            )
+        if match.group(2) == '"':
+            xline = xline [ match.end(): ]
+            if status == 'wait_string':
+                _nextstate = 'lua_plidle2'
+                pywmlx.state.machine_pending_luastring.plural.status = (
+                    'wait_plural'
+                )
+            else:
+                _nextstate = 'lua_plidle3'
+                pywmlx.state.machine_pending_luastring.plural.status = (
+                    'wait_close'
+                )
+        else:
+            xline = None
+        return (xline, _nextstate)
+
+
+
+class LuaPl30:
+    def __init__(self):
+        self.regex = None
+        self.iffail = None
+    
+    def run(self, xline, lineno, match):
+        status = pywmlx.state.machine._pending_luastring.plural.status
+        numequals = 0
+        if status == 'wait_string':
+            numequals = pywmlx.state.machine._pending_luastring.numequals
+        else:
+            numequals = pywmlx.state.machine._pending_luastring.plural.numequals
+        rx = r'(.*?)]={' +  str(numequals) + '}]'
+        realmatch = re.match(rx, xline)
+        _nextstate = 'lua_pl30'
+        if realmatch:
+            xline = xline [ realmatch.end(): ]
+            if status == 'wait_string':
+                pywmlx.state.machine._pending_luastring.addline( 
+                    realmatch.group(1) 
+                )
+                pywmlx.state.machine._pending_luastring.plural.status = (
+                    'wait_plural'
+                )
+                _nextstate = 'lua_plidle2'
+            else:
+                pywmlx.state.machine._pending_luastring.plural.addline( 
+                    realmatch.group(1) 
+                )
+                pywmlx.state.machine._pending_luastring.plural.status = (
+                    'wait_close'
+                )
+                _nextstate = 'lua_plidle3'
+        else:
+            if status == 'wait_string':
+                pywmlx.state.machine._pending_luastring.addline(xline)
+            else:
+                pywmlx.state.machine._pending_luastring.plural.addline(xline)
+            xline = None
+            _nextstate = 'lua_pl30'
+        return (xline, _nextstate)
+
+
+
+#-----------------------------------------------------------------------------
+# 3.  LUA FINAL STATES
+#-----------------------------------------------------------------------------
+# Now the final states:
+#     LuaGowmlState
+#     LuaFinalState
+#-----------------------------------------------------------------------------
+
 
 class LuaGowmlState:
     def __init__(self):
@@ -285,6 +706,7 @@ def setup_luastates():
                                    ('lua_checkdom', LuaCheckdomState),
                                    ('lua_checkpo', LuaCheckpoState),
                                    ('lua_comment', LuaCommentState),
+                                   ('lua_str00', LuaStr00),
                                    ('lua_str01', LuaStr01),
                                    ('lua_str02', LuaStr02),
                                    ('lua_str03', LuaStr03),
@@ -292,6 +714,16 @@ def setup_luastates():
                                    ('lua_str10', LuaStr10),
                                    ('lua_str20', LuaStr20),
                                    ('lua_str30', LuaStr30),
+                                   ('lua_plidle1', LuaPlIdle1),
+                                   ('lua_plidle2', LuaPlIdle2),
+                                   ('lua_plidle3', LuaPlIdle3),
+                                   ('lua_pl01', LuaPl01),
+                                   ('lua_pl02', LuaPl02),
+                                   ('lua_pl03', LuaPl03),
+                                   ('lua_pl03o', LuaPl03o),
+                                   ('lua_pl10', LuaPl10),
+                                   ('lua_pl20', LuaPl20),
+                                   ('lua_pl30', LuaPl30),
                                    ('lua_gowml', LuaGowmlState),
                                    ('lua_final', LuaFinalState)]:
         st = stateclass()

--- a/utils/pywmlx/state/machine.py
+++ b/utils/pywmlx/state/machine.py
@@ -5,6 +5,7 @@ from pywmlx.wmlerr import wmlerr
 from pywmlx.wmlerr import wmlwarn
 from pywmlx.wmlerr import warnall
 from pywmlx.postring import PoCommentedString
+from pywmlx.postring import PoCommentedStringPL
 from pywmlx.state.state import State
 from pywmlx.state.lua_states import setup_luastates
 from pywmlx.state.wml_states import setup_wmlstates
@@ -20,6 +21,10 @@ import pywmlx.nodemanip
 
 # True if --warnall option is used
 _warnall = False
+# True if -D option is used
+_debugmode = False
+# debug output file
+_fdebug = None
 # dictionary of pot sentences
 _dictionary = None
 # dictionary containing lua and WML states
@@ -111,30 +116,84 @@ def checksentence(mystring, finfo, *, islua=False):
 
 
 
+class PendingPlural:
+    def __init__(self):
+        self.string = ''
+        # status values:
+        #    'wait_string'    --> rightly after _ ( when we need to know
+        #                         wich string type we will manage
+        #    'on_string'      --> on first argument, when ", ' or [ was found
+        #    'wait_plural'    --> after first argument. Search for plural or
+        #                         close parenthesis
+        #    'on_plural'      --> on second argument, when ", ' or [ is found
+        #                         (after a comma)
+        #    'wait_close'     --> expect close parenthesis
+        self.status = 'wait_string'
+        self.pluraltype = 0
+        self.numequals = 0
+        self.ismultiline = False
+    
+    def addline(self, value, isfirstline=False):
+        if self.pluraltype != 3:
+            value = re.sub('\\\s*$', '', value)
+        else:
+            value = value.replace('\\', r'\\')
+        if isfirstline:
+            self.string = value
+        else:
+            self.string = self.string + '\n' + value
+    
+    def convert(self):
+        if self.pluraltype == 2:
+            self.string = re.sub(r"\\\'", r"'", self.string)
+        if self.pluraltype != 3 and self.pluraltype!=0:
+            self.string = re.sub(r'(?<!\\)"', r'\"', self.string)
+        if self.pluraltype == 3:
+            self.string = self.string.replace('"', r'\"')
+        if self.ismultiline:    
+            lf = r'\\n"' + '\n"'
+            self.string = re.sub(r'(\n\r|\r\n|[\n\r])', 
+                                lf, self.string)
+            self.string = '""\n"' + self.string + '"'
+        if not self.ismultiline:
+            self.string = '"' + self.string + '"'
+        return PoCommentedStringPL(self.string, ismultiline=self.ismultiline)
+
+
+
 class PendingLuaString:
     def __init__(self, lineno, luatype, luastring, ismultiline, 
-                 istranslatable, numequals=0):
+                 istranslatable, numequals=0, plural=None):
         self.lineno = lineno
         self.luatype = luatype
         self.luastring = ''
         self.ismultiline = ismultiline
         self.istranslatable = istranslatable
         self.numequals = numequals
-        self.addline(luastring, True)
+        if luatype != 'lua_plural':
+            self.addline(luastring, True)
+        self.plural = plural
     
     def addline(self, value, isfirstline=False):
         if self.luatype != 'luastr3':
             value = re.sub('\\\s*$', '', value)
         else:
             value = value.replace('\\', r'\\')
-            # nope
         if isfirstline:
             self.luastring = value
         else:
             self.luastring = self.luastring + '\n' + value
     
+    # this function is used by store, when translating lua pending plural into 
+    # PoCommentedString.plural
+    def storePlural(self):
+        if self.plural is None:
+            return None
+        else:
+            return self.plural.convert()
+    
     def store(self):
-        global _pending_addedinfo 
+        global _pending_addedinfo
         global _pending_overrideinfo
         global _linenosub
         if checkdomain() and self.istranslatable:
@@ -171,7 +230,8 @@ class PendingLuaString:
                                 orderid=(fileno, self.lineno, _linenosub),
                                 ismultiline=self.ismultiline,
                                 wmlinfos=loc_wmlinfos, finfos=[finfo],
-                                addedinfos=loc_addedinfos )
+                                addedinfos=loc_addedinfos,
+                                plural=self.storePlural() )
                 else:
                     loc_posentence.update_with_commented_string(
                            PoCommentedString(
@@ -179,7 +239,8 @@ class PendingLuaString:
                                 orderid=(fileno, self.lineno, _linenosub),
                                 ismultiline=self.ismultiline,
                                 wmlinfos=loc_wmlinfos, finfos=[finfo],
-                                addedinfos=loc_addedinfos
+                                addedinfos=loc_addedinfos,
+                                plural=self.storePlural()
                     ) )
         # finally PendingLuaString.store() will clear pendinginfos,
         # in any case (even if the pending string is not translatable)
@@ -236,15 +297,22 @@ def addstate(name, value):
 
 
 
-def setup(dictionary, initialdomain, domain, wall):
+def setup(dictionary, initialdomain, domain, wall, fdebug):
     global _dictionary
     global _initialdomain
     global _domain
     global _warnall
+    global _debugmode
+    global _fdebug
     _dictionary = dictionary
     _initialdomain = initialdomain
     _domain = domain
     _warnall = wall
+    _fdebug = fdebug
+    if fdebug is None:
+        _debugmode = False
+    else:
+        _debugmode = True
     setup_luastates()
     setup_wmlstates()
 
@@ -263,6 +331,7 @@ def run(*, filebuf, fileref, fileno, startstate, waitwml=True):
     _on_luatag = False
     # cs is "current state"
     cs = _states.get(startstate)
+    cs_debug = startstate
     _current_lineno = 0
     _linenosub = 0
     _waitwml = waitwml
@@ -272,35 +341,48 @@ def run(*, filebuf, fileref, fileno, startstate, waitwml=True):
     for xline in filebuf:
         xline = xline.strip('\n\r')
         _current_lineno += 1
+        # on new line, debug file will write another marker
+        if _debugmode:
+            print('@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@',
+                  file=_fdebug)
         while xline is not None:
-            # action number is used to know what function we should run
-            # debug_file0 = open(os.path.realpath('./debug.txt'), 'a')
-            # print("!!!", xline, file=debug_file0)
-            # debug_file0.close()
+            # print debug infos (if debugmode is on)
+            if _debugmode:
+                lno = '%05d' % _current_lineno
+                print('------------------------------------------------------',
+                      file=_fdebug)
+                print('LINE', lno, '|', xline, file=_fdebug)
+            # action number is used to know what function we should run    
             action = 0
             v = None
             m = None
             if cs.regex is None:
                 # action = 1 --> execute state.run
-                action = 1 
+                action = 1
+                if _debugmode:
+                    print('ALWAYS-RUN x', cs_debug, file=_fdebug)
             else:
                 # m is match
                 m = re.match(cs.regex, xline)
                 if m:
                     # action = 1 --> execute state.run
                     action = 1
+                    if _debugmode:
+                        print('RUN state  \\', cs_debug, file=_fdebug)
                 else:
                     # action = 2 --> change to the state pointed by 
                     #                state.iffail
                     action = 2
+                    if _debugmode:
+                        print('FAIL state |', cs_debug, file=_fdebug)
             if action == 1:
                 # xline, ns: xline --> override xline with new value
                 #            ns --> value of next state
                 xline, ns = cs.run(xline, _current_lineno, m)
-                # debug_cs = ns
+                cs_debug = ns
                 cs = _states.get(ns)
             else:
-                # debug_cs = cs.iffail
+                cs_debug = cs.iffail
                 cs = _states.get(cs.iffail)
             # debug_file = open(os.path.realpath('./debug.txt'), 'a')
             # print(debug_cs, file=debug_file)

--- a/utils/pywmlx/state/machine.py
+++ b/utils/pywmlx/state/machine.py
@@ -122,11 +122,8 @@ class PendingPlural:
         # status values:
         #    'wait_string'    --> rightly after _ ( when we need to know
         #                         wich string type we will manage
-        #    'on_string'      --> on first argument, when ", ' or [ was found
         #    'wait_plural'    --> after first argument. Search for plural or
         #                         close parenthesis
-        #    'on_plural'      --> on second argument, when ", ' or [ is found
-        #                         (after a comma)
         #    'wait_close'     --> expect close parenthesis
         self.status = 'wait_string'
         self.pluraltype = 0
@@ -384,9 +381,6 @@ def run(*, filebuf, fileref, fileno, startstate, waitwml=True):
             else:
                 cs_debug = cs.iffail
                 cs = _states.get(cs.iffail)
-            # debug_file = open(os.path.realpath('./debug.txt'), 'a')
-            # print(debug_cs, file=debug_file)
-            # debug_file.close()
         # end while xline
     # end for xline
     pywmlx.nodemanip.closefile(_dictionary, _current_lineno)

--- a/utils/wmlxgettext
+++ b/utils/wmlxgettext
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 
-# encoding: utf8
+# encoding: utf-8
 #
 # wmlxgettext -- generate a blank .pot file for official campaigns translations
 #                    (build tool for wesnoth core)

--- a/utils/wmlxgettext
+++ b/utils/wmlxgettext
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-# encoding: utf-8
+
+
+# encoding: utf8
 #
 # wmlxgettext -- generate a blank .pot file for official campaigns translations
 #                    (build tool for wesnoth core)
@@ -47,6 +49,11 @@ def commandline(args):
                    [--package-version=PACKAGE_VERSION]
                    [--no-text-colors] [--fuzzy] [--warnall] [-o OUTPUT_FILE]
                    FILE1 FILE2 ... FILEN'''
+    )
+    parser.add_argument(
+        '--version',
+        action='version',
+        version='wmlxgettext 2016.10.03.py3'
     )
     parser.add_argument(
         '-o',
@@ -123,6 +130,15 @@ def commandline(args):
               "ignored.") 
     )
     parser.add_argument(
+        '--DMode',
+        action='store_true',
+        dest='debugmode',
+        default=False,
+        help=("DON'T USE THIS OPTION. It is reserved to test how wmlxgettext "
+              "internally works. If this option is enabled, an extra "
+              "file (debug.txt) will be created. ")
+    )
+    parser.add_argument(
         'filelist',
         help='List of WML/lua files of your UMC (source files)',
         nargs='*'
@@ -139,8 +155,11 @@ def main():
     startPath = os.path.realpath(os.path.normpath(args.start_path))
     sentlist = dict()
     fileno = 0
+    fdebug = None
+    if args.debugmode:
+        fdebug = open('debug.txt', 'w', encoding='utf-8')
     pywmlx.statemachine.setup(sentlist, args.initdom, args.domain, 
-                              args.warnall)
+                              args.warnall, fdebug)
     if args.warnall is True and args.outfile is None:
         pywmlx.wmlwarn('command line warning', 'Writing the output to stdout '
                        '(and then eventually redirect that output to a file) '
@@ -231,6 +250,8 @@ def main():
         print('', file=outfile)
     if args.outfile is not None:
         outfile.close()
+    if args.debugmode:
+        fdebug.close()
 
 
 


### PR DESCRIPTION
# wmlxgettext support for plural

Changelog:
* Added **--version** option (wmlxgettext version number is written in 
  *YYYY.MM.DD.py3* format, where "_py3_" underline the language used on 
  wmlxgettext: python 3.x)
* Added **--DMode** option --> I introduced a "stable" debugging code that can
  be executed only using this option. It will write an extra file (_debug.txt_)
  wich will record all the state sequences. It is a really useful option that
  helps me to debug wmlxgettext if something doesn't work as expected.
  Obliouvsly this option is useless for an end-user.
* Added lua plural support

## tests successfully passed

### lua different string type, but no textdomain changes

The first test I did was focused to find and fix possible bugs on basic usage.
I tested wmlxgettext using this [lua source file](https://github.com/AncientLich/wmlxgettext-unoff/blob/master/wmlxgettext/test/reports/2016.10.03/tlua1.lua)

`wmlxgettext --domain=test1 -o tlua1.pot tlua1.lua`

And this is the [resulting pot file](https://github.com/AncientLich/wmlxgettext-unoff/blob/master/wmlxgettext/test/reports/2016.10.03/tlua1.pot)
Wich is exactly the desired result file.

**NOTE**: As you can notice, header file doesn't have the `nplurals` info, and
all plural sentences are associated to `msgstr[0]` and `msgstr[1]`.
Those settings, infact, higly change from language to language. They will be
"fixed" by the gettext tool _msginit_ .

`msginit -i input.pot -o dest_language.pot -l LOCALIZATION_CODE`


### Old vs new release on pot-update

This test was focused to check if the code I needed to add to allow the support
for plural forms on wmlxgettext introduced or not new bugs on the previous
features.
What we wanted to see here is that there are **NO** differences from the pot
files created by pot-update wesnoth target build, comparing the results created
by current implementation of wmlxgettext vs the new one.

For personal setup I cannot use directly the official pot-update, so why I 
developed a tool called _wescheck.py_ wich is available on my wmlxgettext
personal repository.

_wescheck.py_ originally was intendent to run _perl_ wmlxgettext, then _python_
wmlxgettext, comparing the results and error logs.

Test was performed against wesnoth 1.13.4 source directory

I will omit to write here all the tecnical details about the test, wich can be
[readed here](https://github.com/AncientLich/wmlxgettext-unoff/blob/master/wmlxgettext/test/reports/2016.10.03/wescheck.txt) if you are really interested.

What is important is the [resulting diff file](https://github.com/AncientLich/wmlxgettext-unoff/blob/master/wmlxgettext/test/reports/2016.10.03/test2.diff).

As you can check, the result is the desired one (all the differences, except ù
one, are related to file time creation, wich is expected). 

There is only an actual difference: on line 197 of the diff file you can notice
that the NEW wmlxgettext implementation captured another translatable string 
previously ignored

```lua
local wait_description = cfg.wait_description or _("input")
```

The new captured string (_input_) comes from this lua line code
(under data/lua/wml/message.lua:233, as marked by the diff file)


### testing updates on the same sentences

This test want to verify that the plural form is successfully updated on the
same sentence. This is the [lua test file](https://github.com/AncientLich/wmlxgettext-unoff/blob/master/wmlxgettext/test/reports/2016.10.03/tlua3.lua) we used as source. 

We have to test different scenarios:
    
1) Sentence that originally doesn't have a plural form, but later will have it.
Desired result: sentence with plural form, with references of every time
the sentence was met (regardless if plural form was specified or not)
**on pot file:** sentence1 (singular), sentence1 (plural)
2) Sentence that originally HAVE a plural form, but later not.
It is the opposite of case 1, but the expected result is the same.
**on pot file:** sentence2 (singular), sentence2 (plural)
3) Sentence that, for any reason, definde different plural values in different
points. Desired result: we want that the FIRST plural occurrence will be used
and other implementations will be discarded
**on pot file:** sentence3 (singular), sentence3 (plural)
4) Case 1 and 3 combined.
**on pot file:** sentence4 (singular), sentence4 (plural)

`./wmlxgettext --domain=test3 -o tlua3.pot tlua3.lua`

will produce [this pot file](https://github.com/AncientLich/wmlxgettext-unoff/blob/master/wmlxgettext/test/reports/2016.10.03/tlua3.pot), wich is exactly the result we expected.


### testing plural form and multiple textdomain

This test will focus to verify if the pot file will contain ONLY the desired
translations contained into the desired textdomain.

This is the [lua test file](https://github.com/AncientLich/wmlxgettext-unoff/blob/master/wmlxgettext/test/reports/2016.10.03/tlua4.lua) I used, and this is the
[pot file](https://github.com/AncientLich/wmlxgettext-unoff/blob/master/wmlxgettext/test/reports/2016.10.03/tlua4.pot) produced.


### testing mixed WML-lua file

This is the final test with a custom file. 
Here the [WML test file](https://github.com/AncientLich/wmlxgettext-unoff/blob/master/wmlxgettext/test/reports/2016.10.03/test5.cfg) used for the test, and here the
[generated POT file](https://github.com/AncientLich/wmlxgettext-unoff/blob/master/wmlxgettext/test/reports/2016.10.03/test5.pot)
