### PR TITLE
de-cap village_support

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -46,7 +46,7 @@ int get_village_gold(const std::string& value, const game_classification* classi
 
 int get_village_support(const std::string& value)
 {
-	return util::clamp<int>(lexical_cast_default<int>(value, 1), 0, 4);
+	return util::clamp<int>(lexical_cast_default<int>(value, 1), 0, 65536);
 }
 
 int get_xp_modifier(const std::string& value)


### PR DESCRIPTION
There should be no functional limit on village_support.

Reason: other workarounds for setting no cost/no income do not work reliably. e.g. in LotI, your cash may decrease even when taking a snapshot of gold at `side turn` and restoring at `turn refresh`. See  Dugy/Legend_of_the_Invincibles/utils/utils.cfg at `#define DISABLE_UPKEEP` and recent patch pulls there.

Further, I have a request that a standard config setting for a map be, `player_support` or `base_side_support` for a given side. This would make it possible to have a base level of support not tied to villages on-map.

See also discussion at https://github.com/Dugy/Legend_of_the_Invincibles/pull/11