### PR TITLE
Made Drake Flying Animations working on more terrains.

### DIFF
--- a/data/core/macros/animation-utils.cfg
+++ b/data/core/macros/animation-utils.cfg
@@ -775,7 +775,7 @@
 #enddef
 
 #define DRAKE_UNWALKABLE_TERRAINS
-!,Wwf,*^B*,!,W*,W*^V*,Chs,Chw,S*,S*^V*,Q*,Mv#enddef
+!,Wwf*^*,Kme*^*,*^B*,!,W*^*,S*^*,Chs*^*,Chw*^*,Cm*^*,Km*^*,Q*^*,Mv*^*,*^Qov,*^Vm,*^Vhs#enddef
 
 #define DRAKE_STANDING_ANIM DRAKE_NAME
     [standing_anim]

--- a/data/core/macros/animation-utils.cfg
+++ b/data/core/macros/animation-utils.cfg
@@ -775,7 +775,7 @@
 #enddef
 
 #define DRAKE_UNWALKABLE_TERRAINS
-!,Wwf*^*,Kme*^*,*^B*,!,W*^*,S*^*,Chs*^*,Chw*^*,Cm*^*,Km*^*,Q*^*,Mv*^*,*^Qov,*^Vm,*^Vhs#enddef
+!,Wwf*^*,Kme*^*,*^B*,!,W*^*,S*^*,Chs*^*,Chw*^*,Cm*^*,Km*^*,Q*^*,Mv*^*,*^Qov,*^Vm#enddef
 
 #define DRAKE_STANDING_ANIM DRAKE_NAME
     [standing_anim]

--- a/data/core/terrain.cfg
+++ b/data/core/terrain.cfg
@@ -1822,7 +1822,7 @@ Merfolk and nagas have 60% defense in submerged villages, whereas land based uni
     editor_name= _ "Aquatic Castle"
     string=Cm
     aliasof=Ct,Wwr
-    submerge=0.3
+    submerge=0.4
     unit_height_adjust=3
     recruit_onto=true
     editor_group=castle, water
@@ -2033,7 +2033,7 @@ Merfolk and nagas have 60% defense in submerged villages, whereas land based uni
     editor_name= _ "Aquatic Keep"
     string=Km
     aliasof=Ct, Wwr
-    submerge=0.3
+    submerge=0.4
     unit_height_adjust=10
     recruit_onto=true
     recruit_from=true

--- a/data/core/units/goblins/Wolf_Rider.cfg
+++ b/data/core/units/goblins/Wolf_Rider.cfg
@@ -13,7 +13,7 @@
     [/standing_anim]
     [standing_anim]
         start_time=-50
-        terrain_type=!,*^B*,!,Chs^*,Chw^*,W*^*,S*^*,*^Vm
+        terrain_type=!,*^B*,!,Chs*^*,Chw*^*,W*^*,S*^*,*^Vm,*^Vhs
         [frame]
             image="units/goblins/wolf-rider-water.png:50"
         [/frame]

--- a/data/core/units/goblins/Wolf_Rider.cfg
+++ b/data/core/units/goblins/Wolf_Rider.cfg
@@ -13,7 +13,7 @@
     [/standing_anim]
     [standing_anim]
         start_time=-50
-        terrain_type=!,*^B*,!,Chs*^*,Chw*^*,W*^*,S*^*,*^Vm
+        terrain_type=!,*^B*,Cme*^*,Kme*^*,Wwr*^*,Wwf*^*,!,Chs*^*,Chw*^*,Cm*^*,Km*^*,W*^*,S*^*,*^Vm
         [frame]
             image="units/goblins/wolf-rider-water.png:50"
         [/frame]

--- a/data/core/units/goblins/Wolf_Rider.cfg
+++ b/data/core/units/goblins/Wolf_Rider.cfg
@@ -13,7 +13,7 @@
     [/standing_anim]
     [standing_anim]
         start_time=-50
-        terrain_type=!,*^B*,!,Chs*^*,Chw*^*,W*^*,S*^*,*^Vm,*^Vhs
+        terrain_type=!,*^B*,!,Chs*^*,Chw*^*,W*^*,S*^*,*^Vm
         [frame]
             image="units/goblins/wolf-rider-water.png:50"
         [/frame]

--- a/data/core/units/monsters/Wolf.cfg
+++ b/data/core/units/monsters/Wolf.cfg
@@ -14,7 +14,7 @@
     [/standing_anim]
     [standing_anim]
         start_time=-50
-        terrain_type=!,*^B*,!,Chs*^*,Chw*^*,W*^*,S*^*,*^Vm,*^Vhs
+        terrain_type=!,*^B*,!,Chs*^*,Chw*^*,W*^*,S*^*,*^Vm
         [frame]
             image="units/monsters/wolf-water.png"
             duration=50

--- a/data/core/units/monsters/Wolf.cfg
+++ b/data/core/units/monsters/Wolf.cfg
@@ -14,7 +14,7 @@
     [/standing_anim]
     [standing_anim]
         start_time=-50
-        terrain_type=!,*^B*,!,Chs*^*,Chw*^*,W*^*,S*^*,*^Vm
+        terrain_type=!,*^B*,Kme*^*,!,Chs*^*,Chw*^*,Cm*^*,Km*^*,W*^*,S*^*,*^Vm
         [frame]
             image="units/monsters/wolf-water.png"
             duration=50

--- a/data/core/units/monsters/Wolf.cfg
+++ b/data/core/units/monsters/Wolf.cfg
@@ -14,7 +14,7 @@
     [/standing_anim]
     [standing_anim]
         start_time=-50
-        terrain_type=!,*^B*,!,Chs^*,Chw^*,W*^*,S*^*,*^Vm
+        terrain_type=!,*^B*,!,Chs*^*,Chw*^*,W*^*,S*^*,*^Vm,*^Vhs
         [frame]
             image="units/monsters/wolf-water.png"
             duration=50

--- a/data/core/units/saurians/Skirmisher.cfg
+++ b/data/core/units/saurians/Skirmisher.cfg
@@ -23,13 +23,7 @@ Spears are their preferred weapon, as their powerful hind legs can drive a spear
     [/abilities]
     [idle_anim]
         {STANDARD_IDLE_FILTER}
-        [filter]
-            [filter_location]
-                [not]
-                    terrain=C*,K*,*^V*
-                [/not]
-            [/filter_location]
-        [/filter]
+        terrain_type=!,C*^*,K*^*,*^V*
         start_time=0
         [frame]
             image="units/saurians/skirmisher/skirmisher-idle-[1~7,6,5,6,8~13].png:200,units/saurians/skirmisher/skirmisher-idle-[12,13,12,13].png:[225*2,250*2]"


### PR DESCRIPTION
E.g. they weren't working on water with water lilies before.
The terrain codes are now more generic too, for the case somebody wants to make an UMC variation.
Also had a look on other places where terrain codes get used.

There is also the DRAKE_FLYING_ANIMATION macro. It's not getting used, seems to be an old Artifact. DRAKE_STANDING_ANIMATION does the same thing.
I guess I can't just remove it but have to move it to macros/deprecated-utils?
The onliest reference to that macro is in data/tools/emacs_mode/wesnoth-wml-data.el