### PR TITLE
Adjust AppVeyor configurations

### DIFF
--- a/.appveyor.vs2013.yml
+++ b/.appveyor.vs2013.yml
@@ -5,6 +5,8 @@ configuration:
  - Release
  - Debug
 platform: win32
+skip_branch_with_pr: true
+shallow_clone: true
 before_build:
   - cd ..
   - ps: wget https://github.com/aquileia/external/archive/VC12.zip -O VC12.zip

--- a/.appveyor.vs2015.yml
+++ b/.appveyor.vs2015.yml
@@ -5,6 +5,8 @@ configuration:
  - Release
  - Debug
 platform: win32
+skip_branch_with_pr: true
+shallow_clone: true
 before_build:
   - cd ..
   - ps: wget https://github.com/aquileia/external/archive/VC14.zip -O VC14.zip


### PR DESCRIPTION
Do not build branches with an open PR.

Use ZIP and clone only the commit in question. This should significantly reduce the time needed to download the repository. Live testing was exceeding 40 minutes and forcing a quota-exceeded timeout.