### PR TITLE
Fix an issue with "quick replay" when joining multiplayer games

### DIFF
--- a/changelog
+++ b/changelog
@@ -39,6 +39,7 @@ Version 1.13.6+dev:
  * Miscellaneous and bug fixes:
    * Fixed severe lag/freeze on slow PCs (bug #25356)
    * Updated wmlscope to handle the square braces syntax in file paths
+   * Fixed an issue preventing quick replay when joining multiplayer matches
 
 Version 1.13.6:
  * AI:

--- a/src/game_initialization/multiplayer.cpp
+++ b/src/game_initialization/multiplayer.cpp
@@ -354,8 +354,9 @@ static std::unique_ptr<wesnothd_connection> open_connection(CVideo& video, const
 // The functions enter_(screen)_mode are simple functions that take care of
 // creating the dialogs, then, according to the dialog result, of calling other
 // of those screen functions.
-static void enter_wait_mode(CVideo& video, const config& game_config, saved_game& state, wesnothd_connection* connection,
-	mp::lobby_info& li, bool observe, int current_turn = 0)
+static void enter_wait_mode(CVideo& video, const config& game_config,
+		saved_game& state, wesnothd_connection* connection,
+		mp::lobby_info& li, bool observe)
 {
 	DBG_MP << "entering wait mode" << std::endl;
 
@@ -364,7 +365,7 @@ static void enter_wait_mode(CVideo& video, const config& game_config, saved_game
 	campaign_info.reset(new mp_campaign_info(*connection));
 	campaign_info->is_host = false;
 	if(preferences::skip_mp_replay() || preferences::blindfold_replay()) {
-		campaign_info->skip_replay_until_turn = current_turn;
+		campaign_info->skip_replay = true;
 		campaign_info->skip_replay_blindfolded = preferences::blindfold_replay();
 	}
 
@@ -471,7 +472,6 @@ static void enter_lobby_mode(CVideo& video, const config& game_config,
 	assert(connection);
 	DBG_MP << "entering lobby mode" << std::endl;
 
-	int current_turn = 0;
 	while (true) {
 		const config &cfg = game_config.child("lobby_music");
 		if (cfg) {
@@ -505,7 +505,7 @@ static void enter_lobby_mode(CVideo& video, const config& game_config,
 			case gui2::dialogs::lobby_main::JOIN:
 			case gui2::dialogs::lobby_main::OBSERVE:
 				try {
-					enter_wait_mode(video, game_config, state, connection, li, dlg.get_retval() == gui2::dialogs::lobby_main::OBSERVE, current_turn);
+					enter_wait_mode(video, game_config, state, connection, li, dlg.get_retval() == gui2::dialogs::lobby_main::OBSERVE);
 				} catch(config::error& error) {
 					if(!error.message.empty()) {
 						gui2::show_error_message(video, error.message);

--- a/src/game_initialization/playcampaign.hpp
+++ b/src/game_initialization/playcampaign.hpp
@@ -40,7 +40,7 @@ struct mp_campaign_info
 	mp_campaign_info(wesnothd_connection& wdc)
 		: connected_players()
 		, is_host()
-		, skip_replay_until_turn(0)
+		, skip_replay(false)
 		, skip_replay_blindfolded(false)
 		, connection(wdc)
 	{
@@ -49,7 +49,7 @@ struct mp_campaign_info
 	/// players and observers
 	std::set<std::string> connected_players;
 	bool is_host;
-	int skip_replay_until_turn;
+	bool skip_replay;
 	bool skip_replay_blindfolded;
 	wesnothd_connection& connection;
 };

--- a/src/playmp_controller.cpp
+++ b/src/playmp_controller.cpp
@@ -43,8 +43,8 @@ playmp_controller::playmp_controller(const config& level,
 		saved_game& state_of_game, const config& game_config,
 		const ter_data_cache & tdata, CVideo& video,
 		mp_campaign_info* mp_info)
-	: playsingle_controller(level, state_of_game,
-	game_config, tdata, video, mp_info && mp_info->skip_replay_until_turn != 0) //this || means that if blindfold is enabled, quick replays will be on.
+	: playsingle_controller(level, state_of_game, game_config, tdata, video,
+			mp_info && mp_info->skip_replay)
 	, network_processing_stopped_(false)
 	, blindfold_(*gui_, mp_info && mp_info->skip_replay_blindfolded)
 	, mp_info_(mp_info)
@@ -53,11 +53,6 @@ playmp_controller::playmp_controller(const config& level,
 
 	//turn_data_.set_host(is_host);
 	turn_data_.host_transfer().attach_handler(this);
-	// We stop quick replay if play isn't yet past turn 1
-	if (!mp_info_ || mp_info_->skip_replay_until_turn > 0)
-	{
-		skip_replay_ = false;
-	}
 }
 
 playmp_controller::~playmp_controller() {
@@ -334,9 +329,6 @@ void playmp_controller::play_network_turn(){
 	{
 		if (!network_processing_stopped_) {
 			process_network_data();
-			if (!mp_info_ || mp_info_->skip_replay_until_turn > 0) {
-				skip_replay_ = false;
-			}
 		}
 
 		play_slice_catch();


### PR DESCRIPTION
Hey,

I noticed that replays were not skipped when joining a multiplayer game with "Quick Replay" being selected. This fixes the issue.

In addition, I changed the `skip_replay_until_turn` option to a boolean, since specific turn numbers are never specified and have no effect.