### PR TITLE
Allow wesnoth.select_unit() to deselect the unit

### DIFF
--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -2544,6 +2544,10 @@ int game_lua_kernel::intf_select_hex(lua_State *L)
  */
 int game_lua_kernel::intf_select_unit(lua_State *L)
 {
+	if(lua_isnoneornil(L, 1)) {
+		play_controller_.get_mouse_handler_base().select_hex(map_location::null_location(), false, false, false);
+		return 0;
+	}
 	const map_location loc = luaW_checklocation(L, 1);
 	if(!map().on_board(loc)) return luaL_argerror(L, 1, "not on board");
 	bool highlight = true;


### PR DESCRIPTION
Since @vultraz recently decided to remove this feature from wesnoth.deselect_hex, there is now a need to support this behaviour in some other way,

Should probably also search all uses of deselect_hex in master to decide if they should also deselect the unit.