### PR TITLE
Do not load Markov name generator if a CFG generator could be loaded

### DIFF
--- a/src/utils/name_generator_factory.cpp
+++ b/src/utils/name_generator_factory.cpp
@@ -45,6 +45,7 @@ void name_generator_factory::add_name_generator_from_config(const config& config
 			lg::wml_error() << ex.what() << '\n';
 		}
 	}
+
 	if(config.has_attribute(markov_name)) {
 		config::attribute_value markov_name_list = config[markov_name];
 

--- a/src/utils/name_generator_factory.cpp
+++ b/src/utils/name_generator_factory.cpp
@@ -34,26 +34,18 @@ name_generator_factory::name_generator_factory(const config& config, std::vector
 
 void name_generator_factory::add_name_generator_from_config(const config& config, const std::string id, const std::string prefix) {
  	std::string cfg_name 	= prefix + "name_generator";
+	std::string markov_name = prefix + "names";
 
 	if(config.has_attribute(cfg_name)) {
 		try {
 			name_generators_[id] = std::shared_ptr<name_generator>(new context_free_grammar_generator(config[cfg_name]));
+			return;
 		}
 		catch (const name_generator_invalid_exception& ex) {
 			lg::wml_error() << ex.what() << '\n';
-			fall_back_to_markov(config, id, prefix);
 		}
 	}
-	else {
-		fall_back_to_markov(config, id, prefix);
-	}
-}
-
-
-void name_generator_factory::fall_back_to_markov(const config& config, const std::string id, const std::string prefix) {
-	std::string markov_name = prefix + "names";
-
-	if(config.has_attribute(markov_name)) {
+	else if(config.has_attribute(markov_name)) {
 		config::attribute_value markov_name_list = config[markov_name];
 
 		if(!markov_name_list.blank()) {
@@ -61,7 +53,6 @@ void name_generator_factory::fall_back_to_markov(const config& config, const std
 		}
 	}
 }
-
 
 std::shared_ptr<name_generator> name_generator_factory::get_name_generator() {
 	std::map<std::string, std::shared_ptr<name_generator>>::const_iterator it = name_generators_.find("");

--- a/src/utils/name_generator_factory.cpp
+++ b/src/utils/name_generator_factory.cpp
@@ -34,7 +34,6 @@ name_generator_factory::name_generator_factory(const config& config, std::vector
 
 void name_generator_factory::add_name_generator_from_config(const config& config, const std::string id, const std::string prefix) {
  	std::string cfg_name 	= prefix + "name_generator";
-	std::string markov_name = prefix + "names";
 
 	if(config.has_attribute(cfg_name)) {
 		try {
@@ -42,8 +41,17 @@ void name_generator_factory::add_name_generator_from_config(const config& config
 		}
 		catch (const name_generator_invalid_exception& ex) {
 			lg::wml_error() << ex.what() << '\n';
+			fall_back_to_markov(config, id, prefix);
 		}
 	}
+	else {
+		fall_back_to_markov(config, id, prefix);
+	}
+}
+
+
+void name_generator_factory::fall_back_to_markov(const config& config, const std::string id, const std::string prefix) {
+	std::string markov_name = prefix + "names";
 
 	if(config.has_attribute(markov_name)) {
 		config::attribute_value markov_name_list = config[markov_name];
@@ -53,6 +61,7 @@ void name_generator_factory::add_name_generator_from_config(const config& config
 		}
 	}
 }
+
 
 std::shared_ptr<name_generator> name_generator_factory::get_name_generator() {
 	std::map<std::string, std::shared_ptr<name_generator>>::const_iterator it = name_generators_.find("");

--- a/src/utils/name_generator_factory.cpp
+++ b/src/utils/name_generator_factory.cpp
@@ -45,7 +45,7 @@ void name_generator_factory::add_name_generator_from_config(const config& config
 			lg::wml_error() << ex.what() << '\n';
 		}
 	}
-	else if(config.has_attribute(markov_name)) {
+	if(config.has_attribute(markov_name)) {
 		config::attribute_value markov_name_list = config[markov_name];
 
 		if(!markov_name_list.blank()) {

--- a/src/utils/name_generator_factory.hpp
+++ b/src/utils/name_generator_factory.hpp
@@ -55,15 +55,6 @@ private:
 	 * @returns a name generator or nullptr if not found
 	 */
 	void add_name_generator_from_config(const config& config, const std::string id, const std::string prefix);
-
-	/**
-	 * Determines a Markov-chain name generator from WML data
-	 * @param config the WML data to be parsed for name generators
-	 * @param the prefix to look for
-	 * @returns a name generator or nullptr if not found
-	 */
-	void fall_back_to_markov(const config& config, const std::string id, const std::string prefix);
-
 };
 
 #endif

--- a/src/utils/name_generator_factory.hpp
+++ b/src/utils/name_generator_factory.hpp
@@ -48,12 +48,22 @@ private:
 	std::map<std::string, std::shared_ptr<name_generator>> name_generators_;
 
 	/**
-	 * Determines a name generator from WML data
+	 * Determines a name generator from WML data. Tries first to load a context-free generator,
+	 * then falls back to Markov.
 	 * @param config the WML data to be parsed for name generators
 	 * @param the prefix to look for
 	 * @returns a name generator or nullptr if not found
 	 */
 	void add_name_generator_from_config(const config& config, const std::string id, const std::string prefix);
+
+	/**
+	 * Determines a Markov-chain name generator from WML data
+	 * @param config the WML data to be parsed for name generators
+	 * @param the prefix to look for
+	 * @returns a name generator or nullptr if not found
+	 */
+	void fall_back_to_markov(const config& config, const std::string id, const std::string prefix);
+
 };
 
 #endif


### PR DESCRIPTION
name_generator_factory::add_name_generator_from_config now only falls
back to loading a Markov-chain generator if the loading of the context-
free grammar generator fails or there is none available.

Motivation for the change: Until now, the CFG generator would be ignored for the base names. The Markov generator can't be adapted to my locale. c.f. [Forum discussion](https://forums.wesnoth.org/viewtopic.php?f=12&p=607975#p607889).