### PR TITLE
floating label: remove dead code. Found by cppcheck.

### DIFF
--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -257,10 +257,7 @@ SDL_Rect get_floating_label_rect(int handle)
 
 floating_label_context::floating_label_context()
 {
-	surface const screen = nullptr;
-	if(screen != nullptr) {
-		draw_floating_labels(screen);
-	}
+	const surface screen = nullptr;
 
 	label_contexts.push(std::set<int>());
 }
@@ -277,10 +274,7 @@ floating_label_context::~floating_label_context()
 
 	label_contexts.pop();
 
-	surface const screen = nullptr;
-	if(screen != nullptr) {
-		undraw_floating_labels(screen);
-	}
+	const surface screen = nullptr;
 }
 
 void draw_floating_labels(surface screen)


### PR DESCRIPTION
````
[src/floating_label.cpp:261]: (style) Condition 'screen!=nullptr' is always false
[src/floating_label.cpp:281]: (style) Condition 'screen!=nullptr' is always false
````