### PR TITLE
This removes references to blit_surface and introduces masks for colours

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1506,7 +1506,6 @@ void display::draw_text_in_hex(const map_location& loc,
 	drawing_buffer_add(layer, loc, x, y, text_surf);
 }
 
-//TODO: convert this to use sdl::ttexture
 void display::render_image(int x, int y, const display::tdrawing_layer drawing_layer,
 		const map_location& loc, surface image,
 		bool hreverse, bool greyscale, fixed_t alpha,

--- a/src/font/text.cpp
+++ b/src/font/text.cpp
@@ -101,7 +101,7 @@ ttext::~ttext()
 	surface_.assign(nullptr);
 }
 
-surface ttext::render() const
+surface& ttext::render() const
 {
 	this->rerender();
 	return surface_;

--- a/src/font/text.hpp
+++ b/src/font/text.hpp
@@ -91,7 +91,7 @@ public:
 	 * Before rendering it tests whether a redraw is needed and if so it first
 	 * redraws the surface before returning it.
 	 */
-	surface render() const;
+	surface& render() const;
 
 	/** Returns the width needed for the text. */
 	int get_width() const;

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -1125,9 +1125,9 @@ void timage::draw(surface& canvas,
 
 				for(int x = 0; x < columns; ++x) {
 					for(int y = 0; y < rows; ++y) {
-						const SDL_Rect dest = sdl::create_rect(
+						SDL_Rect dest = sdl::create_rect(
 								x * image_->w, y * image_->h, 0, 0);
-						blit_surface(image_, nullptr, surf, &dest);
+						sdl_blit(image_, nullptr, surf, &dest);
 					}
 				}
 
@@ -1153,7 +1153,7 @@ void timage::draw(surface& canvas,
 		surf = flip_surface(surf, false);
 	}
 
-	blit_surface(surf, &src_clip, canvas, &dst_clip);
+	sdl_blit(surf, &src_clip, canvas, &dst_clip);
 }
 
 timage::tresize_mode timage::get_resize_mode(const std::string& resize_mode)
@@ -1350,7 +1350,7 @@ void ttext::draw(surface& canvas,
 							 : PANGO_ELLIPSIZE_END)
 			.set_characters_per_line(characters_per_line_);
 
-	surface surf = text_renderer.render();
+	surface& surf = text_renderer.render();
 	if(surf->w == 0) {
 		DBG_GUI_D << "Text: Rendering '" << text
 				  << "' resulted in an empty canvas, leave.\n";

--- a/src/sdl/utils.cpp
+++ b/src/sdl/utils.cpp
@@ -64,10 +64,10 @@ const_surface_lock::~const_surface_lock()
 SDL_Color int_to_color(const Uint32 rgb)
 {
 	SDL_Color result;
-	result.r = (0x00FF0000 & rgb )>> 16;
-	result.g = (0x0000FF00 & rgb) >> 8;
-	result.b = (0x000000FF & rgb);
-	result.a = SDL_ALPHA_OPAQUE;
+	result.r = static_cast<Uint8>((SDL_RED_MASK & rgb) >> SDL_RED_BITSHIFT);
+	result.g = static_cast<Uint8>((SDL_GREEN_MASK & rgb) >> SDL_GREEN_BITSHIFT);
+	result.b = static_cast<Uint8>((SDL_BLUE_MASK & rgb) >> SDL_BLUE_BITSHIFT);
+	result.a = static_cast<Uint8>((SDL_ALPHA_MASK & rgb) >> SDL_ALPHA_BITSHIFT);
 	return result;
 }
 
@@ -110,8 +110,8 @@ bool operator<(const surface& a, const surface& b)
 bool is_neutral(const surface& surf)
 {
 	return (surf->format->BytesPerPixel == 4 &&
-		surf->format->Rmask == 0xFF0000u &&
-		(surf->format->Amask | 0xFF000000u) == 0xFF000000u);
+		surf->format->Rmask == SDL_RED_MASK &&
+		(surf->format->Amask | SDL_ALPHA_MASK) == SDL_ALPHA_MASK);
 }
 
 static SDL_PixelFormat& get_neutral_pixel_format()
@@ -121,7 +121,8 @@ static SDL_PixelFormat& get_neutral_pixel_format()
 
 		if(first_time) {
 			first_time = false;
-			surface surf(SDL_CreateRGBSurface(SDL_SWSURFACE,1,1,32,0xFF0000,0xFF00,0xFF,0xFF000000));
+			surface surf(SDL_CreateRGBSurface(SDL_SWSURFACE,1,1,32,SDL_RED_MASK,SDL_GREEN_MASK,
+											  SDL_BLUE_MASK,SDL_ALPHA_MASK));
 			format = *surf->format;
 			format.palette = nullptr;
 		}

--- a/src/sdl/utils.hpp
+++ b/src/sdl/utils.hpp
@@ -45,6 +45,16 @@
 #define SDL_BUTTON_WHEELRIGHT 7
 #endif
 
+#define SDL_ALPHA_MASK (0xFF000000)
+#define SDL_RED_MASK   (0x00FF0000)
+#define SDL_GREEN_MASK (0x0000FF00)
+#define SDL_BLUE_MASK  (0x000000FF)
+
+#define SDL_ALPHA_BITSHIFT (24)
+#define SDL_RED_BITSHIFT   (16)
+#define SDL_GREEN_BITSHIFT (8)
+#define SDL_BLUE_BITSHIFT  (0)
+
 SDL_Keycode sdl_keysym_from_name(std::string const &keyname);
 
 class surface

--- a/src/widgets/multimenu.cpp
+++ b/src/widgets/multimenu.cpp
@@ -26,7 +26,8 @@ namespace gui {
 		surface img = image::get_image(active_items_[row_index]
 									   ? "buttons/checkbox-pressed.png"
 									   : "buttons/checkbox.png");
-		blit_surface(img, nullptr, video().getSurface(), &rect);
+		SDL_Rect tmprect = rect;
+		sdl_blit(img, nullptr, video().getSurface(), &tmprect);
 		SDL_Rect newrect = {
 				Sint16 (rect.x + img->w + 2),
 				rect.y,


### PR DESCRIPTION
blit_surface is slow compared to the SDL functions and is something we want to remove in order to add hardware rendering.

colours are currently defined by people manually typing out the bit masks, this
lays the groundwork for defining them manually each time. This also starts to acknowledge that alpha is a part of colours.