### PR TITLE
[don't merge yet] Generalizing the FAI concept of action objects

### DIFF
--- a/src/ai/default/contexts.hpp
+++ b/src/ai/default/contexts.hpp
@@ -55,11 +55,11 @@ struct target {
 };
 
 
-class attack_analysis : public game_logic::formula_callable
+class attack_analysis : public game_logic::action_callable
 {
 public:
 	attack_analysis() :
-		game_logic::formula_callable(),
+		game_logic::action_callable(),
 		target(),
 		movements(),
 		target_value(0.0),
@@ -138,6 +138,7 @@ public:
 	/** Is true if the units involved in this attack sequence are surrounded. */
 	bool is_surrounded;
 
+	variant execute_self(variant ctxt) override;
 };
 
 

--- a/src/ai/formula/ai.hpp
+++ b/src/ai/formula/ai.hpp
@@ -87,6 +87,7 @@ public:
 
 	virtual void add_formula_function(const std::string& name, game_logic::const_formula_ptr formula, game_logic::const_formula_ptr precondition, const std::vector<std::string>& args);
 
+#if 0
 	//class responsible for looking for possible infinite loops when calling set_var or set_unit_var
 	class gamestate_change_observer : public events::observer
 	{
@@ -106,6 +107,7 @@ public:
 
 		bool continue_check();
 	};
+#endif
 
 	typedef game_logic::position_callable::move_map_backup move_map_backup;
 
@@ -157,17 +159,18 @@ private:
 	const config cfg_;
 	recursion_counter recursion_counter_;
 	void display_message(const std::string& msg) const;
-	variant execute_variant(const variant& var, ai_context &ai_, bool commandline=false);
 	virtual variant get_value(const std::string& key) const;
+	void set_value(const std::string& key, const variant& value);
 	virtual void get_inputs(game_logic::formula_input_vector* inputs) const;
 
 	mutable variant keeps_cache_;
 
-	gamestate_change_observer infinite_loop_guardian_;
+//	gamestate_change_observer infinite_loop_guardian_;
 	game_logic::map_formula_callable vars_;
 	game_logic::ai_function_symbol_table function_table_;
 
 	friend class ai_default;
+	friend ai_context& get_ai_context(const formula_callable* for_fai);
 };
 
 } //end of namespace ai

--- a/src/ai/formula/callable_objects.hpp
+++ b/src/ai/formula/callable_objects.hpp
@@ -45,7 +45,7 @@ private:
 	void collect_possible_attacks(std::vector<variant>& vars, map_location attacker_location, map_location attack_position) const;
 };
 
-class attack_callable : public formula_callable {
+class attack_callable : public action_callable {
 	map_location move_from_, src_, dst_;
 	battle_context bc_;
 	variant get_value(const std::string& key) const;
@@ -65,10 +65,10 @@ public:
 	 * (nondeterministic in consequent game runs) if method argument is not
 	 * attack_callable */
 	int do_compare(const game_logic::formula_callable* callable) const;
+	variant execute_self(variant ctxt) override;
 };
 
-
-class move_callable : public game_logic::formula_callable {
+class move_callable : public action_callable {
 	map_location src_, dst_;
 	variant get_value(const std::string& key) const {
 		if(key == "src") {
@@ -94,10 +94,10 @@ public:
 
 	const map_location& src() const { return src_; }
 	const map_location& dst() const { return dst_; }
+	variant execute_self(variant ctxt) override;
 };
 
-
-class move_partial_callable : public game_logic::formula_callable {
+class move_partial_callable : public action_callable {
 	map_location src_, dst_;
 	variant get_value(const std::string& key) const {
 		if(key == "src") {
@@ -123,11 +123,10 @@ public:
 
 	const map_location& src() const { return src_; }
 	const map_location& dst() const { return dst_; }
+	variant execute_self(variant ctxt) override;
 };
 
-
-
-class recall_callable : public formula_callable {
+class recall_callable : public action_callable {
 	map_location loc_;
 	std::string id_;
 
@@ -141,10 +140,10 @@ public:
 
 	const map_location& loc() const { return loc_; }
 	const std::string& id() const { return id_; }
+	variant execute_self(variant ctxt) override;
 };
 
-
-class recruit_callable : public formula_callable {
+class recruit_callable : public action_callable {
 	map_location loc_;
 	std::string type_;
 
@@ -158,26 +157,10 @@ public:
 
 	const map_location& loc() const { return loc_; }
 	const std::string& type() const { return type_; }
+	variant execute_self(variant ctxt) override;
 };
 
-
-class set_var_callable : public formula_callable {
-	std::string key_;
-	variant value_;
-	variant get_value(const std::string& key) const;
-
-	void get_inputs(formula_input_vector* inputs) const;
-public:
-	set_var_callable(const std::string& key, const variant& value)
-	  : key_(key), value_(value)
-	{}
-
-	const std::string& key() const { return key_; }
-	variant value() const { return value_; }
-};
-
-
-class set_unit_var_callable : public formula_callable {
+class set_unit_var_callable : public action_callable {
 	std::string key_;
 	variant value_;
 	map_location loc_;
@@ -192,56 +175,18 @@ public:
 	const std::string& key() const { return key_; }
 	variant value() const { return value_; }
 	const map_location loc() const { return loc_; }
+	variant execute_self(variant ctxt) override;
 };
 
-class fallback_callable : public formula_callable {
+class fallback_callable : public action_callable {
 	variant get_value(const std::string& /*key*/) const { return variant(); }
 public:
 	explicit fallback_callable() {
 	}
+	variant execute_self(variant ctxt) override;
 };
 
-class safe_call_callable : public formula_callable {
-	variant main_;
-	variant backup_;
-	expression_ptr backup_formula_;
-	variant get_value(const std::string& key) const;
-
-	void get_inputs(formula_input_vector* inputs) const;
-public:
-	safe_call_callable(const variant& main, const expression_ptr& backup)
-		: main_(main)
-		, backup_()
-		, backup_formula_(backup)
-	{}
-
-	const variant& get_main() const { return main_; }
-	const expression_ptr& get_backup() const { return backup_formula_; }
-
-	void set_backup_result(const variant& v) {
-		backup_ = v;
-	}
-};
-
-
-class safe_call_result : public formula_callable {
-	const formula_callable* failed_callable_;
-	const map_location current_unit_location_;
-	const int status_;
-
-	variant get_value(const std::string& key) const;
-
-	void get_inputs(formula_input_vector* inputs) const;
-
-public:
-	safe_call_result(const formula_callable* callable, int status,
-			    const map_location& loc = map_location() )
-	  : failed_callable_(callable), current_unit_location_(loc), status_(status)
-	{}
-};
-
-
-class move_map_callable : public game_logic::formula_callable {
+class move_map_callable : public formula_callable {
 	typedef std::multimap<map_location, map_location> move_map;
 	const move_map& srcdst_;
 	const move_map& dstsrc_;

--- a/src/ai/formula/function_table.cpp
+++ b/src/ai/formula/function_table.cpp
@@ -1133,18 +1133,6 @@ private:
 };
 
 
-class set_var_function : public function_expression {
-public:
-	explicit set_var_function(const args_list& args)
-	  : function_expression("set_var", args, 2, 2)
-	{}
-private:
-	variant execute(const formula_callable& variables, formula_debugger *fdb) const {
-		return variant(new set_var_callable(args()[0]->evaluate(variables,add_debug_info(fdb,0,"set_var:key")).as_string(), args()[1]->evaluate(variables,add_debug_info(fdb,1,"set_var:value"))));
-	}
-};
-
-
 class set_unit_var_function : public function_expression {
 public:
 	explicit set_unit_var_function(const args_list& args)
@@ -1188,21 +1176,6 @@ private:
 			return variant();
 		}
 		return variant(new attack_callable(move_from, src, dst, weapon));
-	}
-};
-
-
-class safe_call_function : public function_expression {
-public:
-	explicit safe_call_function(const args_list& args)
-	  : function_expression("safe_call", args, 2, 2)
-	{}
-private:
-	variant execute(const formula_callable& variables, formula_debugger *fdb) const {
-		const variant main = args()[0]->evaluate(variables,fdb);
-		const expression_ptr backup_formula = args()[1];
-
-		return variant(new safe_call_callable(main, backup_formula));
 	}
 };
 
@@ -1623,7 +1596,7 @@ public:
 #define FUNCTION(name) add_function(#name, formula_function_ptr( \
 	new builtin_formula_function<name##_function>(#name)))
 
-ai_function_symbol_table::ai_function_symbol_table(ai::formula_ai& ai) {
+ai_function_symbol_table::ai_function_symbol_table(ai::formula_ai& ai) : function_symbol_table(new action_function_symbol_table) {
 	FUNCTION(outcomes);
 	//AI_FUNCTION(evaluate_for_position);
 	FUNCTION(move);
@@ -1632,14 +1605,12 @@ ai_function_symbol_table::ai_function_symbol_table(ai::formula_ai& ai) {
 	AI_FUNCTION(rate_action);
 	FUNCTION(recall);
 	FUNCTION(recruit);
-	FUNCTION(safe_call);
 	FUNCTION(get_unit_type);
 	AI_FUNCTION(is_avoided_location);
 	FUNCTION(is_village);
 	AI_FUNCTION(is_unowned_village);
 	FUNCTION(unit_at);
 	AI_FUNCTION(unit_moves);
-	FUNCTION(set_var);
 	FUNCTION(set_unit_var);
 	FUNCTION(fallback);
 	FUNCTION(units_can_reach);

--- a/src/formula/callable.hpp
+++ b/src/formula/callable.hpp
@@ -74,9 +74,11 @@ public:
 		serialize_to_string(str);
 	}
 
+
 	bool has_key(const std::string& key) const
 		{ return !query_value(key).is_null(); }
 
+protected:
 	template<typename T, typename K>
 	static variant convert_map(const std::map<T, K>& input_map)
 	{
@@ -118,7 +120,6 @@ public:
 		inputs->push_back(formula_input(key, access_type));
 	}
 
-protected:
 	virtual void set_value(const std::string& key, const variant& value);
 	virtual int do_compare(const formula_callable* callable) const {
 		if( type_ < callable->type_ )
@@ -145,6 +146,11 @@ protected:
 private:
 	virtual variant get_value(const std::string& key) const = 0;
 	bool has_self_;
+};
+
+class action_callable : public formula_callable {
+public:
+	virtual variant execute_self(variant ctxt) = 0;
 };
 
 class formula_callable_with_backup : public formula_callable {

--- a/src/formula/callable_objects.hpp
+++ b/src/formula/callable_objects.hpp
@@ -16,6 +16,7 @@
 #define CALLABLE_OBJECTS_HPP_INCLUDED
 
 #include "formula/callable.hpp"
+#include "formula/formula.hpp"
 
 #include "units/unit.hpp"
 
@@ -171,6 +172,58 @@ public:
 
 private:
 	const team& team_;
+};
+
+class set_var_callable : public action_callable {
+	std::string key_;
+	variant value_;
+	variant get_value(const std::string& key) const;
+
+	void get_inputs(std::vector<game_logic::formula_input>* inputs) const;
+public:
+	set_var_callable(const std::string& key, const variant& value)
+		: key_(key), value_(value) {}
+
+	const std::string& key() const { return key_; }
+	variant value() const { return value_; }
+	variant execute_self(variant ctxt) override;
+};
+
+class safe_call_callable : public action_callable {
+	variant main_;
+	variant backup_;
+	expression_ptr backup_formula_;
+	variant get_value(const std::string& key) const;
+
+	void get_inputs(std::vector<game_logic::formula_input>* inputs) const;
+public:
+	safe_call_callable(const variant& main, const expression_ptr& backup)
+		: main_(main)
+		, backup_()
+		, backup_formula_(backup) {}
+
+	const variant& get_main() const { return main_; }
+	const expression_ptr& get_backup() const { return backup_formula_; }
+
+	void set_backup_result(const variant& v) {
+		backup_ = v;
+	}
+	variant execute_self(variant ctxt) override;
+};
+
+class safe_call_result : public formula_callable {
+	const formula_callable* failed_callable_;
+	const map_location current_unit_location_;
+	const int status_;
+
+	variant get_value(const std::string& key) const;
+
+	void get_inputs(std::vector<game_logic::formula_input>* inputs) const;
+
+public:
+	safe_call_result(const formula_callable* callable, int status,
+		const map_location& loc = map_location())
+		: failed_callable_(callable), current_unit_location_(loc), status_(status) {}
 };
 
 } // namespace game_logic

--- a/src/formula/debugger.cpp
+++ b/src/formula/debugger.cpp
@@ -120,7 +120,7 @@ void formula_debugger::add_debug_info(int arg_number, const std::string& f_name)
 }
 
 
-const std::deque<debug_info>& formula_debugger::get_call_stack() const
+const std::list<debug_info>& formula_debugger::get_call_stack() const
 {
 	return call_stack_;
 }
@@ -131,20 +131,20 @@ const breakpoint_ptr formula_debugger::get_current_breakpoint() const
 	return current_breakpoint_;
 }
 
-const std::deque<debug_info>& formula_debugger::get_execution_trace() const
+const std::list<debug_info>& formula_debugger::get_execution_trace() const
 {
 	return execution_trace_;
 }
 
 void formula_debugger::check_breakpoints()
 {
-	for( std::deque< breakpoint_ptr >::iterator b = breakpoints_.begin(); b!= breakpoints_.end(); ++b) {
+	for(std::list<breakpoint_ptr>::iterator b = breakpoints_.begin(); b != breakpoints_.end(); ++b) {
 		if ((*b)->is_break_now()){
 			current_breakpoint_ = (*b);
 			show_gui();
 			current_breakpoint_ = breakpoint_ptr();
 			if ((*b)->is_one_time_only()) {
-				breakpoints_.erase(b);
+				b = breakpoints_.erase(b);
 			}
 			break;
 		}
@@ -272,8 +272,8 @@ public:
 
 	virtual bool is_break_now() const
 	{
-		const std::deque<debug_info> &call_stack = fdb_.get_call_stack();
-		if ((call_stack.size() == 1) && (call_stack[0].evaluated()) ) {
+		const std::list<debug_info> &call_stack = fdb_.get_call_stack();
+		if ((call_stack.size() == 1) && (call_stack.front().evaluated()) ) {
 			return true;
 		}
 		return false;
@@ -294,7 +294,7 @@ public:
 
 	virtual bool is_break_now() const
 	{
-		const std::deque<debug_info> &call_stack = fdb_.get_call_stack();
+		const std::list<debug_info> &call_stack = fdb_.get_call_stack();
 		if (call_stack.empty() || call_stack.back().evaluated()) {
 			return false;
 		}
@@ -317,7 +317,7 @@ public:
 
 	virtual bool is_break_now() const
 	{
-		const std::deque<debug_info> &call_stack = fdb_.get_call_stack();
+		const std::list<debug_info> &call_stack = fdb_.get_call_stack();
 		if (call_stack.empty() || call_stack.back().evaluated()) {
 			return false;
 		}
@@ -345,7 +345,7 @@ public:
 
 	virtual bool is_break_now() const
 	{
-		const std::deque<debug_info> &call_stack = fdb_.get_call_stack();
+		const std::list<debug_info> &call_stack = fdb_.get_call_stack();
 		if (call_stack.empty() || call_stack.back().evaluated()) {
 			return false;
 		}

--- a/src/formula/debugger.hpp
+++ b/src/formula/debugger.hpp
@@ -23,7 +23,7 @@
 
 #include "formula/variant.hpp"
 #include "formula/debugger_fwd.hpp"
-#include <deque>
+#include <list>
 
 namespace game_logic {
 
@@ -97,13 +97,13 @@ public:
 	void check_breakpoints();
 
 
-	const std::deque<debug_info>& get_call_stack() const;
+	const std::list<debug_info>& get_call_stack() const;
 
 
 	const breakpoint_ptr get_current_breakpoint() const;
 
 
-	const std::deque<debug_info>& get_execution_trace() const;
+	const std::list<debug_info>& get_execution_trace() const;
 
 
 	variant evaluate_arg_callback(const formula_expression &expression, const formula_callable &variables);
@@ -142,11 +142,11 @@ public:
 	}
 
 private:
-	std::deque<debug_info> call_stack_;
+	std::list<debug_info> call_stack_;
 	int counter_;
 	breakpoint_ptr current_breakpoint_;
-	std::deque< breakpoint_ptr > breakpoints_;
-	std::deque<debug_info> execution_trace_;
+	std::list< breakpoint_ptr > breakpoints_;
+	std::list<debug_info> execution_trace_;
 	int arg_number_extra_debug_info;
 	std::string f_name_extra_debug_info;
 

--- a/src/formula/function.hpp
+++ b/src/formula/function.hpp
@@ -19,6 +19,8 @@
 #include "formula/formula.hpp"
 #include "formula/callable.hpp"
 
+#include <set>
+
 namespace game_logic {
 
 class formula_expression {
@@ -134,19 +136,22 @@ typedef std::shared_ptr<formula_function> formula_function_ptr;
 typedef std::map<std::string, formula_function_ptr> functions_map;
 
 class function_symbol_table {
+	function_symbol_table* parent = nullptr;
 	functions_map custom_formulas_;
 public:
+	explicit function_symbol_table(function_symbol_table* parent = nullptr);
+	~function_symbol_table();
 	void add_function(const std::string& name, formula_function_ptr fcn);
 	expression_ptr create_function(const std::string& fn, const std::vector<expression_ptr>& args) const;
-	std::vector<std::string> get_function_names() const;
+	std::set<std::string> get_function_names() const;
 	bool empty() {return custom_formulas_.empty();}
+	static function_symbol_table* get_builtins();
 };
 
-expression_ptr create_function(const std::string& fn,
-                               const std::vector<expression_ptr>& args,
-							   const function_symbol_table* symbols);
-std::vector<std::string> builtin_function_names();
-
+class action_function_symbol_table : public function_symbol_table {
+public:
+	action_function_symbol_table();
+};
 
 class wrapper_formula : public formula_expression {
 public:

--- a/src/formula/variant.hpp
+++ b/src/formula/variant.hpp
@@ -161,6 +161,7 @@ public:
 		return type().to_string();
 	}
 
+	variant execute_variant(const variant& to_exec);
 private:
 	template<typename T>
 	std::shared_ptr<T> value_cast() const


### PR DESCRIPTION
This is still not quite finished for a couple of reasons; in particular, the infinite loop protections around `set_var()`, `set_unit_var()`, and `'continue'` have been removed, which might be a problem. I don't understand how these could _cause_ infinite loops, but I assume the protection had been there for a reason.

The goal of this is to generalize the idea of a WFL object that the engine can execute to produce some effect. The concept already existed in the FormulaAI engine, but was not generally available to code using the WFL APIs. Vultraz wishes to use action objects in other contexts, such as GUI2 or perhaps even ActionWML, so I've attempted to disentangle it from the FormulaAI code. I'm not sure I've succeeded, and the API currently feels a little wonky as well (particularly the difference between the `execute_variant` function in `variant` and `formula_callable` and the `execute` function in `action_callable` - they roughly do the same thing, but take their arguments in opposite order).