### PR TITLE
Added an option to skip replays entirely when joining MP games

### DIFF
--- a/data/gui/window/lobby_main.cfg
+++ b/data/gui/window/lobby_main.cfg
@@ -614,16 +614,22 @@
 
 					[option]
 						label = _ "Normal Replays"
+						tooltip = _ "Show a replay of games when observing"
 					[/option]
 
 					[option]
 						label = _ "Quick Replays"
-						tooltip = _ "Skip quickly to the active turn when observing"
+						tooltip = _ "Show a quick replay of games when observing"
 					[/option]
 
 					[option]
 						label = _ "Enter Blindfolded"
 						tooltip = _ "Do not show the map until given control of a side"
+					[/option]
+
+					[option]
+						label = _ "No Replays"
+						tooltip = _ "Skip to the active turn when observing"
 					[/option]
 				[/menu_button]
 			[/column]
@@ -765,16 +771,22 @@
 
 									[option]
 										label = _ "Normal Replays"
+										tooltip = _ "Show a replay of games when observing"
 									[/option]
 
 									[option]
 										label = _ "Quick Replays"
-										tooltip = _ "Skip quickly to the active turn when observing"
+										tooltip = _ "Show a quick replay of games when observing"
 									[/option]
 
 									[option]
 										label = _ "Enter Blindfolded"
 										tooltip = _ "Do not show the map until given control of a side"
+									[/option]
+
+									[option]
+										label = _ "No Replays"
+										tooltip = _ "Skip to the active turn when observing"
 									[/option]
 								[/menu_button]
 							[/column]

--- a/src/game_initialization/multiplayer.cpp
+++ b/src/game_initialization/multiplayer.cpp
@@ -367,11 +367,6 @@ static void enter_wait_mode(CVideo& video, const config& game_config,
 	if (li.get_game_by_id(game_id)) {
 		campaign_info->current_turn = li.get_game_by_id(game_id)->current_turn;
 	}
-	if(preferences::skip_mp_replay() || preferences::blindfold_replay()) {
-		campaign_info->skip_replay = true;
-		campaign_info->skip_replay_blindfolded = preferences::blindfold_replay();
-	}
-
 
 	gui2::dialogs::mp_join_game dlg(state, li, *connection, true, observe);
 

--- a/src/game_initialization/playcampaign.hpp
+++ b/src/game_initialization/playcampaign.hpp
@@ -41,8 +41,6 @@ struct mp_campaign_info
 		: connected_players()
 		, is_host()
 		, current_turn(0)
-		, skip_replay(false)
-		, skip_replay_blindfolded(false)
 		, connection(wdc)
 	{
 
@@ -51,8 +49,6 @@ struct mp_campaign_info
 	std::set<std::string> connected_players;
 	bool is_host;
 	unsigned current_turn;
-	bool skip_replay;
-	bool skip_replay_blindfolded;
 	wesnothd_connection& connection;
 };
 

--- a/src/game_preferences.cpp
+++ b/src/game_preferences.cpp
@@ -740,14 +740,14 @@ void set_options(const config& values)
 	options_initialized = false;
 }
 
-bool skip_mp_replay()
+bool quick_mp_replay()
 {
-	return preferences::get("skip_mp_replay", false);
+	return preferences::get("quick_mp_replay", false);
 }
 
-void set_skip_mp_replay(bool value)
+void set_quick_mp_replay(bool value)
 {
-	preferences::set("skip_mp_replay", value);
+	preferences::set("quick_mp_replay", value);
 }
 
 bool blindfold_replay()
@@ -758,6 +758,16 @@ bool blindfold_replay()
 void set_blindfold_replay(bool value)
 {
 	preferences::set("blindfold_replay", value);
+}
+
+bool skip_mp_replay()
+{
+	return preferences::get("skip_mp_replay", false);
+}
+
+void set_skip_mp_replay(bool value)
+{
+	preferences::set("skip_mp_replay", value);
 }
 
 bool countdown()

--- a/src/game_preferences.hpp
+++ b/src/game_preferences.hpp
@@ -169,11 +169,14 @@ class acquaintance;
 	const config& options();
 	void set_options(const config& values);
 
-	bool skip_mp_replay();
-	void set_skip_mp_replay(bool value);
+	bool quick_mp_replay();
+	void set_quick_mp_replay(bool value);
 
 	bool blindfold_replay();
 	void set_blindfold_replay(bool value);
+
+	bool skip_mp_replay();
+	void set_skip_mp_replay(bool value);
 
 	bool countdown();
 	void set_countdown(bool value);

--- a/src/gui/dialogs/lobby/lobby.cpp
+++ b/src/gui/dialogs/lobby/lobby.cpp
@@ -732,12 +732,16 @@ void lobby_main::pre_show(window& window)
 
 	menu_button& replay_options = find_widget<menu_button>(&window, "replay_options", false);
 
-	if(preferences::skip_mp_replay()) {
+	if(preferences::quick_mp_replay()) {
 		replay_options.set_selected(1);
 	}
 
 	if(preferences::blindfold_replay()) {
 		replay_options.set_selected(2);
+	}
+
+	if(preferences::skip_mp_replay()) {
+		replay_options.set_selected(3);
 	}
 
 	replay_options.connect_click_handler(
@@ -1123,8 +1127,10 @@ void lobby_main::skip_replay_changed_callback(window& window)
 {
 	// TODO: this prefence should probably be controlled with an enum
 	const int value = find_widget<menu_button>(&window, "replay_options", false).get_value();
-	preferences::set_skip_mp_replay(value == 1);
+
+	preferences::set_quick_mp_replay(value == 1);
 	preferences::set_blindfold_replay(value == 2);
+	preferences::set_skip_mp_replay(value == 3);
 }
 
 int lobby_main::get_game_index_from_id(const int game_id) const

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -137,7 +137,7 @@ static void clear_resources()
 
 play_controller::play_controller(const config& level, saved_game& state_of_game,
 		const config& game_config, const ter_data_cache& tdata,
-		CVideo& video, bool skip_replay)
+		CVideo& video, bool quick_replay)
 	: controller_base(game_config, video)
 	, observer()
 	, quit_confirmation()
@@ -160,7 +160,7 @@ play_controller::play_controller(const config& level, saved_game& state_of_game,
 	, xp_mod_(new unit_experience_accelerator(level["experience_modifier"].to_int(100)))
 	, statistics_context_(new statistics::scenario_context(level["name"]))
 	, replay_(new replay(state_of_game.get_replay()))
-	, skip_replay_(skip_replay)
+	, quick_replay_(quick_replay)
 	, linger_(false)
 	, init_side_done_now_(false)
 	, victory_when_enemies_defeated_(level["victory_when_enemies_defeated"].to_bool(true))

--- a/src/play_controller.hpp
+++ b/src/play_controller.hpp
@@ -79,7 +79,7 @@ public:
 	play_controller(const config& level, saved_game& state_of_game,
 		const config& game_config,
 		const ter_data_cache& tdata,
-		CVideo& video, bool skip_replay);
+		CVideo& video, bool quick_replay);
 	virtual ~play_controller();
 
 	//event handler, overridden from observer
@@ -185,8 +185,8 @@ public:
 	 */
 	config to_config() const;
 
-	bool is_skipping_replay() const { return skip_replay_; }
-	void toggle_skipping_replay() { skip_replay_ = !skip_replay_; }
+	bool is_skipping_replay() const { return quick_replay_; }
+	void toggle_skipping_replay() { quick_replay_ = !quick_replay_; }
 	bool is_linger_mode() const { return linger_; }
 	void do_autosave();
 
@@ -336,7 +336,7 @@ protected:
 	const actions::undo_list& undo_stack() const { return *gamestate().undo_stack_; };
 	std::unique_ptr<replay> replay_;
 
-	bool skip_replay_;
+	bool quick_replay_;
 	bool linger_;
 	/**
 	 * Whether we did init sides in this session

--- a/src/playmp_controller.hpp
+++ b/src/playmp_controller.hpp
@@ -70,7 +70,9 @@ private:
 	void set_end_scenario_button();
 	void reset_end_scenario_button();
 	void process_network_data();
+
 	mp_campaign_info* mp_info_;
+	bool skipping_replay_;
 };
 
 #endif

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -70,8 +70,8 @@ static lg::log_domain log_enginerefac("enginerefac");
 playsingle_controller::playsingle_controller(const config& level,
 	saved_game& state_of_game,
 	const config& game_config, const ter_data_cache & tdata,
-	CVideo& video, bool skip_replay)
-	: play_controller(level, state_of_game, game_config, tdata, video, skip_replay)
+	CVideo& video, bool quick_replay)
+	: play_controller(level, state_of_game, game_config, tdata, video, quick_replay)
 	, cursor_setter_(cursor::NORMAL)
 	, textbox_info_()
 	, replay_sender_(*resources::recorder)

--- a/src/playsingle_controller.hpp
+++ b/src/playsingle_controller.hpp
@@ -38,7 +38,7 @@ class playsingle_controller : public play_controller
 {
 public:
 	playsingle_controller(const config& level, saved_game& state_of_game,
-		const config& game_config, const ter_data_cache & tdata, CVideo& video, bool skip_replay);
+		const config& game_config, const ter_data_cache & tdata, CVideo& video, bool quick_replay);
 	virtual ~playsingle_controller();
 
 	LEVEL_RESULT play_scenario(const config& level);


### PR DESCRIPTION
This adds a new replay mode to the MP lobby options that allows skipping replays entirely when joining games. It works by locking video updates completely while the game catches up.

I kept the old version around that allows viewing a quick version of the replay. It still doesn't address the issues gfgtdf addressed in #919, which should still be dealt with in a future commit:

- Breaks if [modify_turns] is present in scenario WML
- Still shows the most recent turn using a regular, slow replay