### PR TITLE
HttT: don't kill Gryphons in the recall list

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/14_Plunging_Into_the_Darkness.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/14_Plunging_Into_the_Darkness.cfg
@@ -540,6 +540,7 @@
                 # This kills the gryphon unit so it can travel some more
                 [kill]
                     type=Gryphon
+                    x,y=13,23
                 [/kill]
 
                 [move_unit_fake]
@@ -614,6 +615,7 @@
                 # This gets rid of the gryphon
                 [kill]
                     type=Gryphon
+                    x,y=15,19
                 [/kill]
 
                 [unit]
@@ -642,6 +644,7 @@
                 # This gets rid of the gryphon rider
                 [kill]
                     type=Gryphon Rider
+                    x,y=15,19
                 [/kill]
 
                 [move_unit_fake]


### PR DESCRIPTION
The player can't have recruited Gryphons yet, but may have summoned them using `:create'.  Don't kill any such Gryphons, only the one added by the event.

I ran into this when I tried going through HttT with dwarves rather than elves.  I had edited the savefile by hand to permit Konrad to recruit Gryphon Riders, but my level 1 Gryphon Riders disappeared between The Dwarven Doors and The Lost General.