### PR TITLE
Suppress NO_FIFO_DIR message on WIN32

### DIFF
--- a/src/server/server.hpp
+++ b/src/server/server.hpp
@@ -117,8 +117,10 @@ private:
 		return result;
 	}
 
+#ifndef _WIN32
 	/** server socket/fifo. */
 	std::string input_path_;
+#endif
 
 	const std::string config_file_;
 	config cfg_;


### PR DESCRIPTION
Clean up the #if guards to suppress the message and code which does not execute on Windows because it has no FIFO support.