### PR TITLE
Fix bug: use of undeclared identifier LOCALEDIR

### DIFF
--- a/src/filesystem_common.cpp
+++ b/src/filesystem_common.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 
 #include "filesystem.hpp"
+#include "wesconfig.h"
 
 #include "config.hpp"
 #include "game_config.hpp"


### PR DESCRIPTION
While given by the toolset, the default is set in wesonfig.h and should be used.