### PR TITLE
Partial relayout

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,6 @@
 Version 1.13.7+dev:
+ * Performance:
+   * Greatly speeded up switching between add-ons in the add-on manager (bug #25523)
 
 Version 1.13.7:
  * AI:

--- a/src/gui/widgets/grid.hpp
+++ b/src/gui/widgets/grid.hpp
@@ -221,6 +221,13 @@ public:
 	virtual void demand_reduce_height(const unsigned maximum_height) override;
 
 	/**
+	 * Attempts to lay out the grid without laying out the entire window.
+	 * If the grid needs to grow, asks the parent grid for more space, recursively.
+	 * If the grid is the top-level grid, falls back to laying out the whole window.
+	 */
+	void relayout();
+
+	/**
 	 * Recalculates the best size.
 	 *
 	 * This is used for scrollbar containers when they try to update their

--- a/src/gui/widgets/scrollbar_container.cpp
+++ b/src/gui/widgets/scrollbar_container.cpp
@@ -582,10 +582,11 @@ bool scrollbar_container::content_resize_request(const bool force_sizing)
 				  == widget::visibility::invisible)) {
 
 			DBG_GUI_L << LOG_HEADER
-					  << " can't use horizontal scrollbar, ask window.\n";
-			window* window = get_window();
-			assert(window);
-			window->invalidate_layout();
+					  << " can't use horizontal scrollbar, ask grid.\n";
+			layout_initialise(true);
+			grid* grid = get_parent_grid();
+			assert(grid);
+			grid->relayout();
 			return false;
 		}
 	}
@@ -598,10 +599,11 @@ bool scrollbar_container::content_resize_request(const bool force_sizing)
 				  == widget::visibility::invisible)) {
 
 			DBG_GUI_L << LOG_HEADER
-					  << " can't use vertical scrollbar, ask window.\n";
-			window* window = get_window();
-			assert(window);
-			window->invalidate_layout();
+					  << " can't use vertical scrollbar, ask grid.\n";
+			layout_initialise(true);
+			grid* grid = get_parent_grid();
+			assert(grid);
+			grid->relayout();
 			return false;
 		}
 	}

--- a/src/gui/widgets/widget.cpp
+++ b/src/gui/widgets/widget.cpp
@@ -14,6 +14,7 @@
 
 #define GETTEXT_DOMAIN "wesnoth-lib"
 
+#include "gui/widgets/grid.hpp"
 #include "gui/widgets/settings.hpp"
 #include "gui/widgets/window.hpp"
 #include "gui/core/event/message.hpp"
@@ -135,6 +136,16 @@ const window* widget::get_window() const
 
 	// on error dynamic_cast returns nullptr which is what we want.
 	return dynamic_cast<const window*>(result);
+}
+
+grid* widget::get_parent_grid()
+{
+	widget* result = parent_;
+	while(result && dynamic_cast<grid*>(result) == nullptr) {
+		result = result->parent_;
+	}
+
+	return result ? dynamic_cast<grid*>(result) : nullptr;
 }
 
 dialogs::modal_dialog* widget::dialog()

--- a/src/gui/widgets/widget.hpp
+++ b/src/gui/widgets/widget.hpp
@@ -32,6 +32,7 @@ namespace gui2
 struct builder_widget;
 namespace dialogs { class modal_dialog; }
 class window;
+class grid;
 
 namespace iteration
 {
@@ -176,9 +177,17 @@ public:
 	 * Get the parent window.
 	 *
 	 * @returns                   Pointer to parent window.
-	 * @retval nullptr               No parent window found.
+	 * @retval nullptr            No parent window found.
 	 */
 	window* get_window();
+
+	/**
+	 * Get the parent grid.
+	 *
+	 * @returns                 Pointer to parent grid.
+	 * @retval nullptr          No parent grid found.
+	 */
+	grid* get_parent_grid();
 
 	/** The constant version of @ref get_window. */
 	const window* get_window() const;


### PR DESCRIPTION
This pull request is a response to [bug #25523](https://gna.org/bugs/index.php?25523).

Debugging immediately showed me that changing the text of any label (e.g. add-on author name, or description) causes the whole window to be laid out, which is expensive. In addition, it's unnecessary in the add-on manager, as the containing grid has plenty of space available.

To improve performance, this branch implements **partial relayout**, where only the containing grid is laid out. If laying out the grid fails, then the function calls itself on the parent grid recursively. Finally, if even the root grid doesn't have enough space, then it falls back to laying out the window like before.

My testing shows that this branch is a **huge improvement** for add-on manager responsiveness. In theory, it can speed up other dialogs as well, but I didn't notice any other improvements in quick testing. It is possible that other dialogs trigger full relayouts in other ways (not via `scrollbar_container`) and thus don't make use of partial relayout.