### PR TITLE
manual: remove description about default weapon choice

### DIFF
--- a/doc/manual/manual.txt
+++ b/doc/manual/manual.txt
@@ -1264,9 +1264,8 @@ allows the enemy to do least damage to you, rather than choosing the
 maximum expected damage to the enemy.
 
 In particular, use your ranged weapons if the enemy has no ranged
-attack. The computer's default choice only looks for the most damage
-you can deal, so using it will often result in your units taking more
-damage than necessary.
+attack. Using it will often reduce the damage which your units take 
+until the enemy dies.
 
 Time of Day
 ^^^^^^^^^^^


### PR DESCRIPTION
Recent wesnoth don't choose default weapon only by the maximum taking damage, so change description.

But I'm not English native, the new description may have English mistakes.