### PR TITLE
Fix a unit test

### DIFF
--- a/data/test/scenarios/interrupts.cfg
+++ b/data/test/scenarios/interrupts.cfg
@@ -90,11 +90,17 @@
 	[/event]
 	[event]
 		name=success
-		{SUCCEED}
+		[endlevel]
+			result=victory
+			linger_mode = yes
+		[/endlevel]
 	[/event]
 	[event]
 		name=fail
-		{FAIL}
+		[endlevel]
+			result=defeat
+			linger_mode = yes
+		[/endlevel]
 	[/event]
 )}
 


### PR DESCRIPTION
For some reason the macro RESULT causes the test to crash Lua.

Don't see why. Don't know why this fixes it. But this gets the tests working.