### PR TITLE
zombies

### DIFF
--- a/data/core/units/undead/Corpse_Soulless.cfg
+++ b/data/core/units/undead/Corpse_Soulless.cfg
@@ -8,13 +8,13 @@
 #enddef
 
 # Variant animations for the Soulless
-#define UNIT_BODY_SOULLESS_GRAPHICS BASE_NAME DEATH_FRAMES_NUMBER
+#define UNIT_BODY_SOULLESS_GRAPHICS BASE_NAME
     image="units/undead/{BASE_NAME}.png"
     {DEFENSE_ANIM "units/undead/{BASE_NAME}-defend.png" "units/undead/{BASE_NAME}.png" {SOUND_LIST:ZOMBIE_HIT} }
     [death]
         start_time=0
         [frame]
-            image="units/undead/{BASE_NAME}-die-[1~{DEATH_FRAMES_NUMBER}].png:150,units/undead/soulless-die-[5~10].png:150"
+            image="units/undead/{BASE_NAME}-die-[1~4].png:150,units/undead/soulless-die-[5~10].png:150"
         [/frame]
     [/death]
     [attack_anim]
@@ -93,7 +93,7 @@
     [/defense]
 
     {UNIT_BODY_SOULLESS_STATS smallfoot 4 28}
-    {UNIT_BODY_SOULLESS_GRAPHICS soulless 4}
+    {UNIT_BODY_SOULLESS_GRAPHICS soulless}
 
     [variation]
         variation_id=drake
@@ -101,7 +101,7 @@
         inherit=yes
         profile=unit_image
         {UNIT_BODY_SOULLESS_STATS    drakefoot 4 36}
-        {UNIT_BODY_SOULLESS_GRAPHICS soulless-drake 4}
+        {UNIT_BODY_SOULLESS_GRAPHICS soulless-drake}
         [movement_costs]
             unwalkable=4
         [/movement_costs]
@@ -116,7 +116,7 @@
         inherit=yes
         profile=unit_image
         {UNIT_BODY_SOULLESS_STATS    dwarvishfoot 3 33}
-        {UNIT_BODY_SOULLESS_GRAPHICS soulless-dwarf 4}
+        {UNIT_BODY_SOULLESS_GRAPHICS soulless-dwarf}
         [movement_costs]
             deep_water=3
         [/movement_costs]
@@ -128,7 +128,7 @@
         inherit=yes
         profile=unit_image
         {UNIT_BODY_SOULLESS_STATS    smallfoot 4 23}
-        {UNIT_BODY_SOULLESS_GRAPHICS soulless-goblin 4}
+        {UNIT_BODY_SOULLESS_GRAPHICS soulless-goblin}
     [/variation]
 
     [variation]
@@ -137,7 +137,7 @@
         inherit=yes
         # Default portrait is fine for Mounted
         {UNIT_BODY_SOULLESS_STATS    mounted 5 33}
-        {UNIT_BODY_SOULLESS_GRAPHICS soulless-mounted 4}
+        {UNIT_BODY_SOULLESS_GRAPHICS soulless-mounted}
     [/variation]
 
     [variation]
@@ -146,9 +146,13 @@
         inherit=yes
         profile=unit_image
         {UNIT_BODY_SOULLESS_STATS    fly 5 33}
-        {UNIT_BODY_SOULLESS_GRAPHICS soulless-drake 3}
+        {UNIT_BODY_SOULLESS_GRAPHICS soulless-drake}
+        [movement_costs]
+            deep_water=1
+        [/movement_costs]
         [defense]
             mountains=40
+            deep_water=50
         [/defense]
     [/variation]
 
@@ -158,7 +162,7 @@
         inherit=yes
         profile=unit_image
         {UNIT_BODY_SOULLESS_STATS    lizard 4 25}
-        {UNIT_BODY_SOULLESS_GRAPHICS soulless-saurian 4}
+        {UNIT_BODY_SOULLESS_GRAPHICS soulless-saurian}
     [/variation]
 
     [variation]
@@ -167,11 +171,15 @@
         inherit=yes
         profile=unit_image
         {UNIT_BODY_SOULLESS_STATS    swimmer 4 28}
-        {UNIT_BODY_SOULLESS_GRAPHICS soulless-swimmer 4}
+        {UNIT_BODY_SOULLESS_GRAPHICS soulless-swimmer}
         [movement_costs]
             forest=4
             hills=4
+            deep_water=1
         [/movement_costs]
+        [defense]
+            deep_water=50
+        [/defense]
     [/variation]
 
     [variation]
@@ -180,7 +188,7 @@
         inherit=yes
         profile=unit_image
         {UNIT_BODY_SOULLESS_STATS    largefoot 4 33}
-        {UNIT_BODY_SOULLESS_GRAPHICS soulless-troll 4}
+        {UNIT_BODY_SOULLESS_GRAPHICS soulless-troll}
     [/variation]
 
     [variation]
@@ -189,7 +197,7 @@
         inherit=yes
         profile=unit_image
         {UNIT_BODY_SOULLESS_STATS    treefolk 3 40}
-        {UNIT_BODY_SOULLESS_GRAPHICS soulless-wose 4}
+        {UNIT_BODY_SOULLESS_GRAPHICS soulless-wose}
         [movement_costs]
             deep_water=3
         [/movement_costs]
@@ -201,7 +209,7 @@
         inherit=yes
         profile=unit_image
         {UNIT_BODY_SOULLESS_STATS orcishfoot 5 30}
-        {UNIT_BODY_SOULLESS_GRAPHICS soulless-wolf 4}
+        {UNIT_BODY_SOULLESS_GRAPHICS soulless-wolf}
         [defense]
             village=50
         [/defense]
@@ -211,17 +219,19 @@
         variation_id=bat
         variation_name= _ "wc_variation^Bat"
         inherit=yes
-        image="units/undead/soulless-bat-se-3.png"
-        {UNIT_BODY_SOULLESS_STATS fly 5 24}
         profile=unit_image
+        {UNIT_BODY_SOULLESS_STATS fly 5 24}
+        image="units/undead/soulless-bat-se-3.png"
         die_sound="bat-flapping.wav"
         [movement_costs]
             cave=1
             fungus=1
+            deep_water=1
         [/movement_costs]
         [defense]
             cave=50
             fungus=50
+            deep_water=50
         [/defense]
         [resistance]
             cold=70
@@ -324,3 +334,6 @@
         [/attack_anim]
     [/variation]
 [/unit_type]
+
+#undef UNIT_BODY_SOULLESS_STATS
+#undef UNIT_BODY_SOULLESS_GRAPHICS

--- a/data/core/units/undead/Corpse_Soulless.cfg
+++ b/data/core/units/undead/Corpse_Soulless.cfg
@@ -138,6 +138,7 @@
         # Default portrait is fine for Mounted
         {UNIT_BODY_SOULLESS_STATS    mounted 5 33}
         {UNIT_BODY_SOULLESS_GRAPHICS soulless-mounted}
+        description= _ "The technique of animating a dead body is unfortunately well-known in the dark arts; practitioners often use it to raise servants and soldiers from unwilling corpses. These shamblers are often numerous, but fragile; a touch of combat can waken them, though, making them far more formidable."+{SPECIAL_NOTES}+{SPECIAL_NOTES_PLAGUE}+{SPECIAL_NOTES_DEFENSE_CAP}
     [/variation]
 
     [variation]

--- a/data/core/units/undead/Corpse_Walking.cfg
+++ b/data/core/units/undead/Corpse_Walking.cfg
@@ -153,6 +153,7 @@
         # Default portrait is fine for Mounted
         {UNIT_BODY_WALKING_CORPSE_STATS    mounted 5 21}
         {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-mounted}
+        description= _ "Walking Corpses are the bodies of the dead, re-animated by dark magic. Though not especially dangerous to a trained soldier, the sight of one’s former comrades amongst their number is frightening to say the least."+{SPECIAL_NOTES}+{SPECIAL_NOTES_PLAGUE}+{SPECIAL_NOTES_DEFENSE_CAP}
     [/variation]
 
     [variation]

--- a/data/core/units/undead/Corpse_Walking.cfg
+++ b/data/core/units/undead/Corpse_Walking.cfg
@@ -8,13 +8,13 @@
 #enddef
 
 # Variant animations for the Walking Corpse
-#define UNIT_BODY_WALKING_CORPSE_GRAPHICS NBASE_NAME DEATH_FRAMES_NUMBER
-    image="units/undead/{NBASE_NAME}.png"
-    {DEFENSE_ANIM "units/undead/{NBASE_NAME}-defend.png" "units/undead/{NBASE_NAME}.png" {SOUND_LIST:ZOMBIE_WEAK_HIT} }
+#define UNIT_BODY_WALKING_CORPSE_GRAPHICS BASE_NAME
+    image="units/undead/{BASE_NAME}.png"
+    {DEFENSE_ANIM "units/undead/{BASE_NAME}-defend.png" "units/undead/{BASE_NAME}.png" {SOUND_LIST:ZOMBIE_WEAK_HIT} }
     [death]
         start_time=0
         [frame]
-            image="units/undead/{NBASE_NAME}-die-[1~{DEATH_FRAMES_NUMBER}].png:150,units/undead/soulless-die-[5~10].png:150"
+            image="units/undead/{BASE_NAME}-die-[1~4].png:150,units/undead/soulless-die-[5~10].png:150"
         [/frame]
     [/death]
     [attack_anim]
@@ -24,7 +24,7 @@
         direction=s
         start_time=-200
         [frame]
-            image="units/undead/{NBASE_NAME}-attack-s.png:400"
+            image="units/undead/{BASE_NAME}-attack-s.png:400"
             sound=zombie-attack.wav
         [/frame]
     [/attack_anim]
@@ -35,7 +35,7 @@
         direction=n
         start_time=-200
         [frame]
-            image="units/undead/{NBASE_NAME}-attack-n.png:400"
+            image="units/undead/{BASE_NAME}-attack-n.png:400"
             sound=zombie-attack.wav
         [/frame]
     [/attack_anim]
@@ -46,7 +46,7 @@
         direction=se,sw,ne,nw
         start_time=-200
         [frame]
-            image="units/undead/{NBASE_NAME}-attack.png:400"
+            image="units/undead/{BASE_NAME}-attack.png:400"
             sound=zombie-attack.wav
         [/frame]
     [/attack_anim]
@@ -92,7 +92,7 @@
     [/defense]
 
     {UNIT_BODY_WALKING_CORPSE_STATS    smallfoot 4 18}
-    {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie 4}
+    {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie}
 
     [variation]
         variation_id=drake
@@ -100,7 +100,7 @@
         inherit=yes
         profile=unit_image
         {UNIT_BODY_WALKING_CORPSE_STATS    drakefoot 4 23}
-        {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-drake 4}
+        {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-drake}
         [movement_costs]
             unwalkable=4
         [/movement_costs]
@@ -115,7 +115,7 @@
         inherit=yes
         profile=unit_image
         {UNIT_BODY_WALKING_CORPSE_STATS    dwarvishfoot 3 21}
-        {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-dwarf 4}
+        {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-dwarf}
         [movement_costs]
             deep_water=3
         [/movement_costs]
@@ -127,7 +127,7 @@
         inherit=yes
         profile=unit_image
         {UNIT_BODY_WALKING_CORPSE_STATS    smallfoot 4 13}
-        {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-goblin 4}
+        {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-goblin}
     [/variation]
 
     [variation]
@@ -136,9 +136,13 @@
         inherit=yes
         profile=unit_image
         {UNIT_BODY_WALKING_CORPSE_STATS    fly 5 21}
-        {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-drake 4}
+        {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-drake}
+        [movement_costs]
+            deep_water=1
+        [/movement_costs]
         [defense]
             mountains=40
+            deep_water=50
         [/defense]
     [/variation]
 
@@ -148,7 +152,7 @@
         inherit=yes
         # Default portrait is fine for Mounted
         {UNIT_BODY_WALKING_CORPSE_STATS    mounted 5 21}
-        {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-mounted 4}
+        {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-mounted}
     [/variation]
 
     [variation]
@@ -157,7 +161,7 @@
         inherit=yes
         profile=unit_image
         {UNIT_BODY_WALKING_CORPSE_STATS    lizard 4 16}
-        {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-saurian 4}
+        {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-saurian}
     [/variation]
 
     [variation]
@@ -166,11 +170,15 @@
         inherit=yes
         profile=unit_image
         {UNIT_BODY_WALKING_CORPSE_STATS    swimmer 4 18}
-        {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-swimmer 4}
+        {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-swimmer}
         [movement_costs]
             forest=4
             hills=4
+            deep_water=1
         [/movement_costs]
+        [defense]
+            deep_water=50
+        [/defense]
     [/variation]
 
     [variation]
@@ -179,7 +187,7 @@
         inherit=yes
         profile=unit_image
         {UNIT_BODY_WALKING_CORPSE_STATS    largefoot 4 21}
-        {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-troll 4}
+        {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-troll}
     [/variation]
 
     [variation]
@@ -188,7 +196,7 @@
         inherit=yes
         profile=unit_image
         {UNIT_BODY_WALKING_CORPSE_STATS    treefolk 3 26}
-        {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-wose 4}
+        {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-wose}
         [movement_costs]
             deep_water=3
         [/movement_costs]
@@ -200,7 +208,7 @@
         inherit=yes
         profile=unit_image
         {UNIT_BODY_WALKING_CORPSE_STATS orcishfoot 5 19}
-        {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-wolf 4}
+        {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-wolf}
         [defense]
             village=50
         [/defense]
@@ -210,17 +218,19 @@
         variation_id=bat
         variation_name= _ "wc_variation^Bat"
         inherit=yes
-        image="units/undead/zombie-bat-se-3.png"
-        {UNIT_BODY_WALKING_CORPSE_STATS fly 5 15}
         profile=unit_image
+        {UNIT_BODY_WALKING_CORPSE_STATS fly 5 15}
+        image="units/undead/zombie-bat-se-3.png"
         die_sound="bat-flapping.wav"
         [movement_costs]
             cave=1
             fungus=1
+            deep_water=1
         [/movement_costs]
         [defense]
             cave=50
             fungus=50
+            deep_water=50
         [/defense]
         [resistance]
             cold=70


### PR DESCRIPTION
fix regression of a701a2e (movement/defense on deep water for some variations)
since da255ab all death animations use exactly 4 specific frames, simplyfied macros
NBASE_NAME -> BASE_NAME
#undef soulless macros too

What would be possible too is the wolf variation using some wolf sounds. This is the bat doing with the die sound. But I don't have a specific suggestion here.