### PR TITLE
help(editor): fix duplication of text attribute

### DIFF
--- a/data/core/editor/help.cfg
+++ b/data/core/editor/help.cfg
@@ -37,9 +37,9 @@ The paint tool utilizes the brushes and the terrain palette."
 [topic]
     id=editor_tool_fill
     title= _ "Fill Tool"
-    text= _ "Evil Tool for painting."
     text= "<img>src=icons/action/editor-tool-fill_60.png align=left box=yes</img>" + _ "Fill continuous regions of terrain with a different one!
 
+Evil Tool for painting.
 The fill tool utilizes the terrain palette."
 [/topic]
 # wmllint: markcheck on


### PR DESCRIPTION
There are duplication of text attribute, so some sentence is not displayed.