### PR TITLE
Fix bug: CMake out of tree

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -339,8 +339,9 @@ set_source_files_properties(${libwesnoth-lua_STAT_SRC} PROPERTIES LANGUAGE CXX)
 
 # Inject a header into the Lua sources for Wesnoth-specific changes
 # makedepend won't see it so we have to specifically add it as a dependancy.
-set_source_files_properties(${libwesnoth-lua_STAT_SRC} PROPERTIES COMPILE_FLAGS "-include ../src/wesnoth_lua_config.h")
-set_source_files_properties(${libwesnoth-lua_STAT_SRC} PROPERTIES OBJECT_DEPENDS src/wesnoth_lua_config.h)
+file(GLOB wesnoth_lua_config wesnoth_lua_config.h)
+set_source_files_properties(${libwesnoth-lua_STAT_SRC} PROPERTIES COMPILE_FLAGS "-include ${wesnoth_lua_config}")
+set_source_files_properties(${libwesnoth-lua_STAT_SRC} PROPERTIES OBJECT_DEPENDS ${wesnoth_lua_config})
 
 if(UNIX AND NOT CMAKE_COMPILER_IS_GNUCXX)
 	# Assume the compiler is the clang compiler.


### PR DESCRIPTION
Fix how wesnoth_lua_config.h is specified to allow out-of-tree builds.

I don't do out-of-tree builds so all I can say is it didn't break my build.