### PR TITLE
resolve compile warning (clang)

### DIFF
--- a/src/game_initialization/flg_manager.cpp
+++ b/src/game_initialization/flg_manager.cpp
@@ -32,7 +32,6 @@ flg_manager::flg_manager(const std::vector<const config*>& era_factions,
 		const config& side, const bool lock_settings, const bool use_map_settings, const bool saved_game)
 	: era_factions_(era_factions)
 	, side_(side)
-	, use_map_settings_(use_map_settings)
 	, saved_game_(saved_game)
 	, has_no_recruits_(get_original_recruits(side_).empty() && side_["previous_recruits"].empty())
 	, faction_lock_(side_["faction_lock"].to_bool(lock_settings) && (use_map_settings || lock_settings))

--- a/src/game_initialization/flg_manager.hpp
+++ b/src/game_initialization/flg_manager.hpp
@@ -105,7 +105,6 @@ private:
 
 	const config& side_;
 
-	const bool use_map_settings_;
 	const bool saved_game_;
 	const bool has_no_recruits_;
 


### PR DESCRIPTION
In file included from ../src/game_initialization/flg_manager.cpp:15:
../src/game_initialization/flg_manager.hpp:108:13: warning: private field 'use_map_settings_' is not used [-Wunused-private-field]
        const bool use_map_settings_;
                   ^