### PR TITLE
Fix bug #25332, some sentences are not shown in help pages

### DIFF
--- a/src/font/sdl_ttf.cpp
+++ b/src/font/sdl_ttf.cpp
@@ -320,7 +320,7 @@ static surface render_text(const std::string& text, int fontsize, const color_t&
 					j_end = i->end(); j != j_end; ++j) {
 				adjust_surface_alpha(*j, SDL_ALPHA_OPAQUE); // direct blit without alpha blending
 				SDL_Rect dstrect = sdl::create_rect(xpos, ypos, 0, 0);
-				sdl_blit(*j, nullptr, res, &dstrect);
+				blit_surface(*j, nullptr, res, &dstrect);
 				xpos += (*j)->w;
 				height = std::max<size_t>((*j)->h, height);
 			}

--- a/src/font/sdl_ttf.cpp
+++ b/src/font/sdl_ttf.cpp
@@ -306,7 +306,6 @@ static surface render_text(const std::string& text, int fontsize, const color_t&
 		adjust_surface_alpha(surf, SDL_ALPHA_OPAQUE);
 		return surf;
 	} else {
-
 		surface res(create_compatible_surface(surfaces.front().front(),width,height));
 		if (res.null())
 			return res;
@@ -319,7 +318,7 @@ static surface render_text(const std::string& text, int fontsize, const color_t&
 
 			for(std::vector<surface>::iterator j = i->begin(),
 					j_end = i->end(); j != j_end; ++j) {
-				adjust_surface_alpha(*j, SDL_ALPHA_TRANSPARENT); // direct blit without alpha blending
+				adjust_surface_alpha(*j, SDL_ALPHA_OPAQUE); // direct blit without alpha blending
 				SDL_Rect dstrect = sdl::create_rect(xpos, ypos, 0, 0);
 				sdl_blit(*j, nullptr, res, &dstrect);
 				xpos += (*j)->w;

--- a/src/font/sdl_ttf.cpp
+++ b/src/font/sdl_ttf.cpp
@@ -303,7 +303,6 @@ static surface render_text(const std::string& text, int fontsize, const color_t&
 		return surface();
 	} else if (surfaces.size() == 1 && surfaces.front().size() == 1) {
 		surface surf = surfaces.front().front();
-		adjust_surface_alpha(surf, SDL_ALPHA_OPAQUE);
 		return surf;
 	} else {
 		surface res(create_compatible_surface(surfaces.front().front(),width,height));
@@ -318,7 +317,6 @@ static surface render_text(const std::string& text, int fontsize, const color_t&
 
 			for(std::vector<surface>::iterator j = i->begin(),
 					j_end = i->end(); j != j_end; ++j) {
-				adjust_surface_alpha(*j, SDL_ALPHA_OPAQUE); // direct blit without alpha blending
 				SDL_Rect dstrect = sdl::create_rect(xpos, ypos, 0, 0);
 				blit_surface(*j, nullptr, res, &dstrect);
 				xpos += (*j)->w;


### PR DESCRIPTION
fix bug #25332  https://gna.org/bugs/index.php?25332

render_text() separates sentences which use plural fonts to plural surfaces, but render_text() makes the surfaces invisible when blit surfaces.