### PR TITLE
Avoid hidden variable warnings produced in MSVC compilation

### DIFF
--- a/src/ai/lua/core.cpp
+++ b/src/ai/lua/core.cpp
@@ -785,26 +785,26 @@ static int impl_ai_aspect_get(lua_State* L)
 	}
 	
 	typedef std::vector<std::string> string_list;
-	if(typesafe_aspect<bool>* aspect = try_aspect_as<bool>(iter->second)) {
-		lua_pushboolean(L, aspect->get());
-	} else if(typesafe_aspect<int>* aspect = try_aspect_as<int>(iter->second)) {
-		lua_pushinteger(L, aspect->get());
-	} else if(typesafe_aspect<double>* aspect = try_aspect_as<double>(iter->second)) {
-		lua_pushnumber(L, aspect->get());
-	} else if(typesafe_aspect<config>* aspect = try_aspect_as<config>(iter->second)) {
-		luaW_pushconfig(L, aspect->get());
-	} else if(typesafe_aspect<string_list>* aspect = try_aspect_as<string_list>(iter->second)) {
-		lua_push(L, aspect->get());
-	} else if(typesafe_aspect<terrain_filter>* aspect = try_aspect_as<terrain_filter>(iter->second)) {
+	if(typesafe_aspect<bool>* aspect_as_bool = try_aspect_as<bool>(iter->second)) {
+		lua_pushboolean(L, aspect_as_bool->get());
+	} else if(typesafe_aspect<int>* aspect_as_int = try_aspect_as<int>(iter->second)) {
+		lua_pushinteger(L, aspect_as_int->get());
+	} else if(typesafe_aspect<double>* aspect_as_double = try_aspect_as<double>(iter->second)) {
+		lua_pushnumber(L, aspect_as_double->get());
+	} else if(typesafe_aspect<config>* aspect_as_config = try_aspect_as<config>(iter->second)) {
+		luaW_pushconfig(L, aspect_as_config->get());
+	} else if(typesafe_aspect<string_list>* aspect_as_string_list = try_aspect_as<string_list>(iter->second)) {
+		lua_push(L, aspect_as_string_list->get());
+	} else if(typesafe_aspect<terrain_filter>* aspect_as_terrain_filter = try_aspect_as<terrain_filter>(iter->second)) {
 		std::set<map_location> result;
-		aspect->get().get_locations(result);
+		aspect_as_terrain_filter->get().get_locations(result);
 		lua_push(L, result);
-	} else if(typesafe_aspect<attacks_vector>* aspect = try_aspect_as<attacks_vector>(iter->second)) {
+	} else if(typesafe_aspect<attacks_vector>* aspect_as_attacks_vector = try_aspect_as<attacks_vector>(iter->second)) {
 		// This case is caught separately above, but should the get_* aspect functions ever be
 		// deprecated, this is the place to move the code of cfun_ai_get_attacks to.
-		(void) aspect;
-	} else if(typesafe_aspect<unit_advancements_aspect>* aspect = try_aspect_as<unit_advancements_aspect>(iter->second)) {
-		const unit_advancements_aspect& val = aspect->get();
+		(void) aspect_as_attacks_vector;
+	} else if(typesafe_aspect<unit_advancements_aspect>* aspect_as_unit_advancements_aspects = try_aspect_as<unit_advancements_aspect>(iter->second)) {
+		const unit_advancements_aspect& val = aspect_as_unit_advancements_aspects->get();
 		int my_side = luaW_getglobal(L, "ai", "side") - 1;
 		lua_newtable(L);
 		std::hash<map_location> lhash;

--- a/src/game_initialization/multiplayer_ui.cpp
+++ b/src/game_initialization/multiplayer_ui.cpp
@@ -512,12 +512,12 @@ void ui::process_message(const config& msg, const bool whisper) {
 
 void ui::process_network_data(const config& data)
 {
-	if (const config &c = data.child("error")) {
-		throw wesnothd_error(c["message"]);
-	} else if (const config &c = data.child("message")) {
-		process_message(c);
-	} else if (const config &c = data.child("whisper")) {
-		process_message(c, true);
+	if (const config &error = data.child("error")) {
+		throw wesnothd_error(error["message"]);
+	} else if (const config &message = data.child("message")) {
+		process_message(message);
+	} else if (const config &whisper = data.child("whisper")) {
+		process_message(whisper, true);
 	} else if(data.child("gamelist")) {
 		const cursor::setter cursor_setter(cursor::WAIT);
 		gamelist_initialized_ = true;
@@ -525,10 +525,10 @@ void ui::process_network_data(const config& data)
 		gamelist_updated(false);
 		gamelist_refresh_ = false;
 		lobby_clock_ = SDL_GetTicks();
-	} else if (const config &c = data.child("gamelist_diff")) {
+	} else if (const config &gamelist_diff = data.child("gamelist_diff")) {
 		if(gamelist_initialized_) {
 			try {
-				gamelist_.apply_diff(c);
+				gamelist_.apply_diff(gamelist_diff);
 			} catch(config::error& e) {
 				ERR_CF << "Error while applying the gamelist diff: '"
 					<< e.message << "' Getting a new gamelist.\n";
@@ -536,39 +536,39 @@ void ui::process_network_data(const config& data)
 			}
 			gamelist_refresh_ = true;
 		}
-	} else if (const config &c = data.child("room_join")) {
-		if (c["player"] == preferences::login()) {
+	} else if (const config &room_join = data.child("room_join")) {
+		if (room_join["player"] == preferences::login()) {
 			chat_.add_message(time(nullptr), "server",
-				"You have joined the room '" + c["room"].str() + "'");
+				"You have joined the room '" + room_join["room"].str() + "'");
 		} else {
 			chat_.add_message(time(nullptr), "server",
-				c["player"].str() + " has joined the room '" + c["room"].str() + "'");
+				room_join["player"].str() + " has joined the room '" + room_join["room"].str() + "'");
 		}
 		chat_.update_textbox(chat_textbox_);
-	} else if (const config &c = data.child("room_part")) {
-		if (c["player"] == preferences::login()) {
+	} else if (const config &room_part = data.child("room_part")) {
+		if (room_part["player"] == preferences::login()) {
 			chat_.add_message(time(nullptr), "server",
-				"You have left the room '" + c["room"].str() + "'");
+				"You have left the room '" + room_part["room"].str() + "'");
 		} else {
 			chat_.add_message(time(nullptr), "server",
-				c["player"].str() + " has left the room '" + c["room"].str() + "'");
+				room_part["player"].str() + " has left the room '" + room_part["room"].str() + "'");
 		}
 		chat_.update_textbox(chat_textbox_);
-	} else if (const config &c = data.child("room_query_response")) {
-		if (const config &ms = c.child("members")) {
+	} else if (const config &room_query_response = data.child("room_query_response")) {
+		if (const config &ms = room_query_response.child("members")) {
 			std::stringstream ss;
-			ss << "Room " << c["room"].str() << " members: ";
+			ss << "Room " << room_query_response["room"].str() << " members: ";
 			for (const config& m : ms.child_range("member")) {
 				ss << m["name"] << " ";
 			}
 			chat_.add_message(time(nullptr), "server", ss.str());
 			chat_.update_textbox(chat_textbox_);
 		}
-		if (const config &rs = c.child("rooms")) {
+		if (const config &rooms = room_query_response.child("rooms")) {
 			std::stringstream ss;
 			ss << "Rooms: ";
-			for (const config& r : rs.child_range("room")) {
-				ss << r["name"].str() << "(" << r["size"].str() << ") ";
+			for (const config& room : rooms.child_range("room")) {
+				ss << room["name"].str() << "(" << room["size"].str() << ") ";
 			}
 			chat_.add_message(time(nullptr), "server", ss.str());
 			chat_.update_textbox(chat_textbox_);

--- a/src/gui/dialogs/lobby/lobby.cpp
+++ b/src/gui/dialogs/lobby/lobby.cpp
@@ -833,12 +833,12 @@ void tlobby_main::network_handler()
 
 void tlobby_main::process_network_data(const config& data)
 {
-	if(const config& c = data.child("error")) {
-		throw wesnothd_error(c["message"]);
+	if(const config& error = data.child("error")) {
+		throw wesnothd_error(error["message"]);
 	} else if(data.child("gamelist")) {
 		process_gamelist(data);
-	} else if(const config& c = data.child("gamelist_diff")) {
-		process_gamelist_diff(c);
+	} else if(const config& gamelist_diff = data.child("gamelist_diff")) {
+		process_gamelist_diff(gamelist_diff);
 	}
 
 	chatbox_->process_network_data(data);

--- a/src/gui/widgets/chatbox.cpp
+++ b/src/gui/widgets/chatbox.cpp
@@ -711,16 +711,16 @@ void tchatbox::process_message(const ::config& data, bool whisper /*= false*/)
 
 bool tchatbox::process_network_data(const ::config& data)
 {
-	if(const ::config& c = data.child("message")) {
-		process_message(c);
-	} else if(const ::config& c = data.child("whisper")) {
-		process_message(c, true);
-	} else if(const ::config& c = data.child("room_join")) {
-		process_room_join(c);
-	} else if(const ::config& c = data.child("room_part")) {
-		process_room_part(c);
-	} else if(const ::config& c = data.child("room_query_response")) {
-		process_room_query_response(c);
+	if(const ::config& message = data.child("message")) {
+		process_message(message);
+	} else if(const ::config& whisper = data.child("whisper")) {
+		process_message(whisper, true);
+	} else if(const ::config& room_join = data.child("room_join")) {
+		process_room_join(room_join);
+	} else if(const ::config& room_part = data.child("room_part")) {
+		process_room_part(room_part);
+	} else if(const ::config& room_query_response = data.child("room_query_response")) {
+		process_room_query_response(room_query_response);
 	}
 
 	return false;

--- a/src/playturn.cpp
+++ b/src/playturn.cpp
@@ -132,25 +132,25 @@ turn_info::PROCESS_DATA_RESULT turn_info::process_network_data(const config& cfg
 		ERR_NW << "processing network data while still having data on the replay." << std::endl;
 	}
 
-	if (const config &msg = cfg.child("message"))
+	if (const config &message = cfg.child("message"))
 	{
-		resources::screen->get_chat_manager().add_chat_message(time(nullptr), msg["sender"], msg["side"],
-				msg["message"], events::chat_handler::MESSAGE_PUBLIC,
+		resources::screen->get_chat_manager().add_chat_message(time(nullptr), message["sender"], message["side"],
+				message["message"], events::chat_handler::MESSAGE_PUBLIC,
 				preferences::message_bell());
 	}
-	else if (const config &msg = cfg.child("whisper") /*&& is_observer()*/)
+	else if (const config &whisper = cfg.child("whisper") /*&& is_observer()*/)
 	{
-		resources::screen->get_chat_manager().add_chat_message(time(nullptr), "whisper: " + msg["sender"].str(), 0,
-				msg["message"], events::chat_handler::MESSAGE_PRIVATE,
+		resources::screen->get_chat_manager().add_chat_message(time(nullptr), "whisper: " + whisper["sender"].str(), 0,
+				whisper["message"], events::chat_handler::MESSAGE_PRIVATE,
 				preferences::message_bell());
 	}
-	else if (const config &ob = cfg.child("observer") )
+	else if (const config &observer = cfg.child("observer") )
 	{
-		resources::screen->get_chat_manager().add_observer(ob["name"]);
+		resources::screen->get_chat_manager().add_observer(observer["name"]);
 	}
-	else if (const config &ob = cfg.child("observer_quit"))
+	else if (const config &observer_quit = cfg.child("observer_quit"))
 	{
-		resources::screen->get_chat_manager().remove_observer(ob["name"]);
+		resources::screen->get_chat_manager().remove_observer(observer_quit["name"]);
 	}
 	else if (cfg.child("leave_game")) {
 		throw ingame_wesnothd_error("");
@@ -269,10 +269,10 @@ turn_info::PROCESS_DATA_RESULT turn_info::process_network_data(const config& cfg
 			first_observer_option_idx = options.size();
 
 			//get all observers in as options to transfer control
-			for (const std::string &ob : resources::screen->observers()) {
-				t_vars["player"] = ob;
+			for (const std::string &screen_observers : resources::screen->observers()) {
+				t_vars["player"] = screen_observers;
 				options.push_back(vgettext("Give control to observer $player", t_vars));
-				observers.push_back(ob);
+				observers.push_back(screen_observers);
 				control_change_options++;
 			}
 
@@ -282,8 +282,8 @@ turn_info::PROCESS_DATA_RESULT turn_info::process_network_data(const config& cfg
 			options.push_back(_("Save and abort game"));
 
 			t_vars["player"] = tm.current_player();
-			const std::string msg =  vgettext("$player has left the game. What do you want to do?", t_vars);
-			gui2::tsimple_item_selector dlg("", msg, options);
+			const std::string gettext_message =  vgettext("$player has left the game. What do you want to do?", t_vars);
+			gui2::tsimple_item_selector dlg("", gettext_message, options);
 			dlg.set_single_button(true);
 			dlg.show(resources::screen->video());
 			action = dlg.selected_index();

--- a/src/replay.cpp
+++ b/src/replay.cpp
@@ -705,27 +705,27 @@ REPLAY_RETURN do_replay_handle(bool one_move)
 			ERR_REPLAY << "found "<<  cfg->debug() <<" in replay" << std::endl;
 			//do nothing
 		}
-		else if (const config &child = cfg->child("speak"))
+		else if (const config &speak = cfg->child("speak"))
 		{
-			const std::string &team_name = child["team_name"];
-			const std::string &speaker_name = child["id"];
-			const std::string &message = child["message"];
+			const std::string &team_name = speak["team_name"];
+			const std::string &speaker_name = speak["id"];
+			const std::string &message = speak["message"];
 			//if (!preferences::parse_should_show_lobby_join(speaker_name, message)) return;
 			bool is_whisper = (speaker_name.find("whisper: ") == 0);
 			if(resources::recorder->add_chat_message_location()) {
 				DBG_REPLAY << "tried to add a chat message twice.\n";
 				if (!resources::controller->is_skipping_replay() || is_whisper) {
-					int side = child["side"];
-					resources::screen->get_chat_manager().add_chat_message(get_time(child), speaker_name, side, message,
+					int side = speak["side"];
+					resources::screen->get_chat_manager().add_chat_message(get_time(speak), speaker_name, side, message,
 						(team_name.empty() ? events::chat_handler::MESSAGE_PUBLIC
 						: events::chat_handler::MESSAGE_PRIVATE),
 						preferences::message_bell());
 				}
 			}
 		}
-		else if (const config &child = cfg->child("label"))
+		else if (const config &label_config = cfg->child("label"))
 		{
-			terrain_label label(resources::screen->labels(), child);
+			terrain_label label(resources::screen->labels(), label_config);
 
 			resources::screen->labels().set_label(label.location(),
 						label.text(),
@@ -733,14 +733,14 @@ REPLAY_RETURN do_replay_handle(bool one_move)
 						label.team_name(),
 						label.color());
 		}
-		else if (const config &child = cfg->child("clear_labels"))
+		else if (const config &clear_labels = cfg->child("clear_labels"))
 		{
-			resources::screen->labels().clear(std::string(child["team_name"]), child["force"].to_bool());
+			resources::screen->labels().clear(std::string(clear_labels["team_name"]), clear_labels["force"].to_bool());
 		}
-		else if (const config &child = cfg->child("rename"))
+		else if (const config &rename = cfg->child("rename"))
 		{
-			const map_location loc(child);
-			const std::string &name = child["name"];
+			const map_location loc(rename);
+			const std::string &name = rename["name"];
 
 			unit_map::iterator u = resources::units->find(loc);
 			if (u.valid() && !u->unrenamable()) {
@@ -786,17 +786,17 @@ REPLAY_RETURN do_replay_handle(bool one_move)
 			}
 			else
 			{
-				if (const config &child = cfg->child("verify")) {
-					verify(*resources::units, child);
+				if (const config &cfg_verify = cfg->child("verify")) {
+					verify(*resources::units, cfg_verify);
 				}
 
 				return REPLAY_FOUND_END_TURN;
 			}
 		}
-		else if (const config &child = cfg->child("countdown_update"))
+		else if (const config &countdown_update = cfg->child("countdown_update"))
 		{
-			int val = child["value"];
-			int tval = child["team"];
+			int val = countdown_update["value"];
+			int tval = countdown_update["team"];
 			if (tval <= 0  || tval > int(resources::gameboard->teams().size())) {
 				std::stringstream errbuf;
 				errbuf << "Illegal countdown update \n"

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -697,12 +697,12 @@ static void convert_old_saves_1_11_0(config& cfg)
 
 		//get variables according to old hierarchy and copy them to new carryover_sides
 		if(!snapshot.empty()){
-			if(const config& variables = snapshot.child("variables")){
-				carryover.add_child("variables", variables);
+			if(const config& variables_from_snapshot = snapshot.child("variables")){
+				carryover.add_child("variables", variables_from_snapshot);
 				carryover_start.add_child("variables", replay_start.child_or_empty("variables"));
-			} else if (const config& variables = cfg.child("variables")){
-				carryover.add_child("variables", variables);
-				carryover_start.add_child("variables", variables);
+			} else if (const config& variables_from_cfg = cfg.child("variables")){
+				carryover.add_child("variables", variables_from_cfg);
+				carryover_start.add_child("variables", variables_from_cfg);
 			}
 		} else if (!replay_start.empty()){
 			if(const config& variables = replay_start.child("variables")){

--- a/src/scripting/lua_gui2.cpp
+++ b/src/scripting/lua_gui2.cpp
@@ -129,42 +129,42 @@ static gui2::twidget *find_widget(lua_State *L, int i, bool readonly)
 	for (; !lua_isnoneornil(L, i); ++i)
 	{
 #ifdef GUI2_EXPERIMENTAL_LISTBOX
-		if (gui2::tlist *l = dynamic_cast<gui2::tlist *>(w))
+		if (gui2::tlist *list = dynamic_cast<gui2::tlist *>(w))
 #else
-		if (gui2::tlistbox *l = dynamic_cast<gui2::tlistbox *>(w))
+		if (gui2::tlistbox *list = dynamic_cast<gui2::tlistbox *>(w))
 #endif
 		{
 			int v = lua_tointeger(L, i);
 			if (v < 1)
 				goto error_call_destructors_1;
-			int n = l->get_item_count();
+			int n = list->get_item_count();
 			if (v > n) {
 				if (readonly)
 					goto error_call_destructors_1;
 				utils::string_map dummy;
 				for (; n < v; ++n)
-					l->add_row(dummy);
+					list->add_row(dummy);
 			}
-			w = l->get_row_grid(v - 1);
+			w = list->get_row_grid(v - 1);
 		}
-		else if (gui2::tmulti_page *l = dynamic_cast<gui2::tmulti_page *>(w))
+		else if (gui2::tmulti_page *multi_page = dynamic_cast<gui2::tmulti_page *>(w))
 		{
 			int v = lua_tointeger(L, i);
 			if (v < 1)
 				goto error_call_destructors_1;
-			int n = l->get_page_count();
+			int n = multi_page->get_page_count();
 			if (v > n) {
 				if (readonly)
 					goto error_call_destructors_1;
 				utils::string_map dummy;
 				for (; n < v; ++n)
-					l->add_page(dummy);
+					multi_page->add_page(dummy);
 			}
-			w = &l->page_grid(v - 1);
+			w = &multi_page->page_grid(v - 1);
 		}
-		else if (gui2::ttree_view *tv = dynamic_cast<gui2::ttree_view *>(w))
+		else if (gui2::ttree_view *tree_view = dynamic_cast<gui2::ttree_view *>(w))
 		{
-			gui2::ttree_view_node& tvn = tv->get_root_node();
+			gui2::ttree_view_node& tvn = tree_view->get_root_node();
 			if(lua_isnumber(L, i))
 			{
 				int v = lua_tointeger(L, i);
@@ -183,40 +183,40 @@ static gui2::twidget *find_widget(lua_State *L, int i, bool readonly)
 				w = tvn.find(m, false);
 			}
 		}
-		else if (gui2::ttree_view_node *tvn = dynamic_cast<gui2::ttree_view_node *>(w))
+		else if (gui2::ttree_view_node *tree_view_node = dynamic_cast<gui2::ttree_view_node *>(w))
 		{
 			if(lua_isnumber(L, i))
 			{
 				int v = lua_tointeger(L, i);
 				if (v < 1)
 					goto error_call_destructors_1;
-				int n = tvn->count_children();
+				int n = tree_view_node->count_children();
 				if (v > n) {
 					goto error_call_destructors_1;
 				}
-				w = &tvn->get_child_at(v - 1);
+				w = &tree_view_node->get_child_at(v - 1);
 
 			}
 			else
 			{
 				std::string m = luaL_checkstring(L, i);
-				w = tvn->find(m, false);
+				w = tree_view_node->find(m, false);
 			}
 		}
-		else if(gui2::tstacked_widget* sw = dynamic_cast<gui2::tstacked_widget*>(w)) {
+		else if(gui2::tstacked_widget* stacked_widget = dynamic_cast<gui2::tstacked_widget*>(w)) {
 			if(lua_isnumber(L, i)) {
 				int v = lua_tointeger(L, i);
 				if(v < 1) {
 					goto error_call_destructors_1;
 				}
-				int n = sw->get_layer_count();
+				int n = stacked_widget->get_layer_count();
 				if(v > n) {
 					goto error_call_destructors_1;
 				}
-				w = sw->get_layer_grid(v - 1);
+				w = stacked_widget->get_layer_grid(v - 1);
 			} else {
 				std::string m = luaL_checkstring(L, i);
-				w = sw->find(m, false);
+				w = stacked_widget->find(m, false);
 			}
 		}
 		else
@@ -423,71 +423,71 @@ int intf_set_dialog_value(lua_State *L)
 	gui2::twidget *w = find_widget(L, 2, false);
 
 #ifdef GUI2_EXPERIMENTAL_LISTBOX
-	if (gui2::tlist *l = dynamic_cast<gui2::tlist *>(w))
+	if (gui2::tlist *list = dynamic_cast<gui2::tlist *>(w))
 #else
-	if (gui2::tlistbox *l = dynamic_cast<gui2::tlistbox *>(w))
+	if (gui2::tlistbox *list = dynamic_cast<gui2::tlistbox *>(w))
 #endif
 	{
 		int v = luaL_checkinteger(L, 1);
-		int n = l->get_item_count();
+		int n = list->get_item_count();
 		if (1 <= v && v <= n)
-			l->select_row(v - 1);
+			list->select_row(v - 1);
 		else
 			return luaL_argerror(L, 1, "out of bounds");
 	}
-	else if (gui2::tmulti_page *l = dynamic_cast<gui2::tmulti_page *>(w))
+	else if (gui2::tmulti_page *multi_page = dynamic_cast<gui2::tmulti_page *>(w))
 	{
 		int v = luaL_checkinteger(L, 1);
-		int n = l->get_page_count();
+		int n = multi_page->get_page_count();
 		if (1 <= v && v <= n)
-			l->select_page(v - 1);
+			multi_page->select_page(v - 1);
 		else
 			return luaL_argerror(L, 1, "out of bounds");
 	}
-	else if (gui2::tselectable_ *s = dynamic_cast<gui2::tselectable_ *>(w))
+	else if (gui2::tselectable_ *selectable = dynamic_cast<gui2::tselectable_ *>(w))
 	{
-		if(s->num_states() == 2) {
-			s->set_value_bool(luaW_toboolean(L, 1));
+		if(selectable->num_states() == 2) {
+			selectable->set_value_bool(luaW_toboolean(L, 1));
 		}
 		else {
-			s->set_value(luaL_checkinteger(L, 1) -1);
+			selectable->set_value(luaL_checkinteger(L, 1) -1);
 		}
 	}
-	else if (gui2::ttext_box *t = dynamic_cast<gui2::ttext_box *>(w))
+	else if (gui2::ttext_box *text_box = dynamic_cast<gui2::ttext_box *>(w))
 	{
 		const t_string& text = luaW_checktstring(L, 1);
-		t->set_value(text.str());
+		text_box->set_value(text.str());
 	}
-	else if (gui2::tslider *s = dynamic_cast<gui2::tslider *>(w))
+	else if (gui2::tslider *slider = dynamic_cast<gui2::tslider *>(w))
 	{
 		const int v = luaL_checkinteger(L, 1);
-		const int m = s->get_minimum_value();
-		const int n = s->get_maximum_value();
+		const int m = slider->get_minimum_value();
+		const int n = slider->get_maximum_value();
 		if (m <= v && v <= n)
-			s->set_value(v);
+			slider->set_value(v);
 		else
 			return luaL_argerror(L, 1, "out of bounds");
 	}
-	else if (gui2::tprogress_bar *p = dynamic_cast<gui2::tprogress_bar *>(w))
+	else if (gui2::tprogress_bar *progress_bar = dynamic_cast<gui2::tprogress_bar *>(w))
 	{
 		const int v = luaL_checkinteger(L, 1);
 		if (0 <= v && v <= 100)
-			p->set_percentage(v);
+			progress_bar->set_percentage(v);
 		else
 			return luaL_argerror(L, 1, "out of bounds");
 	}
-	else if(gui2::tstacked_widget* sw = dynamic_cast<gui2::tstacked_widget*>(w)) {
+	else if(gui2::tstacked_widget* stacked_widget = dynamic_cast<gui2::tstacked_widget*>(w)) {
 		const int v = luaL_checkinteger(L, 1);
-		const int n = sw->get_layer_count();
+		const int n = stacked_widget->get_layer_count();
 		if(v >= 0 && v <= n) {
-			sw->select_layer(v - 1);
+			stacked_widget->select_layer(v - 1);
 		}
 	}
-	else if(gui2::tunit_preview_pane* upp = dynamic_cast<gui2::tunit_preview_pane*>(w)) {
+	else if(gui2::tunit_preview_pane* unit_preview_pane = dynamic_cast<gui2::tunit_preview_pane*>(w)) {
 		if(const unit_type* ut = luaW_tounittype(L, 1)) {
-			upp->set_displayed_type(*ut);
+			unit_preview_pane->set_displayed_type(*ut);
 		} else if(unit* u = luaW_tounit(L, 1)) {
-			upp->set_displayed_unit(*u);
+			unit_preview_pane->set_displayed_unit(*u);
 		} else {
 			return luaL_typerror(L, 1, "unit or unit type");
 		}
@@ -513,37 +513,37 @@ int intf_get_dialog_value(lua_State *L)
 	gui2::twidget *w = find_widget(L, 1, true);
 
 #ifdef GUI2_EXPERIMENTAL_LISTBOX
-	if (gui2::tlist *l = dynamic_cast<gui2::tlist *>(w))
+	if (gui2::tlist *list = dynamic_cast<gui2::tlist *>(w))
 #else
-	if (gui2::tlistbox *l = dynamic_cast<gui2::tlistbox *>(w))
+	if (gui2::tlistbox *list = dynamic_cast<gui2::tlistbox *>(w))
 #endif
 	{
-		lua_pushinteger(L, l->get_selected_row() + 1);
-	} else if (gui2::tmulti_page *l = dynamic_cast<gui2::tmulti_page *>(w)) {
-		lua_pushinteger(L, l->get_selected_page() + 1);
-	} else if (gui2::tselectable_ *s = dynamic_cast<gui2::tselectable_ *>(w)) {
+		lua_pushinteger(L, list->get_selected_row() + 1);
+	} else if (gui2::tmulti_page *multi_page = dynamic_cast<gui2::tmulti_page *>(w)) {
+		lua_pushinteger(L, multi_page->get_selected_page() + 1);
+	} else if (gui2::tselectable_ *selectable = dynamic_cast<gui2::tselectable_ *>(w)) {
 
-		if(s->num_states() == 2) {
-			lua_pushboolean(L, s->get_value_bool());
+		if(selectable->num_states() == 2) {
+			lua_pushboolean(L, selectable->get_value_bool());
 		}
 		else {
-			lua_pushinteger(L, s->get_value() + 1);
+			lua_pushinteger(L, selectable->get_value() + 1);
 		}
-	} else if (gui2::ttext_box *t = dynamic_cast<gui2::ttext_box *>(w)) {
-		lua_pushstring(L, t->get_value().c_str());
-	} else if (gui2::tslider *s = dynamic_cast<gui2::tslider *>(w)) {
-		lua_pushinteger(L, s->get_value());
-	} else if (gui2::tprogress_bar *p = dynamic_cast<gui2::tprogress_bar *>(w)) {
-		lua_pushinteger(L, p->get_percentage());
-	} else if (gui2::ttree_view *tv = dynamic_cast<gui2::ttree_view *>(w)) {
-		std::vector<int> path = tv->selected_item()->describe_path();
+	} else if (gui2::ttext_box *text_box = dynamic_cast<gui2::ttext_box *>(w)) {
+		lua_pushstring(L, text_box->get_value().c_str());
+	} else if (gui2::tslider *slider = dynamic_cast<gui2::tslider *>(w)) {
+		lua_pushinteger(L, slider->get_value());
+	} else if (gui2::tprogress_bar *progress_bar = dynamic_cast<gui2::tprogress_bar *>(w)) {
+		lua_pushinteger(L, progress_bar->get_percentage());
+	} else if (gui2::ttree_view *tree_view = dynamic_cast<gui2::ttree_view *>(w)) {
+		std::vector<int> path = tree_view->selected_item()->describe_path();
 		lua_createtable(L, path.size(), 0);
 		for(size_t i =0; i < path.size(); ++i) {
 			lua_pushinteger(L, path[i] + 1);
 			lua_rawseti(L, -2, i + 1);
 		}
-	} else if(gui2::tstacked_widget* sw = dynamic_cast<gui2::tstacked_widget*>(w)) {
-		lua_pushinteger(L, sw->current_layer());
+	} else if(gui2::tstacked_widget* stacked_widget = dynamic_cast<gui2::tstacked_widget*>(w)) {
+		lua_pushinteger(L, stacked_widget->current_layer());
 	} else
 		return luaL_argerror(L, lua_gettop(L), "unsupported widget");
 
@@ -579,18 +579,18 @@ int intf_remove_dialog_item(lua_State *L)
 	gui2::twidget *w = find_widget(L, 3, true);
 
 #ifdef GUI2_EXPERIMENTAL_LISTBOX
-	if (gui2::tlist *l = dynamic_cast<gui2::tlist *>(w))
+	if (gui2::tlist *list = dynamic_cast<gui2::tlist *>(w))
 #else
-	if (gui2::tlistbox *l = dynamic_cast<gui2::tlistbox *>(w))
+	if (gui2::tlistbox *list = dynamic_cast<gui2::tlistbox *>(w))
 #endif
 	{
-		l->remove_row(pos, number);
-	} else if (gui2::tmulti_page *l = dynamic_cast<gui2::tmulti_page *>(w)) {
-		l->remove_page(pos, number);
-	} else if (gui2::ttree_view *tv = dynamic_cast<gui2::ttree_view *>(w)) {
-		remove_treeview_node(tv->get_root_node(), pos, number);
-	} else if (gui2::ttree_view_node *tvn = dynamic_cast<gui2::ttree_view_node *>(w)) {
-		remove_treeview_node(*tvn, pos, number);
+		list->remove_row(pos, number);
+	} else if (gui2::tmulti_page *multi_page = dynamic_cast<gui2::tmulti_page *>(w)) {
+		multi_page->remove_page(pos, number);
+	} else if (gui2::ttree_view *tree_view = dynamic_cast<gui2::ttree_view *>(w)) {
+		remove_treeview_node(tree_view->get_root_node(), pos, number);
+	} else if (gui2::ttree_view_node *tree_view_node = dynamic_cast<gui2::ttree_view_node *>(w)) {
+		remove_treeview_node(*tree_view_node, pos, number);
 	} else
 		return luaL_argerror(L, lua_gettop(L), "unsupported widget");
 

--- a/src/server/game.cpp
+++ b/src/server/game.cpp
@@ -960,8 +960,8 @@ bool game::process_turn(simple_wml::document& data, const socket_ptr user) {
 		simple_wml::node* const speak = (**command).child("speak");
 		if (speak == nullptr) {
 			simple_wml::document* mdata = new simple_wml::document;
-			simple_wml::node& turn = mdata->root().add_child("turn");
-			(**command).copy_into(turn.add_child("command"));
+			simple_wml::node& mturn = mdata->root().add_child("turn");
+			(**command).copy_into(mturn.add_child("command"));
 			send_data(*mdata, user, "game replay");
 			record_data(mdata);
 			continue;
@@ -974,9 +974,9 @@ bool game::process_turn(simple_wml::document& data, const socket_ptr user) {
 		}
 
 		std::unique_ptr<simple_wml::document> message(new simple_wml::document);
-		simple_wml::node& turn = message->root().add_child("turn");
-		simple_wml::node& command = turn.add_child("command");
-		speak->copy_into(command.add_child("speak"));
+		simple_wml::node& message_turn = message->root().add_child("turn");
+		simple_wml::node& message_turn_command = message_turn.add_child("command");
+		speak->copy_into(message_turn_command.add_child("speak"));
 		if (to_sides == "") {
 			send_data(*message, user, "game message");
 			record_data(message.release());

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -419,20 +419,20 @@ void theme::object::modify_location(const _rect& rect){
 	location_modified_ = true;
 }
 
-void theme::object::modify_location(std::string rect_str, SDL_Rect ref_rect){
+void theme::object::modify_location(std::string rect_str, SDL_Rect location_ref_rect){
 	_rect rect = { 0, 0, 0, 0 };
 	const std::vector<std::string> items = utils::split(rect_str.c_str());
 	if(items.size() >= 1) {
-		rect.x1 = compute(items[0], ref_rect.x, ref_rect.x + ref_rect.w);
+		rect.x1 = compute(items[0], location_ref_rect.x, location_ref_rect.x + location_ref_rect.w);
 	}
 	if(items.size() >= 2) {
-		rect.y1 = compute(items[1], ref_rect.y, ref_rect.y + ref_rect.h);
+		rect.y1 = compute(items[1], location_ref_rect.y, location_ref_rect.y + location_ref_rect.h);
 	}
 	if(items.size() >= 3) {
-		rect.x2 = compute(items[2], ref_rect.x + ref_rect.w, rect.x1);
+		rect.x2 = compute(items[2], location_ref_rect.x + location_ref_rect.w, rect.x1);
 	}
 	if(items.size() >= 4) {
-		rect.y2 = compute(items[3], ref_rect.y + ref_rect.h, rect.y1);
+		rect.y2 = compute(items[3], location_ref_rect.y + location_ref_rect.h, rect.y1);
 	}
 	modify_location(rect);
 }
@@ -825,8 +825,8 @@ void theme::set_object_location(theme::object& element, std::string rect_str, st
 		ref_element = find_element(ref_id);
 	}
 	if (ref_element.get_id() == ref_id){
-		SDL_Rect ref_rect = ref_element.get_location();
-		element.modify_location(rect_str, ref_rect);
+		SDL_Rect location_ref_rect = ref_element.get_location();
+		element.modify_location(rect_str, location_ref_rect);
 	}
 }
 


### PR DESCRIPTION
An extension of af73336, hopefully this will remove some more of the warnings which pop up in MSVC compilation. Also try to use more explanatory variable names as code should generally be self-documenting and easy to read.

(Not that I think the names I picked are necessarily easier to read, but some of the older code is hard for me to interpret. Especially those single-character variable names!)