### PR TITLE
Don't mix new and free in lua_interpreter.cpp

### DIFF
--- a/src/gui/dialogs/lua_interpreter.cpp
+++ b/src/gui/dialogs/lua_interpreter.cpp
@@ -332,13 +332,12 @@ public:
 	bool do_history_expansion (std::string & cmd) {
 #ifdef HAVE_HISTORY
 		// Do history expansions
-		char * cmd_cstr = new char [cmd.length()+1];
-		strcpy (cmd_cstr, cmd.c_str());
+		std::unique_ptr<char[]> cmd_cstr(new char[cmd.length()+1]);
+		strcpy (cmd_cstr.get(), cmd.c_str());
 
 		char * expansion;
 
-		int result = history_expand(cmd_cstr, &expansion);
-		free(cmd_cstr);
+		int result = history_expand(cmd_cstr.get(), &expansion);
 
 		if (result < 0 || result == 2) {
 			cmd = expansion; // return error message in cmd var


### PR DESCRIPTION
In practice, it probably doesn't matter since cmd_string is a char array and not a complex data type, but nevertheless it is wrong to mix new and free. Also, this seemed like a good sized change to figure out how to send PRs. Appologies if it is too minor to bother about.