### PR TITLE
Fix bug: Slow narrator (Partial 25186)

### DIFF
--- a/data/lua/wml/message.lua
+++ b/data/lua/wml/message.lua
@@ -387,7 +387,9 @@ function wesnoth.wml_actions.message(cfg)
 	end
 	
 	-- Unhilight the speaker
-	wesnoth.deselect_hex()
+	if speaker and not cfg.highlight == false then
+		wesnoth.deselect_hex()
+	end
 
 	if #options > 0 then
 		if option_chosen > #options then


### PR DESCRIPTION
No need to deselect when it was already done.

While this is the fix for the specific complaint, it does not address the larger issue of [message] being generally slow.