### PR TITLE
Fix the unit portrait being displayed with only second_image is provided

### DIFF
--- a/data/lua/wml/message.lua
+++ b/data/lua/wml/message.lua
@@ -12,7 +12,7 @@ local function get_image(cfg, speaker)
 	local image = cfg.image
 	local left_side = true
 
-	if speaker and (image == nil or image == "") then
+	if speaker and (image == nil or image == "") and (cfg.second_image == nil or cfg.second_image == "") then
 		image = speaker.portrait
 	end
 


### PR DESCRIPTION
Currently, if only second_image is provided, the unit portrait gets displayed as well.