### PR TITLE
Stop "quick replay" mode in MP games once the client caught up

### DIFF
--- a/src/game_initialization/multiplayer.cpp
+++ b/src/game_initialization/multiplayer.cpp
@@ -356,7 +356,7 @@ static std::unique_ptr<wesnothd_connection> open_connection(CVideo& video, const
 // of those screen functions.
 static void enter_wait_mode(CVideo& video, const config& game_config,
 		saved_game& state, wesnothd_connection* connection,
-		mp::lobby_info& li, bool observe)
+		mp::lobby_info& li, int game_id, bool observe)
 {
 	DBG_MP << "entering wait mode" << std::endl;
 
@@ -364,6 +364,9 @@ static void enter_wait_mode(CVideo& video, const config& game_config,
 	std::unique_ptr<mp_campaign_info> campaign_info;
 	campaign_info.reset(new mp_campaign_info(*connection));
 	campaign_info->is_host = false;
+	if (li.get_game_by_id(game_id)) {
+		campaign_info->current_turn = li.get_game_by_id(game_id)->current_turn;
+	}
 	if(preferences::skip_mp_replay() || preferences::blindfold_replay()) {
 		campaign_info->skip_replay = true;
 		campaign_info->skip_replay_blindfolded = preferences::blindfold_replay();
@@ -505,7 +508,9 @@ static void enter_lobby_mode(CVideo& video, const config& game_config,
 			case gui2::dialogs::lobby_main::JOIN:
 			case gui2::dialogs::lobby_main::OBSERVE:
 				try {
-					enter_wait_mode(video, game_config, state, connection, li, dlg.get_retval() == gui2::dialogs::lobby_main::OBSERVE);
+					enter_wait_mode(video, game_config, state, connection, li,
+							dlg.get_joined_game_id(),
+							dlg.get_retval() == gui2::dialogs::lobby_main::OBSERVE);
 				} catch(config::error& error) {
 					if(!error.message.empty()) {
 						gui2::show_error_message(video, error.message);

--- a/src/game_initialization/playcampaign.hpp
+++ b/src/game_initialization/playcampaign.hpp
@@ -40,6 +40,7 @@ struct mp_campaign_info
 	mp_campaign_info(wesnothd_connection& wdc)
 		: connected_players()
 		, is_host()
+		, current_turn(0)
 		, skip_replay(false)
 		, skip_replay_blindfolded(false)
 		, connection(wdc)
@@ -49,6 +50,7 @@ struct mp_campaign_info
 	/// players and observers
 	std::set<std::string> connected_players;
 	bool is_host;
+	unsigned current_turn;
 	bool skip_replay;
 	bool skip_replay_blindfolded;
 	wesnothd_connection& connection;

--- a/src/gui/dialogs/lobby/lobby.cpp
+++ b/src/gui/dialogs/lobby/lobby.cpp
@@ -993,9 +993,7 @@ bool lobby_main::do_game_join(int idx, bool observe)
 	}
 
 	wesnothd_connection_.send_data(response);
-	if(observe && game.started) {
-		// playmp_controller::set_replay_last_turn(game.current_turn);
-	}
+	joined_game_id_ = game.id;
 	return true;
 }
 

--- a/src/gui/dialogs/lobby/lobby.hpp
+++ b/src/gui/dialogs/lobby/lobby.hpp
@@ -85,6 +85,8 @@ public:
 		preferences_callback_ = f;
 	}
 
+	int get_joined_game_id() const { return joined_game_id_; }
+
 	void update_gamelist();
 
 protected:
@@ -218,6 +220,8 @@ private:
 	bool delay_playerlist_update_;
 
 	bool delay_gamelist_update_;
+
+	int joined_game_id_;
 
 	friend struct lobby_delay_gamelist_update_guard;
 };

--- a/src/playmp_controller.cpp
+++ b/src/playmp_controller.cpp
@@ -53,6 +53,9 @@ playmp_controller::playmp_controller(const config& level,
 
 	//turn_data_.set_host(is_host);
 	turn_data_.host_transfer().attach_handler(this);
+	if (!mp_info || mp_info->current_turn == turn()) {
+		skip_replay_ = false;
+	}
 }
 
 playmp_controller::~playmp_controller() {
@@ -329,6 +332,9 @@ void playmp_controller::play_network_turn(){
 	{
 		if (!network_processing_stopped_) {
 			process_network_data();
+			if (!mp_info_ || mp_info_->current_turn == turn()) {
+				skip_replay_ = false;
+			}
 		}
 
 		play_slice_catch();


### PR DESCRIPTION
After #916, quick replays worked again when joining MP games but the "quick replay" mode was not deactivated when the client caught up.

This takes note of the joined game's current turn at the time of joining, and disables quick replay mode once that turn is reached.

