### PR TITLE
Delete old ability's description:Unpoison

### DIFF
--- a/doc/manual/manual.txt
+++ b/doc/manual/manual.txt
@@ -866,9 +866,6 @@ Submerge::
 Teleport::
   This unit may teleport between any two friendly villages using one of its
   moves.
-Unpoison::
-  A curer can cure a unit of poison, although that unit will receive no additional
-  healing on the turn it is cured of the poison.
 
 Experience
 ^^^^^^^^^^


### PR DESCRIPTION
There is "Unpoison" in the manual, but I don't know the ability such name.
It has almost same description as "Cure".
I think it is an old ability, so it should be deleted.