### PR TITLE
Add ability to horizontally align story text

### DIFF
--- a/src/storyscreen/part.cpp
+++ b/src/storyscreen/part.cpp
@@ -151,6 +151,7 @@ part::part(const vconfig &part_cfg)
 	, text_()
 	, text_title_()
 	, text_block_loc_(part::BLOCK_BOTTOM)
+	, text_alignment_(part::TEXT_LEFT)
 	, title_alignment_(part::TEXT_LEFT)
 	, music_()
 	, sound_()
@@ -240,6 +241,9 @@ void part::resolve_wml(const vconfig &cfg)
 	}
 	if(cfg.has_attribute("text_layout")) {
 		text_block_loc_ = string_tblock_loc(cfg["text_layout"]);
+	}
+	if(cfg.has_attribute("text_alignment")) {
+		text_alignment_ = string_title_align(cfg["text_alignment"]);
 	}
 	if(cfg.has_attribute("title_alignment")) {
 		title_alignment_ = string_title_align(cfg["title_alignment"]);

--- a/src/storyscreen/part.hpp
+++ b/src/storyscreen/part.hpp
@@ -315,6 +315,11 @@ public:
 		return text_block_loc_;
 	}
 
+	/** Retrieves the alignment of the story text within the text area. */
+	TEXT_ALIGNMENT story_text_alignment() const {
+		return text_alignment_;
+	}
+
 	/** Retrieves the alignment of the title text against the screen. */
 	TEXT_ALIGNMENT title_text_alignment() const {
 		return title_alignment_;
@@ -341,6 +346,7 @@ private:
 	std::string text_;
 	std::string text_title_;
 	BLOCK_LOCATION text_block_loc_;
+	TEXT_ALIGNMENT text_alignment_;
 	TEXT_ALIGNMENT title_alignment_;
 
 	std::string music_;

--- a/src/storyscreen/render.cpp
+++ b/src/storyscreen/render.cpp
@@ -439,6 +439,21 @@ void part_ui::render_story_box()
 	SDL_Rect dstrect = {0,0,0,0};
 
 
+	// Convert the story part text alignment types into the Pango equivalents
+	PangoAlignment story_text_alignment = PANGO_ALIGN_LEFT;
+
+	switch(p_.story_text_alignment()) {
+	case part::TEXT_CENTERED:
+		story_text_alignment = PANGO_ALIGN_CENTER;
+		break;
+	case part::TEXT_RIGHT:
+		story_text_alignment = PANGO_ALIGN_RIGHT;
+		break;
+	default:
+		break; // already set before
+	}
+
+
 	while(true) {
 
 		if (dirty_) {
@@ -466,6 +481,7 @@ void part_ui::render_story_box()
 			t.set_text(p_.text(), false);
 		}
 		t.set_font_style(font::ttext::STYLE_NORMAL)
+				.set_alignment(story_text_alignment)
 				.set_font_size(storybox_font_size)
 				.set_foreground_color(storybox_font_color)
 				.set_maximum_width(max_width)


### PR DESCRIPTION
Adds an optional attribute `text_alignment` to the [part] tag for story text alignment.
```
[story]
    [part]
        story= _"Blah"
        text_alignment=center
    [/part]
[/story
```

![](http://imgur.com/F8KLl57l.png)