### PR TITLE
Stop replacing listboxes with panes with --new-widgets

### DIFF
--- a/src/gui/widgets/listbox.cpp
+++ b/src/gui/widgets/listbox.cpp
@@ -979,34 +979,6 @@ widget* builder_listbox::build() const
 	}
 	return widget;
 #else
-	if(new_widgets) {
-
-		pane* p = new pane(list_builder);
-		p->set_id(id);
-
-
-		grid* g = new grid();
-		g->set_rows_cols(1, 1);
-#if 0
-		g->set_child(
-				  p
-				, 0
-				, 0
-				, grid::VERTICAL_GROW_SEND_TO_CLIENT
-					| grid::HORIZONTAL_GROW_SEND_TO_CLIENT
-				, grid::BORDER_ALL);
-#else
-		viewport* view = new viewport(*p);
-		g->set_child(view,
-						0,
-						0,
-						grid::VERTICAL_GROW_SEND_TO_CLIENT
-						| grid::HORIZONTAL_GROW_SEND_TO_CLIENT,
-						grid::BORDER_ALL);
-#endif
-		return g;
-	}
-
 	listbox* widget
 			= new listbox(has_minimum_, has_maximum_, generator_base::vertical_list, true);
 


### PR DESCRIPTION
I don't see the point of such a change. More important, it breaks all dialogs which search a listbox with `find_widget<listbox>()` and don't have a separate code path for `--new-widgets`, such as the new add-on manager. In particular, testing the new add-on manager without code changes is impossible because it is disabled without `--new-widgets` and fails to find the add-on list with it.

Besides, list boxes have been improved over the years with useful features such as an easy way to register sortable columns (commit a30d816ac7995ca6a2382de2268e765b9292f7ee). Writing pane codepaths for all the places where those features are used would be significant effort for no benefit.
