### PR TITLE
Fix #24681: Use composed hotkeys where appropriate and revert help to be ':'

### DIFF
--- a/data/core/hotkeys.cfg
+++ b/data/core/hotkeys.cfg
@@ -83,7 +83,7 @@
 [/hotkey]
 [hotkey]
     command=command
-    key=;
+    key=:
 [/hotkey]
 [hotkey]
     command=continue

--- a/src/controller_base.cpp
+++ b/src/controller_base.cpp
@@ -54,6 +54,11 @@ void controller_base::handle_event(const SDL_Event& event)
 	static const hotkey::hotkey_command& quit_hotkey = hotkey::hotkey_command::get_command_by_command(hotkey::HOTKEY_QUIT_GAME);
 
 	switch(event.type) {
+	case SDL_TEXTINPUT:
+		if(have_keyboard_focus()) {
+			hotkey::key_event(event, get_hotkey_command_executor());
+		}
+		break;
 	case SDL_KEYDOWN:
 		// Detect key press events, unless there something that has keyboard focus
 		// in which case the key press events should go only to it.

--- a/src/hotkey/command_executor.cpp
+++ b/src/hotkey/command_executor.cpp
@@ -567,7 +567,10 @@ static void event_execute( const SDL_Event& event, command_executor* executor)
 		return;
 	}
 
-	bool press = event.type == SDL_KEYDOWN || event.type == SDL_JOYBUTTONDOWN || event.type == SDL_MOUSEBUTTONDOWN;
+	bool press = event.type == SDL_KEYDOWN ||
+			event.type == SDL_JOYBUTTONDOWN ||
+			event.type == SDL_MOUSEBUTTONDOWN ||
+			event.type == SDL_TEXTINPUT;
 
 	execute_command(hotkey::get_hotkey_command(hk->get_command()), executor, -1, press);
 	executor->set_button_state();

--- a/src/hotkey/hotkey_item.cpp
+++ b/src/hotkey/hotkey_item.cpp
@@ -128,14 +128,8 @@ bool hotkey_base::bindings_equal(hotkey_ptr other)
 
 bool hotkey_base::matches(const SDL_Event &event) const
 {
-	unsigned int mods = sdl_get_mods();
-
 	if (!hotkey::is_scope_active(hotkey::get_hotkey_command(get_command()).scope) ||
 			!active() || is_disabled()) {
-		return false;
-	}
-
-	if ((mods != mod_)) {
 		return false;
 	}
 
@@ -164,9 +158,9 @@ hotkey_ptr create_hotkey(const std::string &id, SDL_Event &event)
 	case SDL_KEYUP: {
 		hotkey_keyboard_ptr keyboard(new hotkey_keyboard());
 		base = std::dynamic_pointer_cast<hotkey_base>(keyboard);
-		SDL_Scancode code;
-		code = event.key.keysym.scancode;
-		keyboard->set_scancode(code);
+		SDL_Keycode code;
+		code = event.key.keysym.sym;
+		keyboard->set_keycode(code);
 		break;
 	}
 	case SDL_MOUSEBUTTONDOWN:
@@ -221,11 +215,12 @@ hotkey_ptr load_from_config(const config& cfg)
 		hotkey_keyboard_ptr keyboard(new hotkey_keyboard());
 		base = std::dynamic_pointer_cast<hotkey_base>(keyboard);
 
-		SDL_Scancode scancode = SDL_GetScancodeFromName(key_cfg.c_str());
-		if (scancode == SDL_SCANCODE_UNKNOWN) {
+		SDL_Keycode keycode = SDL_GetKeyFromName(key_cfg.c_str());
+		if (keycode == SDLK_UNKNOWN) {
 			ERR_G<< "Unknown key: " << key_cfg << "\n";
 		}
-		keyboard->set_scancode(scancode);
+		keyboard->set_text(key_cfg);
+		keyboard->set_keycode(keycode);
 	}
 
 	if (base == hotkey_ptr()) {
@@ -257,6 +252,11 @@ bool hotkey_mouse::matches_helper(const SDL_Event &event) const
 		return false;
 	}
 
+	unsigned int mods = sdl_get_mods();
+	if ((mods != mod_)) {
+		return false;
+	}
+
 	if (event.button.button != button_) {
 		return false;
 	}
@@ -279,7 +279,7 @@ void hotkey_mouse::save_helper(config &item) const
 
 const std::string hotkey_keyboard::get_name_helper() const
 {
-	std::string ret = std::string(SDL_GetKeyName(SDL_GetKeyFromScancode(scancode_)));
+	std::string ret = text_;
 
 	if (ret.size() == 1) {
 		boost::algorithm::to_lower(ret);
@@ -290,18 +290,21 @@ const std::string hotkey_keyboard::get_name_helper() const
 
 bool hotkey_keyboard::matches_helper(const SDL_Event &event) const
 {
-	if (event.type != SDL_KEYDOWN && event.type != SDL_KEYUP) {
+	unsigned int mods = sdl_get_mods();
+
+	if (event.type == SDL_TEXTINPUT && text_.length() == 1) {
+		std::string text = std::string(event.text.text);
+		boost::algorithm::to_lower(text);
+		if (text == ":") {
+			mods = mods & ~KMOD_SHIFT;
+		}
+		return  text_ == text && mods == mod_;
+	} else if ((event.type == SDL_KEYDOWN || event.type == SDL_KEYUP) &&
+			(text_.length() > 1 || mods & (KMOD_CTRL|KMOD_ALT|KMOD_GUI)) ) {
+		return event.key.keysym.sym == keycode_ && mods == mod_;
+	} else {
 		return false;
 	}
-
-	SDL_Scancode code;
-	code = event.key.keysym.scancode;
-
-	if (code != scancode_) {
-		return false;
-	}
-
-	return true;
 }
 
 bool hotkey_mouse::bindings_equal_helper(hotkey_ptr other) const
@@ -317,8 +320,8 @@ bool hotkey_mouse::bindings_equal_helper(hotkey_ptr other) const
 
 void hotkey_keyboard::save_helper(config &item) const
 {
-	if (scancode_ != SDL_SCANCODE_UNKNOWN) {
-		item["key"] = SDL_GetScancodeName(scancode_);
+	if (keycode_ != SDLK_UNKNOWN) {
+		item["key"] = SDL_GetKeyName(keycode_);
 	}
 }
 
@@ -341,7 +344,7 @@ bool hotkey_keyboard::bindings_equal_helper(hotkey_ptr other) const
 		return false;
 	}
 
-	return scancode_ == other_k->scancode_;
+	return keycode_ == other_k->keycode_;
 }
 
 void del_hotkey(hotkey_ptr item)

--- a/src/hotkey/hotkey_item.hpp
+++ b/src/hotkey/hotkey_item.hpp
@@ -21,6 +21,7 @@
 #include <memory>
 #include <vector>
 #include <string>
+#include <boost/algorithm/string.hpp>
 
 class config;
 class CVideo;
@@ -256,6 +257,7 @@ public:
 	void set_text(std::string text)
 	{
 		text_ = text;
+		boost::algorithm::to_lower(text_);
 	}
 
 	/**
@@ -437,6 +439,8 @@ std::string get_names(std::string id);
 void save_hotkeys(config& cfg);
 
 hotkey_ptr show_binding_dialog(CVideo& video, const std::string& id);
+
+bool is_hotkeyable_event(const SDL_Event &event);
 
 }
 

--- a/src/hotkey/hotkey_item.hpp
+++ b/src/hotkey/hotkey_item.hpp
@@ -241,16 +241,21 @@ public:
 	/**
 	 * Initialise new instance of this class that has no key associated with is.
 	 */
-	hotkey_keyboard() : hotkey_base(), scancode_(SDL_SCANCODE_UNKNOWN)
+	hotkey_keyboard() : hotkey_base(), keycode_(SDLK_UNKNOWN), text_("")
 	{}
 
 	/**
-	 * Set the scancode associated with this class.
-	 * @param scancode The SDL_Scancode that this hotkey should be associated with
+	 * Set the keycode associated with this class.
+	 * @param keycode_ The SDL_Keycode that this hotkey should be associated with
 	 */
-	void set_scancode(SDL_Scancode scancode)
+	void set_keycode(SDL_Keycode keycode)
 	{
-		scancode_ = scancode;
+		keycode_ = keycode;
+	}
+
+	void set_text(std::string text)
+	{
+		text_ = text;
 	}
 
 	/**
@@ -259,11 +264,12 @@ public:
 	 */
 	virtual bool valid() const
 	{
-		return scancode_ != SDL_SCANCODE_UNKNOWN;
+		return keycode_ != SDLK_UNKNOWN && text_ != "";
 	}
 
 protected:
-	SDL_Scancode scancode_;
+	SDL_Keycode keycode_;
+	std::string text_;
 
 	virtual void save_helper(config& cfg) const;
 	virtual const std::string get_name_helper() const;

--- a/src/hotkey/hotkey_preferences_display.cpp
+++ b/src/hotkey/hotkey_preferences_display.cpp
@@ -72,9 +72,7 @@ hotkey::hotkey_ptr show_binding_dialog(CVideo& video, const std::string& id)
 		SDL_PollEvent(&event);
 		events::peek_for_resize();
 
-	} while (event.type  != SDL_KEYUP && event.type != SDL_JOYBUTTONUP
-			&& event.type != SDL_JOYHATMOTION
-			&& event.type != SDL_MOUSEBUTTONUP);
+	} while (!hotkey::is_hotkeyable_event(event));
 
 	restorer.restore();
 	return keycode == SDLK_ESCAPE ? hotkey::hotkey_ptr() : hotkey::create_hotkey(id, event);

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -14,8 +14,6 @@
 
 #include "key.hpp"
 
-#include <SDL_keyboard.h>
-
 CKey::CKey() :
 	key_list(SDL_GetKeyboardState(nullptr))
 {
@@ -24,4 +22,52 @@ CKey::CKey() :
 bool CKey::operator[](int k) const
 {
 	return key_list[SDL_GetScancodeFromKey(k)] > 0;
+}
+
+bool CKey::is_uncomposable(const SDL_KeyboardEvent &event) {
+
+	switch (event.keysym.sym) {
+		case SDLK_RETURN:
+		case SDLK_ESCAPE:
+		case SDLK_BACKSPACE:
+		case SDLK_TAB:
+		case SDLK_F1:
+		case SDLK_F2:
+		case SDLK_F3:
+		case SDLK_F4:
+		case SDLK_F5:
+		case SDLK_F6:
+		case SDLK_F7:
+		case SDLK_F8:
+		case SDLK_F9:
+		case SDLK_F10:
+		case SDLK_F11:
+		case SDLK_F12:
+		case SDLK_F13:
+		case SDLK_F14:
+		case SDLK_F15:
+		case SDLK_F16:
+		case SDLK_F17:
+		case SDLK_F18:
+		case SDLK_F19:
+		case SDLK_F20:
+		case SDLK_F21:
+		case SDLK_F22:
+		case SDLK_F23:
+		case SDLK_F24:
+		case SDLK_INSERT:
+		case SDLK_HOME:
+		case SDLK_PAGEUP:
+		case SDLK_PAGEDOWN:
+		case SDLK_DELETE:
+		case SDLK_END:
+		case SDLK_UP:
+		case SDLK_DOWN:
+		case SDLK_LEFT:
+		case SDLK_RIGHT:
+
+			return true;
+		default:
+			return false;
+	}
 }

--- a/src/key.hpp
+++ b/src/key.hpp
@@ -16,6 +16,7 @@
 #define KEY_HPP_INCLUDED
 
 #include <cstdint>
+#include <SDL.h>
 
 /**
  * Class that keeps track of all the keys on the keyboard.
@@ -31,6 +32,7 @@ class CKey
 public:
 	CKey();
 	bool operator[](int k) const;
+	static bool is_uncomposable(const SDL_KeyboardEvent &event);
 };
 
 #endif

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -1022,6 +1022,8 @@ int main(int argc, char** argv)
 	//declare this here so that it will always be at the front of the event queue.
 	events::event_context global_context;
 
+	SDL_StartTextInput();
+
 	try {
 		std::cerr << "Battle for Wesnoth v" << game_config::revision << '\n';
 		const time_t t = time(nullptr);


### PR DESCRIPTION
This enables textinput events in SDL and adds handling of them. The events
are processed for hotkeys if the length of the hotkey string is 1 (which is the
case for all straightforward hotkeys).