### PR TITLE
styled_widget: respect minimum size even for non-text widgets

### DIFF
--- a/src/gui/widgets/spacer.cpp
+++ b/src/gui/widgets/spacer.cpp
@@ -28,6 +28,24 @@ namespace gui2
 
 REGISTER_WIDGET(spacer)
 
+void spacer::request_reduce_width(const unsigned maximum_width)
+{
+	if(best_size_ != point()) {
+		// This spacer is of fixed size, do nothing.
+	} else {
+		styled_widget::request_reduce_width(maximum_width);
+	}
+}
+
+void spacer::request_reduce_height(const unsigned maximum_height)
+{
+	if(best_size_ != point()) {
+		// This spacer is of fixed size, do nothing.
+	} else {
+		styled_widget::request_reduce_height(maximum_height);
+	}
+}
+
 point spacer::calculate_best_size() const
 {
 	return best_size_ != point() ? best_size_

--- a/src/gui/widgets/spacer.hpp
+++ b/src/gui/widgets/spacer.hpp
@@ -44,6 +44,12 @@ public:
 
 	/***** ***** ***** ***** layout functions ***** ***** ***** *****/
 
+	/** See @ref widget::request_reduce_width. */
+	virtual void request_reduce_width(const unsigned maximum_width) override;
+
+	/** See @ref widget::request_reduce_height. */
+	virtual void request_reduce_height(const unsigned maximum_height) override;
+
 private:
 	/** See @ref widget::calculate_best_size. */
 	virtual point calculate_best_size() const override;

--- a/src/gui/widgets/styled_widget.cpp
+++ b/src/gui/widgets/styled_widget.cpp
@@ -31,6 +31,7 @@
 
 #include "utils/functional.hpp"
 
+#include <algorithm>
 #include <iomanip>
 
 #define LOG_SCOPE_HEADER                                                       \
@@ -218,9 +219,34 @@ void styled_widget::request_reduce_width(const unsigned maximum_width)
 				  << "' maximum_width " << maximum_width << " result " << size
 				  << ".\n";
 
+	} else if(label_.empty()) {
+		point size = get_best_size();
+		point min_size = get_config_minimum_size();
+		size.x = std::min(size.x, std::max<int>(maximum_width, min_size.x));
+		set_layout_size(size);
+
+		DBG_GUI_L << LOG_HEADER << " styled_widget " << id()
+		          << " maximum_width " << maximum_width << " result " << size
+		          << ".\n";
 	} else {
 		DBG_GUI_L << LOG_HEADER << " label '" << debug_truncate(label_)
 				  << "' failed; either no label or wrapping not allowed.\n";
+	}
+}
+
+void styled_widget::request_reduce_height(const unsigned maximum_height)
+{
+	if(!label_.empty()) {
+		// Do nothing
+	} else {
+		point size = get_best_size();
+		point min_size = get_config_minimum_size();
+		size.y = std::min(size.y, std::max<int>(maximum_height, min_size.y));
+		set_layout_size(size);
+
+		DBG_GUI_L << LOG_HEADER << " styled_widget " << id()
+		          << " maximum_height " << maximum_height << " result " << size
+		          << ".\n";
 	}
 }
 

--- a/src/gui/widgets/styled_widget.hpp
+++ b/src/gui/widgets/styled_widget.hpp
@@ -176,6 +176,9 @@ public:
 	/** See @ref widget::request_reduce_width. */
 	virtual void request_reduce_width(const unsigned maximum_width) override;
 
+	/** See @ref widget::request_reduce_height. */
+	virtual void request_reduce_height(const unsigned maximum_height) override;
+
 protected:
 	/** See @ref widget::calculate_best_size. */
 	virtual point calculate_best_size() const override;


### PR DESCRIPTION
For widgets which don't contain text (`label_` is empty),
`request_reduce_width()` and `request_reduce_height()` can be implemented in a
way that respects the minimum size set in widget definition. However,
neither of those functions do anything for non-text widgets.

This pull request simply implements the request_reduce_* functions for non-text
widgets, and overrides the implementation for spacers because ingame WML
messages break otherwise.

This is the only commit I intend to have in this PR.