### PR TITLE
Fixed hard-coded word order in attack_type::describe_modification

### DIFF
--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -351,79 +351,83 @@ bool attack_type::describe_modification(const config& cfg,std::string* descripti
 		if(!increase_damage.empty()) {
 			add_and(desc);
 			desc << vngettext(
-						  "$number damage",
-						  "$number damage",
-						  std::stoi(increase_damage),
-						  utils::string_map({{"number", utils::print_modifier(increase_damage)}}));
+				"$number damage",
+				"$number damage",
+				std::stoi(increase_damage),
+				utils::string_map({{"number", utils::print_modifier(increase_damage)}}));
 		}
 
 		if(!set_damage.empty()) {
 			add_and(desc);
 			desc << vngettext(
-						  "$number damage",
-						  "$number damage",
-						  std::stoi(set_damage),
-						  utils::string_map({{"number", set_damage}}));
+				"$number damage",
+				"$number damage",
+				std::stoi(set_damage),
+				utils::string_map({{"number", set_damage}}));
 		}
 
 		if(!increase_attacks.empty()) {
 			add_and(desc);
 			desc << vngettext(
-						  "$attacks strike",
-						  "$attacks strikes",
-						  std::stoi(increase_attacks),
-						  utils::string_map({{"attacks", utils::print_modifier(increase_attacks)}}));
+				"$attacks strike",
+				"$attacks strikes",
+				std::stoi(increase_attacks),
+				utils::string_map({{"attacks", utils::print_modifier(increase_attacks)}}));
 		}
 
 		if(!set_attacks.empty()) {
 			add_and(desc);
 			desc << vngettext(
-						  "$attacks strike",
-						  "$attacks strikes",
-						  std::stoi(set_attacks),
-						  utils::string_map({{"attacks", set_attacks}}));
+				"$attacks strike",
+				"$attacks strikes",
+				std::stoi(set_attacks),
+				utils::string_map({{"attacks", set_attacks}}));
 		}
 
 		if(!set_accuracy.empty()) {
 			add_and(desc);
-			desc << vgettext("$percent|% accuracy",
-								  utils::string_map({{"percent", set_accuracy}}));
+			desc << vgettext(
+				"$percent|% accuracy",
+				utils::string_map({{"percent", set_accuracy}}));
 		}
 
 		if(!increase_accuracy.empty()) {
 			add_and(desc);
-			desc << vgettext("$percent|% accuracy",
-								  utils::string_map({{"percent", utils::print_modifier(increase_accuracy)}}));
+			desc << vgettext(
+				"$percent|% accuracy",
+				utils::string_map({{"percent", utils::print_modifier(increase_accuracy)}}));
 		}
 
 		if(!set_parry.empty()) {
 			add_and(desc);
-			desc << vgettext("$strength parry",
-								  utils::string_map({{"strength", set_parry}}));
+			desc << vgettext(
+				"$strength parry",
+				utils::string_map({{"strength", set_parry}}));
 		}
 
 		if(!increase_parry.empty()) {
 			add_and(desc);
-			desc << vgettext("$strength parry",
-								  utils::string_map({{"strength", utils::print_modifier(increase_parry)}}));
+			desc << vgettext(
+				"$strength parry",
+				utils::string_map({{"strength", utils::print_modifier(increase_parry)}}));
 		}
 
 		if(!set_movement.empty()) {
 			add_and(desc);
 			desc << vngettext(
-						  "$points movement point",
-						  "$points movement points",
-						  std::stoi(set_movement),
-						  utils::string_map({{"points", set_movement}}));
+				"$points movement point",
+				"$points movement points",
+				std::stoi(set_movement),
+				utils::string_map({{"points", set_movement}}));
 		}
 
 		if(!increase_movement.empty()) {
 			add_and(desc);
 			desc << vngettext(
-						  "$points movement point",
-						  "$points movement points",
-						  std::stoi(increase_movement),
-						  utils::string_map({{"points", utils::print_modifier(increase_movement)}}));
+				"$points movement point",
+				"$points movement points",
+				std::stoi(increase_movement),
+				utils::string_map({{"points", utils::print_modifier(increase_movement)}}));
 		}
 
 		*description = desc.str();

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -348,7 +348,7 @@ bool attack_type::describe_modification(const config& cfg,std::string* descripti
 
 		std::stringstream desc;
 
-		if(increase_damage.empty() == false) {
+		if(!increase_damage.empty()) {
 			utils::string_map symbols;
 			symbols["damage"] = utils::print_modifier(increase_damage);
 			add_and(desc);
@@ -388,34 +388,28 @@ bool attack_type::describe_modification(const config& cfg,std::string* descripti
 					std::stoi(set_attacks), symbols);
 		}
 
-		if(set_accuracy.empty() == false) {
-			int accuracy = std::stoi(set_accuracy);
-
+		if(!set_accuracy.empty()) {
 			add_and(desc);
-			// xgettext:no-c-format
-			desc << accuracy << " " << _("% accuracy");
+			desc << vgettext("$percent|% accuracy",
+								  utils::string_map({{"percent", set_accuracy}}));
 		}
 
-		if(increase_accuracy.empty() == false) {
+		if(!increase_accuracy.empty()) {
 			add_and(desc);
-			int inc_acc = std::stoi(increase_accuracy);
-			// Help xgettext with a directive to recognize the string as a non C printf-like string
-			// xgettext:no-c-format
-			desc << utils::signed_value(inc_acc) << _("% accuracy");
+			desc << vgettext("$percent|% accuracy",
+								  utils::string_map({{"percent", utils::print_modifier(increase_accuracy)}}));
 		}
 
-		if(set_parry.empty() == false) {
-			int parry = std::stoi(set_parry);
-
+		if(!set_parry.empty()) {
 			add_and(desc);
-			desc << parry << _(" parry");
+			desc << vgettext("$number parry",
+								  utils::string_map({{"number", set_parry}}));
 		}
 
-		if(increase_parry.empty() == false) {
+		if(!increase_parry.empty()) {
 			add_and(desc);
-			int inc_parry = std::stoi(increase_parry);
-			// xgettext:no-c-format
-			desc << utils::signed_value(inc_parry) << _("% parry");
+			desc << vgettext("$number parry",
+								  utils::string_map({{"number", utils::print_modifier(increase_parry)}}));
 		}
 
 		if(!set_movement.empty()) {

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -349,43 +349,39 @@ bool attack_type::describe_modification(const config& cfg,std::string* descripti
 		std::stringstream desc;
 
 		if(!increase_damage.empty()) {
-			utils::string_map symbols;
-			symbols["damage"] = utils::print_modifier(increase_damage);
 			add_and(desc);
 			desc << vngettext(
-					"$damage damage",
-					"$damage damage",
-					std::stoi(increase_damage), symbols);
+						  "$number damage",
+						  "$number damage",
+						  std::stoi(increase_damage),
+						  utils::string_map({{"number", utils::print_modifier(increase_damage)}}));
 		}
 
 		if(!set_damage.empty()) {
-			utils::string_map symbols;
-			symbols["damage"] = set_damage;
 			add_and(desc);
 			desc << vngettext(
-					"$damage damage",
-					"$damage damage",
-					std::stoi(set_damage), symbols);
+						  "$number damage",
+						  "$number damage",
+						  std::stoi(set_damage),
+						  utils::string_map({{"number", set_damage}}));
 		}
 
 		if(!increase_attacks.empty()) {
-			utils::string_map symbols;
-			symbols["attacks"] = utils::print_modifier(increase_attacks);
 			add_and(desc);
 			desc << vngettext(
-					"$attacks strike",
-					"$attacks strikes",
-					std::stoi(increase_attacks), symbols);
+						  "$attacks strike",
+						  "$attacks strikes",
+						  std::stoi(increase_attacks),
+						  utils::string_map({{"attacks", utils::print_modifier(increase_attacks)}}));
 		}
 
 		if(!set_attacks.empty()) {
-			utils::string_map symbols;
-			symbols["attacks"] = set_attacks;
 			add_and(desc);
 			desc << vngettext(
-					"$attacks strike",
-					"$attacks strikes",
-					std::stoi(set_attacks), symbols);
+						  "$attacks strike",
+						  "$attacks strikes",
+						  std::stoi(set_attacks),
+						  utils::string_map({{"attacks", set_attacks}}));
 		}
 
 		if(!set_accuracy.empty()) {
@@ -402,34 +398,32 @@ bool attack_type::describe_modification(const config& cfg,std::string* descripti
 
 		if(!set_parry.empty()) {
 			add_and(desc);
-			desc << vgettext("$number parry",
-								  utils::string_map({{"number", set_parry}}));
+			desc << vgettext("$strength parry",
+								  utils::string_map({{"strength", set_parry}}));
 		}
 
 		if(!increase_parry.empty()) {
 			add_and(desc);
-			desc << vgettext("$number parry",
-								  utils::string_map({{"number", utils::print_modifier(increase_parry)}}));
+			desc << vgettext("$strength parry",
+								  utils::string_map({{"strength", utils::print_modifier(increase_parry)}}));
 		}
 
 		if(!set_movement.empty()) {
-			utils::string_map symbols;
-			symbols["points"] = set_movement;
 			add_and(desc);
 			desc << vngettext(
-					"$points movement point",
-					"$points movement points",
-					std::stoi(set_movement), symbols);
+						  "$points movement point",
+						  "$points movement points",
+						  std::stoi(set_movement),
+						  utils::string_map({{"points", set_movement}}));
 		}
 
 		if(!increase_movement.empty()) {
-			utils::string_map symbols;
-			symbols["points"] = utils::print_modifier(increase_movement);
 			add_and(desc);
 			desc << vngettext(
-					"$points movement point",
-					"$points movement points",
-					std::stoi(increase_movement), symbols);
+						  "$points movement point",
+						  "$points movement points",
+						  std::stoi(increase_movement),
+						  utils::string_map({{"points", utils::print_modifier(increase_movement)}}));
 		}
 
 		*description = desc.str();

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -20,6 +20,7 @@
 #include "units/attack_type.hpp"
 #include "formula/callable_objects.hpp"
 #include "formula/formula.hpp"
+#include "formula/string_utils.hpp"
 
 #include "lexical_cast.hpp"
 #include "log.hpp"
@@ -348,29 +349,43 @@ bool attack_type::describe_modification(const config& cfg,std::string* descripti
 		std::stringstream desc;
 
 		if(increase_damage.empty() == false) {
+			utils::string_map symbols;
+			symbols["damage"] = utils::print_modifier(increase_damage);
 			add_and(desc);
-			int inc_damage = std::stoi(increase_damage);
-			desc << utils::print_modifier(increase_damage) << " "
-				 << _n("damage","damage", inc_damage);
+			desc << vngettext(
+					"$damage damage",
+					"$damage damage",
+					std::stoi(increase_damage), symbols);
 		}
 
-		if(set_damage.empty() == false) {
+		if(!set_damage.empty()) {
+			utils::string_map symbols;
+			symbols["damage"] = set_damage;
 			add_and(desc);
-			int damage = std::stoi(increase_damage);
-			desc << set_damage << " " << _n("damage","damage", damage);
+			desc << vngettext(
+					"$damage damage",
+					"$damage damage",
+					std::stoi(set_damage), symbols);
 		}
 
-		if(increase_attacks.empty() == false) {
+		if(!increase_attacks.empty()) {
+			utils::string_map symbols;
+			symbols["attacks"] = utils::print_modifier(increase_attacks);
 			add_and(desc);
-			int inc_attacks = std::stoi(increase_attacks);
-			desc << utils::print_modifier(increase_attacks) << " "
-				 << _n("strike", "strikes", inc_attacks);
+			desc << vngettext(
+					"$attacks strike",
+					"$attacks strikes",
+					std::stoi(increase_attacks), symbols);
 		}
 
-		if(set_attacks.empty() == false) {
-			int num_attacks = std::stoi(set_attacks);
+		if(!set_attacks.empty()) {
+			utils::string_map symbols;
+			symbols["attacks"] = set_attacks;
 			add_and(desc);
-			desc << set_attacks << " " << _n("strike", "strikes", num_attacks);
+			desc << vngettext(
+					"$attacks strike",
+					"$attacks strikes",
+					std::stoi(set_attacks), symbols);
 		}
 
 		if(set_accuracy.empty() == false) {
@@ -403,17 +418,24 @@ bool attack_type::describe_modification(const config& cfg,std::string* descripti
 			desc << utils::signed_value(inc_parry) << _("% parry");
 		}
 
-		if(set_movement.empty() == false) {
-			int movement_used = std::stoi(set_movement);
-
+		if(!set_movement.empty()) {
+			utils::string_map symbols;
+			symbols["points"] = set_movement;
 			add_and(desc);
-			desc << movement_used << " " << _n("movement point","movement points",movement_used);
+			desc << vngettext(
+					"$points movement point",
+					"$points movement points",
+					std::stoi(set_movement), symbols);
 		}
 
-		if(increase_movement.empty() == false) {
+		if(!increase_movement.empty()) {
+			utils::string_map symbols;
+			symbols["points"] = utils::print_modifier(increase_movement);
 			add_and(desc);
-			int inc_move = std::stoi(increase_movement);
-			desc << increase_movement << " " << _n("movement point","movement points",inc_move);
+			desc << vngettext(
+					"$points movement point",
+					"$points movement points",
+					std::stoi(increase_movement), symbols);
 		}
 
 		*description = desc.str();

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -351,10 +351,10 @@ bool attack_type::describe_modification(const config& cfg,std::string* descripti
 		if(!increase_damage.empty()) {
 			add_and(desc);
 			desc << vngettext(
-				"$number damage",
-				"$number damage",
+				"$number_or_percent damage",
+				"$number_or_percent damage",
 				std::stoi(increase_damage),
-				utils::string_map({{"number", utils::print_modifier(increase_damage)}}));
+				utils::string_map({{"number_or_percent", utils::print_modifier(increase_damage)}}));
 		}
 
 		if(!set_damage.empty()) {
@@ -369,19 +369,19 @@ bool attack_type::describe_modification(const config& cfg,std::string* descripti
 		if(!increase_attacks.empty()) {
 			add_and(desc);
 			desc << vngettext(
-				"$attacks strike",
-				"$attacks strikes",
+				"$number_or_percent strike",
+				"$number_or_percent strikes",
 				std::stoi(increase_attacks),
-				utils::string_map({{"attacks", utils::print_modifier(increase_attacks)}}));
+				utils::string_map({{"number_or_percent", utils::print_modifier(increase_attacks)}}));
 		}
 
 		if(!set_attacks.empty()) {
 			add_and(desc);
 			desc << vngettext(
-				"$attacks strike",
-				"$attacks strikes",
+				"$number strike",
+				"$number strikes",
 				std::stoi(set_attacks),
-				utils::string_map({{"attacks", set_attacks}}));
+				utils::string_map({{"number", set_attacks}}));
 		}
 
 		if(!set_accuracy.empty()) {
@@ -401,33 +401,33 @@ bool attack_type::describe_modification(const config& cfg,std::string* descripti
 		if(!set_parry.empty()) {
 			add_and(desc);
 			desc << vgettext(
-				"$strength parry",
-				utils::string_map({{"strength", set_parry}}));
+				"$number parry",
+				utils::string_map({{"number", set_parry}}));
 		}
 
 		if(!increase_parry.empty()) {
 			add_and(desc);
 			desc << vgettext(
-				"$strength parry",
-				utils::string_map({{"strength", utils::print_modifier(increase_parry)}}));
+				"$number_or_percent parry",
+				utils::string_map({{"number_or_percent", utils::print_modifier(increase_parry)}}));
 		}
 
 		if(!set_movement.empty()) {
 			add_and(desc);
 			desc << vngettext(
-				"$points movement point",
-				"$points movement points",
+				"$number movement point",
+				"$number movement points",
 				std::stoi(set_movement),
-				utils::string_map({{"points", set_movement}}));
+				utils::string_map({{"number", set_movement}}));
 		}
 
 		if(!increase_movement.empty()) {
 			add_and(desc);
 			desc << vngettext(
-				"$points movement point",
-				"$points movement points",
+				"$number_or_percent movement point",
+				"$number_or_percent movement points",
 				std::stoi(increase_movement),
-				utils::string_map({{"points", utils::print_modifier(increase_movement)}}));
+				utils::string_map({{"number_or_percent", utils::print_modifier(increase_movement)}}));
 		}
 
 		*description = desc.str();


### PR DESCRIPTION
- Replaced _ with vgettext
- Replaced _n with vngettext
- Set_damage now uses set_damage rather than increase_damage
- Add missing utils::print_modifier to increase_movement

Fixes https://gna.org/bugs/?25468