### PR TITLE
Prevent alpha underflow and reduce Shadow translucency (bug #14503)

### DIFF
--- a/src/units/frame.cpp
+++ b/src/units/frame.cpp
@@ -888,7 +888,7 @@ const frame_parameters unit_frame::merge_parameters(int current_time, const fram
 	/** The engine provides a highlight ratio for selected units and visible "invisible" units */
 	result.highlight_ratio = current_val.highlight_ratio != 1.0 ? current_val.highlight_ratio : animation_val.highlight_ratio;
 	if(primary && engine_val.highlight_ratio != 1.0) {
-		result.highlight_ratio = result.highlight_ratio + engine_val.highlight_ratio - 1.0; // selected unit
+		result.highlight_ratio = result.highlight_ratio * engine_val.highlight_ratio; // selected unit
 	}
 
 	assert(engine_val.offset == 0);

--- a/src/units/frame.cpp
+++ b/src/units/frame.cpp
@@ -886,8 +886,9 @@ const frame_parameters unit_frame::merge_parameters(int current_time, const fram
 	}
 
 	/** The engine provides a highlight ratio for selected units and visible "invisible" units */
-	result.highlight_ratio = current_val.highlight_ratio != 1.0 ? current_val.highlight_ratio : animation_val.highlight_ratio;
-	if(primary && engine_val.highlight_ratio != 1.0) {
+	result.highlight_ratio = (current_val.highlight_ratio < 0.999 || current_val.highlight_ratio > 1.001) ?
+		current_val.highlight_ratio : animation_val.highlight_ratio;
+	if(primary && (engine_val.highlight_ratio < 0.999 || engine_val.highlight_ratio > 1.001)) {
 		result.highlight_ratio = result.highlight_ratio * engine_val.highlight_ratio; // selected unit
 	}
 


### PR DESCRIPTION
Attempt to compromise between day and night visibility for the Shadow sprite, due to the Nightstalker ability making it nearly invisible at night, otherwise.

Ghost -> Shadow (Nightstalker) -> Nightgaunt (Nightstalker)
Ghost -> Wraith -> Spectre

Ghost units have translucency animations to simulate their ethereal nature - currently all of the above units except for Nightgaunt because it only has one sprite frame.

Nightstalker units are invisible at night-time, invisibility producing a dimming of the sprite to 50% (https://github.com/wesnoth/wesnoth/blob/master/src/units/drawer.cpp#L108). This applies to any unit deemed 'invisible', not just Nightstalkers. Combining this with the alpha reduction for the ghost translucency animation produces long periods of non-visible sprites (https://gna.org/bugs/?14503).

Edit: In fact, with recent builds (March 2017) the alpha animation for Shadow actually results in an underflow, causing an unsightly blinking effect.

So, without making a special exception for ghost units, leaving the sprites marked as invisible at 50%, the best compromise I can come up with is to reduce the translucency on the Shadow. A similar alpha level should be applied to Nightgaunt too, should it ever become animated with variable alpha levels.

Open to other ideas, this is a strong request from @beetlenaut.