### PR TITLE
Fix Lua stack corruption

### DIFF
--- a/src/ai/lua/core.cpp
+++ b/src/ai/lua/core.cpp
@@ -1038,7 +1038,6 @@ void lua_ai_context::update_state()
 	
 	// Call the function
 	if (!luaW_pcall(L, 2, 1, true)) { // [-1: Result  -2: AI state]
-		lua_pop(L, 2); // (The result in this case is an error message.)
 		return; // return with stack size 0 []
 	}
 	


### PR DESCRIPTION
Do NOT pop the error message off the stack.
It has already been popped.