### PR TITLE
SCons Fix bug: Git Hash

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -541,6 +541,8 @@ if not env['static_test']:
 try:
     if call(env.subst("utils/autorevision -t h > $build_dir/revision.h"), shell=True) == 0:
         env["have_autorevision"] = True
+        if not call(env.subst("cmp -s $build_dir/revision.h src/revision.h"), shell=True) == 0:
+            call(env.subst("cp $build_dir/revision.h src/revision.h"), shell=True)
 except:
     pass
 


### PR DESCRIPTION
SCons failed to rebuild game_config when the Git hash changes. The newer version was not copied into the source tree.