### PR TITLE
SCons and CMake all tools

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -368,6 +368,7 @@ set(wesnoth-sdl_SRC
 	sdl/rect.cpp
 	sdl/window.cpp
 	sdl/utils.cpp
+	sdl/utils_basic.cpp
 	xBRZ/xbrz.cpp
 )
 
@@ -1184,9 +1185,6 @@ set(exploder_SRC
 	tools/exploder_utils.cpp
 	tools/exploder_cutter.cpp
 	tools/exploder_composer.cpp
-	tools/dummy_video.cpp
-	sdl/utils.cpp
-	tracer.cpp
 )
 
 add_executable(exploder ${exploder_SRC})
@@ -1204,9 +1202,6 @@ set(cutter_SRC
 	tools/cutter.cpp
 	tools/exploder_utils.cpp
 	tools/exploder_cutter.cpp
-	tools/dummy_video.cpp
-	sdl/utils.cpp
-	tracer.cpp
 )
 
 add_executable(cutter ${cutter_SRC})
@@ -1221,7 +1216,6 @@ set_target_properties(cutter PROPERTIES OUTPUT_NAME ${BINARY_PREFIX}cutter${BINA
 install(TARGETS cutter DESTINATION ${BINDIR})
 
 set(schema_generator_SRC
-	tools/dummy_video.cpp
 	tools/schema/schema_generator.cpp
 	tools/schema/sourceparser.cpp
 	tools/schema/error_container.cpp
@@ -1245,7 +1239,6 @@ set(schema_validator_SRC
 	tools/validator/validator_tool.cpp
 	serialization/schema_validator.cpp
 	serialization/validator.cpp
-	tools/dummy_video.cpp
 	tools/schema/tag.cpp
 	filesystem_boost.cpp
 	filesystem_common.cpp
@@ -1271,10 +1264,7 @@ set(wesmage_SRC
 	wesmage/exit.cpp
 	wesmage/filter.cpp
 	wesmage/options.cpp
-	tools/dummy_video.cpp
 	tools/exploder_utils.cpp
-	sdl/utils.cpp
-	tracer.cpp
 )
 
 add_executable(wesmage ${wesmage_SRC})
@@ -1393,10 +1383,7 @@ if(ENABLE_TESTS)
 		# Due to its unique nature the program is never installed.
 		set(create_images_SRC
 			tests/create_images.cpp
-			tools/dummy_video.cpp
 			tools/exploder_utils.cpp
-			sdl/utils.cpp
-			tracer.cpp
 		)
 
 		add_executable(create_images ${create_images_SRC})

--- a/src/SConscript
+++ b/src/SConscript
@@ -164,6 +164,7 @@ libwesnoth_sdl_sources = Split("""
     sdl/exception.cpp
     sdl/rect.cpp
     sdl/utils.cpp
+    sdl/utils_basic.cpp
     sdl/window.cpp
     tracer.cpp
     xBRZ/xbrz.cpp
@@ -681,6 +682,13 @@ schema_generator_sources = Split("""
     """)
 client_env.WesnothProgram("schema_generator", schema_generator_sources + [libwesnoth_core, libdummy_video], have_client_prereqs)
 
+schema_validator_sources = Split("""
+	tools/validator/validator_tool.cpp
+	config_cache.cpp
+	utils/sha1.cpp
+    """)
+client_env.WesnothProgram("schema_validator", schema_validator_sources + [libwesnoth_core, libwesnoth_extras], have_client_prereqs)
+
 test_utils_sources = Split("""
     tests/utils/fake_display.cpp
     tests/utils/fake_event_source.cpp
@@ -688,17 +696,13 @@ test_utils_sources = Split("""
     """)
 
 wesmage_sources = Split("""
-    sdl/utils.cpp
-    sdl/window.cpp
-    tools/dummy_video.cpp
     tools/exploder_utils.cpp
-    tracer.cpp
     wesmage/exit.cpp
     wesmage/filter.cpp
     wesmage/options.cpp
     wesmage/wesmage.cpp
     """)
-client_env.WesnothProgram("wesmage", wesmage_sources + [libwesnoth_core], have_client_prereqs, OBJPREFIX = "wesmage_", LIBS = ["$LIBS", "png"])
+client_env.WesnothProgram("wesmage", wesmage_sources + [libwesnoth_core, libwesnoth_sdl], have_client_prereqs, OBJPREFIX = "wesmage_", LIBS = ["$LIBS", "png"])
 
 libtest_utils = test_env.Library("test_utils", test_utils_sources)
 
@@ -737,15 +741,11 @@ test_sources.extend(test_env.Object("tests/test_config_cache.cpp"))
 test = test_env.WesnothProgram("test", test_sources +  [libtest_utils, libwesnoth_extras, libwesnoth_core, libwesnoth, libwesnoth_sdl, libwesnoth_extras], have_test_prereqs)
 
 create_images_sources = Split("""
-    sdl/utils.cpp
-    sdl/window.cpp
     tests/create_images.cpp
-    tools/dummy_video.cpp
     tools/exploder_utils.cpp
-    tracer.cpp
 """)
 
-env.WesnothProgram("create_images", create_images_sources + [libwesnoth_core], have_server_prereqs, OBJPREFIX = "create_images_", LIBS = ["$LIBS", "png"])
+client_env.WesnothProgram("create_images", create_images_sources + [libwesnoth_core, libwesnoth_sdl], have_client_prereqs, OBJPREFIX = "create_images_", LIBS = ["$LIBS", "png"])
 
 if env.get("have_autorevision"):
     game_config_env.Append(CPPDEFINES = 'LOAD_REVISION')

--- a/src/sdl/utils.cpp
+++ b/src/sdl/utils.cpp
@@ -37,28 +37,40 @@
 
 #include <boost/math/constants/constants.hpp>
 
-surface_lock::surface_lock(surface &surf) : surface_(surf), locked_(false)
+SDL_Color int_to_color(const Uint32 rgb)
 {
-	if (SDL_MUSTLOCK(surface_))
-		locked_ = SDL_LockSurface(surface_) == 0;
+	SDL_Color result;
+	result.r = static_cast<Uint8>((SDL_RED_MASK & rgb) >> SDL_RED_BITSHIFT);
+	result.g = static_cast<Uint8>((SDL_GREEN_MASK & rgb) >> SDL_GREEN_BITSHIFT);
+	result.b = static_cast<Uint8>((SDL_BLUE_MASK & rgb) >> SDL_BLUE_BITSHIFT);
+	result.a = SDL_ALPHA_OPAQUE;
+	return result;
 }
 
-surface_lock::~surface_lock()
+SDL_Color string_to_color(const std::string& color_string)
 {
-	if (locked_)
-		SDL_UnlockSurface(surface_);
+	SDL_Color color = {0,0,0,0};
+
+	std::vector<Uint32> temp_rgb;
+	if(string2rgb(color_string, temp_rgb) && !temp_rgb.empty()) {
+		color = int_to_color(temp_rgb[0]);
+	}
+
+	return color;
 }
 
-const_surface_lock::const_surface_lock(const surface &surf) : surface_(surf), locked_(false)
+SDL_Color create_color(const unsigned char red
+		, unsigned char green
+		, unsigned char blue
+		, unsigned char alpha)
 {
-	if (SDL_MUSTLOCK(surface_))
-		locked_ = SDL_LockSurface(surface_) == 0;
-}
+	SDL_Color result;
+	result.r = red;
+	result.g = green;
+	result.b = blue;
+	result.a = alpha;
 
-const_surface_lock::~const_surface_lock()
-{
-	if (locked_)
-		SDL_UnlockSurface(surface_);
+	return result;
 }
 
 SDL_Keycode sdl_keysym_from_name(const std::string& keyname)
@@ -76,55 +88,6 @@ bool is_neutral(const surface& surf)
 	return (surf->format->BytesPerPixel == 4 &&
 			surf->format->Rmask == SDL_RED_MASK &&
 			(surf->format->Amask | SDL_ALPHA_MASK) == SDL_ALPHA_MASK);
-}
-
-static SDL_PixelFormat& get_neutral_pixel_format()
-	{
-		static bool first_time = true;
-		static SDL_PixelFormat format;
-
-		if(first_time) {
-			first_time = false;
-			surface surf(SDL_CreateRGBSurface(SDL_SWSURFACE,1,1,32,SDL_RED_MASK,SDL_GREEN_MASK,
-											  SDL_BLUE_MASK,SDL_ALPHA_MASK));
-			format = *surf->format;
-			format.palette = nullptr;
-		}
-
-		return format;
-	}
-
-surface make_neutral_surface(const surface &surf)
-{
-	if(surf == nullptr) {
-		std::cerr << "null neutral surface...\n";
-		return nullptr;
-	}
-
-	surface result = SDL_ConvertSurface(surf,&get_neutral_pixel_format(),SDL_SWSURFACE);
-	if(result != nullptr) {
-		adjust_surface_alpha(result, SDL_ALPHA_OPAQUE);
-	}
-
-	return result;
-}
-
-surface create_neutral_surface(int w, int h)
-{
-	if (w < 0 || h < 0) {
-		std::cerr << "error : neutral surface with negative dimensions\n";
-		return nullptr;
-	}
-
-	SDL_PixelFormat format = get_neutral_pixel_format();
-	surface result = SDL_CreateRGBSurface(SDL_SWSURFACE, w, h,
-			format.BitsPerPixel,
-			format.Rmask,
-			format.Gmask,
-			format.Bmask,
-			format.Amask);
-
-	return result;
 }
 
 surface stretch_surface_horizontal(
@@ -311,147 +274,6 @@ surface scale_surface_nn (const surface & surf, int w, int h)
 	}
 
 	adjust_surface_alpha(dst, SDL_ALPHA_OPAQUE);
-	return dst;
-}
-
-// NOTE: Don't pass this function 0 scaling arguments.
-surface scale_surface(const surface &surf, int w, int h) {
-	return scale_surface(surf, w, h, true);
-}
-
-surface scale_surface(const surface &surf, int w, int h, bool optimize)
-{
-	// Since SDL version 1.1.5 0 is transparent, before 255 was transparent.
-	assert(SDL_ALPHA_TRANSPARENT==0);
-
-	if(surf == nullptr)
-		return nullptr;
-
-	if(w == surf->w && h == surf->h) {
-		return surf;
-	}
-	assert(w >= 0);
-	assert(h >= 0);
-
-	surface dst(create_neutral_surface(w,h));
-
-	if (w == 0 || h ==0) {
-		std::cerr << "Create an empty image\n";
-		return dst;
-	}
-
-	surface src(make_neutral_surface(surf));
-	// Now both surfaces are always in the "neutral" pixel format
-
-	if(src == nullptr || dst == nullptr) {
-		std::cerr << "Could not create surface to scale onto\n";
-		return nullptr;
-	}
-
-	{
-		const_surface_lock src_lock(src);
-		surface_lock dst_lock(dst);
-
-		const Uint32* const src_pixels = src_lock.pixels();
-		Uint32* const dst_pixels = dst_lock.pixels();
-
-		fixed_t xratio = fxpdiv(surf->w,w);
-		fixed_t yratio = fxpdiv(surf->h,h);
-
-		fixed_t ysrc = ftofxp(0.0);
-		for(int ydst = 0; ydst != h; ++ydst, ysrc += yratio) {
-			fixed_t xsrc = ftofxp(0.0);
-			for(int xdst = 0; xdst != w; ++xdst, xsrc += xratio) {
-				const int xsrcint = fxptoi(xsrc);
-				const int ysrcint = fxptoi(ysrc);
-
-				const Uint32* const src_word = src_pixels + ysrcint*src->w + xsrcint;
-				Uint32* const dst_word = dst_pixels +    ydst*dst->w + xdst;
-				const int dx = (xsrcint + 1 < src->w) ? 1 : 0;
-				const int dy = (ysrcint + 1 < src->h) ? src->w : 0;
-
-				Uint8 r,g,b,a;
-				Uint32 rr,gg,bb,aa, temp;
-
-				Uint32 pix[4], bilin[4];
-
-				// This next part is the fixed point
-				// equivalent of "take everything to
-				// the right of the decimal point."
-				// These fundamental weights decide
-				// the contributions from various
-				// input pixels. The labels assume
-				// that the upper left corner of the
-				// screen ("northeast") is 0,0 but the
-				// code should still be consistent if
-				// the graphics origin is actually
-				// somewhere else.
-				//
-				// That is, the bilin array holds the
-				// "geometric" weights. I.E. If I'm scaling
-				// a 2 x 2 block a 10 x 10 block, then for
-				// pixel (2,2) of ouptut, the upper left
-				// pixel should be 10:1 more influential than
-				// the upper right, and also 10:1 more influential
-				// than lower left, and 100:1 more influential
-				// than lower right.
-
-				const fixed_t e = 0x000000FF & xsrc;
-				const fixed_t s = 0x000000FF & ysrc;
-				const fixed_t n = 0xFF - s;
-				// Not called "w" to avoid hiding a function parameter
-				// (would cause a compiler warning in MSVC2015 with /W4)
-				const fixed_t we = 0xFF - e;
-
-				pix[0] = *src_word;              // northwest
-				pix[1] = *(src_word + dx);       // northeast
-				pix[2] = *(src_word + dy);       // southwest
-				pix[3] = *(src_word + dx + dy);  // southeast
-
-				bilin[0] = n*we;
-				bilin[1] = n*e;
-				bilin[2] = s*we;
-				bilin[3] = s*e;
-
-				int loc;
-				rr = bb = gg = aa = 0;
-				for (loc=0; loc<4; loc++) {
-				  a = pix[loc] >> 24;
-				  r = pix[loc] >> 16;
-				  g = pix[loc] >> 8;
-				  b = pix[loc] >> 0;
-
-				  //We also have to implement weighting by alpha for the RGB components
-				  //If a unit has some parts solid and some parts translucent,
-				  //i.e. a red cloak but a dark shadow, then when we scale in
-				  //the shadow shouldn't appear to become red at the edges.
-				  //This part also smoothly interpolates between alpha=0 being
-				  //transparent and having no contribution, vs being opaque.
-				  temp = (a * bilin[loc]);
-				  rr += r * temp;
-				  gg += g * temp;
-				  bb += b * temp;
-				  aa += temp;
-				}
-
-				a = aa >> (16); // we average the alphas, they don't get weighted by any other factor besides bilin
-				if (a != 0) {
-					rr /= a;	// finish alpha weighting: divide by sum of alphas
-					gg /= a;
-					bb /= a;
-				}
-				r = rr >> (16); // now shift over by 16 for the bilin part
-				g = gg >> (16);
-				b = bb >> (16);
-				*dst_word = (a << 24) + (r << 16) + (g << 8) + b;
-			}
-		}
-	}
-
-	if(optimize) {
-		adjust_surface_alpha(dst, SDL_ALPHA_OPAQUE);
-	}
-
 	return dst;
 }
 
@@ -1092,61 +914,6 @@ surface recolor_image(surface surf, const color_range_map& map_rgb, bool optimiz
 	}
 
 	return nsurf;
-}
-
-surface brighten_image(const surface &surf, fixed_t amount, bool optimize)
-{
-	if(surf == nullptr) {
-		return nullptr;
-	}
-
-	surface nsurf(make_neutral_surface(surf));
-
-	if(nsurf == nullptr) {
-		std::cerr << "could not make neutral surface...\n";
-		return nullptr;
-	}
-
-	{
-		surface_lock lock(nsurf);
-		Uint32* beg = lock.pixels();
-		Uint32* end = beg + nsurf->w*surf->h;
-
-		if (amount < 0) amount = 0;
-		while(beg != end) {
-			Uint8 alpha = (*beg) >> 24;
-
-			if(alpha) {
-				Uint8 r, g, b;
-				r = (*beg) >> 16;
-				g = (*beg) >> 8;
-				b = (*beg);
-
-				r = std::min<unsigned>(unsigned(fxpmult(r, amount)),255);
-				g = std::min<unsigned>(unsigned(fxpmult(g, amount)),255);
-				b = std::min<unsigned>(unsigned(fxpmult(b, amount)),255);
-
-				*beg = (alpha << 24) + (r << 16) + (g << 8) + b;
-			}
-
-			++beg;
-		}
-	}
-
-	if(optimize) {
-		adjust_surface_alpha(nsurf, SDL_ALPHA_OPAQUE);
-	}
-
-	return nsurf;
-}
-
-void adjust_surface_alpha(surface& surf, fixed_t amount)
-{
-	if(surf == nullptr) {
-		return;
-	}
-
-	SDL_SetSurfaceAlphaMod(surf, Uint8(amount));
 }
 
 class pixel_callable : public game_logic::formula_callable {
@@ -1800,111 +1567,6 @@ surface blur_alpha_surface(const surface &surf, int depth, bool optimize)
 	return res;
 }
 
-surface cut_surface(const surface &surf, SDL_Rect const &r)
-{
-	if(surf == nullptr)
-		return nullptr;
-
-	surface res = create_compatible_surface(surf, r.w, r.h);
-
-	if(res == nullptr) {
-		std::cerr << "Could not create a new surface in cut_surface()\n";
-		return nullptr;
-	}
-
-	size_t sbpp = surf->format->BytesPerPixel;
-	size_t spitch = surf->pitch;
-	size_t rbpp = res->format->BytesPerPixel;
-	size_t rpitch = res->pitch;
-
-	// compute the areas to copy
-	SDL_Rect src_rect = r;
-	SDL_Rect dst_rect = { 0, 0, r.w, r.h };
-
-	if (src_rect.x < 0) {
-		if (src_rect.x + src_rect.w <= 0)
-			return res;
-		dst_rect.x -= src_rect.x;
-		dst_rect.w += src_rect.x;
-		src_rect.w += src_rect.x;
-		src_rect.x = 0;
-	}
-	if (src_rect.y < 0) {
-		if (src_rect.y + src_rect.h <= 0)
-			return res;
-		dst_rect.y -= src_rect.y;
-		dst_rect.h += src_rect.y;
-		src_rect.h += src_rect.y;
-		src_rect.y = 0;
-	}
-
-	if(src_rect.x >= surf->w || src_rect.y >= surf->h)
-		return res;
-
-	const_surface_lock slock(surf);
-	surface_lock rlock(res);
-
-	const Uint8* src = reinterpret_cast<const Uint8 *>(slock.pixels());
-	Uint8* dest = reinterpret_cast<Uint8 *>(rlock.pixels());
-
-	for(int y = 0; y < src_rect.h && (src_rect.y + y) < surf->h; ++y) {
-		const Uint8* line_src  = src  + (src_rect.y + y) * spitch + src_rect.x * sbpp;
-		Uint8* line_dest = dest + (dst_rect.y + y) * rpitch + dst_rect.x * rbpp;
-		size_t size = src_rect.w + src_rect.x <= surf->w ? src_rect.w : surf->w - src_rect.x;
-
-		assert(rpitch >= src_rect.w * rbpp);
-		memcpy(line_dest, line_src, size * rbpp);
-	}
-
-	return res;
-}
-surface blend_surface(
-		  const surface &surf
-		, const double amount
-		, const Uint32 color
-		, const bool optimize)
-{
-	if(surf== nullptr) {
-		return nullptr;
-	}
-
-	surface nsurf(make_neutral_surface(surf));
-
-	if(nsurf == nullptr) {
-		std::cerr << "could not make neutral surface...\n";
-		return nullptr;
-	}
-
-	{
-		surface_lock lock(nsurf);
-		Uint32* beg = lock.pixels();
-		Uint32* end = beg + nsurf->w*surf->h;
-
-		Uint16 ratio = amount * 256;
-		const Uint16 red   = ratio * static_cast<Uint8>(color >> 16);
-		const Uint16 green = ratio * static_cast<Uint8>(color >> 8);
-		const Uint16 blue  = ratio * static_cast<Uint8>(color);
-		ratio = 256 - ratio;
-
-		while(beg != end) {
-			Uint8 a = static_cast<Uint8>(*beg >> 24);
-			Uint8 r = (ratio * static_cast<Uint8>(*beg >> 16) + red)   >> 8;
-			Uint8 g = (ratio * static_cast<Uint8>(*beg >> 8)  + green) >> 8;
-			Uint8 b = (ratio * static_cast<Uint8>(*beg)       + blue)  >> 8;
-
-			*beg = (a << 24) | (r << 16) | (g << 8) | b;
-
-			++beg;
-		}
-	}
-
-	if(optimize) {
-		adjust_surface_alpha(nsurf, SDL_ALPHA_OPAQUE);
-	}
-
-	return nsurf;
-}
-
 /* Simplified RotSprite algorithm.
  * http://en.wikipedia.org/wiki/Image_scaling#RotSprite
  * Lifted from: http://github.com/salmonmoose/SpriteRotator
@@ -2176,25 +1838,6 @@ surface flop_surface(const surface &surf, bool optimize)
 	}
 
 	return nsurf;
-}
-
-surface create_compatible_surface(const surface &surf, int width, int height)
-{
-	if(surf == nullptr)
-		return nullptr;
-
-	if(width == -1)
-		width = surf->w;
-
-	if(height == -1)
-		height = surf->h;
-
-	surface s = SDL_CreateRGBSurface(SDL_SWSURFACE, width, height, surf->format->BitsPerPixel,
-		surf->format->Rmask, surf->format->Gmask, surf->format->Bmask, surf->format->Amask);
-	if (surf->format->palette) {
-		SDL_SetPaletteColors(s->format->palette, surf->format->palette->colors, 0, surf->format->palette->ncolors);
-	}
-	return s;
 }
 
 void blit_surface(const surface& surf,

--- a/src/sdl/utils_basic.cpp
+++ b/src/sdl/utils_basic.cpp
@@ -1,0 +1,417 @@
+/*
+   Copyright (C) 2003 - 2016 by David White <dave@whitevine.net>
+   Part of the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+/**
+ *  @file
+ *  Basic support routines for the SDL-graphics-library.
+ */
+
+#include "sdl/utils.hpp"
+
+#include <cassert>
+#include <iostream>
+
+surface_lock::surface_lock(surface &surf) : surface_(surf), locked_(false)
+{
+	if (SDL_MUSTLOCK(surface_))
+		locked_ = SDL_LockSurface(surface_) == 0;
+}
+
+surface_lock::~surface_lock()
+{
+	if (locked_)
+		SDL_UnlockSurface(surface_);
+}
+
+const_surface_lock::const_surface_lock(const surface &surf) : surface_(surf), locked_(false)
+{
+	if (SDL_MUSTLOCK(surface_))
+		locked_ = SDL_LockSurface(surface_) == 0;
+}
+
+const_surface_lock::~const_surface_lock()
+{
+	if (locked_)
+		SDL_UnlockSurface(surface_);
+}
+
+static SDL_PixelFormat& get_neutral_pixel_format()
+{
+	static bool first_time = true;
+	static SDL_PixelFormat format;
+
+	if(first_time) {
+		first_time = false;
+		surface surf(SDL_CreateRGBSurface(SDL_SWSURFACE,1,1,32,0xFF0000,0xFF00,0xFF,0xFF000000));
+		format = *surf->format;
+		format.palette = nullptr;
+	}
+
+	return format;
+}
+
+surface make_neutral_surface(const surface &surf)
+{
+	if(surf == nullptr) {
+		std::cerr << "null neutral surface...\n";
+		return nullptr;
+	}
+
+	surface result = SDL_ConvertSurface(surf,&get_neutral_pixel_format(),SDL_SWSURFACE);
+	if(result != nullptr) {
+		adjust_surface_alpha(result, SDL_ALPHA_OPAQUE);
+	}
+
+	return result;
+}
+
+surface create_neutral_surface(int w, int h)
+{
+	if (w < 0 || h < 0) {
+		std::cerr << "error : neutral surface with negative dimensions\n";
+		return nullptr;
+	}
+
+	SDL_PixelFormat format = get_neutral_pixel_format();
+	surface result = SDL_CreateRGBSurface(SDL_SWSURFACE, w, h,
+			format.BitsPerPixel,
+			format.Rmask,
+			format.Gmask,
+			format.Bmask,
+			format.Amask);
+
+	return result;
+}
+
+// NOTE: Don't pass this function 0 scaling arguments.
+surface scale_surface(const surface &surf, int w, int h)
+{
+	return scale_surface(surf, w, h, true);
+}
+
+surface scale_surface(const surface &surf, int w, int h, bool optimize)
+{
+	// Since SDL version 1.1.5 0 is transparent, before 255 was transparent.
+	assert(SDL_ALPHA_TRANSPARENT==0);
+
+	if(surf == nullptr)
+		return nullptr;
+
+	if(w == surf->w && h == surf->h) {
+		return surf;
+	}
+	assert(w >= 0);
+	assert(h >= 0);
+
+	surface dst(create_neutral_surface(w,h));
+
+	if (w == 0 || h ==0) {
+		std::cerr << "Create an empty image\n";
+		return dst;
+	}
+
+	surface src(make_neutral_surface(surf));
+	// Now both surfaces are always in the "neutral" pixel format
+
+	if(src == nullptr || dst == nullptr) {
+		std::cerr << "Could not create surface to scale onto\n";
+		return nullptr;
+	}
+
+	{
+		const_surface_lock src_lock(src);
+		surface_lock dst_lock(dst);
+
+		const Uint32* const src_pixels = src_lock.pixels();
+		Uint32* const dst_pixels = dst_lock.pixels();
+
+		fixed_t xratio = fxpdiv(surf->w,w);
+		fixed_t yratio = fxpdiv(surf->h,h);
+
+		fixed_t ysrc = ftofxp(0.0);
+		for(int ydst = 0; ydst != h; ++ydst, ysrc += yratio) {
+			fixed_t xsrc = ftofxp(0.0);
+			for(int xdst = 0; xdst != w; ++xdst, xsrc += xratio) {
+				const int xsrcint = fxptoi(xsrc);
+				const int ysrcint = fxptoi(ysrc);
+
+				const Uint32* const src_word = src_pixels + ysrcint*src->w + xsrcint;
+				Uint32* const dst_word = dst_pixels +    ydst*dst->w + xdst;
+				const int dx = (xsrcint + 1 < src->w) ? 1 : 0;
+				const int dy = (ysrcint + 1 < src->h) ? src->w : 0;
+
+				Uint8 r,g,b,a;
+				Uint32 rr,gg,bb,aa, temp;
+
+				Uint32 pix[4], bilin[4];
+
+				// This next part is the fixed point
+				// equivalent of "take everything to
+				// the right of the decimal point."
+				// These fundamental weights decide
+				// the contributions from various
+				// input pixels. The labels assume
+				// that the upper left corner of the
+				// screen ("northeast") is 0,0 but the
+				// code should still be consistent if
+				// the graphics origin is actually
+				// somewhere else.
+				//
+				// That is, the bilin array holds the
+				// "geometric" weights. I.E. If I'm scaling
+				// a 2 x 2 block a 10 x 10 block, then for
+				// pixel (2,2) of ouptut, the upper left
+				// pixel should be 10:1 more influential than
+				// the upper right, and also 10:1 more influential
+				// than lower left, and 100:1 more influential
+				// than lower right.
+
+				const fixed_t e = 0x000000FF & xsrc;
+				const fixed_t s = 0x000000FF & ysrc;
+				const fixed_t n = 0xFF - s;
+				// Not called "w" to avoid hiding a function parameter
+				// (would cause a compiler warning in MSVC2015 with /W4)
+				const fixed_t we = 0xFF - e;
+
+				pix[0] = *src_word;              // northwest
+				pix[1] = *(src_word + dx);       // northeast
+				pix[2] = *(src_word + dy);       // southwest
+				pix[3] = *(src_word + dx + dy);  // southeast
+
+				bilin[0] = n*we;
+				bilin[1] = n*e;
+				bilin[2] = s*we;
+				bilin[3] = s*e;
+
+				int loc;
+				rr = bb = gg = aa = 0;
+				for (loc=0; loc<4; loc++) {
+				  a = pix[loc] >> 24;
+				  r = pix[loc] >> 16;
+				  g = pix[loc] >> 8;
+				  b = pix[loc] >> 0;
+
+				  //We also have to implement weighting by alpha for the RGB components
+				  //If a unit has some parts solid and some parts translucent,
+				  //i.e. a red cloak but a dark shadow, then when we scale in
+				  //the shadow shouldn't appear to become red at the edges.
+				  //This part also smoothly interpolates between alpha=0 being
+				  //transparent and having no contribution, vs being opaque.
+				  temp = (a * bilin[loc]);
+				  rr += r * temp;
+				  gg += g * temp;
+				  bb += b * temp;
+				  aa += temp;
+				}
+
+				a = aa >> (16); // we average the alphas, they don't get weighted by any other factor besides bilin
+				if (a != 0) {
+					rr /= a;	// finish alpha weighting: divide by sum of alphas
+					gg /= a;
+					bb /= a;
+				}
+				r = rr >> (16); // now shift over by 16 for the bilin part
+				g = gg >> (16);
+				b = bb >> (16);
+				*dst_word = (a << 24) + (r << 16) + (g << 8) + b;
+			}
+		}
+	}
+
+	if(optimize) {
+		adjust_surface_alpha(dst, SDL_ALPHA_OPAQUE);
+	}
+
+	return dst;
+}
+
+surface brighten_image(const surface &surf, fixed_t amount, bool optimize)
+{
+	if(surf == nullptr) {
+		return nullptr;
+	}
+
+	surface nsurf(make_neutral_surface(surf));
+
+	if(nsurf == nullptr) {
+		std::cerr << "could not make neutral surface...\n";
+		return nullptr;
+	}
+
+	{
+		surface_lock lock(nsurf);
+		Uint32* beg = lock.pixels();
+		Uint32* end = beg + nsurf->w*surf->h;
+
+		if (amount < 0) amount = 0;
+		while(beg != end) {
+			Uint8 alpha = (*beg) >> 24;
+
+			if(alpha) {
+				Uint8 r, g, b;
+				r = (*beg) >> 16;
+				g = (*beg) >> 8;
+				b = (*beg);
+
+				r = std::min<unsigned>(unsigned(fxpmult(r, amount)),255);
+				g = std::min<unsigned>(unsigned(fxpmult(g, amount)),255);
+				b = std::min<unsigned>(unsigned(fxpmult(b, amount)),255);
+
+				*beg = (alpha << 24) + (r << 16) + (g << 8) + b;
+			}
+
+			++beg;
+		}
+	}
+
+	if(optimize) {
+		adjust_surface_alpha(nsurf, SDL_ALPHA_OPAQUE);
+	}
+
+	return nsurf;
+}
+
+void adjust_surface_alpha(surface& surf, fixed_t amount)
+{
+	if(surf == nullptr) {
+		return;
+	}
+
+	SDL_SetSurfaceAlphaMod(surf, Uint8(amount));
+}
+
+surface cut_surface(const surface &surf, SDL_Rect const &r)
+{
+	if(surf == nullptr)
+		return nullptr;
+
+	surface res = create_compatible_surface(surf, r.w, r.h);
+
+	if(res == nullptr) {
+		std::cerr << "Could not create a new surface in cut_surface()\n";
+		return nullptr;
+	}
+
+	size_t sbpp = surf->format->BytesPerPixel;
+	size_t spitch = surf->pitch;
+	size_t rbpp = res->format->BytesPerPixel;
+	size_t rpitch = res->pitch;
+
+	// compute the areas to copy
+	SDL_Rect src_rect = r;
+	SDL_Rect dst_rect = { 0, 0, r.w, r.h };
+
+	if (src_rect.x < 0) {
+		if (src_rect.x + src_rect.w <= 0)
+			return res;
+		dst_rect.x -= src_rect.x;
+		dst_rect.w += src_rect.x;
+		src_rect.w += src_rect.x;
+		src_rect.x = 0;
+	}
+	if (src_rect.y < 0) {
+		if (src_rect.y + src_rect.h <= 0)
+			return res;
+		dst_rect.y -= src_rect.y;
+		dst_rect.h += src_rect.y;
+		src_rect.h += src_rect.y;
+		src_rect.y = 0;
+	}
+
+	if(src_rect.x >= surf->w || src_rect.y >= surf->h)
+		return res;
+
+	const_surface_lock slock(surf);
+	surface_lock rlock(res);
+
+	const Uint8* src = reinterpret_cast<const Uint8 *>(slock.pixels());
+	Uint8* dest = reinterpret_cast<Uint8 *>(rlock.pixels());
+
+	for(int y = 0; y < src_rect.h && (src_rect.y + y) < surf->h; ++y) {
+		const Uint8* line_src  = src  + (src_rect.y + y) * spitch + src_rect.x * sbpp;
+		Uint8* line_dest = dest + (dst_rect.y + y) * rpitch + dst_rect.x * rbpp;
+		size_t size = src_rect.w + src_rect.x <= surf->w ? src_rect.w : surf->w - src_rect.x;
+
+		assert(rpitch >= src_rect.w * rbpp);
+		memcpy(line_dest, line_src, size * rbpp);
+	}
+
+	return res;
+}
+
+surface blend_surface(
+		  const surface &surf
+		, const double amount
+		, const Uint32 color
+		, const bool optimize)
+{
+	if(surf== nullptr) {
+		return nullptr;
+	}
+
+	surface nsurf(make_neutral_surface(surf));
+
+	if(nsurf == nullptr) {
+		std::cerr << "could not make neutral surface...\n";
+		return nullptr;
+	}
+
+	{
+		surface_lock lock(nsurf);
+		Uint32* beg = lock.pixels();
+		Uint32* end = beg + nsurf->w*surf->h;
+
+		Uint16 ratio = amount * 256;
+		const Uint16 red   = ratio * static_cast<Uint8>(color >> 16);
+		const Uint16 green = ratio * static_cast<Uint8>(color >> 8);
+		const Uint16 blue  = ratio * static_cast<Uint8>(color);
+		ratio = 256 - ratio;
+
+		while(beg != end) {
+			Uint8 a = static_cast<Uint8>(*beg >> 24);
+			Uint8 r = (ratio * static_cast<Uint8>(*beg >> 16) + red)   >> 8;
+			Uint8 g = (ratio * static_cast<Uint8>(*beg >> 8)  + green) >> 8;
+			Uint8 b = (ratio * static_cast<Uint8>(*beg)       + blue)  >> 8;
+
+			*beg = (a << 24) | (r << 16) | (g << 8) | b;
+
+			++beg;
+		}
+	}
+
+	if(optimize) {
+		adjust_surface_alpha(nsurf, SDL_ALPHA_OPAQUE);
+	}
+
+	return nsurf;
+}
+
+surface create_compatible_surface(const surface &surf, int width, int height)
+{
+	if(surf == nullptr)
+		return nullptr;
+
+	if(width == -1)
+		width = surf->w;
+
+	if(height == -1)
+		height = surf->h;
+
+	surface s = SDL_CreateRGBSurface(SDL_SWSURFACE, width, height, surf->format->BitsPerPixel,
+		surf->format->Rmask, surf->format->Gmask, surf->format->Bmask, surf->format->Amask);
+	if (surf->format->palette) {
+		SDL_SetPaletteColors(s->format->palette, surf->format->palette->colors, 0, surf->format->palette->ncolors);
+	}
+	return s;
+}


### PR DESCRIPTION
Refactor sdl/utils.cpp into two files. This allows building all tools without pulling in the entire engine.

Note that the size of some targets could be further reduced by additional refactoring in other areas.

SCons and CMake can now build all of the following targets:

* campaignd
* create_images
* cutter
* exploder
* schema_generator
* schema_validator
* test
* wesmage
* wesnoth
* wesnothd