### PR TITLE
Lua integer indices

### DIFF
--- a/data/campaigns/Eastern_Invasion/lua/bandits.lua
+++ b/data/campaigns/Eastern_Invasion/lua/bandits.lua
@@ -27,8 +27,8 @@ function wml_actions.spread_bandit_villages(cfg)
 	for i = 0, (count - 1) do
 		village_i = helper.rand("1.."..#villages)
 
-		wesnoth.set_variable("bandit_villages["..i.."].x", villages[village_i][1])
-		wesnoth.set_variable("bandit_villages["..i.."].y", villages[village_i][2])
+		wesnoth.set_variable(string.format("bandit_villages[%d].x", i), villages[village_i][1])
+		wesnoth.set_variable(string.format("bandit_villages[%d].y", i), villages[village_i][2])
 		table.remove(villages, village_i)
 	end
 end
@@ -75,7 +75,7 @@ function wml_actions.bandit_village_capture(cfg)
 
 	for i=1,#bandit_villages do
 		if bandit_villages[i].x == x and bandit_villages[i].y == y then
-			wesnoth.set_variable("bandit_villages["..(i - 1).."]")
+			wesnoth.set_variable(string.format("bandit_villages[%d]", i - 1))
 
 			local visited = wesnoth.get_variable("villages_visited")
 			wesnoth.set_variable("villages_visited", visited + 1)

--- a/data/campaigns/Legend_of_Wesmere/lua/wml_tags.lua
+++ b/data/campaigns/Legend_of_Wesmere/lua/wml_tags.lua
@@ -73,13 +73,13 @@ function wesnoth.wml_actions.persistent_carryover_store(cfg)
 		--TODO: apply carryover multipler and carryover bonus.
 		V["side_store.gold"] = side.gold
 		for i = 1, V["side_store.unit.length"] do
-			V["side_store.unit[" .. (i - 1)  .. "].x"] = nil
-			V["side_store.unit[" .. (i - 1) .. "].y"] = nil
-			V["side_store.unit[" .. (i - 1) .. "].hitpoints"] = nil
-			V["side_store.unit[" .. (i - 1) .. "].moves"] = nil 
-			V["side_store.unit[" .. (i - 1) .. "].side"] = nil 
-			V["side_store.unit[" .. (i - 1) .. "].goto_x"] = nil 
-			V["side_store.unit[" .. (i - 1) .. "].goto_y"] = nil 
+			V[string.format("side_store.unit[%d].x", i - 1)] = nil
+			V[string.format("side_store.unit[%d].y", i - 1)] = nil
+			V[string.format("side_store.unit[%d].hitpoints", i - 1)] = nil
+			V[string.format("side_store.unit[%d].moves", i - 1)] = nil
+			V[string.format("side_store.unit[%d].side", i - 1)] = nil
+			V[string.format("side_store.unit[%d].goto_x", i - 1)] = nil
+			V[string.format("side_store.unit[%d].goto_y", i - 1)] = nil
 		end
 		wml_actions.set_global_variable {
 			namespace = cfg.scenario_id,
@@ -114,16 +114,16 @@ function wesnoth.wml_actions.persistent_carryover_unstore(cfg)
 			end
 		end
 		for i = 1, V["side_store.unit.length"] do
-			V["side_store.unit[" .. (i - 1) .. "].side"] = num
-			local u = wesnoth.get_unit(V["side_store.unit[" .. (i - 1) .. "].id"])
+			V[string.format("side_store.unit[%d].side", i - 1)] = num
+			local u = wesnoth.get_unit(V[string.format("side_store.unit[%d].id", i - 1)])
 			
 			if u then
-				V["side_store.unit[" .. (i - 1) .. "].x"] = u.x
-				V["side_store.unit[" .. (i - 1) .. "].y"] = u.y
+				V[string.format("side_store.unit[%d].x", i - 1)] = u.x
+				V[string.format("side_store.unit[%d].y", i - 1)] = u.y
 				u:extract()
 			end
 			wml_actions.unstore_unit {
-				variable = "side_store.unit[" .. (i - 1) .. "]",
+				variable = string.format("side_store.unit[%d]", i - 1),
 				find_vacant = false,
 				check_passability = false,
 				advance = false,

--- a/data/lua/helper.lua
+++ b/data/lua/helper.lua
@@ -103,7 +103,7 @@ function helper.modify_unit(filter, vars)
 		kill = true
 	})
 	for i = 0, wesnoth.get_variable("LUA_modify_unit.length") - 1 do
-		local u = "LUA_modify_unit[" .. i .. "]"
+		local u = string.format("LUA_modify_unit[%d]", i)
 		for k, v in pairs(vars) do
 			wesnoth.set_variable(u .. '.' .. k, v)
 		end

--- a/data/multiplayer/scenarios/2p_Dark_Forecast.lua
+++ b/data/multiplayer/scenarios/2p_Dark_Forecast.lua
@@ -160,7 +160,7 @@ end
 -- @a base_gold_amount, gold_increment: used to cauculate the amount of gold available for each timed spawn
 -- @a units_amount, gold_per_unit_amount: used to cauculate the number of units spawned in each timed spawn
 local function create_timed_spaws(interval, num_spawns, base_gold_amount, gold_increment, units_amount, gold_per_unit_amount)
-	local configure_gold_factor = (wesnoth.get_variable("enemey_gold_factor") + 100)/100
+	local configure_gold_factor = ((wesnoth.get_variable("enemey_gold_factor") or 0) + 100)/100
 	local random_spawn_numbers = {}
 	for i = 1, #random_spawns do
 		table.insert(random_spawn_numbers, i)

--- a/data/multiplayer/scenarios/2p_Dark_Forecast.lua
+++ b/data/multiplayer/scenarios/2p_Dark_Forecast.lua
@@ -251,7 +251,7 @@ local function final_spawn()
 	local spawn = wesnoth.get_variable(string.format("fixed_spawn[%d]", spawn_index))
 	wesnoth.set_variable(string.format("fixed_spawn[%d]", spawn_index))
 	local types = {}
-	for tag in wesnoth.child_range(spawn, "type") do
+	for tag in helper.child_range(spawn, "type") do
 		table.insert(types, tag.type)
 	end
 	place_units(types, spawn.x, spawn.y)
@@ -325,7 +325,7 @@ on_event("die", function()
 	if wesnoth.current.turn < wesnoth.get_variable("final_turn") then
 		return
 	end
-	if wesnoth.have_unit { side = "1,2"} then
+	if wesnoth.wml_conditionals.have_unit { side = "1,2"} then
 		return
 	end
 	wesnoth.wml_actions.music {

--- a/data/multiplayer/scenarios/2p_Dark_Forecast.lua
+++ b/data/multiplayer/scenarios/2p_Dark_Forecast.lua
@@ -191,14 +191,14 @@ local function create_timed_spaws(interval, num_spawns, base_gold_amount, gold_i
 					break
 				end
 			end
-			wesnoth.set_variable("timed_spawn[" .. (spawn_number - 1) .. "]", {
+			wesnoth.set_variable(string.format("timed_spawn[%d]", spawn_number - 1), {
 				units = math.ceil(units),
 				turn = turn,
 				gold = helper.round(gold * configure_gold_factor),
 				pool_num = random_spawn_numbers[spawn_number],
 			})
 		else
-			wesnoth.set_variable("timed_spawn[" .. (spawn_number - 1) .. "]", {
+			wesnoth.set_variable(string.format("timed_spawn[%d]", spawn_number - 1), {
 				units = units_amount + 1,
 				turn = turn,
 				gold = gold,
@@ -248,8 +248,8 @@ local function final_spawn()
 		return
 	end
 	local spawn_index = wesnoth.random(spawns_left) - 1
-	local spawn = wesnoth.get_variable("fixed_spawn[" .. spawn_index .. "]")
-	wesnoth.set_variable("fixed_spawn[" .. spawn_index .. "]")
+	local spawn = wesnoth.get_variable(string.format("fixed_spawn[%d]", spawn_index))
+	wesnoth.set_variable(string.format("fixed_spawn[%d]", spawn_index))
 	local types = {}
 	for tag in wesnoth.child_range(spawn, "type") do
 		table.insert(types, tag.type)
@@ -392,7 +392,7 @@ on_event("prestart", function()
 		if weather_to_dispense[index].turns_left <= 0 then
 			table.remove(weather_to_dispense, index)
 		end
-		wesnoth.set_variable("weather_event[" .. event_num .. "]", {
+		wesnoth.set_variable(string.format("weather_event[%d]", event_num), {
 			turn = turn,
 			weather_id = weather_id,
 		})
@@ -401,7 +401,7 @@ on_event("prestart", function()
 		-- Second snow happens half the time.
 		if weather_id == "snowfall" and heavy_snowfall_turns_left >= 0 and wesnoth.random(2) == 2 then
 			num_turns = get_weather_duration(heavy_snowfall_turns_left)
-			wesnoth.set_variable("weather_event[" .. event_num .. "]", {
+			wesnoth.set_variable(string.format("weather_event[%d]", event_num), {
 				turn = turn,
 				weather_id = "heavy snowfall",
 			})
@@ -411,7 +411,7 @@ on_event("prestart", function()
 		end
 		-- Go back to clear weather.
 		num_turns = get_weather_duration(clear_turns_left)
-		wesnoth.set_variable("weather_event[" .. event_num .. "]", {
+		wesnoth.set_variable(string.format("weather_event[%d]", event_num), {
 			turn = turn,
 			weather_id = "clear",
 		})

--- a/src/wesnoth_lua_config.h
+++ b/src/wesnoth_lua_config.h
@@ -49,6 +49,7 @@
  */
 #define LUA_COMPAT_5_2
 #define LUA_COMPAT_5_1
+#define LUA_COMPAT_FLOATSTRING
 
 
 


### PR DESCRIPTION
@gfgtdf requested assistance with a crash in MP scenario 2p_Dark_Forecast

The cause turned out to be a change from Lua 5.2 to 5.3 which converts numbers to always have a fractional part. This means integer values will have ".0" at the end. The unexpected input caused the engine to crash.

1. Changed all mainline which builds similar indices to conform to Lua 5.3

2. The MP startup is not complete, worked around this with a temporary fix

3. There were two issues with the Wesnoth API in the scenario

4. Updated the Lua configuration to enable compatibility with 5.2 for this error



2p_Dark_Forecast can now be played to victory/defeat although there is an error which appears complaining about an audio track being duplicated. (This may be due to my rapid play-through and is not a real error.)

The Lua compatibility should prevent errors in UMC, but will mask any remaining errors in mainline.