### PR TITLE
removed DRAKE_FLYING_ANIM

### DIFF
--- a/data/core/macros/animation-utils.cfg
+++ b/data/core/macros/animation-utils.cfg
@@ -232,40 +232,6 @@
     [/filter]
 #enddef
 
-#define DRAKE_FLYING_ANIM STANDING_IMAGE FLYING_IMAGE
-    [standing_anim]
-        start_time=0
-        [filter]
-            [filter_location]
-                terrain_type=!,W*,Qx*,Ql*
-                [or]
-                    terrain_type=Wwf,Wwr,*^V*
-                [/or]
-            [/filter_location]
-        [/filter]
-        [frame]
-            image={STANDING_IMAGE}:150
-        [/frame]
-    [/standing_anim]
-
-    [standing_anim]
-        start_time=0
-        layer=60
-        submerge=0.01
-        [filter]
-            [filter_location]
-                terrain_type=W*,Qx*,Ql*
-                [not]
-                    terrain_type=Wwf,Wwr,*^V*
-                [/not]
-            [/filter_location]
-        [/filter]
-        [frame]
-            image={FLYING_IMAGE}:150
-        [/frame]
-    [/standing_anim]
-#enddef
-
 #define MISSILE_FRAME_WAIL
     # Animate a projectile for a wail attack.
     [if]

--- a/data/core/macros/deprecated-utils.cfg
+++ b/data/core/macros/deprecated-utils.cfg
@@ -323,3 +323,37 @@ _"No gold carried over to the next scenario."#enddef
 
 # wmlindent: opener "{FOREACH "
 # wmlindent: closer "{NEXT "
+
+#define DRAKE_FLYING_ANIM STANDING_IMAGE FLYING_IMAGE
+    [standing_anim]
+        start_time=0
+        [filter]
+            [filter_location]
+                terrain_type=!,W*,Qx*,Ql*
+                [or]
+                    terrain_type=Wwf,Wwr,*^V*
+                [/or]
+            [/filter_location]
+        [/filter]
+        [frame]
+            image={STANDING_IMAGE}:150
+        [/frame]
+    [/standing_anim]
+
+    [standing_anim]
+        start_time=0
+        layer=60
+        submerge=0.01
+        [filter]
+            [filter_location]
+                terrain_type=W*,Qx*,Ql*
+                [not]
+                    terrain_type=Wwf,Wwr,*^V*
+                [/not]
+            [/filter_location]
+        [/filter]
+        [frame]
+            image={FLYING_IMAGE}:150
+        [/frame]
+    [/standing_anim]
+#enddef


### PR DESCRIPTION
This macro isn't used anywhere in 1.12, probably even since the drakes animations have been remade.
Not even Ageless Era uses it.
DRAKE_STANDING_ANIM is the macro which gets used instead.