### PR TITLE
Install dependencies dialog: Use _n() to fetch a translation string

### DIFF
--- a/src/gui/dialogs/addon/install_dependencies.cpp
+++ b/src/gui/dialogs/addon/install_dependencies.cpp
@@ -16,6 +16,7 @@
 
 #define GETTEXT_DOMAIN "wesnoth"
 
+#include "gettext.hpp"
 #include "gui/auxiliary/find_widget.hpp"
 #include "gui/widgets/addon_list.hpp"
 #include "gui/widgets/label.hpp"
@@ -32,13 +33,12 @@ REGISTER_DIALOG(install_dependencies)
 
 void install_dependencies::pre_show(window& window)
 {
-	find_widget<label>(&window, "label", false).set_label(
-		t_string(
+	find_widget<label>(&window, "label", false).set_label(t_string(
+		_n(
 			"The selected add-on has the following dependency, which is not currently installed. Do you wish to install it before continuing?",
 			"The selected add-on has the following dependencies, which are not currently installed. Do you wish to install them before continuing?",
-			addons_.size(),
-			"wesnoth")
-	);
+			addons_.size())
+	));
 
 	find_widget<addon_list>(&window, "dependencies", false).set_addons(addons_);
 }


### PR DESCRIPTION
Soliton said in IRC that translation strings with plural forms should be fetched with `_n()`, `sngettext()` or `vngettext()`.

The reason why I made this a pull request instead of pushing directly to master is that I'm unsure on whether it's a good idea at all to convert a _translated string_ into a `t_string`, as the code is doing. Since `_n()`, `sngettext()` and `vngettext()` all return `std::string`, the conversion is inevitable if the code has to use those functions.