### PR TITLE
Add support for AppVeyor Continuous Integration for Visual Studio

### DIFF
--- a/.appveyor.vs2013.yml
+++ b/.appveyor.vs2013.yml
@@ -1,0 +1,14 @@
+version: Wesnoth-VS2013-{branch}-{build}
+clone_folder: C:\projects\wesnoth
+image: Visual Studio 2013
+configuration:
+ - Release
+ - Debug
+platform: win32
+before_build:
+  - cd ..
+  - ps: wget https://github.com/aquileia/external/archive/VC12.zip -O VC12.zip
+  - 7z x VC12.ZIP
+  - ren external-VC12 external
+  - cd wesnoth
+  - set PATH=C:\projects\external\dll;%PATH%

--- a/.appveyor.vs2015.yml
+++ b/.appveyor.vs2015.yml
@@ -1,0 +1,21 @@
+version: Wesnoth-VS2015-{branch}-{build}
+clone_folder: C:\projects\wesnoth
+image: Visual Studio 2015
+configuration:
+ - Release
+ - Debug
+platform: win32
+before_build:
+  - cd ..
+  - ps: wget https://github.com/aquileia/external/archive/VC14.zip -O VC14.zip
+  - 7z x VC14.ZIP
+  - ren external-VC14 external
+  - cd wesnoth
+  - mkdir projectfiles\VC14
+  - xcopy /E /I /H /Y projectfiles\VC12 projectfiles\VC14
+  - cd projectfiles\VC14
+  - "\"c:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Common7\\IDE\\devenv.exe\" wesnoth.sln /upgrade"
+  - cd ..\..
+  - set PATH=C:\projects\external\dll;%PATH%
+build_script:
+  - msbuild projectfiles\VC14\wesnoth.sln /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"


### PR DESCRIPTION
    0) Visit https://appveyor.com
    1) Sign in using your GitHub account.
    2) Under projects tab: New Project
    3) Click Add for wesnoth
    4) Click back to Projects
    5) Hover to right of wesnoth, click gear icon (Edit Project Settings)
    6) Set project name ie., "Battle for Wesnoth (Visual Studio 2013)"
    7) Enter custom configuration .yml name: .appveyor.vs2013.yml
    8) Check to skip branches without appveyor.yml
    9) Click Save
    A) If desired, repeat 2 through 9 for Visual Studio 2015

Total run time for both toolsets is about 3.75 hours.

Note that each configuration builds both Debug and Release. Edit the .yml to only choose one.

There is a one-hour quota per build. Each build takes approximately 50 minutes. Cloning the repository takes from 5 to 20 minutes. Using a shallow clone zip file, reverting spirit_po and eliminating the Boost tests are the best ways to decrease runtime.

At present, AppVeyor does not support IRC notification. There is an open github issue requiresing the feature. It may be possible to add IRC notification as a build step.