### PR TITLE
UtbS S1: Fix objectives if Necro appears early

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg
@@ -1112,10 +1112,25 @@
             [objective]
                 description= _ "Death of Garak"
                 condition=lose
+                [show_if]
+                    # We could just use [have_unit], but if Garak or Zhul dies and the player
+                    # checks the objectives, the respective objective won't be displayed,
+                    # and disappearing objectives for no good reason would look buggy.
+                    [variable]
+                        name=found_garak
+                        boolean_equals=yes
+                    [/variable]
+                [/show_if]
             [/objective]
             [objective]
                 description= _ "Death of Zhul"
                 condition=lose
+                [show_if]
+                    [variable]
+                        name=found_zhul
+                        boolean_equals=yes
+                    [/variable]
+                [/show_if]
             [/objective]
 
             [gold_carryover]


### PR DESCRIPTION
If the necromancer appears before Garak or Zhul are found, the objectives are wrong.