### PR TITLE
Fix size reduction of grids

### DIFF
--- a/src/gui/widgets/grid.cpp
+++ b/src/gui/widgets/grid.cpp
@@ -273,6 +273,7 @@ void tgrid::request_reduce_width(const unsigned maximum_width)
 	}
 
 	set_layout_size(size);
+	set_size(size);
 	layout(origin_);
 }
 
@@ -365,6 +366,7 @@ void tgrid::request_reduce_height(const unsigned maximum_height)
 			  << " resulting height " << size.y << ".\n";
 
 	set_layout_size(size);
+	set_size(size);
 	layout(origin_);
 }
 

--- a/src/gui/widgets/grid.cpp
+++ b/src/gui/widgets/grid.cpp
@@ -470,7 +470,8 @@ void tgrid::place(const tpoint& origin, const tpoint& size)
 	}
 
 	if(best_size.x > size.x || best_size.y > size.y) {
-		// The assertion below fails quite often so try to give as much information as possible.
+		// This situation isn't necessarily a problem, as the grid can and often is shrunk afterwards
+		// with request_reduce_width() and request_reduce_height().
 		std::stringstream out;
 		out << " Failed to place a grid, we have " << size << " space but we need " << best_size << " space.";
 		out << " This happened at a grid with the id '" << id() << "'";
@@ -479,7 +480,7 @@ void tgrid::place(const tpoint& origin, const tpoint& size)
 			out << " in a '" << typeid(*pw).name() << "' with the id '" << pw->id() << "'";
 			pw = pw->parent();
 		}
-		ERR_GUI_L << LOG_HEADER << out.str() << ".\n";
+		LOG_GUI_L << LOG_HEADER << out.str() << ".\n";
 
 		return;
 	}

--- a/src/gui/widgets/grid.cpp
+++ b/src/gui/widgets/grid.cpp
@@ -272,7 +272,8 @@ void tgrid::request_reduce_width(const unsigned maximum_width)
 		}
 	}
 
-	set_layout_size(calculate_best_size());
+	set_layout_size(size);
+	layout(origin_);
 }
 
 void tgrid::demand_reduce_width(const unsigned /*maximum_width*/)
@@ -360,12 +361,11 @@ void tgrid::request_reduce_height(const unsigned maximum_height)
 		}
 	}
 
-	size = calculate_best_size();
-
 	DBG_GUI_L << LOG_HEADER << " Requested maximum " << maximum_height
 			  << " resulting height " << size.y << ".\n";
 
 	set_layout_size(size);
+	layout(origin_);
 }
 
 void tgrid::demand_reduce_height(const unsigned /*maximum_height*/)
@@ -444,6 +444,8 @@ void tgrid::place(const tpoint& origin, const tpoint& size)
 	/***** INIT *****/
 
 	twidget::place(origin, size);
+
+	origin_ = origin;
 
 	if(!rows_ || !cols_) {
 		return;
@@ -546,6 +548,8 @@ void tgrid::place(const tpoint& origin, const tpoint& size)
 
 void tgrid::set_origin(const tpoint& origin)
 {
+	origin_ = origin;
+
 	const tpoint movement = {origin.x - get_x(), origin.y - get_y()};
 
 	// Inherited.

--- a/src/gui/widgets/grid.hpp
+++ b/src/gui/widgets/grid.hpp
@@ -467,6 +467,9 @@ private:
 	/** The grow factor for all columns. */
 	std::vector<unsigned> col_grow_factor_;
 
+	/** Where the grid is placed. */
+	tpoint origin_;
+
 	/**
 	 * The child items.
 	 *

--- a/src/gui/widgets/grid.hpp
+++ b/src/gui/widgets/grid.hpp
@@ -26,7 +26,7 @@ namespace gui2
  * This class holds a number of widgets and their wanted layout parameters. It
  * also layouts the items in the grid and handles their drawing.
  */
-class tgrid : public twidget
+class tgrid final : public twidget
 {
 	friend class tdebug_layout_graph;
 	friend struct tgrid_implementation;


### PR DESCRIPTION
Currently `tgrid::request_reduce_width()` and `tgrid::request_reduce_height()` call `calculate_best_size()` at the end, which [clears saved sizes](https://github.com/wesnoth/wesnoth/blob/5984daae6e1c008ffc32e52c671a1cc66270dc55/src/gui/widgets/grid.cpp#L387-L391) of rows and columns. In addition, after calculating sizes for rows and columns the functions don't do anything useful with that information.

This pull request fixes both issues, and stops the infamous "failed to place a grid" message from being shown with the default log level. Failing to place a grid initially isn't an error because the size of the grid can be reduced.