### PR TITLE
Fix warnings in spirit_po

### DIFF
--- a/src/gettext_boost.cpp
+++ b/src/gettext_boost.cpp
@@ -134,7 +134,7 @@ namespace
 					extra_messages_.emplace(get_base().domain(domain), cat);
 				} catch(spirit_po::catalog_exception& e) {
 					throw_po_error(lang_name_long, domain, e.what());
-				} catch(std::ios::failure& e) {
+				} catch(std::ios::failure&) {
 					throw_po_error(lang_name_long, domain, strerror(errno));
 				}
 			}

--- a/src/spirit_po/po_message.hpp
+++ b/src/spirit_po/po_message.hpp
@@ -32,7 +32,7 @@ struct po_message {
 
   // Check if message is plural. We do this for now by testing msgid_plural.size().
   // Recommended to use this method in case we change it in the future.
-  bool is_plural() const { return static_cast<bool>(id_plural().size()); } 
+  bool is_plural() const { return (id_plural().size() != 0); } 
 };
 
 /***


### PR DESCRIPTION
This fixes the 2 warnings during a Visual Studio Release build.

It does not fix the other 24 warnings from a Debug build.