### PR TITLE
Size lock widget

### DIFF
--- a/data/gui/macros/_initial.cfg
+++ b/data/gui/macros/_initial.cfg
@@ -202,6 +202,24 @@
 	[/stacked_widget]
 #enddef
 
+# Forces a widget to be of a certain size and blocks it from growing.
+#
+# WIDTH                      Width for the widget.
+# HEIGHT                     Height for the widget.
+# WIDGET                     The widget to add to the item.
+#
+#define GUI_FORCE_WIDGET_SIZE WIDTH HEIGHT WIDGET
+	[size_lock]
+		definition = "default"
+		width = "{WIDTH}"
+		height = "{HEIGHT}"
+
+		[widget]
+			{WIDGET}
+		[/widget]
+	[/size_lock]
+#enddef
+
 #define GUI_WINDOW_FULLSCREEN
 	automatic_placement = "false"
 	x = 0

--- a/data/gui/schema.cfg
+++ b/data/gui/schema.cfg
@@ -1087,6 +1087,21 @@
                 [/key]
             [/tag]
             [tag]
+                name="size_lock_definition"
+                min="0"
+                max="-1"
+                super="generic/widget_definition"
+                [tag]
+                    name="resolution"
+                    min="0"
+                    max="-1"
+                    super="generic/widget_definition/resolution"
+                    [link]
+                        name="gui/window/resolution/grid"
+                    [/link]
+                [/tag]
+            [/tag]
+            [tag]
                 name="slider_definition"
                 min="0"
                 max="-1"
@@ -1894,6 +1909,28 @@
                                         type="scrollbar_mode"
                                         default=initial_auto
                                     [/key]
+                                [/tag]
+                                [tag]
+                                    name="size_lock"
+                                    min="0"
+                                    max="-1"
+                                    super="generic/widget_instance"
+                                    [key]
+                                        name="height"
+                                        type="f_unsigned"
+                                        mandatory="true"
+                                    [/key]
+                                    [key]
+                                        name="width"
+                                        type="f_unsigned"
+                                        mandatory="true"
+                                    [/key]
+                                    [tag]
+                                        name="widget"
+                                        min="1"
+                                        max="1"
+                                        super="gui/window/resolution/grid/row/column"
+                                    [/tag]
                                 [/tag]
                                 [tag]
                                     name="slider"

--- a/data/gui/widget/size_lock_default.cfg
+++ b/data/gui/widget/size_lock_default.cfg
@@ -1,0 +1,14 @@
+#textdomain wesnoth-lib
+###
+### Definition of a size lock
+###
+
+[size_lock_definition]
+	id = "default"
+	description = "a size lock"
+
+	[resolution]
+		[grid]
+		[/grid]
+	[/resolution]
+[/size_lock_definition]

--- a/data/gui/window/lobby_main.cfg
+++ b/data/gui/window/lobby_main.cfg
@@ -816,7 +816,7 @@
 				[column]
 					horizontal_grow = "true"
 					vertical_grow = "true"
-					{GUI_FORCE_WIDGET_MINIMUM_SIZE 0 "((screen_height * 20) / 100)" (
+					{GUI_FORCE_WIDGET_SIZE 0 "((screen_height * 20) / 100)" (
 						[grid]
 							[row]
 								grow_factor = 1
@@ -911,7 +911,7 @@
 										[column]
 											horizontal_grow = "true"
 											vertical_grow = "true"
-											{GUI_FORCE_WIDGET_MINIMUM_SIZE 0 "((screen_height * 25 / 100))" (
+											{GUI_FORCE_WIDGET_SIZE 0 "((screen_height * 25 / 100))" (
 												[chatbox]
 													id = "chat"
 												[/chatbox]

--- a/data/gui/window/mp_join_game.cfg
+++ b/data/gui/window/mp_join_game.cfg
@@ -575,7 +575,7 @@
 											horizontal_grow = "true"
 											vertical_grow = "true"
 
-											{GUI_FORCE_WIDGET_MINIMUM_SIZE 0 "((screen_height * 25 / 100))" (
+											{GUI_FORCE_WIDGET_SIZE 0 "((screen_height * 25 / 100))" (
 												[chatbox]
 													id = "chat"
 												[/chatbox]

--- a/data/gui/window/mp_staging.cfg
+++ b/data/gui/window/mp_staging.cfg
@@ -710,7 +710,7 @@
 											horizontal_grow = "true"
 											vertical_grow = "true"
 
-											{GUI_FORCE_WIDGET_MINIMUM_SIZE 0 "((screen_height * 25 / 100))" (
+											{GUI_FORCE_WIDGET_SIZE 0 "((screen_height * 25 / 100))" (
 												[chatbox]
 													id = "chat"
 												[/chatbox]

--- a/projectfiles/VC12/wesnoth.vcxproj
+++ b/projectfiles/VC12/wesnoth.vcxproj
@@ -2525,6 +2525,14 @@
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Debug|Win32'">$(IntDir)Gui\Widgets\</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Release|Win32'">$(IntDir)Gui\Widgets\</ObjectFileName>
     </ClCompile>
+    <ClCompile Include="..\..\src\gui\widgets\size_lock.cpp">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)Gui\Widgets</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)Gui\Widgets</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='ReleaseDEBUG|Win32'">$(IntDir)Gui\Widgets</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Debug|Win32'">$(IntDir)Gui\Widgets</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug_with_VLD|Win32'">$(IntDir)Gui\Widgets</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Release|Win32'">$(IntDir)Gui\Widgets</ObjectFileName>
+    </ClCompile>
     <ClCompile Include="..\..\src\gui\widgets\slider.cpp">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug_with_VLD|Win32'">$(IntDir)Gui\Widgets\</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)Gui\Widgets\</ObjectFileName>
@@ -4209,6 +4217,7 @@
     <ClInclude Include="..\..\src\gui\widgets\scroll_label.hpp" />
     <ClInclude Include="..\..\src\gui\widgets\selectable.hpp" />
     <ClInclude Include="..\..\src\gui\widgets\settings.hpp" />
+    <ClInclude Include="..\..\src\gui\widgets\size_lock.hpp" />
     <ClInclude Include="..\..\src\gui\widgets\slider.hpp" />
     <ClInclude Include="..\..\src\gui\widgets\spacer.hpp" />
     <ClInclude Include="..\..\src\gui\widgets\stacked_widget.hpp" />

--- a/projectfiles/VC12/wesnoth.vcxproj.filters
+++ b/projectfiles/VC12/wesnoth.vcxproj.filters
@@ -1513,6 +1513,9 @@
     <ClCompile Include="..\..\src\font\text_formatting.cpp">
       <Filter>Font</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\gui\widgets\size_lock.cpp">
+      <Filter>Gui\Widgets</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\addon\client.hpp">
@@ -2928,6 +2931,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\font\error.hpp">
       <Filter>Font</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\gui\widgets\size_lock.hpp">
+      <Filter>Gui\Widgets</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -533,6 +533,7 @@ set(wesnoth-gui_widget_SRC
 	gui/widgets/scrollbar_container.cpp
 	gui/widgets/scrollbar_panel.cpp
 	gui/widgets/settings.cpp
+	gui/widgets/size_lock.cpp
 	gui/widgets/slider.cpp
 	gui/widgets/spacer.cpp
 	gui/widgets/stacked_widget.cpp

--- a/src/SConscript
+++ b/src/SConscript
@@ -457,6 +457,7 @@ wesnoth_sources = Split("""
     gui/widgets/scrollbar_panel.cpp
     gui/widgets/scrollbar.cpp
     gui/widgets/settings.cpp
+    gui/widgets/size_lock.cpp
     gui/widgets/slider.cpp
     gui/widgets/spacer.cpp
     gui/widgets/stacked_widget.cpp

--- a/src/gui/core/window_builder.cpp
+++ b/src/gui/core/window_builder.cpp
@@ -34,6 +34,7 @@
 #include "gui/widgets/scroll_label.hpp"
 #include "gui/widgets/scrollbar_panel.hpp"
 #include "gui/widgets/settings.hpp"
+#include "gui/widgets/size_lock.hpp"
 #include "gui/widgets/slider.hpp"
 #include "gui/widgets/stacked_widget.hpp"
 #include "gui/widgets/toggle_button.hpp"
@@ -220,6 +221,7 @@ builder_widget_ptr create_builder_widget(const config& cfg)
 	TRY(drawing);
 	TRY(password_box);
 	TRY(unit_preview_pane);
+	TRY(size_lock);
 #undef TRY
 #endif
 

--- a/src/gui/widgets/container.hpp
+++ b/src/gui/widgets/container.hpp
@@ -85,7 +85,7 @@ public:
 	/** See @ref widget::demand_reduce_height. */
 	virtual void demand_reduce_height(const unsigned maximum_height) override;
 
-private:
+protected:
 	/** See @ref widget::calculate_best_size. */
 	virtual point calculate_best_size() const override;
 

--- a/src/gui/widgets/size_lock.cpp
+++ b/src/gui/widgets/size_lock.cpp
@@ -1,0 +1,168 @@
+/*
+   Copyright (C) 2016 Jyrki Vesterinen <sandgtx@gmail.com>
+   Part of the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#define GETTEXT_DOMAIN "wesnoth-lib"
+
+#include "size_lock.hpp"
+
+#include <gettext.hpp>
+#include <gui/core/register_widget.hpp>
+#include <gui/widgets/helper.hpp>
+#include <gui/widgets/settings.hpp>
+#include <wml_exception.hpp>
+
+namespace gui2
+{
+
+REGISTER_WIDGET(size_lock)
+
+void size_lock::place(const point& origin, const point& size)
+{
+	point content_size = widget_->get_best_size();
+
+	if (content_size.x > size.x)
+	{
+		reduce_width(size.x);
+		content_size = widget_->get_best_size();
+	}
+
+	if (content_size.y > size.y)
+	{
+		reduce_height(size.y);
+		content_size = widget_->get_best_size();
+	}
+
+	container_base::place(origin, size);
+}
+
+void size_lock::layout_children()
+{
+	assert(widget_ != nullptr);
+
+	widget_->layout_children();
+}
+
+void size_lock::finalize(builder_widget_const_ptr widget_builder)
+{
+	set_rows_cols(1u, 1u);
+
+	widget_ = widget_builder->build();
+	set_child(widget_, 0u, 0u,
+		grid::VERTICAL_GROW_SEND_TO_CLIENT | grid::HORIZONTAL_GROW_SEND_TO_CLIENT,
+		0u);
+}
+
+size_lock_definition::size_lock_definition(const config& cfg) :
+	styled_widget_definition(cfg)
+{
+	DBG_GUI_P << "Parsing fixed size widget " << id << '\n';
+
+	load_resolutions<resolution>(cfg);
+}
+
+/*WIKI
+ * @page = GUIWidgetDefinitionWML
+ * @order = 1_size_lock
+ *
+ * == Size lock ==
+ *
+ * A size lock contains one child widget and forces it to have the specified size.
+ * This can be used, for example, when there are two list boxes in different rows of
+ * the same grid and it's desired that only one list box changes size when its
+ * contents change.
+ *
+ * A size lock has no states.
+ * @begin{parent}{name="gui/"}
+ * @begin{tag}{name="size_lock_definition"}{min=0}{max=-1}{super="generic/widget_definition"}
+ * @end{tag}{name="size_lock_definition"}
+ * @end{tag}{name="gui/"}
+ */
+size_lock_definition::resolution::resolution(const config& cfg) :
+	resolution_definition(cfg), grid(nullptr)
+{
+	// Add a dummy state since every widget needs a state.
+	static config dummy("draw");
+	state.push_back(state_definition(dummy));
+
+	const config& child = cfg.child("grid");
+	VALIDATE(child, _("No grid defined."));
+
+	grid = std::make_shared<builder_grid>(child);
+}
+
+/*WIKI
+ * @page = GUIWidgetInstanceWML
+ * @order = 2_size_lock
+ * @begin{parent}{name="gui/window/resolution/grid/row/column/"}
+ * @begin{tag}{name="size_lock"}{min=0}{max=-1}{super="generic/widget_instance"}
+ * == Size lock ==
+ *
+ * A size lock contains one child widget and forces it to have the specified size.
+ * This can be used, for example, when there are two list boxes in different rows of
+ * the same grid and it's desired that only one list box changes size when its
+ * contents change.
+ *
+ * @begin{table}{config}
+ *    widget & section    & mandatory &           The widget. $
+ *    width  & f_unsigned & mandatory &           The width of the widget. $
+ *    height & f_unsigned & mandatory &           The height of the widget. $
+ * @end{table}
+ *
+ * The variables available are the same as for window resolution, see
+ * [[GuiToolkitWML#Resolution_2]] for the list of items.
+ * @end{tag}{name="size_lock"}
+ * @end{parent}{name="gui/window/resolution/grid/row/column/"}
+ */
+
+namespace implementation
+{
+
+builder_size_lock::builder_size_lock(const config& cfg) :
+	builder_styled_widget(cfg), content_(nullptr), width_(cfg["width"]), height_(cfg["height"])
+{
+	VALIDATE(cfg.has_child("widget"), _("No widget defined."));
+	content_ = create_builder_widget(cfg.child("widget"));
+}
+
+widget* builder_size_lock::build() const
+{
+	size_lock* widget = new size_lock();
+
+	init_control(widget);
+
+	DBG_GUI_G << "Window builder: placed fixed size widget '" << id <<
+		"' with definition '" << definition << "'.\n";
+
+	auto conf = std::static_pointer_cast<const size_lock_definition::resolution>(widget->config());
+	assert(conf != nullptr);
+
+	widget->init_grid(conf->grid);
+
+	game_logic::map_formula_callable size = get_screen_size_variables();
+
+	const unsigned width = width_(size);
+	const unsigned height = height_(size);
+
+	VALIDATE(width > 0 || height > 0, _("Invalid size."));
+
+	widget->set_size(point(width, height));
+
+	widget->finalize(content_);
+
+	return widget;
+}
+
+}
+
+}

--- a/src/gui/widgets/size_lock.hpp
+++ b/src/gui/widgets/size_lock.hpp
@@ -1,0 +1,137 @@
+/*
+   Copyright (C) 2016 Jyrki Vesterinen <sandgtx@gmail.com>
+   Part of the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#ifndef GUI_WIDGETS_SIZE_FIXATER_HPP_INCLUDED
+#define GUI_WIDGETS_SIZE_FIXATER_HPP_INCLUDED
+
+#include <gui/widgets/container.hpp>
+
+#include <gui/auxiliary/formula.hpp>
+#include <gui/core/widget_definition.hpp>
+#include <gui/core/window_builder.hpp>
+#include <gui/widgets/generator.hpp>
+
+namespace gui2
+{
+
+namespace implementation
+{
+struct builder_size_lock;
+}
+
+/* A fixed-size widget that wraps an arbitrary widget and forces it to the given size. */
+
+class size_lock : public container_base
+{
+	friend struct implementation::builder_size_lock;
+
+public:
+	size_lock() :
+		container_base(1),
+		widget_(nullptr)
+	{}
+
+	/** See @ref control::get_active. */
+	bool get_active() const override
+	{
+		return true;
+	}
+
+	/** See @ref control::get_state. */
+	unsigned get_state() const override
+	{
+		return 0;
+	}
+
+	/** See @ref widget::place. */
+	void place(const point& origin, const point& size) override;
+
+	/** See @ref widget::layout_children. */
+	void layout_children() override;
+
+	void set_size(const point& size)
+	{
+		size_ = size;
+	}
+
+protected:
+	point calculate_best_size() const override
+	{
+		return size_;
+	}
+
+private:
+	point size_;
+
+	/**
+	 * Points to the actual widget.
+	 *
+	 * The widget is owned by container_base (the base class).
+	 */
+	widget* widget_;
+
+	/**
+	 * Finishes the building initialization of the widget.
+	 *
+	 * @param widget_builder      The builder to build the contents of the
+	 *                            widget.
+	 */
+	void finalize(builder_widget_const_ptr widget_builder);
+
+	/** See @ref control::get_control_type. */
+	const std::string& get_control_type() const override
+	{
+		static const std::string control_type = "size_lock";
+		return control_type;
+	}
+
+	/** See @ref container_::set_self_active. */
+	void set_self_active(const bool) override
+	{
+		// DO NOTHING
+	}
+};
+
+struct size_lock_definition : public styled_widget_definition
+{
+	explicit size_lock_definition(const config& cfg);
+
+	struct resolution : public resolution_definition
+	{
+		explicit resolution(const config& cfg);
+
+		builder_grid_ptr grid;
+	};
+};
+
+namespace implementation
+{
+
+struct builder_size_lock : public builder_styled_widget
+{
+	explicit builder_size_lock(const config& cfg);
+
+	using builder_styled_widget::build;
+
+	widget* build() const;
+
+private:
+	builder_widget_const_ptr content_;
+	typed_formula<unsigned> width_;
+	typed_formula<unsigned> height_;
+};
+}
+}
+
+#endif


### PR DESCRIPTION
# Motivation

http://i.imgur.com/2b8urXq.png

The chat box in the MP lobby is in a grid.

```
|-----------|
|filter area|
|-----------|
| game list |
|-----------|
|  chatbox  |
|-----------|
```

On `invalidate_layout()`, a grid determines the size of all child widgets by querying their optimal sizes with `get_best_size()` and distributing any surplus space according to the grow factors.

For a chatbox, the optimal size is however much is enough to show all the existing messages at once, without a scrollbar.

As a result, the chatbox randomly grows way too large. It looks ugly, takes space away from the game list, and when it gets even larger, breaks the layout system itself.

# Size lock

This pull request introduces a new GUI2 widget called **size lock**. A size lock wraps an arbitrary widget. Its `get_best_size()` function returns the values the developer has set with a formula. As a result, the preferred size of the wrapped widget is completely ignored.

Note that a size lock can still grow beyond the allocated size if the *containing grid* decides to give additional space to the size lock. However, at least in the case of the chat boxes, it's actually an advantage because it allows the chat box to take all available horizontal space while still having a fixed height.

I locked the size of all chat boxes except the one in low-resolution MP lobby.

I left the low-resolution MP lobby one alone because trying to lock its size resulted in the lower grid disappearing completely. Further investigation showed that the player list in the lower grid wants to be initially higher than available height, and thus layout of the lower grid fails. I plan to fix that by allowing GUI2 to retry layout with minimum sizes if it fails with preferred sizes.

Since the oversized chatbox problem occurs in the 800x600 lobby as well, this PR is not yet a complete fix for that bug.