### PR TITLE
[DON'T MERGE YET] Convert boost::regex to std::regex attempt 2

### DIFF
--- a/src/ai/composite/component.cpp
+++ b/src/ai/composite/component.cpp
@@ -26,7 +26,7 @@
 
 #include "ai/formula/ai.hpp"
 
-#include <boost/regex.hpp>
+#include <regex>
 
 namespace pathfind {
 
@@ -141,10 +141,10 @@ static component *find_component(component *root, const std::string &path, path_
 	}
 
 	//match path elements in [modify_ai] tag
-	boost::regex re(R"""(([^\.^\[]+)(\[(\d*)\]|\[([^\]]+)\]|()))""");
+	std::regex re(R"""(([^\.^\[]+)(\[(\d*)\]|\[([^\]]+)\]|()))""");
 	int const sub_matches[] = {1,3,4};
-	boost::sregex_token_iterator i(path.begin(), path.end(), re, sub_matches);
-	boost::sregex_token_iterator j;
+	std::sregex_token_iterator i(path.begin(), path.end(), re, sub_matches);
+	std::sregex_token_iterator j;
 
 	component *c  = root;
 

--- a/src/editor/map/map_context.cpp
+++ b/src/editor/map/map_context.cpp
@@ -32,11 +32,9 @@
 #include "units/unit.hpp"
 #include "wml_exception.hpp"
 
-
 #include "formula/string_utils.hpp"
 
-#include <boost/regex.hpp>
-
+#include <regex>
 
 namespace editor {
 
@@ -159,10 +157,9 @@ map_context::map_context(const config& game_config, const std::string& filename,
 	}
 
 	// 1.0 Pure map data
-	boost::regex rexpression_map_data(R"""(map_data\s*=\s*"(.+?)")""");
-	boost::smatch matched_map_data;
-	if (!boost::regex_search(file_string, matched_map_data, rexpression_map_data,
-			boost::regex_constants::match_not_dot_null)) {
+	std::regex rexpression_map_data(R"""(map_data\s*=\s*"(.+?)")""");
+	std::smatch matched_map_data;
+	if (!std::regex_search(file_string, matched_map_data, rexpression_map_data)) {
 		map_ = editor_map::from_string(game_config, file_string); //throws on error
 		pure_map_ = true;
 
@@ -172,13 +169,13 @@ map_context::map_context(const config& game_config, const std::string& filename,
 
 	// 2.0 Embedded map
 	const std::string& map_data = matched_map_data[1];
-	boost::regex rexpression_macro(R"""(\{(.+?)\})""");
-	boost::smatch matched_macro;
-	if (!boost::regex_search(map_data, matched_macro, rexpression_macro)) {
+	std::regex rexpression_macro(R"""(\{(.+?)\})""");
+	std::smatch matched_macro;
+	if (!std::regex_search(map_data, matched_macro, rexpression_macro)) {
 		// We have a map_data string but no macro ---> embedded or scenario
 
-		boost::regex rexpression_scenario(R"""(\[(scenario|test|multiplayer)\])""");
-		if (!boost::regex_search(file_string, rexpression_scenario)) {
+		std::regex rexpression_scenario(R"""(\[(scenario|test|multiplayer)\])""");
+		if (!std::regex_search(file_string, rexpression_scenario)) {
 			LOG_ED << "Loading generated scenario file" << std::endl;
 			// 4.0 editor generated scenario
 			try {
@@ -555,10 +552,9 @@ bool map_context::save_map()
 			filesystem::write_file(get_filename(), map_data);
 		} else {
 			std::string map_string = filesystem::read_file(get_filename());
-			boost::regex rexpression_map_data(R"""((.*map_data\s*=\s*")(.+?)(".*))""");
-			boost::smatch matched_map_data;
-			if (boost::regex_search(map_string, matched_map_data, rexpression_map_data,
-					boost::regex_constants::match_not_dot_null)) {
+			std::regex rexpression_map_data(R"""((.*map_data\s*=\s*")(.+?)(".*))""");
+			std::smatch matched_map_data;
+			if (std::regex_search(map_string, matched_map_data, rexpression_map_data)) {
 				std::stringstream ss;
 				ss << matched_map_data[1];
 				ss << map_data;

--- a/src/game_events/action_wml.cpp
+++ b/src/game_events/action_wml.cpp
@@ -65,7 +65,7 @@
 #include "wml_exception.hpp"
 #include "whiteboard/manager.hpp"
 
-#include <boost/regex.hpp>
+#include <regex>
 
 static lg::log_domain log_engine("engine");
 #define DBG_NG LOG_STREAM(debug, log_engine)
@@ -518,7 +518,7 @@ namespace {
 			static const std::string s_sep = "(, |\\n)";
 			static const std::string s_prefix = R"""((\d+ )?)""";
 			static const std::string s_all = "(" + s_prefix + s_terrain + s_sep + ")+";
-			static const boost::regex r_all(s_all);
+			static const std::regex r_all(s_all);
 
 			const std::string& mapfile = filesystem::get_wml_location(filename_);
 			std::string res = "";
@@ -526,7 +526,7 @@ namespace {
 				res = filesystem::read_file(mapfile);
 			}
 			config retv;
-			if(boost::regex_match(res, r_all))
+			if(std::regex_match(res, r_all))
 			{
 				retv["map_data"] = res;
 			}

--- a/src/serialization/schema_validator.cpp
+++ b/src/serialization/schema_validator.cpp
@@ -156,7 +156,7 @@ bool schema_validator::read_config_file(const std::string &filename){
 		}
 		for(const config &type : g.child_range("type")) {
 			try{
-				types_[type["name"].str()] = boost::regex( type["value"].str());
+				types_[type["name"].str()] = std::regex( type["value"].str());
 			}
 			catch (std::exception){
 			// Need to check all type values in schema-generator
@@ -267,11 +267,11 @@ void schema_validator::validate_key(const config & cfg,
 		// checking existing keys
 		const class_key * key =stack_.top()->find_key(name);
 		if (key){
-			std::map<std::string,boost::regex>::iterator itt =
+			std::map<std::string,std::regex>::iterator itt =
 					types_.find(key->get_type());
 			if (itt != types_.end()){
-				boost::smatch sub;
-				bool res = boost::regex_match(value,sub,itt->second);
+				std::smatch sub;
+				bool res = std::regex_match(value,sub,itt->second);
 				if (!res ) {
 					cache_.top()[&cfg].push_back(
 							message_info(WRONG_VALUE,file,start_line,0,

--- a/src/serialization/schema_validator.hpp
+++ b/src/serialization/schema_validator.hpp
@@ -21,12 +21,9 @@
 #include "config_cache.hpp"
 #include "serialization/parser.hpp"
 
-
-
-#include <boost/regex.hpp>
-
 #include <iostream>
 #include <queue>
+#include <regex>
 #include <string>
 #include <stack>
 
@@ -146,7 +143,7 @@ private:
 	/**
 	 * Type validators.
 	 */
-	 std::map<std::string,boost::regex> types_;
+	 std::map<std::string,std::regex> types_;
 };
 }//namespace schema_validation{
 

--- a/src/tools/schema/sourceparser.cpp
+++ b/src/tools/schema/sourceparser.cpp
@@ -18,8 +18,7 @@
 
 #include "tools/schema/sourceparser.hpp"
 
-#include <boost/regex.hpp>
-
+#include <regex>
 #include <stack>
 
 namespace schema_validation{
@@ -429,9 +428,9 @@ bool class_source_parser::parse_keys(){
 			close_opened_tags();
 			return false;
 		}
-		static const boost::regex value (get_key_value() );
-		boost::smatch sub;
-		bool res = boost::regex_match(line,sub,value);
+		static const std::regex value (get_key_value() );
+		std::smatch sub;
+		bool res = std::regex_match(line,sub,value);
 		if (res){
 			std::string type = sub[2];
 			class_key key (sub[1],type,sub[3]);
@@ -447,20 +446,20 @@ bool class_source_parser::parse_keys(){
 
 bool class_source_parser::check_valid(const std::string &s){
 	// s must be like " *" or "*"
-	static const boost::regex valid (get_valid());
-	return boost::regex_search(s,valid);
+	static const std::regex valid (get_valid());
+	return std::regex_search(s,valid);
 }
 
 bool class_source_parser::check_wiki(const std::string& s){
-	boost::regex wiki (get_wiki());
-	return boost::regex_match(s,wiki);
+	std::regex wiki (get_wiki());
+	return std::regex_match(s,wiki);
 }
 
 bool class_source_parser::check_tag_begin(const std::string &s){
 	// read tag;
-	static boost::regex tag (get_tag_begin());
-	boost::smatch sub;
-	bool res = boost::regex_match(s,sub,tag);
+	static std::regex tag (get_tag_begin());
+	std::smatch sub;
+	bool res = std::regex_match(s,sub,tag);
 	if (res){
 		std::string link = sub[5];
 		class_tag new_tag;
@@ -479,9 +478,9 @@ bool class_source_parser::check_tag_begin(const std::string &s){
 }
 
 bool class_source_parser::check_tag_end(const std::string &s){
-	static const boost::regex endtag (get_tag_end());
-	boost::smatch sub;
-	bool res = boost::regex_match(s,sub,endtag);
+	static const std::regex endtag (get_tag_end());
+	std::smatch sub;
+	bool res = std::regex_match(s,sub,endtag);
 	if (res){
 		std::string name = sub[1];
 		if (current_.empty()){
@@ -505,9 +504,9 @@ bool class_source_parser::check_tag_end(const std::string &s){
 }
 
 bool class_source_parser::check_allow_link(const std::string &s){
-	static const boost::regex allow_link (get_allow_link());
-	boost::smatch sub;
-	bool res = boost::regex_match(s,sub,allow_link);
+	static const std::regex allow_link (get_allow_link());
+	std::smatch sub;
+	bool res = std::regex_match(s,sub,allow_link);
 	if (res){
 		if (!current_.empty()){
 			std::string link = sub[1];
@@ -521,21 +520,21 @@ bool class_source_parser::check_allow_link(const std::string &s){
 }
 
 bool class_source_parser::check_allow_global(const std::string &s){
-	static const boost::regex allow_global (get_allow_global());
-	boost::smatch sub;
-	bool res = boost::regex_match(s,sub,allow_global);
+	static const std::regex allow_global (get_allow_global());
+	std::smatch sub;
+	bool res = std::regex_match(s,sub,allow_global);
 	if (res){
 		if (!current_.empty()){
-			current_.back().add_link("global/"+sub[1]);
+			current_.back().add_link("global/"+sub[1].str());
 		}
 	}
 	return res;
 }
 
 bool class_source_parser::check_parent_begin(const std::string &s){
-	static const boost::regex parent (get_parent_begin());
-	boost::smatch sub;
-	bool res = boost::regex_match(s,sub,parent);
+	static const std::regex parent (get_parent_begin());
+	std::smatch sub;
+	bool res = std::regex_match(s,sub,parent);
 	if (res){
 		std::string name = sub[1];
 		if (!parent_name_.empty()) {
@@ -547,9 +546,9 @@ bool class_source_parser::check_parent_begin(const std::string &s){
 }
 
 bool class_source_parser::check_parent_end(const std::string &s){
-	static const boost::regex parent (get_parent_end());
-	boost::smatch sub;
-	bool res = boost::regex_match(s,sub,parent);
+	static const std::regex parent (get_parent_end());
+	std::smatch sub;
+	bool res = std::regex_match(s,sub,parent);
 	if (res){
 		std::string name = sub[1];
 		if (parent_name_ == name) {
@@ -562,26 +561,26 @@ bool class_source_parser::check_parent_end(const std::string &s){
 }
 
 bool class_source_parser::check_keys_begin(const std::string &s){
-	static const boost::regex keys (get_table_key_begin());
-	return boost::regex_match(s,keys);
+	static const std::regex keys (get_table_key_begin());
+	return std::regex_match(s,keys);
 
 }
 
 bool class_source_parser::check_keys_end(const std::string &s){
-	static const boost::regex endkeys (get_table_end());
-	bool res = boost::regex_match(s,endkeys);
+	static const std::regex endkeys (get_table_end());
+	bool res = std::regex_match(s,endkeys);
 	return res;
 }
 
 bool class_source_parser::check_allow_type(const std::string &s){
-	static const boost::regex allow_type (get_allow_type());
-	boost::smatch sub;
-	bool res = boost::regex_match(s,sub,allow_type);
+	static const std::regex allow_type (get_allow_type());
+	std::smatch sub;
+	bool res = std::regex_match(s,sub,allow_type);
 	if (res){
 		std::string name = sub[1];
 		std::string value = sub[2];
 		try{
-			boost::regex tmp (value);
+			std::regex tmp (value);
 		}catch(std::exception ){
 			errors_.wrong_type_error(input_,line_,name,value);
 			return true;
@@ -595,9 +594,9 @@ bool class_source_parser::check_allow_type(const std::string &s){
 	return res;
 }
 bool class_source_parser::check_remove_type(const std::string &s){
-	static const boost::regex remove_type (get_remove_type());
-	boost::smatch sub;
-	bool res = boost::regex_match(s,sub,remove_type);
+	static const std::regex remove_type (get_remove_type());
+	std::smatch sub;
+	bool res = std::regex_match(s,sub,remove_type);
 	if (res){
 		std::string name = sub[1];
 		types_[name]="";
@@ -607,9 +606,9 @@ bool class_source_parser::check_remove_type(const std::string &s){
 	return res;
 }
 bool class_source_parser::check_remove_key(const std::string &s){
-	static const boost::regex remove_key (get_remove_key());
-	boost::smatch sub;
-	bool res = boost::regex_match(s,sub,remove_key);
+	static const std::regex remove_key (get_remove_key());
+	std::smatch sub;
+	bool res = std::regex_match(s,sub,remove_key);
 	if (res){
 		if (! current_.empty ()){
 			current_.back ().remove_key_by_name(sub[1]);

--- a/src/units/types.cpp
+++ b/src/units/types.cpp
@@ -34,7 +34,7 @@
 #include "gui/auxiliary/formula.hpp"
 #include "gui/dialogs/loadscreen.hpp"
 
-#include <boost/regex.hpp>
+#include <regex>
 
 static lg::log_domain log_config("config");
 #define ERR_CF LOG_STREAM(err, log_config)
@@ -981,7 +981,7 @@ namespace { // Helpers for set_config()
 		ut_cfg.splice_children(variations, "variation");
 	}
 
-	const boost::regex fai_identifier("[a-zA-Z_]+");
+	const std::regex fai_identifier("[a-zA-Z_]+");
 
 	template<typename MoveT>
 	void patch_movetype(MoveT& mt, const std::string& new_key, const std::string& formula_str, int default_val, bool replace) {
@@ -993,8 +993,8 @@ namespace { // Helpers for set_config()
 		}
 		gui2::tformula<int> formula(formula_str);
 		game_logic::map_formula_callable original;
-		boost::sregex_iterator m(formula_str.begin(), formula_str.end(), fai_identifier);
-		for (const boost::sregex_iterator::value_type& p : std::make_pair(m, boost::sregex_iterator())) {
+		std::sregex_iterator m(formula_str.begin(), formula_str.end(), fai_identifier);
+		for (const std::sregex_iterator::value_type& p : std::make_pair(m, std::sregex_iterator())) {
 			const std::string var_name = p.str();
 			variant val(original_cfg[var_name].to_int(default_val));
 			original.add(var_name, val);


### PR DESCRIPTION
Convert uses of boost::regex and related functions/types to their stdlib counterparts

This covers:
* boost::regex
* boost::regex_match
* boost::smatch
* boost::sregex_iterator
* boost::sregex_token_iterator

boost::regex_constants::match_not_dot_null doesn't have a stdlib counterpart, but according to
@celticminstrel it should be alright to remove it.
