### PR TITLE
Use core strings in campaigns

### DIFF
--- a/data/campaigns/Dead_Water/units/Brawler.cfg
+++ b/data/campaigns/Dead_Water/units/Brawler.cfg
@@ -19,6 +19,7 @@
     {DEFENSE_ANIM "units/merfolk/brawler-defend.png" "units/merfolk/brawler-defend.png" mermen-hit.wav }
     [attack]
         name=fist-merman
+        #textdomain wesnoth-units
         description=_"fist"
         type=impact
         range=melee
@@ -28,6 +29,7 @@
     [attack]
         name=tail-merman
         description=_"tail"
+        #textdomain wesnoth-dw
         type=impact
         range=melee
         damage=9

--- a/data/campaigns/Dead_Water/units/Citizen.cfg
+++ b/data/campaigns/Dead_Water/units/Citizen.cfg
@@ -19,7 +19,9 @@
     {DEFENSE_ANIM "units/merfolk/citizen-defend.png" "units/merfolk/citizen-defend.png" mermen-hit.wav }
     [attack]
         name=fist-merman
+        #textdomain wesnoth-units
         description=_"fist"
+        #textdomain wesnoth-dw
         type=impact
         range=melee
         damage=4

--- a/data/campaigns/Dead_Water/units/Kraken.cfg
+++ b/data/campaigns/Dead_Water/units/Kraken.cfg
@@ -27,6 +27,7 @@
     {DEFENSE_ANIM_DIRECTIONAL_RANGE "units/monsters/kraken-defend.png" "units/monsters/kraken.png" "units/monsters/kraken-defend.png" "units/monsters/kraken.png" squishy-hit.wav ranged}
     [attack]
         name=tentacle
+        #textdomain wesnoth-units
         description=_"tentacle"
         type=impact
         range=melee
@@ -39,6 +40,7 @@
     [attack]
         name=ink
         description=_"ink"
+        #textdomain wesnoth-dw
         type=pierce
         range=ranged
         damage=8

--- a/data/campaigns/Dead_Water/units/Soldier_King.cfg
+++ b/data/campaigns/Dead_Water/units/Soldier_King.cfg
@@ -32,7 +32,9 @@
     [/resistance]
     [attack]
         name=mace-spiked
+        #textdomain wesnoth-units
         description=_"mace"
+        #textdomain wesnoth-dw
         type=impact
         range=melee
         damage=8

--- a/data/campaigns/Dead_Water/units/Warrior_King.cfg
+++ b/data/campaigns/Dead_Water/units/Warrior_King.cfg
@@ -33,7 +33,9 @@
     [/resistance]
     [attack]
         name=mace-spiked
+        #textdomain wesnoth-units
         description=_"mace"
+        #textdomain wesnoth-dw
         type=impact
         range=melee
         damage=9

--- a/data/campaigns/Dead_Water/units/Young_King.cfg
+++ b/data/campaigns/Dead_Water/units/Young_King.cfg
@@ -28,7 +28,9 @@
     #     {DEFENSE_ANIM "units/merfolk/young_king-defend.png" "units/merfolk/young_king.png" mermen-hit.wav }
     [attack]
         name=mace
+        #textdomain wesnoth-units
         description=_"mace"
+        #textdomain wesnoth-dw
         type=impact
         range=melee
         damage=7

--- a/data/campaigns/Delfadors_Memoirs/units/Mage_Commander.cfg
+++ b/data/campaigns/Delfadors_Memoirs/units/Mage_Commander.cfg
@@ -17,7 +17,9 @@
     [attack]
         icon=attacks/staff-magic.png
         name=staff
+        #textdomain wesnoth-units
         description=_"staff"
+        #textdomain wesnoth-dm
         type=impact
         range=melee
         damage=6 # one less than arch mage

--- a/data/campaigns/Delfadors_Memoirs/units/Mage_Leader.cfg
+++ b/data/campaigns/Delfadors_Memoirs/units/Mage_Leader.cfg
@@ -15,7 +15,9 @@
     description=_"This mage has gained some experience leading others into battle. As a result, level 1 units fight more effectively when they are adjacent to him." +{SPECIAL_NOTES}+{SPECIAL_NOTES_MAGICAL}+{SPECIAL_NOTES_LEADERSHIP}
     [attack]
         name=staff
+        #textdomain wesnoth-units
         description=_"staff"
+        #textdomain wesnoth-dm
         icon=attacks/staff-magic.png
         type=impact
         range=melee

--- a/data/campaigns/Delfadors_Memoirs/units/Mage_Magister.cfg
+++ b/data/campaigns/Delfadors_Memoirs/units/Mage_Magister.cfg
@@ -20,7 +20,9 @@
     [attack]
         icon=attacks/staff-magic.png
         name=staff
+        #textdomain wesnoth-units
         description=_"staff"
+        #textdomain wesnoth-dm
         type=impact
         range=melee
         damage=10		# 1 more than Great Mage, 2 more than Elder Mage

--- a/data/campaigns/Delfadors_Memoirs/units/Wose_Shaman.cfg
+++ b/data/campaigns/Delfadors_Memoirs/units/Wose_Shaman.cfg
@@ -29,6 +29,7 @@
     description=_"These woses are able to command forest plants such as vines and creepers to hinder their enemies."+{SPECIAL_NOTES}+{SPECIAL_NOTES_AMBUSH}+{SPECIAL_NOTES_REGENERATES}+{SPECIAL_NOTES_SLOW}
     [attack]
         name=crush
+        #textdomain wesnoth-units
         description=_"crush"
         type=impact
         range=melee
@@ -39,6 +40,7 @@
     [attack]
         name=entangle
         description=_"entangle"
+        #textdomain wesnoth-dm
         type=impact
         [specials]
             {WEAPON_SPECIAL_SLOW}

--- a/data/campaigns/Delfadors_Memoirs/utils/items.cfg
+++ b/data/campaigns/Delfadors_Memoirs/utils/items.cfg
@@ -67,8 +67,10 @@
 
             [effect]
                 apply_to=new_attack
-                name="lightning"
+                name=lightning
+                #textdomain wesnoth-units
                 description=_"lightning"
+                #textdomain wesnoth-dm
                 icon=attacks/lightning.png
                 type=fire
                 range=ranged

--- a/data/campaigns/Descent_Into_Darkness/units/Apprentice_Mage.cfg
+++ b/data/campaigns/Descent_Into_Darkness/units/Apprentice_Mage.cfg
@@ -19,7 +19,9 @@
     die_sound={SOUND_LIST:HUMAN_DIE}
     [attack]
         name=short sword
+        #textdomain wesnoth-units
         description=_ "short sword"
+        #textdomain wesnoth-did
         icon=attacks/sword-human-short.png
         type=blade
         range=melee

--- a/data/campaigns/Descent_Into_Darkness/units/Apprentice_Necromancer.cfg
+++ b/data/campaigns/Descent_Into_Darkness/units/Apprentice_Necromancer.cfg
@@ -18,6 +18,7 @@
     die_sound={SOUND_LIST:HUMAN_DIE}
     [attack]
         name=short sword
+        #textdomain wesnoth-units
         description=_ "short sword"
         icon=attacks/sword-human-short.png
         type=blade
@@ -40,6 +41,7 @@
     [attack]
         name=shadow wave
         description=_"shadow wave"
+        #textdomain wesnoth-did
         type=arcane
         [specials]
             {WEAPON_SPECIAL_MAGICAL}

--- a/data/campaigns/Descent_Into_Darkness/units/Dark_Mage.cfg
+++ b/data/campaigns/Descent_Into_Darkness/units/Dark_Mage.cfg
@@ -19,6 +19,7 @@
     {DEFENSE_ANIM "units/dark-mage-defend.png" "units/dark-mage.png" {SOUND_LIST:HUMAN_HIT} }
     [attack]
         name=short sword
+        #textdomain wesnoth-units
         description=_ "short sword"
         icon=attacks/sword-human-short.png
         type=blade
@@ -44,6 +45,7 @@
     [attack]
         name=shadow wave
         description=_"shadow wave"
+        #textdomain wesnoth-did
         type=arcane
         [specials]
             {WEAPON_SPECIAL_MAGICAL}

--- a/data/campaigns/Descent_Into_Darkness/units/Frontier_Baroness.cfg
+++ b/data/campaigns/Descent_Into_Darkness/units/Frontier_Baroness.cfg
@@ -60,6 +60,7 @@
     [/defend]
     [attack]
         name=staff
+        #textdomain wesnoth-units
         description= _"staff"
         type=impact
         range=melee
@@ -70,6 +71,7 @@
     [attack]
         name=sling
         description= _"sling"
+        #textdomain wesnoth-did
         type=impact
         range=ranged
         damage=6

--- a/data/campaigns/Eastern_Invasion/units/Bone_Knight.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Bone_Knight.cfg
@@ -27,7 +27,9 @@
     die_sound=skeleton-big-die.ogg
     [attack]
         name=axe
+        #textdomain wesnoth-units
         description=_"axe"
+        #textdomain wesnoth-ei
         type=blade
         range=melee
         damage=8
@@ -35,7 +37,7 @@
     [/attack]
     [attack]
         name=trample
-        icon="attacks/blank-attack.png"
+        icon=attacks/blank-attack.png
         description=_"trample"
         type=impact
         range=melee

--- a/data/campaigns/Eastern_Invasion/units/Horse_Lord.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Horse_Lord.cfg
@@ -29,8 +29,8 @@
         number=4
     [/attack]
     [attack]
-        name=morning star
-        description= _"morning star"
+        name=flail
+        description= _"flail"
         #textdomain wesnoth-ei
         type=impact
         range=melee
@@ -43,7 +43,7 @@
     [/attack]
     [attack_anim]
         [filter_attack]
-            name=morning star
+            name=flail
         [/filter_attack]
         start_time=-300
         [frame]

--- a/data/campaigns/Eastern_Invasion/units/Horse_Lord.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Horse_Lord.cfg
@@ -20,6 +20,7 @@
     die_sound=horse-die.ogg
     [attack]
         name=greatsword
+        #textdomain wesnoth-units
         description= _"greatsword"
         type=blade
         icon=attacks/greatsword-human.png
@@ -30,6 +31,7 @@
     [attack]
         name=morning star
         description= _"morning star"
+        #textdomain wesnoth-ei
         type=impact
         range=melee
         damage=18

--- a/data/campaigns/Eastern_Invasion/units/Mounted_Fighter.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Mounted_Fighter.cfg
@@ -19,6 +19,7 @@
     die_sound=horse-die.ogg
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
         icon=attacks/sword-human.png
         type=blade
@@ -29,6 +30,7 @@
     [attack]
         name=morning star
         description= _"morning star"
+        #textdomain wesnoth-ei
         type=impact
         range=melee
         damage=9

--- a/data/campaigns/Eastern_Invasion/units/Mounted_Fighter.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Mounted_Fighter.cfg
@@ -28,8 +28,8 @@
         number=3
     [/attack]
     [attack]
-        name=morning star
-        description= _"morning star"
+        name=flail
+        description= _"flail"
         #textdomain wesnoth-ei
         type=impact
         range=melee
@@ -39,7 +39,7 @@
     [/attack]
     [attack_anim]
         [filter_attack]
-            name=morning star
+            name=flail
         [/filter_attack]
         start_time=-300
         [frame]

--- a/data/campaigns/Eastern_Invasion/units/Mounted_Warrior.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Mounted_Warrior.cfg
@@ -28,8 +28,8 @@
         number=4
     [/attack]
     [attack]
-        name=morning star
-        description= _"morning star"
+        name=flail
+        description= _"flail"
         #textdomain wesnoth-ei
         type=impact
         range=melee
@@ -42,7 +42,7 @@
     [/attack]
     [attack_anim]
         [filter_attack]
-            name=morning star
+            name=flail
         [/filter_attack]
         start_time=-300
         [frame]

--- a/data/campaigns/Eastern_Invasion/units/Mounted_Warrior.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Mounted_Warrior.cfg
@@ -19,6 +19,7 @@
     die_sound=horse-die.ogg
     [attack]
         name=greatsword
+        #textdomain wesnoth-units
         description= _"greatsword"
         icon=attacks/greatsword-human.png
         type=blade
@@ -29,6 +30,7 @@
     [attack]
         name=morning star
         description= _"morning star"
+        #textdomain wesnoth-ei
         type=impact
         range=melee
         damage=12

--- a/data/campaigns/Eastern_Invasion/units/Skeleton_Rider.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Skeleton_Rider.cfg
@@ -37,7 +37,9 @@
     [/abilities]
     [attack]
         name=axe
+        #textdomain wesnoth-units
         description= _"axe"
+        #textdomain wesnoth-ei
         type=blade
         range=melee
         damage=6

--- a/data/campaigns/Heir_To_The_Throne/scenarios/19c_Cliffs_of_Thoria.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/19c_Cliffs_of_Thoria.cfg
@@ -187,10 +187,10 @@
 
     [event]
         name=prestart
-        #For Home of the Northern Elves: where do we come from?
-        #the position where we are - impassable mountains, looking for a way out
-        #the sunk loyalist fleet with the flag of wesnoth
-        #the conversation with the drakes
+        # For Home of the Northern Elves: where do we come from?
+        # the position where we are - impassable mountains, looking for a way out
+        # the sunk loyalist fleet with the flag of wesnoth
+        # the conversation with the drakes
         [set_variable]
             name=A_Choice_Was_Made
             value=c
@@ -340,8 +340,8 @@
         [/message]
         [message]
             role=merman-advisor
-            #po: Yes, "Eastern Shore" is correct. Mermen are water-oriented;
-            #po: it's the eastern shore of the Great Ocean.
+            # po: Yes, "Eastern Shore" is correct. Mermen are water-oriented;
+            # po: it's the eastern shore of the Great Ocean.
             message= _ "I was born in the Bay of Pearls and spent my entire life on the Eastern Shore. But I have spoken with those who have traveled the Western Ocean and met drakes on their journeys. Therefore, I am certain beyond doubt that the creature flying in front of us is a drake, Delfador. Concerning the drakes having never been seen in Wesnoth, must I remind you that we are not in Wesnoth anymore? There are many unthinkable things and creatures which can be found outside of Wesnoth."
         [/message]
         [message]
@@ -359,11 +359,11 @@
         [/message]
         [message]
             speaker=Keh Ohn
-            #wmllint: display on
+            # wmllint: display on
             # wmllint: local spelling Soooo
             message= _ "(releasing a torrent of fire towards Konrad and Li’sar)
 Soooo... It is you who sent your subordinates to attack us. Now when we’ve destroyed them, you come to do the job yourselves."
-            #wmllint: display off
+            # wmllint: display off
         [/message]
         [message]
             speaker=Konrad

--- a/data/campaigns/Heir_To_The_Throne/units/Battle_Princess.cfg
+++ b/data/campaigns/Heir_To_The_Throne/units/Battle_Princess.cfg
@@ -28,7 +28,9 @@
     die_sound={SOUND_LIST:HUMAN_FEMALE_DIE}
     [attack]
         name=saber
+        #textdomain wesnoth-units
         description= _"saber"
+        #textdomain wesnoth-httt
         icon=attacks/saber-human.png
         type=blade
         range=melee
@@ -123,7 +125,9 @@
         die_sound={SOUND_LIST:HUMAN_FEMALE_DIE}
         [attack]
             name=saber
+            #textdomain wesnoth-units
             description= _"saber"
+            #textdomain wesnoth-httt
             icon=attacks/saber-human.png
             type=blade
             range=melee

--- a/data/campaigns/Heir_To_The_Throne/units/Commander.cfg
+++ b/data/campaigns/Heir_To_The_Throne/units/Commander.cfg
@@ -20,6 +20,7 @@
     {DEFENSE_ANIM_RANGE "units/konrad-commander{AFFIX}-defend.png" "units/konrad-commander{AFFIX}.png" {SOUND_LIST:HUMAN_HIT} melee}
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
         icon=attacks/sword-human.png
         type=blade
@@ -30,6 +31,7 @@
     [attack]
         name=bow
         description= _"bow"
+        #textdomain wesnoth-httt
         type=pierce
         range=ranged
         damage=6

--- a/data/campaigns/Heir_To_The_Throne/units/Fighter.cfg
+++ b/data/campaigns/Heir_To_The_Throne/units/Fighter.cfg
@@ -16,7 +16,9 @@
     die_sound={SOUND_LIST:HUMAN_DIE}
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
+        #textdomain wesnoth-httt
         icon=attacks/sword-human.png
         type=blade
         range=melee

--- a/data/campaigns/Heir_To_The_Throne/units/Lord.cfg
+++ b/data/campaigns/Heir_To_The_Throne/units/Lord.cfg
@@ -21,6 +21,7 @@
     {DEFENSE_ANIM_RANGE "units/konrad-lord{AFFIX}-defend.png" "units/konrad-lord{AFFIX}-attack-w1.png" {SOUND_LIST:HUMAN_HIT} melee}
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
         icon=attacks/greatsword-human.png
         type=blade
@@ -31,6 +32,7 @@
     [attack]
         name=bow
         description= _"bow"
+        #textdomain wesnoth-httt
         icon=attacks/bow-elven.png
         type=pierce
         range=ranged

--- a/data/campaigns/Heir_To_The_Throne/units/Princess.cfg
+++ b/data/campaigns/Heir_To_The_Throne/units/Princess.cfg
@@ -28,7 +28,9 @@
     die_sound={SOUND_LIST:HUMAN_FEMALE_DIE}
     [attack]
         name=saber
+        #textdomain wesnoth-units
         description= _"saber"
+        #textdomain wesnoth-httt
         icon=attacks/saber-human.png
         type=blade
         range=melee
@@ -80,7 +82,9 @@
         die_sound={SOUND_LIST:HUMAN_FEMALE_DIE}
         [attack]
             name=saber
+            #textdomain wesnoth-units
             description= _"saber"
+            #textdomain wesnoth-httt
             icon=attacks/saber-human.png
             type=blade
             range=melee

--- a/data/campaigns/Heir_To_The_Throne/units/Sea_Orc.cfg
+++ b/data/campaigns/Heir_To_The_Throne/units/Sea_Orc.cfg
@@ -12,7 +12,7 @@
     [/standing_anim]
     [standing_anim]
         start_time=-350
-        terrain_type=!,*^B*,!,Chs^*,Chw^*,W*^*,S*^*,*^Vm
+        terrain_type=!,*^B*,S*^Vhs,Kme*^*,!,Km*^*,Cm*^*,Chs*^*,Chw*^*,W*^*,S*^*,*^Vm
         [frame]
             image="units/sea-orc-swim[1,2].png:[350,350]"
         [/frame]
@@ -32,7 +32,9 @@
     {DEFENSE_ANIM "units/sea-orc-defend.png" "units/sea-orc.png" {SOUND_LIST:ORC_SMALL_HIT} }
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
+        #textdomain wesnoth-httt
         icon=attacks/sword-orcish.png
         type=blade
         range=melee

--- a/data/campaigns/Heir_To_The_Throne/units/Sleeping_Gryphon.cfg
+++ b/data/campaigns/Heir_To_The_Throne/units/Sleeping_Gryphon.cfg
@@ -26,7 +26,9 @@
     [/defense]
     [attack]
         name=claws
+        #textdomain wesnoth-units
         description= _"claws"
+        #textdomain wesnoth-httt
         icon=attacks/claws-animal.png
         type=blade
         range=melee

--- a/data/campaigns/Liberty/units/Bone_Knight.cfg
+++ b/data/campaigns/Liberty/units/Bone_Knight.cfg
@@ -27,7 +27,9 @@
     die_sound=skeleton-big-die.ogg
     [attack]
         name=axe
+        #textdomain wesnoth-units
         description=_"axe"
+        #textdomain wesnoth-l
         type=blade
         range=melee
         damage=8

--- a/data/campaigns/Liberty/units/Death_Squire.cfg
+++ b/data/campaigns/Liberty/units/Death_Squire.cfg
@@ -28,7 +28,9 @@
     die_sound={SOUND_LIST:SKELETON_DIE}
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description=_"sword"
+        #textdomain wesnoth-l
         type=blade
         range=melee
         damage=8

--- a/data/campaigns/Liberty/units/Rogue_Mage.cfg
+++ b/data/campaigns/Liberty/units/Rogue_Mage.cfg
@@ -4,7 +4,6 @@
     id=Rogue Mage
     name= _ "Rogue Mage"
     race=human
-    gender=male
     image="units/human-outlaws/rogue-mage.png"
     hitpoints=30
     movement_type=smallfoot
@@ -20,7 +19,9 @@
     die_sound={SOUND_LIST:HUMAN_DIE}
     [attack]
         name=short sword
+        #textdomain wesnoth-units
         description= _ "short sword"
+        #textdomain wesnoth-l
         icon=attacks/sword-human-short.png
         type=blade
         range=melee

--- a/data/campaigns/Liberty/units/Shadow_Lord.cfg
+++ b/data/campaigns/Liberty/units/Shadow_Lord.cfg
@@ -4,7 +4,6 @@
     id=Shadow Lord
     name= _ "Shadow Lord"
     race=human
-    gender=male
     image="units/human-outlaws/shadow-lord.png"
     hitpoints=53
     [abilities]

--- a/data/campaigns/Liberty/units/Shadow_Mage.cfg
+++ b/data/campaigns/Liberty/units/Shadow_Mage.cfg
@@ -4,7 +4,6 @@
     id=Shadow Mage
     name= _ "Shadow Mage"
     race=human
-    gender=male
     image="units/human-outlaws/shadow-mage.png"
     hitpoints=42
     [abilities]
@@ -29,7 +28,9 @@
     {DEFENSE_ANIM "units/human-outlaws/shadow-mage-defend2.png" "units/human-outlaws/shadow-mage-defend1.png" {SOUND_LIST:HUMAN_OLD_HIT} }
     [attack]
         name=short sword
+        #textdomain wesnoth-units
         description= _ "short sword"
+        #textdomain wesnoth-l
         icon=attacks/sword-human-short.png
         type=blade
         range=melee

--- a/data/campaigns/Liberty/units/Skeleton_Rider.cfg
+++ b/data/campaigns/Liberty/units/Skeleton_Rider.cfg
@@ -37,7 +37,9 @@
     [/abilities]
     [attack]
         name=axe
+        #textdomain wesnoth-units
         description= _"axe"
+        #textdomain wesnoth-l
         type=blade
         range=melee
         damage=6

--- a/data/campaigns/Sceptre_of_Fire/units/Haldric_II.cfg
+++ b/data/campaigns/Sceptre_of_Fire/units/Haldric_II.cfg
@@ -22,7 +22,9 @@
     {DEFENSE_ANIM "units/heroes/haldric-ii-defend.png" "units/heroes/haldric-ii.png" {SOUND_LIST:HUMAN_HIT} }
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
+        #textdomain wesnoth-sof
         type=blade
         range=melee
         damage=9

--- a/data/campaigns/Secrets_of_the_Ancients/units/Bone_Captain.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/units/Bone_Captain.cfg
@@ -32,6 +32,7 @@
         name=saber
         #textdomain wesnoth-units
         description=_"saber"
+        #textdomain wesnoth-sota
         type=blade
         range=melee
         damage=7

--- a/data/campaigns/Secrets_of_the_Ancients/units/Delinquent.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/units/Delinquent.cfg
@@ -34,6 +34,7 @@
     [attack]
         name=sling
         description=_"sling"
+        #textdomain wesnoth-sota
         type=impact
         range=ranged
         damage=2

--- a/data/campaigns/Secrets_of_the_Ancients/units/Necro_Ancient_Lich.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/units/Necro_Ancient_Lich.cfg
@@ -52,6 +52,7 @@
     [attack]
         name=shadow wave
         description=_"shadow wave"
+        #textdomain wesnoth-sota
         type=arcane
         [specials]
             {WEAPON_SPECIAL_MAGICAL}

--- a/data/campaigns/Secrets_of_the_Ancients/units/Orcish_Shaman.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/units/Orcish_Shaman.cfg
@@ -34,6 +34,7 @@
     [attack]
         name=curse
         description= _"curse"
+        #textdomain wesnoth-sota
         type=pierce
         range=ranged
         damage=8

--- a/data/campaigns/Secrets_of_the_Ancients/units/Sailor.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/units/Sailor.cfg
@@ -21,6 +21,7 @@
         name=saber
         #textdomain wesnoth-units
         description=_"saber"
+        #textdomain wesnoth-sota
         type=blade
         range=melee
         damage=7

--- a/data/campaigns/Secrets_of_the_Ancients/units/Sea_Captain.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/units/Sea_Captain.cfg
@@ -24,6 +24,7 @@
         name=saber
         #textdomain wesnoth-units
         description=_"saber"
+        #textdomain wesnoth-sota
         type=blade
         range=melee
         damage=7

--- a/data/campaigns/Son_Of_The_Black_Eye/units/Novice_Orcish_Shaman.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/units/Novice_Orcish_Shaman.cfg
@@ -22,6 +22,7 @@
     {DEFENSE_ANIM "units/novice-orcish-shaman-defend-2.png" "units/novice-orcish-shaman-defend-1.png" {SOUND_LIST:ORC_HIT} }
     [attack]
         name=staff
+        #textdomain wesnoth-units
         description= _"staff"
         type=impact
         range=melee
@@ -32,6 +33,7 @@
     [attack]
         name=curse
         description= _"curse"
+        #textdomain wesnoth-sotbe
         type=pierce
         range=ranged
         damage=7

--- a/data/campaigns/Son_Of_The_Black_Eye/units/Old_Orcish_Shaman.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/units/Old_Orcish_Shaman.cfg
@@ -22,6 +22,7 @@
     {DEFENSE_ANIM "units/elder-orcish-shaman-defend-2.png" "units/elder-orcish-shaman-defend-1.png" {SOUND_LIST:ORC_HIT} }
     [attack]
         name=staff
+        #textdomain wesnoth-units
         description= _"staff"
         type=impact
         range=melee
@@ -32,6 +33,7 @@
     [attack]
         name=curse
         description= _"curse"
+        #textdomain wesnoth-sotbe
         type=pierce
         range=ranged
         damage=9

--- a/data/campaigns/Son_Of_The_Black_Eye/units/Orcish_Shaman.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/units/Orcish_Shaman.cfg
@@ -22,6 +22,7 @@
     {DEFENSE_ANIM "units/orcish-shaman-defend-2.png" "units/orcish-shaman-defend-1.png" {SOUND_LIST:ORC_HIT} }
     [attack]
         name=staff
+        #textdomain wesnoth-units
         description= _"staff"
         type=impact
         range=melee
@@ -32,6 +33,7 @@
     [attack]
         name=curse
         description= _"curse"
+        #textdomain wesnoth-sotbe
         type=pierce
         range=ranged
         damage=8

--- a/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Rune_Lord.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Rune_Lord.cfg
@@ -30,6 +30,7 @@
     [attack]
         name=hammer
         description= _"hammer"
+        #textdomain wesnoth-thot
         icon=attacks/hammer-dwarven-runic.png
         type=impact
         [specials]
@@ -74,6 +75,7 @@
     id=Undead Dwarvish Rune Lord
     hide_help=no
     do_not_list=no
+    #textdomain wesnoth-units
     description= _ "Except for those with almost supernatural skill, the highest rank a runecrafter can rise to is that of the Dwarvish Runemaster. Striking blows nearly as powerful as those of the best warriors, they would be fearsome without their craft, but with it they are also nigh on invincible, since their runes cause the physical blows of their enemies to deal less damage than would be expected."+{SPECIAL_NOTES}+{SPECIAL_NOTES_MAGICAL}+{SPECIAL_NOTES_ARCANE}
     {DEFENSE_ANIM "units/karrag-defend.png" "units/karrag.png" {SOUND_LIST:LICH_HIT} }
     die_sound=lich-die.ogg
@@ -97,6 +99,7 @@
     [attack]
         name=shadow wave
         description=_"shadow wave"
+        #textdomain wesnoth-thot
         type=arcane
         [specials]
             {WEAPON_SPECIAL_MAGICAL}

--- a/data/campaigns/The_Rise_Of_Wesnoth/units/Autumn_Shyde.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/units/Autumn_Shyde.cfg
@@ -3,6 +3,7 @@
     id=Autumn Shyde
     #textdomain wesnoth-units
     name= _ "female^Elvish Shyde"
+    #textdomain wesnoth-trow
     race=elf
     gender=female
     image="units/autumn-shyde.png"
@@ -15,6 +16,7 @@
     level=3
     alignment=neutral
     advances_to=null
+    {AMLA_DEFAULT}
     cost=52
     usage=healer
     hide_help=yes

--- a/data/campaigns/The_Rise_Of_Wesnoth/units/Familiar.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/units/Familiar.cfg
@@ -29,7 +29,9 @@
 
     [attack]
         name=bite
+        #textdomain wesnoth-units
         description= _"bite"
+        #textdomain wesnoth-trow
         icon=attacks/fangs-animal.png
         type=blade
         range=melee

--- a/data/campaigns/The_Rise_Of_Wesnoth/units/Noble_Commander.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/units/Noble_Commander.cfg
@@ -23,6 +23,7 @@
     {DEFENSE_ANIM_RANGE "units/noble-commander-bow-defend.png" "units/noble-commander-bow.png" {SOUND_LIST:HUMAN_HIT} ranged}
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
         type=blade
         range=melee
@@ -33,6 +34,7 @@
     [attack]
         name=bow
         description= _"bow"
+        #textdomain wesnoth-trow
         type=pierce
         range=ranged
         damage=6

--- a/data/campaigns/The_Rise_Of_Wesnoth/units/Noble_Fighter.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/units/Noble_Fighter.cfg
@@ -19,7 +19,9 @@
     die_sound={SOUND_LIST:HUMAN_DIE}
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
+        #textdomain wesnoth-trow
         type=blade
         range=melee
         damage=7

--- a/data/campaigns/The_Rise_Of_Wesnoth/units/Noble_Lord.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/units/Noble_Lord.cfg
@@ -24,6 +24,7 @@
     {DEFENSE_ANIM_RANGE "units/noble-lord-bow-defend.png" "units/noble-lord-bow.png" {SOUND_LIST:HUMAN_HIT} ranged}
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
         type=blade
         icon=attacks/greatsword-human.png
@@ -34,6 +35,7 @@
     [attack]
         name=bow
         description= _"bow"
+        #textdomain wesnoth-trow
         type=pierce
         range=ranged
         damage=8

--- a/data/campaigns/The_Rise_Of_Wesnoth/units/Vampire_Lady.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/units/Vampire_Lady.cfg
@@ -32,7 +32,9 @@
     [/attack]
     [attack]
         name=curse
+        #textdomain wesnoth-units
         description= _"curse"
+        #textdomain wesnoth-trow
         icon=attacks/wail.png
         type=pierce
         range=ranged

--- a/data/campaigns/The_Rise_Of_Wesnoth/units/Wesfolk_Lady.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/units/Wesfolk_Lady.cfg
@@ -60,6 +60,7 @@
     [/leading_anim]
     [attack]
         name=staff
+        #textdomain wesnoth-units
         description=_"staff"
         icon=attacks/quarterstaff.png
         type=impact
@@ -70,6 +71,7 @@
     [attack]
         name=sling
         description=_"sling"
+        #textdomain wesnoth-trow
         type=impact
         range=ranged
         damage=6

--- a/data/campaigns/The_Rise_Of_Wesnoth/units/Wesfolk_Leader.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/units/Wesfolk_Leader.cfg
@@ -61,6 +61,7 @@
     [/leading_anim]
     [attack]
         name=staff
+        #textdomain wesnoth-units
         description= _ "staff"
         icon=attacks/quarterstaff.png
         type=impact
@@ -71,6 +72,7 @@
     [attack]
         name=sling
         description= _ "sling"
+        #textdomain wesnoth-trow
         type=impact
         range=ranged
         damage=8

--- a/data/campaigns/The_Rise_Of_Wesnoth/units/Wesfolk_Outcast.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/units/Wesfolk_Outcast.cfg
@@ -60,6 +60,7 @@
     [/leading_anim]
     [attack]
         name=staff
+        #textdomain wesnoth-units
         description=_"staff"
         icon=attacks/quarterstaff.png
         type=impact
@@ -70,6 +71,7 @@
     [attack]
         name=sling
         description=_"sling"
+        #textdomain wesnoth-trow
         type=impact
         range=ranged
         damage=4

--- a/data/campaigns/The_South_Guard/units/Horseman_Commander.cfg
+++ b/data/campaigns/The_South_Guard/units/Horseman_Commander.cfg
@@ -27,6 +27,7 @@
     die_sound=horse-die.ogg
     [attack]
         name=lance
+        #textdomain wesnoth-units
         description= _"lance"
         type=pierce
         [specials]
@@ -39,6 +40,7 @@
     [attack]
         name=mace
         description= _"mace"
+        #textdomain wesnoth-tsg
         type=impact
         range=melee
         damage=13

--- a/data/campaigns/The_South_Guard/units/Infantry_Commander.cfg
+++ b/data/campaigns/The_South_Guard/units/Infantry_Commander.cfg
@@ -36,7 +36,9 @@
     [/attack]
     [attack]
         name=shield
-        description= _"shield"
+        #textdomain wesnoth-units
+        description= _"shield bash"
+        #textdomain wesnoth-tsg
         type=impact
         range=melee
         damage=10

--- a/data/campaigns/The_South_Guard/units/Junior_Commander.cfg
+++ b/data/campaigns/The_South_Guard/units/Junior_Commander.cfg
@@ -27,7 +27,9 @@
     die_sound=horse-die.ogg
     [attack]
         name=spear
+        #textdomain wesnoth-units
         description= _"spear"
+        #textdomain wesnoth-tsg
         type=pierce
         range=melee
         damage=6

--- a/data/campaigns/The_South_Guard/units/Mounted_General.cfg
+++ b/data/campaigns/The_South_Guard/units/Mounted_General.cfg
@@ -28,6 +28,7 @@
     die_sound=horse-die.ogg
     [attack]
         name=lance
+        #textdomain wesnoth-units
         description= _"lance"
         type=pierce
         [specials]
@@ -40,6 +41,7 @@
     [attack]
         name=mace
         description= _"mace"
+        #textdomain wesnoth-tsg
         type=impact
         range=melee
         damage=19

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Corrupted_Elf.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Corrupted_Elf.cfg
@@ -19,7 +19,9 @@
     {DEFENSE_ANIM "units/elves-desert/corrupted-elf-defend.png" units/elves-desert/corrupted-elf.png {SOUND_LIST:ELF_HIT} }
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
+        #textdomain wesnoth-utbs
         icon=attacks/sword-elven.png
         type=blade
         range=melee

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Archer.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Archer.cfg
@@ -36,6 +36,7 @@
     # ranged attack decreased from 5-4 to 4-4
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
         type=blade
         range=melee
@@ -46,6 +47,7 @@
     [attack]
         name=bow
         description= _"bow"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=4

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Avenger.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Avenger.cfg
@@ -31,6 +31,7 @@
     # ranged attack is decreased by 1 (10-4 to 9-4)
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
         type=blade
         range=melee
@@ -44,6 +45,7 @@
     [attack]
         name=bow
         description= _"bow"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=9

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Captain.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Captain.cfg
@@ -30,6 +30,7 @@
     # ranged attack decreased from 5-3 to 4-3
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
         type=blade
         range=melee
@@ -40,6 +41,7 @@
     [attack]
         name=bow
         description= _"bow"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=4

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Champion.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Champion.cfg
@@ -20,6 +20,7 @@
     # ranged attack decreased from 9-3 to 8-3
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
         type=blade
         range=melee
@@ -30,6 +31,7 @@
     [attack]
         name=bow
         description= _"bow"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=8

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Druid.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Druid.cfg
@@ -23,6 +23,7 @@
     # ranged attack decreased from 6-2 to 5-2 and 6-3 to 5-3
     [attack]
         name=staff
+        #textdomain wesnoth-units
         description= _"staff"
         type=impact
         range=melee
@@ -46,6 +47,7 @@
     [attack]
         name=thorns
         description= _"thorns"
+        #textdomain wesnoth-utbs
         type=pierce
         [specials]
             {WEAPON_SPECIAL_MAGICAL}

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Fighter.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Fighter.cfg
@@ -18,6 +18,7 @@
     die_sound={SOUND_LIST:ELF_HIT}
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
         type=blade
         range=melee
@@ -28,6 +29,7 @@
     [attack]
         name=bow
         description= _"bow"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=2

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Hero.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Hero.cfg
@@ -19,6 +19,7 @@
     # ranged attack decreased from 6-3 to 5-3
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
         type=blade
         range=melee
@@ -29,6 +30,7 @@
     [attack]
         name=bow
         description= _"bow"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=5

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Horseman.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Horseman.cfg
@@ -35,6 +35,7 @@
     # to make up for their other weaker mounted units
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
         type=blade
         range=melee
@@ -45,6 +46,7 @@
     [attack]
         name=bow
         description= _"bow"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=5

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Hunter.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Hunter.cfg
@@ -21,7 +21,9 @@
     {DEFENSE_ANIM_RANGE "units/elves-desert/hunter-ranged-defend.png" units/elves-desert/hunter.png {SOUND_LIST:ELF_HIT} ranged}
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
+        #textdomain wesnoth-utbs
         type=blade
         range=melee
         damage=5

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Marksman.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Marksman.cfg
@@ -19,6 +19,7 @@
     # ranged attack decreased from 9-4 to 8-4
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
         type=blade
         range=melee
@@ -29,6 +30,7 @@
     [attack]
         name=longbow
         description= _"longbow"
+        #textdomain wesnoth-utbs
         type=pierce
         [specials]
             {WEAPON_SPECIAL_MARKSMAN}

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Marshal.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Marshal.cfg
@@ -29,6 +29,7 @@
     # ranged attack decreased from 8-3 to 7-3
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
         type=blade
         range=melee
@@ -39,6 +40,7 @@
     [attack]
         name=bow
         description= _"bow"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=7

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Outrider.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Outrider.cfg
@@ -32,6 +32,7 @@
     # ranged attack decreased from 8-3 to 7-3
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
         type=blade
         range=melee
@@ -42,6 +43,7 @@
     [attack]
         name=bow
         description= _"bow"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=7

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Prowler.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Prowler.cfg
@@ -23,7 +23,9 @@
     {DEFENSE_ANIM "units/elves-desert/prowler.png" units/elves-desert/prowler.png {SOUND_LIST:ELF_HIT} }
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
+        #textdomain wesnoth-utbs
         type=blade
         range=melee
         damage=9

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Ranger.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Ranger.cfg
@@ -33,6 +33,7 @@
     # For comparison the level 2 Rogue unit has a 6,3 backstab attack
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
         type=blade
         range=melee
@@ -46,6 +47,7 @@
     [attack]
         name=bow
         description= _"bow"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=6

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Rider.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Rider.cfg
@@ -31,6 +31,7 @@
     # ranged attack decreased from 9-2 to 8-2
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
         type=blade
         range=melee
@@ -41,6 +42,7 @@
     [attack]
         name=bow
         description= _"bow"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=8

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Scout.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Scout.cfg
@@ -32,6 +32,7 @@
     # ranged attack decreased from 6-2 to 5-2
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
         type=blade
         range=melee
@@ -42,6 +43,7 @@
     [attack]
         name=bow
         description= _"bow"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=5

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Sentinel.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Sentinel.cfg
@@ -22,7 +22,9 @@
     {DEFENSE_ANIM "units/elves-desert/sentinel.png" units/elves-desert/sentinel.png {SOUND_LIST:ELF_HIT} }
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
+        #textdomain wesnoth-utbs
         icon=attacks/sword-elven.png
         type=blade
         range=melee

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Shaman.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Shaman.cfg
@@ -24,6 +24,7 @@
     # ranged attack decreased from 3-2 to 2-2
     [attack]
         name=staff
+        #textdomain wesnoth-units
         description= _"staff"
         type=impact
         range=melee
@@ -35,6 +36,7 @@
     [attack]
         name=entangle
         description= _"entangle"
+        #textdomain wesnoth-utbs
         type=impact
         range=ranged
         damage=2

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Sharpshooter.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Sharpshooter.cfg
@@ -27,6 +27,7 @@
     # exception
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
         type=blade
         range=melee
@@ -37,6 +38,7 @@
     [attack]
         name=longbow
         description= _"longbow"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=10

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Shyde.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Desert_Shyde.cfg
@@ -26,6 +26,7 @@
     # ranged attack decreased from 7-2 to 6-2 and 7-3 to 6-3
     [attack]
         name=faerie touch
+        #textdomain wesnoth-units
         description= _"faerie touch"
         type=impact
         [specials]
@@ -52,6 +53,7 @@
     [attack]
         name=thorns
         description= _"thorns"
+        #textdomain wesnoth-utbs
         type=pierce
         [specials]
             {WEAPON_SPECIAL_MAGICAL}

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Divine_Avatar.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Divine_Avatar.cfg
@@ -21,6 +21,7 @@
     die_sound=magic-holy-miss-2.ogg
     [attack]
         name=fist
+        #textdomain wesnoth-units
         description= _"fist"
         type=arcane
         range=melee
@@ -30,6 +31,7 @@
     [attack]
         name=lightbeam
         description= _"lightbeam"	# wmllint: no spellcheck (until name->id)
+        #textdomain wesnoth-utbs
         type=arcane
         range=ranged
         [specials]

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Kaleh.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Kaleh.cfg
@@ -287,7 +287,7 @@ Enemy units cannot see this unit while it is in desert dunes, desert mountains, 
                     affect_self=yes
                     [filter]
                         [filter_location]
-                            terrain=Hd,Md,Dd^Dc,Dd^Do
+                            terrain=Hd,Md,Mdd,Dd^Dc,Dd^Do
                         [/filter_location]
                     [/filter]
                 [/hides]
@@ -318,6 +318,7 @@ Enemy units cannot see this unit while it is in desert dunes, desert mountains, 
     # Melee damage increased by 1, ranged damage decreased by 1
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
         type=blade
         range=melee
@@ -328,6 +329,7 @@ Enemy units cannot see this unit while it is in desert dunes, desert mountains, 
     [attack]
         name=bow
         description= _"bow"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=2

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Nym.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Nym.cfg
@@ -18,7 +18,9 @@
     {DEFENSE_ANIM "units/elves-desert/nym-defend.png" units/elves-desert/nym.png {SOUND_LIST:ELF_FEMALE_HIT} }
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
+        #textdomain wesnoth-utbs
         type=blade
         range=melee
         damage={SWORD_AMOUNT}

--- a/data/campaigns/Under_the_Burning_Suns/units/humans/Human_Commander.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/humans/Human_Commander.cfg
@@ -47,6 +47,7 @@
     [attack]
         name=bow
         description= _"bow"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=11

--- a/data/campaigns/Under_the_Burning_Suns/units/monsters/Alien_Minion.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/monsters/Alien_Minion.cfg
@@ -29,6 +29,7 @@
         name=fangs
         #textdomain wesnoth-units
         description= _"fangs"
+        #textdomain wesnoth-utbs
         icon=attacks/fangs-horror.png
         type=blade
         range=melee
@@ -37,7 +38,6 @@
     [/attack]
     [attack]
         name=energy ray
-        #textdomain wesnoth-utbs
         description= _"energy ray"
         icon=attacks/energyray.png
         type=cold

--- a/data/campaigns/Under_the_Burning_Suns/units/monsters/Ant.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/monsters/Ant.cfg
@@ -21,7 +21,8 @@
         name=fangs
         #textdomain wesnoth-units
         description= _"fangs"
-        icon="attacks/fangs-ant.png"
+        #textdomain wesnoth-utbs
+        icon=attacks/fangs-ant.png
         type=blade
         range=melee
         damage=6

--- a/data/campaigns/Under_the_Burning_Suns/units/monsters/Crab_Man.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/monsters/Crab_Man.cfg
@@ -21,6 +21,7 @@
         name=claws
         #textdomain wesnoth-units
         description= _"claws"
+        #textdomain wesnoth-utbs
         icon=attacks/claws-crab.png
         type=blade
         range=melee

--- a/data/campaigns/Under_the_Burning_Suns/units/monsters/Darawf.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/monsters/Darawf.cfg
@@ -21,6 +21,7 @@
         name=fist
         #textdomain wesnoth-units
         description= _"fist"
+        #textdomain wesnoth-utbs
         type=impact
         range=melee
         damage=6

--- a/data/campaigns/Under_the_Burning_Suns/units/monsters/Small_Mudcrawler.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/monsters/Small_Mudcrawler.cfg
@@ -14,6 +14,7 @@
         name=fist
         #textdomain wesnoth-units
         description= _"fist"
+        #textdomain wesnoth-utbs
         icon=attacks/mud-glob.png
         type=impact
         range=melee

--- a/data/campaigns/Under_the_Burning_Suns/units/nagas/Naga_Guardian.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/nagas/Naga_Guardian.cfg
@@ -25,6 +25,7 @@
         name=mace
         #textdomain wesnoth-units
         description= _"mace"
+        #textdomain wesnoth-utbs
         type=impact
         range=melee
         damage=7

--- a/data/campaigns/Under_the_Burning_Suns/units/nagas/Naga_Hunter.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/nagas/Naga_Hunter.cfg
@@ -32,6 +32,7 @@
     [attack]
         name=bow
         description= _"bow"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=8

--- a/data/campaigns/Under_the_Burning_Suns/units/nagas/Naga_Sentinel.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/nagas/Naga_Sentinel.cfg
@@ -26,6 +26,7 @@
         name=mace
         #textdomain wesnoth-units
         description= _"mace"
+        #textdomain wesnoth-utbs
         type=impact
         range=melee
         damage=12

--- a/data/campaigns/Under_the_Burning_Suns/units/nagas/Naga_Warden.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/nagas/Naga_Warden.cfg
@@ -25,6 +25,7 @@
         name=mace
         #textdomain wesnoth-units
         description= _"mace"
+        #textdomain wesnoth-utbs
         type=impact
         range=melee
         damage=12

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Archer.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Archer.cfg
@@ -37,6 +37,7 @@
     [attack]
         name=bow
         description= _"bow"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=7

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Corrupted_Elf.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Corrupted_Elf.cfg
@@ -22,6 +22,7 @@
         name=spear
         #textdomain wesnoth-units
         description= _"spear"
+        #textdomain wesnoth-utbs
         type=pierce
         range=melee
         damage=12
@@ -33,7 +34,6 @@
     [/attack]
     [attack]
         name=magic
-        #textdomain wesnoth-utbs
         description= _"magic"
         icon=attacks/dark-missile.png
         type=cold

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Divine_Avatar.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Divine_Avatar.cfg
@@ -31,6 +31,7 @@
     [attack]
         name=lightbeam
         description= _"lightbeam"	# wmllint: no spellcheck (until name->id)
+        #textdomain wesnoth-utbs
         type=arcane
         range=ranged
         [specials]

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Druid.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Druid.cfg
@@ -25,6 +25,7 @@
         name=staff
         #textdomain wesnoth-units
         description= _"staff"
+        #textdomain wesnoth-utbs
         type=impact
         range=melee
         damage=8
@@ -34,7 +35,6 @@
     [/attack]
     [attack]
         name=sand
-        #textdomain wesnoth-utbs
         description= _"sand"
         type=impact
         range=ranged
@@ -49,6 +49,7 @@
         name=thorns
         #textdomain wesnoth-units
         description= _"thorns"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=7

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Fighter.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Fighter.cfg
@@ -29,6 +29,7 @@
         name=spear
         #textdomain wesnoth-units
         description= _"spear"
+        #textdomain wesnoth-utbs
         type=pierce
         range=melee
         damage=10

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Flagbearer.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Flagbearer.cfg
@@ -42,6 +42,7 @@
     [attack]
         name=javelin
         description= _"javelin"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=9

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Flanker.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Flanker.cfg
@@ -24,6 +24,7 @@
         name=sword
         #textdomain wesnoth-units
         description= _"sword"
+        #textdomain wesnoth-utbs
         type=blade
         range=melee
         damage=7
@@ -32,7 +33,6 @@
     [/attack]
     [attack]
         name=blowgun
-        #textdomain wesnoth-utbs
         description= _"blowgun"
         type=pierce
         range=ranged

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Horseman.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Horseman.cfg
@@ -27,6 +27,7 @@
         name=sword
         #textdomain wesnoth-units
         description= _"sword"
+        #textdomain wesnoth-utbs
         type=blade
         range=melee
         damage=7
@@ -36,7 +37,6 @@
     [/attack]
     [attack]
         name=bolas
-        #textdomain wesnoth-utbs
         description= _"bolas"
         type=impact
         range=ranged

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Marksman.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Marksman.cfg
@@ -38,6 +38,7 @@
     [attack]
         name=bow
         description= _"bow"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=9

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Moon_Shyde.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Moon_Shyde.cfg
@@ -58,6 +58,7 @@
         name=touch
         #textdomain wesnoth-units
         description= _"touch"
+        #textdomain wesnoth-utbs
         type=arcane
         range=melee
         damage=9
@@ -66,7 +67,6 @@
     [/attack]
     [attack]
         name=chill gale
-        #textdomain wesnoth-utbs
         description= _"chill gale"
         type=cold
         range=ranged

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Moon_Singer.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Moon_Singer.cfg
@@ -25,6 +25,7 @@
         name=touch
         #textdomain wesnoth-units
         description= _"touch"
+        #textdomain wesnoth-utbs
         type=arcane
         range=melee
         damage=9
@@ -33,7 +34,6 @@
     [/attack]
     [attack]
         name=chill gale
-        #textdomain wesnoth-utbs
         description= _"chill gale"
         type=cold
         range=ranged

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Mystic.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Mystic.cfg
@@ -25,6 +25,7 @@
         name=staff
         #textdomain wesnoth-units
         description= _"staff"
+        #textdomain wesnoth-utbs
         type=impact
         range=melee
         damage=4
@@ -34,7 +35,6 @@
     [/attack]
     [attack]
         name=sand
-        #textdomain wesnoth-utbs
         description= _"sand"
         type=impact
         range=ranged

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Outrider.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Outrider.cfg
@@ -28,6 +28,7 @@
         name=sword
         #textdomain wesnoth-units
         description= _"sword"
+        #textdomain wesnoth-utbs
         type=blade
         range=melee
         damage=8
@@ -37,7 +38,6 @@
     [/attack]
     [attack]
         name=bolas
-        #textdomain wesnoth-utbs
         description= _"bolas"
         type=impact
         range=ranged

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Protector.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Protector.cfg
@@ -46,6 +46,7 @@ Whether the story is true is unknown, but the loyalty and resolve of these mount
         name=javelin
         #textdomain wesnoth-units
         description= _"javelin"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=13

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Ranger.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Ranger.cfg
@@ -25,6 +25,7 @@
         name=sword
         #textdomain wesnoth-units
         description= _"sword"
+        #textdomain wesnoth-utbs
         type=blade
         range=melee
         damage=10
@@ -33,7 +34,6 @@
     [/attack]
     [attack]
         name=blowgun
-        #textdomain wesnoth-utbs
         description= _"blowgun"
         type=pierce
         range=ranged

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Rider.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Rider.cfg
@@ -39,6 +39,7 @@
         name=javelin
         #textdomain wesnoth-units
         description= _"javelin"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=7

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Scout.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Scout.cfg
@@ -24,6 +24,7 @@
         name=sword
         #textdomain wesnoth-units
         description= _"sword"
+        #textdomain wesnoth-utbs
         type=blade
         range=melee
         damage=6
@@ -33,7 +34,6 @@
     [/attack]
     [attack]
         name=bolas
-        #textdomain wesnoth-utbs
         description= _"bolas"
         type=impact
         range=ranged

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Shaman.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Shaman.cfg
@@ -25,6 +25,7 @@
         name=staff
         #textdomain wesnoth-units
         description= _"staff"
+        #textdomain wesnoth-utbs
         type=impact
         range=melee
         damage=5
@@ -34,7 +35,6 @@
     [/attack]
     [attack]
         name=sand
-        #textdomain wesnoth-utbs
         description= _"sand"
         type=impact
         range=ranged
@@ -49,6 +49,7 @@
         name=thorns
         #textdomain wesnoth-units
         description= _"thorns"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=6

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Shyde.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Shyde.cfg
@@ -26,6 +26,7 @@
         name=staff
         #textdomain wesnoth-units
         description= _"staff"
+        #textdomain wesnoth-utbs
         type=impact
         range=melee
         damage=9
@@ -35,7 +36,6 @@
     [/attack]
     [attack]
         name=sand
-        #textdomain wesnoth-utbs
         description= _"sand"
         type=impact
         range=ranged
@@ -50,6 +50,7 @@
         name=thorns
         #textdomain wesnoth-units
         description= _"thorns"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=8

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Stalwart.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Stalwart.cfg
@@ -43,6 +43,7 @@
         name=javelin
         #textdomain wesnoth-units
         description= _"javelin"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=10

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Sun_Shyde.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Sun_Shyde.cfg
@@ -37,6 +37,7 @@
     [attack]
         name=faerie fire
         description= _"faerie fire"
+        #textdomain wesnoth-utbs
         type=arcane
         range=ranged
         damage=11

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Sun_Singer.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Sun_Singer.cfg
@@ -34,6 +34,7 @@
     [attack]
         name=faerie fire
         description= _"faerie fire"
+        #textdomain wesnoth-utbs
         type=arcane
         range=ranged
         damage=10

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Vanguard.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Vanguard.cfg
@@ -41,6 +41,7 @@
     [attack]
         name=javelin
         description= _"javelin"
+        #textdomain wesnoth-utbs
         type=pierce
         range=ranged
         damage=8

--- a/data/campaigns/Under_the_Burning_Suns/units/undead/Spider_Lich.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/undead/Spider_Lich.cfg
@@ -45,6 +45,7 @@
     [attack]
         name=shadow wave
         description=_"shadow wave"
+        #textdomain wesnoth-utbs
         type=arcane
         [specials]
             {WEAPON_SPECIAL_MAGICAL}

--- a/data/campaigns/Under_the_Burning_Suns/units/undead/Undead_Horseman.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/undead/Undead_Horseman.cfg
@@ -40,6 +40,7 @@
         name=axe
         #textdomain wesnoth-units
         description= _"axe"
+        #textdomain wesnoth-utbs
         type=blade
         range=melee
         damage=6

--- a/data/campaigns/tutorial/units/Fighter.cfg
+++ b/data/campaigns/tutorial/units/Fighter.cfg
@@ -20,7 +20,9 @@
     {DEFENSE_ANIM "units/konrad-fighter-defend.png" "units/konrad-fighter.png" {SOUND_LIST:HUMAN_HIT} }
     [attack]
         name=sword
+        #textdomain wesnoth-units
         description= _"sword"
+        #textdomain wesnoth-tutorial
         icon=attacks/sword-human.png
         type=blade
         range=melee

--- a/data/campaigns/tutorial/units/Fighteress.cfg
+++ b/data/campaigns/tutorial/units/Fighteress.cfg
@@ -21,7 +21,9 @@
     die_sound={SOUND_LIST:HUMAN_FEMALE_DIE}
     [attack]
         name=saber
+        #textdomain wesnoth-units
         description= _"saber"
+        #textdomain wesnoth-tutorial
         icon=attacks/saber-human.png
         type=blade
         range=melee

--- a/data/campaigns/tutorial/units/Quintain.cfg
+++ b/data/campaigns/tutorial/units/Quintain.cfg
@@ -21,7 +21,9 @@
     {DEFENSE_ANIM "units/quintain.png" "units/quintain.png" staff.ogg}
     [attack]
         name=flail
+        #textdomain wesnoth-units
         description= _"flail"
+        #textdomain wesnoth-tutorial
         # closest image available
         icon=attacks/morning-star.png
         type=impact

--- a/data/core/units/humans/Loyalist_Iron_Mauler.cfg
+++ b/data/core/units/humans/Loyalist_Iron_Mauler.cfg
@@ -23,8 +23,8 @@ Though staggering in melee combat, there are many drawbacks to being outfitted i
     {DEFENSE_ANIM "units/human-loyalists/siegetrooper-defend-1.png" "units/human-loyalists/siegetrooper-defend-2.png" {SOUND_LIST:HUMAN_HIT} }
     [attack]
         name=mace
-        description=_"mace"
-        icon=attacks/mace-spiked.png
+        description=_"flail"
+        icon=attacks/morning-star.png
         type=impact
         range=melee
         damage=25
@@ -38,6 +38,6 @@ Though staggering in melee combat, there are many drawbacks to being outfitted i
         [frame]
             image="units/human-loyalists/siegetrooper-attack-[1~6].png:[85,100,125,50*3]"
         [/frame]
-        {SOUND:HIT_AND_MISS mace.ogg mace-miss.ogg -100}
+        {SOUND:HIT_AND_MISS flail.ogg flail-miss.ogg -260}
     [/attack_anim]
 [/unit_type]

--- a/data/core/units/humans/Loyalist_Shock_Trooper.cfg
+++ b/data/core/units/humans/Loyalist_Shock_Trooper.cfg
@@ -19,7 +19,7 @@
     usage=fighter
     {DEFENSE_ANIM "units/human-loyalists/shocktrooper-defend-1.png" "units/human-loyalists/shocktrooper-defend-2.png" {SOUND_LIST:HUMAN_HIT} }
     [attack]
-        name=morning star
+        name=flail
         description=_"flail"
         icon=attacks/morning-star.png
         type=impact
@@ -29,7 +29,7 @@
     [/attack]
     [attack_anim]
         [filter_attack]
-            name=morning star
+            name=flail
         [/filter_attack]
         start_time=-260
         {SOUND:HIT_AND_MISS flail.ogg flail-miss.ogg -260}

--- a/data/core/units/humans/Mage_of_Light.cfg
+++ b/data/core/units/humans/Mage_of_Light.cfg
@@ -43,8 +43,8 @@ Following a strict code of piety and honor, these men and women work tirelessly 
         [/frame]
     [/healing_anim]
     [attack]
-        name=morning star
-        description=_"morning star"
+        name=flail
+        description=_"flail"
         type=impact
         range=melee
         damage=7
@@ -83,7 +83,7 @@ Following a strict code of piety and honor, these men and women work tirelessly 
     [/attack_anim]
     [attack_anim]
         [filter_attack]
-            name=morning star
+            name=flail
         [/filter_attack]
 
         start_time=-250
@@ -130,7 +130,7 @@ Following a strict code of piety and honor, these men and women work tirelessly 
         [/attack_anim]
         [attack_anim]
             [filter_attack]
-                name=morning star
+                name=flail
             [/filter_attack]
             [frame]
                 image="units/human-magi/white-cleric+female-magic-3.png:100"

--- a/data/core/units/humans/Outlaw.cfg
+++ b/data/core/units/humans/Outlaw.cfg
@@ -20,7 +20,7 @@
     {DEFENSE_ANIM "units/human-outlaws/outlaw-defend.png" "units/human-outlaws/outlaw.png" {SOUND_LIST:HUMAN_HIT} }
     [attack]
         name=mace-spiked
-        description=_"mace"
+        description=_"morning star"
         type=impact
         range=melee
         damage=8

--- a/data/core/units/humans/Outlaw_Bandit.cfg
+++ b/data/core/units/humans/Outlaw_Bandit.cfg
@@ -19,7 +19,7 @@
     {DEFENSE_ANIM "units/human-outlaws/bandit-defend-2.png" "units/human-outlaws/bandit-defend-1.png" {SOUND_LIST:HUMAN_HIT} }
     [attack]
         name=mace-spiked
-        description=_"mace"
+        description=_"morning star"
         type=impact
         range=melee
         damage=8

--- a/data/core/units/humans/Outlaw_Fugitive.cfg
+++ b/data/core/units/humans/Outlaw_Fugitive.cfg
@@ -25,12 +25,11 @@
     [/abilities]
     [attack]
         name=mace-spiked
-        description= _ "mace"
+        description= _ "morning star"
         type=impact
         range=melee
         damage=11
         number=2
-        icon=attacks/mace.png
     [/attack]
     [attack]
         name=sling

--- a/data/core/units/humans/Outlaw_Highwayman.cfg
+++ b/data/core/units/humans/Outlaw_Highwayman.cfg
@@ -21,8 +21,7 @@
     {DEFENSE_ANIM "units/human-outlaws/highwayman-defend-2.png" "units/human-outlaws/highwayman-defend-1.png" {SOUND_LIST:HUMAN_HIT} }
     [attack]
         name=mace-spiked
-        description= _ "mace"
-        icon=attacks/mace.png
+        description= _ "morning star"
         type=impact
         range=melee
         damage=11

--- a/data/core/units/humans/Royal_Warrior.cfg
+++ b/data/core/units/humans/Royal_Warrior.cfg
@@ -30,7 +30,7 @@
     die_sound={SOUND_LIST:HUMAN_DIE}
     [attack]
         name=mace
-        description= _"mace"
+        description= _"morning star"
         icon=attacks/mace-spiked.png
         type=impact
         range=melee

--- a/data/core/units/khalifate/Arif.cfg
+++ b/data/core/units/khalifate/Arif.cfg
@@ -17,8 +17,8 @@
     die_sound={SOUND_LIST:HUMAN_DIE}
     {DEFENSE_ANIM "units/khalifate/arif.png" "units/khalifate/arif.png" {SOUND_LIST:HUMAN_HIT} }
     [attack]
-        name=long sword
-        description= _ "long sword"
+        name=sword
+        description= _ "sword"
         icon=attacks/sword-human.png
         type=blade
         range=melee
@@ -31,7 +31,7 @@
 
     [attack_anim]
         [filter_attack]
-            name=long sword
+            name=sword
         [/filter_attack]
 
         start_time=-200

--- a/data/core/units/khalifate/Ghazi.cfg
+++ b/data/core/units/khalifate/Ghazi.cfg
@@ -17,8 +17,8 @@
     die_sound={SOUND_LIST:ELF_HIT}
     {DEFENSE_ANIM "units/khalifate/ghazi.png" "units/khalifate/ghazi.png" {SOUND_LIST:ELF_HIT} }
     [attack]
-        name=long sword
-        description= _ "long sword"
+        name=sword
+        description= _ "sword"
         icon=attacks/longsword.png
         type=blade
         range=melee
@@ -43,7 +43,7 @@
 
     [attack_anim]
         [filter_attack]
-            name=long sword
+            name=sword
         [/filter_attack]
 
         start_time=-200

--- a/data/core/units/khalifate/Khalid.cfg
+++ b/data/core/units/khalifate/Khalid.cfg
@@ -24,8 +24,8 @@
     die_sound={SOUND_LIST:ELF_HIT}
     {DEFENSE_ANIM "units/khalifate/khalid.png" "units/khalifate/khalid.png" {SOUND_LIST:ELF_HIT} }
     [attack]
-        name=long sword
-        description= _ "long sword"
+        name=sword
+        description= _ "sword"
         icon=attacks/longsword.png
         type=blade
         range=melee
@@ -50,7 +50,7 @@
 
     [attack_anim]
         [filter_attack]
-            name=long sword
+            name=sword
         [/filter_attack]
 
         start_time=-200

--- a/data/core/units/khalifate/Mighwar.cfg
+++ b/data/core/units/khalifate/Mighwar.cfg
@@ -21,8 +21,8 @@
     die_sound={SOUND_LIST:HUMAN_DIE}
     {DEFENSE_ANIM "units/khalifate/mighwar.png" "units/khalifate/mighwar.png" {SOUND_LIST:HUMAN_HIT} }
     [attack]
-        name=long sword
-        description= _ "long sword"
+        name=longsword
+        description= _ "longsword"
         icon=attacks/longsword.png
         type=blade
         range=melee
@@ -32,7 +32,7 @@
 
     [attack_anim]
         [filter_attack]
-            name=long sword
+            name=longsword
         [/filter_attack]
 
         start_time=-200

--- a/data/core/units/khalifate/Monawish.cfg
+++ b/data/core/units/khalifate/Monawish.cfg
@@ -20,8 +20,8 @@
     die_sound={SOUND_LIST:HUMAN_DIE}
     {DEFENSE_ANIM "units/khalifate/monawish.png" "units/khalifate/monawish.png" {SOUND_LIST:HUMAN_HIT} }
     [attack]
-        name=long sword
-        description= _ "long sword"
+        name=longsword
+        description= _ "longsword"
         icon=attacks/longsword.png
         type=blade
         range=melee
@@ -31,7 +31,7 @@
 
     [attack_anim]
         [filter_attack]
-            name=long sword
+            name=longsword
         [/filter_attack]
 
         start_time=-200

--- a/data/core/units/khalifate/Shuja.cfg
+++ b/data/core/units/khalifate/Shuja.cfg
@@ -18,8 +18,8 @@
     die_sound={SOUND_LIST:ELF_HIT}
     {DEFENSE_ANIM "units/khalifate/shuja.png" "units/khalifate/shuja.png" {SOUND_LIST:ELF_HIT} }
     [attack]
-        name=long sword
-        description= _ "long sword"
+        name=sword
+        description= _ "sword"
         icon=attacks/longsword.png
         type=blade
         range=melee
@@ -44,7 +44,7 @@
 
     [attack_anim]
         [filter_attack]
-            name=long sword
+            name=sword
         [/filter_attack]
 
         start_time=-200


### PR DESCRIPTION
.
This is the continuation of PR #902 
The code style is not everywhere the same, I switched mostly back to the original textdomain after the relevant strings, though this is not necessary. If there Is some preferred variant, I'm happy to make it the same everywhere.
 
Before merging this PR, there are a few edge cases: 
1) There exists "morningstar" and "morning star" - what is the better variant?
2) In some languages "entangle" in wesnoth-units (the entangle of the elves) and "entangle" in wensoth-dm (the entangle of the wose shaman) is translated differently. I can kind of understand it. Should we maybe use different words in english for it? Otherwise I would unify it too.

Talking about that... there were two similar string changes which I would wish for:
3) Khalifate units have "shield bash" - the south guard has a unit with "shield" as attack.
Switching to "shield bash"?
4) There exists "long sword" and "longsword", has been discussed at [gna #25013]. And, if changed, "short sword" would then be "shortsword". (used by orcish/loyalist bowman and the mages in liberty/main character in DiD)

One last idea regarding that topic:
Some attacks are used by different campaigns, but not in core. E.g. "trample", is used by the new utbs, eastern invasion and liberty. Can I move it to the wesnoth-units domain too?

[gna #25013]: <https://gna.org/bugs/index.php?25013>