### PR TITLE
Ability to shrink composite widgets below the default size

### DIFF
--- a/src/gui/widgets/container_base.cpp
+++ b/src/gui/widgets/container_base.cpp
@@ -138,22 +138,22 @@ point container_base::calculate_best_size() const
 
 	point result(grid_.get_best_size());
 	const point border_size = border_space();
-	const point minimum_size = get_config_minimum_size();
+	const point default_size = get_config_default_size();
 
 	// If the best size has a value of 0 it's means no limit so don't
 	// add the border_size might set a very small best size.
 	if(result.x) {
 		result.x += border_size.x;
 	}
-	if(minimum_size.x != 0 && result.x < minimum_size.x) {
-		result.x = minimum_size.x;
+	if(default_size.x != 0 && result.x < default_size.x) {
+		result.x = default_size.x;
 	}
 
 	if(result.y) {
 		result.y += border_size.y;
 	}
-	if(minimum_size.y != 0 && result.y < minimum_size.y) {
-		result.y = minimum_size.y;
+	if(default_size.y != 0 && result.y < default_size.y) {
+		result.y = default_size.y;
 	}
 
 

--- a/src/gui/widgets/container_base.cpp
+++ b/src/gui/widgets/container_base.cpp
@@ -18,6 +18,8 @@
 
 #include "gui/core/log.hpp"
 
+#include <algorithm>
+
 #define LOG_SCOPE_HEADER                                                       \
 	"tcontainer(" + get_control_type() + ") [" + id() + "] " + __func__
 #define LOG_HEADER LOG_SCOPE_HEADER + ':'
@@ -40,12 +42,34 @@ void container_base::layout_initialise(const bool full_initialisation)
 
 void container_base::reduce_width(const unsigned maximum_width)
 {
-	grid_.reduce_width(maximum_width - border_space().x);
+	point size = get_best_size();
+	point grid_size = grid_.get_best_size();
+	if(static_cast<int>(maximum_width) - border_space().x < grid_size.x) {
+		grid_.reduce_width(maximum_width - border_space().x);
+		grid_size = grid_.get_best_size();
+		size.x = grid_size.x + border_space().x;
+		size.y = std::max(size.y, grid_size.y + border_space().y);
+	} else {
+		size.x = maximum_width;
+	}
+
+	set_layout_size(size);
 }
 
 void container_base::request_reduce_width(const unsigned maximum_width)
 {
-	grid_.request_reduce_width(maximum_width - border_space().x);
+	point size = get_best_size();
+	point grid_size = grid_.get_best_size();
+	if(static_cast<int>(maximum_width) - border_space().x < grid_size.x) {
+		grid_.request_reduce_width(maximum_width - border_space().x);
+		grid_size = grid_.get_best_size();
+		size.x = grid_size.x + border_space().x;
+		size.y = std::max(size.y, grid_size.y + border_space().y);
+	} else {
+		size.x = maximum_width;
+	}
+
+	set_layout_size(size);
 }
 
 void container_base::demand_reduce_width(const unsigned maximum_width)
@@ -55,12 +79,32 @@ void container_base::demand_reduce_width(const unsigned maximum_width)
 
 void container_base::reduce_height(const unsigned maximum_height)
 {
-	grid_.reduce_height(maximum_height - border_space().y);
+	point size = get_best_size();
+	point grid_size = grid_.get_best_size();
+	if(static_cast<int>(maximum_height) - border_space().y < grid_size.y) {
+		grid_.reduce_height(maximum_height - border_space().y);
+		grid_size = grid_.get_best_size();
+		size.y = grid_size.y + border_space().y;
+	} else {
+		size.y = maximum_height;
+	}
+
+	set_layout_size(size);
 }
 
 void container_base::request_reduce_height(const unsigned maximum_height)
 {
-	grid_.request_reduce_height(maximum_height - border_space().y);
+	point size = get_best_size();
+	point grid_size = grid_.get_best_size();
+	if(static_cast<int>(maximum_height) - border_space().y < grid_size.y) {
+		grid_.request_reduce_height(maximum_height - border_space().y);
+		grid_size = grid_.get_best_size();
+		size.y = grid_size.y + border_space().y;
+	} else {
+		size.y = maximum_height;
+	}
+
+	set_layout_size(size);
 }
 
 void container_base::demand_reduce_height(const unsigned maximum_height)


### PR DESCRIPTION
Composite widgets, i.e. widgets which inherit container_base, such as the unit preview pane, can have an explicit minimum size set in their definition. The widget will request either that size or however much space the child widgets want, whichever is higher.

If an explicit minimum size is set, the composite widget can't shrink below that size even if there isn't enough space. That limitation has annoyed at least @Vultraz : he wants to specify a minimum size for the unit preview pane but still allow it to shrink below that size before scrollbars show up.

This commit implements ability for composite widgets to shrink below the explicit minimum size, if set. I tested it locally: I set the minimum width of unit preview pane to 1000 pixels by editing [this line](https://github.com/wesnoth/wesnoth/blob/f5e0d38f02e2eb21529b4e5babfccb80b1e7680c/data/gui/widget/unit_preview_pane.cfg#L386). After that, the pane took all available space up to 1000 pixels, but if that much space wasn't available, it shrunk instead of causing a scrollbar to appear.