### PR TITLE
Changed description of the alternative plague ability.

### DIFF
--- a/data/core/macros/abilities.cfg
+++ b/data/core/macros/abilities.cfg
@@ -376,7 +376,7 @@ Enemy units cannot see this unit while it is in deep water, except if they have 
     [plague]
         id=plague({TYPE})
         name= _ "plague"
-        description= _ "When a unit is killed by a Plague attack, that unit is replaced with a unit identical to and on the same side as the unit with the Plague attack. This doesn’t work on Undead or units in villages."
+        description= _ "When a unit is killed by a Plague attack, that unit is replaced with a unit on the same side as the unit with the Plague attack. This doesn’t work on Undead or units in villages."
         type={TYPE}
     [/plague]
 #enddef


### PR DESCRIPTION
This ability gives content creator complete freedom on what unit type to create. (It's also only used in UMC)  While it's probably mostly the lvl0 version of the unit who used the ability, the current description is not fitting.

Credits for spotting and changing this go to Ravana.