### PR TITLE
Reduce dead code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,7 @@ check_compiler_has_flag(CXX_FLAGS_PROJECT "-W" HAS_COMPILER_FLAG_W)
 # MSVC's -Wall is not like gcc's, it really enables *all* warnings which include zillions for system headers and doesn't make sense.
 if(NOT MSVC)
 check_compiler_has_flag(CXX_FLAGS_PROJECT "-Wall" HAS_COMPILER_FLAG_WALL)
+set(CXX_FLAGS_PROJECT "${CXX_FLAGS_PROJECT} -ffunction-sections -Wl,-gc-sections")
 endif(NOT MSVC)
 
 ### Set strict compiler flags.

--- a/SConstruct
+++ b/SConstruct
@@ -480,12 +480,18 @@ for env in [test_env, client_env, env]:
         if env['sanitize']:
             env.AppendUnique(CCFLAGS = ["-fsanitize=" + env["sanitize"]], LINKFLAGS = ["-fsanitize=" + env["sanitize"]])
 
+        env.Append(CCFLAGS = ["-ffunction-sections", "-Wl,-gc-sections"])
+        env.Append(CXXFLAGS = ["-ffunction-sections", "-Wl,-gc-sections"])
+
         env["OPT_FLAGS"] = "-O2"
         env["DEBUG_FLAGS"] = Split("-O0 -DDEBUG -ggdb3")
 
     if "clang" in env["CXX"]:
         # Silence warnings about unused -I options and unknown warning switches.
         env.AppendUnique(CCFLAGS = Split("-Qunused-arguments -Wno-unknown-warning-option"))
+
+        env.Append(CCFLAGS = ["-ffunction-sections", "-Wl,-gc-sections"])
+        env.Append(CXXFLAGS = ["-ffunction-sections", "-Wl,-gc-sections"])
 
     if "suncc" in env["TOOLS"]:
         env["OPT_FLAGS"] = "-g0"


### PR DESCRIPTION
This added a compile-time and a link-time option for gcc and clang. -ffunction-sections causes each function to be placed in a separate section of the object file. -Wl,-gc-functions tells the linker to delete any function sections which are not referenced. The net effect is if a source file has a function which is not used in the final executable program, that function is not present.

While a feature of many modern compilers, function-level linking is a potential source of problems. An example of a potential problem is linking a shared object library (such as a .so .dll or .dylink). In this case, the linker might not see any references to a function and eliminate it from the shared library; in fact, it might eliminate all functions in the shared library.

A better solution, generally used by most major software projects, is to use the "one function, one file" rule. Unfortunately, such a rule seems anethema to wesnoth.