### PR TITLE
VC14 Cleanup

### DIFF
--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -423,7 +423,7 @@ void add_color_info(const config& v)
 		for(const auto& s : utils::split(*a2)) {
 			try {
 				temp.push_back(color_t::from_hex_string(s));
-			} catch(std::invalid_argument& e) {
+			} catch(std::invalid_argument&) {
 				std::stringstream ss;
 				ss << "can't parse color string:\n" << teamC.debug() << "\n";
 				throw config::error(ss.str());
@@ -450,7 +450,7 @@ void add_color_info(const config& v)
 			for(const auto& s : utils::split(rgb.second)) {
 				try {
 					temp.push_back(color_t::from_hex_string(s));
-				} catch(std::invalid_argument& e) {
+				} catch(std::invalid_argument&) {
 					ERR_NG << "Invalid color in palette: " << s << std::endl;
 				}
 			}
@@ -480,7 +480,7 @@ const color_range& color_info(const std::string& name)
 	for(const auto& s : utils::split(name)) {
 		try {
 			temp.push_back(color_t::from_hex_string(s));
-		} catch(std::invalid_argument& e) {
+		} catch(std::invalid_argument&) {
 			throw config::error(_("Invalid color in range: ") + s);
 		}
 	}
@@ -499,7 +499,7 @@ const std::vector<color_t>& tc_info(const std::string& name)
 	std::vector<color_t> temp;
 	try {
 		temp.push_back(color_t::from_hex_string(name));
-	} catch(std::invalid_argument& e) {
+	} catch(std::invalid_argument&) {
 		static std::vector<color_t> stv;
 		ERR_NG << "Invalid color palette: " << name << std::endl;
 		return stv;

--- a/src/generators/default_map_generator_job.cpp
+++ b/src/generators/default_map_generator_job.cpp
@@ -940,7 +940,7 @@ std::string default_map_generator_job::default_generate_map(generator_data data,
 
 	for(int player = 0; player != data.nplayers; ++player) {
 		LOG_NG << "placing castle for " << player << "\n";
-		log_scope("placing castle");
+		lg::scope_logger inner_scope_logging_object__(lg::general(), "placing castle");
 		const int min_x = data.width/3 + 3;
 		const int min_y = data.height/3 + 3;
 		const int max_x = (data.width/3)*2 - 4;
@@ -996,7 +996,7 @@ std::string default_map_generator_job::default_generate_map(generator_data data,
 
 	road_path_calculator calc(terrain, cfg, rng_());
 	for(int road = 0; road != nroads; ++road) {
-		log_scope("creating road");
+		lg::scope_logger another_inner_scope_logging_object__(lg::general(), "creating road");
 
 		/*
 		 * We want the locations to be on the portion of the map we're actually

--- a/src/gettext_boost.cpp
+++ b/src/gettext_boost.cpp
@@ -11,6 +11,9 @@
 
    See the COPYING file for more details.
 */
+#if defined(_MSC_VER)
+#pragma warning(disable: 4714)
+#endif
 
 #include "global.hpp"
 #include "gettext.hpp"
@@ -30,7 +33,7 @@
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #elif defined(_MSC_VER)
 #pragma warning(push)
-#pragma warning(disable: 4714)
+#pragma warning(disable: 4459)
 #endif
 #include "spirit_po.hpp"
 #if defined(__GNUC__)

--- a/src/gettext_boost.cpp
+++ b/src/gettext_boost.cpp
@@ -153,18 +153,18 @@ namespace
 			throw game::error(err.str());
 		}
 
-		const char* get(int domain_id, const char* ctx, const char* id) const override
+		const char* get(int domain_id, const char* ctx, const char* msg_id) const override
 		{
 			auto& base = get_base();
-			const char* msg = base.get(domain_id, ctx, id);
+			const char* msg = base.get(domain_id, ctx, msg_id);
 			if(msg == nullptr) {
 				auto iter = extra_messages_.find(domain_id);
 				if(iter == extra_messages_.end()) {
 					return nullptr;
 				}
 				auto& catalog = iter->second;
-				const char* lookup = ctx ? catalog.pgettext(ctx, id) : catalog.gettext(id);
-				if(lookup != id) {
+				const char* lookup = ctx ? catalog.pgettext(ctx, msg_id) : catalog.gettext(msg_id);
+				if(lookup != msg_id) {
 					// (p)gettext returns the input pointer if the string was not found
 					msg = lookup;
 				}

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -1441,7 +1441,7 @@ void canvas::draw(const bool force)
 
 	// draw items
 	for(auto& shape : shapes_) {
-		log_scope2(log_gui_draw, "Canvas: draw shape.");
+		lg::scope_logger inner_scope_logging_object__(log_gui_draw, "Canvas: draw shape.");
 
 		shape->draw(canvas_, renderer_, variables_);
 	}

--- a/src/gui/widgets/window.cpp
+++ b/src/gui/widgets/window.cpp
@@ -1243,8 +1243,8 @@ void swap_grid(grid* g,
 		parent_grid = find_widget<grid>(content_grid, id, true, false);
 		assert(parent_grid);
 	}
-	if(grid* g = dynamic_cast<grid*>(parent_grid->parent())) {
-		widget = g->swap_child(id, widget, false);
+	if(grid* grandparent_grid = dynamic_cast<grid*>(parent_grid->parent())) {
+		widget = grandparent_grid->swap_child(id, widget, false);
 	} else if(container_base* c
 			  = dynamic_cast<container_base*>(parent_grid->parent())) {
 

--- a/src/serialization/parser.cpp
+++ b/src/serialization/parser.cpp
@@ -36,7 +36,15 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
 #include <boost/iostreams/filter/bzip2.hpp>
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4456)
+#pragma warning(disable: 4458)
+#endif
 #include <boost/iostreams/filter/gzip.hpp>
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 #include <boost/variant/static_visitor.hpp>
 
 static lg::log_domain log_config("config");

--- a/src/serialization/preprocessor.cpp
+++ b/src/serialization/preprocessor.cpp
@@ -1206,15 +1206,15 @@ bool preprocessor_data::get_chunk()
 
 				// If the macro definition has any optional arguments, insert their defaults
 				if (val.optional_arguments.size() > 0) {
-					for (const auto &arg : val.optional_arguments) {
-						if (defines->find(arg.first) == defines->end()) {
+					for (const auto &argument : val.optional_arguments) {
+						if (defines->find(argument.first) == defines->end()) {
 							std::ostringstream res;
 							preprocessor_streambuf *buf = new preprocessor_streambuf(target_);
 
 							buf->textdomain_ = target_.textdomain_;
 							std::istream in(buf);
 
-							std::istringstream *buffer = new std::istringstream(arg.second);
+							std::istringstream *buffer = new std::istringstream(argument.second);
 
 							std::map<std::string, std::string> *temp_defines = new std::map<std::string, std::string>;
 							temp_defines->insert(defines->begin(), defines->end());
@@ -1222,9 +1222,9 @@ bool preprocessor_data::get_chunk()
 							new preprocessor_data(*buf, buffer, val.location, "", val.linenum, dir, val.textdomain, temp_defines, false);
 							res << in.rdbuf();
 
-							DBG_PREPROC << "Setting default for optional argument " << arg.first << " in macro " << symbol << "\n";
+							DBG_PREPROC << "Setting default for optional argument " << argument.first << " in macro " << symbol << "\n";
 
-							(*defines)[arg.first] = res.str();
+							(*defines)[argument.first] = res.str();
 
 							delete buf;
 						}

--- a/src/server/simple_wml.cpp
+++ b/src/server/simple_wml.cpp
@@ -21,7 +21,15 @@
 #include <boost/iostreams/filtering_stream.hpp>
 #include <boost/iostreams/filter/bzip2.hpp>
 #include <boost/iostreams/filter/counter.hpp>
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4456)
+#pragma warning(disable: 4458)
+#endif
 #include <boost/iostreams/filter/gzip.hpp>
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 #include "server/simple_wml.hpp"
 

--- a/src/terrain/translation.hpp
+++ b/src/terrain/translation.hpp
@@ -23,7 +23,14 @@
 #include <boost/bimap.hpp>
 #include <boost/bimap/set_of.hpp>
 #include <boost/bimap/multiset_of.hpp>
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4459)
+#endif
 #include <boost/multi_array.hpp>
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 #include "exceptions.hpp"
 #include "map/location.hpp"
 

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -2274,7 +2274,7 @@ void unit::apply_modifications()
 			lg::wml_error() << "[modifications][advance] is deprecated, use [advancement] instead\n";
 		}
 		for(const config &m : modifications_.child_range(mod)) {
-			log_scope("add mod");
+			lg::scope_logger inner_scope_logging_object__(lg::general(), "add mod");
 			add_modification(ModificationTypes[i], m, true);
 		}
 	}

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -74,7 +74,15 @@
 #include <boost/iostreams/categories.hpp>  // for input, output
 #include <boost/iostreams/copy.hpp>     // for copy
 #include <boost/iostreams/filter/bzip2.hpp>  // for bzip2_compressor, etc
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4456)
+#pragma warning(disable: 4458)
+#endif
 #include <boost/iostreams/filter/gzip.hpp>  // for gzip_compressor, etc
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 #include <boost/iostreams/filtering_stream.hpp>  // for filtering_stream
 #include <boost/program_options/errors.hpp>  // for error
 


### PR DESCRIPTION
These commits should get us to 0 errors / 0 warnings for both Release and Debug builds for Visual Studio 2015.

In general there were three classes of error:

    * A local name hiding another. Renamed the local name

    * The poorly-written logging macro causing a duplicated name to hide an earlier name. Removed the duplicate macro. This eliminated some inner log scopes. A better fix would be to completely replace the lame macro with a better one; but that is too much work for today.

    * Bugs in spirit_po and certain Boost libraries. These were names-hides-name errors. Some could have been fixed by renaming some Wesnoth global variables; some are true bugs in the libraries. Since these are libraries, they messages were suppressed rather than correcting the library.