### PR TITLE
[text_input] Fix bug 25173

### DIFF
--- a/data/lua/wml/message.lua
+++ b/data/lua/wml/message.lua
@@ -230,6 +230,7 @@ local function message_user_choice(cfg, speaker, options, text_input)
 			label = text_input.label or "",
 			text  = text_input.text	 or "",
 			max_length = input_max_size,
+			text_input_was_specified = "yes",
 		}
 	end
 

--- a/src/gui/dialogs/wml_message.cpp
+++ b/src/gui/dialogs/wml_message.cpp
@@ -176,7 +176,7 @@ int show_wml_message(CVideo& video,
 	}
 	assert(dlg.get());
 
-	if(!input.caption.empty()) {
+	if(input.text_input_was_specified) {
 		dlg->set_input(input.caption, &input.text, input.maximum_length);
 	}
 

--- a/src/gui/dialogs/wml_message.hpp
+++ b/src/gui/dialogs/wml_message.hpp
@@ -218,6 +218,8 @@ struct twml_message_input
 	mutable std::string text;
 	/// The maximum length of the text.
 	unsigned maximum_length;
+	/// True when [text_input] appeared in [message]
+	bool text_input_was_specified;
 };
 
 /**

--- a/src/scripting/lua_gui2.cpp
+++ b/src/scripting/lua_gui2.cpp
@@ -280,6 +280,7 @@ int show_message_dialog(lua_State *L, CVideo & video)
 	input.caption = txt_cfg["label"].str();
 	input.text = txt_cfg["text"].str();
 	input.maximum_length = txt_cfg["max_length"].to_int(256);
+	input.text_input_was_specified = txt_cfg["text_input_was_specified"].to_bool(false);
 
 	gui2::twml_message_options options;
 	if (!lua_isnoneornil(L, 2)) {


### PR DESCRIPTION
Added an internal flag to indicate [text_input] appeared so we no longer require label= to be present.