### PR TITLE
Ensure [endlevel] only happens once.

### DIFF
--- a/data/test/macros/wml_unit_test_macros.cfg
+++ b/data/test/macros/wml_unit_test_macros.cfg
@@ -1,39 +1,58 @@
 #textdomain wesnoth
 #define RETURN X
     [if]
-        {X}
+        [variable]
+            name=ended
+            boolean_not_equals=yes
+        [/variable]
         [then]
-            [endlevel]
-                result=victory
-                linger_mode = yes
-            [/endlevel]
+            [if]
+                {X}
+                [then]
+                    {VARIABLE ended yes}
+                    [endlevel]
+                        result=victory
+                        linger_mode = yes
+                    [/endlevel]
+                [/then]
+                [else]
+                    [test_condition]
+                        result=no
+                        {X}
+                    [/test_condition]
+                    {VARIABLE ended yes}
+                    [endlevel]
+                        result=defeat
+                        linger_mode = yes
+                    [/endlevel]
+                [/else]
+            [/if]
         [/then]
-        [else]
-        	[test_condition]
-        		result=no
-        		{X}
-        	[/test_condition]
-            [endlevel]
-                result=defeat
-                linger_mode = yes
-            [/endlevel]
-        [/else]
     [/if]
 #enddef
 
 #define ASSERT X
     [if]
-        {X}
-        [else]
-        	[test_condition]
-        		result=no
-        		{X}
-        	[/test_condition]
-            [endlevel]
-                result=defeat
-                linger_mode = yes
-            [/endlevel]
-        [/else]
+        [variable]
+            name=ended
+            boolean_not_equals=yes
+        [/variable]
+        [then]
+            [if]
+                {X}
+                [else]
+                    [test_condition]
+                        result=no
+                        {X}
+                    [/test_condition]
+                    {VARIABLE ended yes}
+                    [endlevel]
+                        result=defeat
+                        linger_mode = yes
+                    [/endlevel]
+                [/else]
+            [/if]
+        [/then]
     [/if]
 #enddef
 


### PR DESCRIPTION
First come, first served.

This was causing many failures on Travis/CI

Use &w=1 to ignore white space viewing the diff.