### PR TITLE
Add fallback_human() action to the Lua AI

### DIFF
--- a/src/ai/lua/core.cpp
+++ b/src/ai/lua/core.cpp
@@ -344,6 +344,11 @@ static int cfun_ai_check_recall(lua_State *L)
 	return ai_recall(L, false);
 }
 
+static int cfun_ai_fallback_human(lua_State*)
+{
+	throw fallback_ai_to_human_exception();
+}
+
 // Goals and targets
 
 
@@ -971,6 +976,7 @@ static int impl_ai_get(lua_State* L)
 			{ "stopunit_attacks", &cfun_ai_execute_stopunit_attacks },
 			{ "stopunit_moves", &cfun_ai_execute_stopunit_moves },
 			{ "synced_command", &cfun_ai_execute_synced_command },
+			{ "fallback_human", &cfun_ai_fallback_human},
 			{ nullptr, nullptr } };
 	for (const luaL_Reg* p = mutating_callbacks; p->name; ++p) {
 		if(m == p->name) {

--- a/src/menu_events.hpp
+++ b/src/menu_events.hpp
@@ -19,6 +19,7 @@
 #include "chat_events.hpp"
 #include "floating_textbox.hpp"
 #include "units/map.hpp"
+#include "lua_jailbreak_exception.hpp"
 
 #include <vector>
 
@@ -35,7 +36,7 @@ namespace events {
 	class mouse_handler;
 }
 
-struct fallback_ai_to_human_exception {};
+struct fallback_ai_to_human_exception : public lua_jailbreak_exception {IMPLEMENT_LUA_JAILBREAK_EXCEPTION(fallback_ai_to_human_exception)};
 
 namespace events {
 

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -79,6 +79,7 @@ playsingle_controller::playsingle_controller(const config& level,
 	, turn_data_(replay_sender_, network_reader_)
 	, end_turn_(END_TURN_NONE)
 	, skip_next_turn_(false)
+	, ai_fallback_(false)
 	, replay_()
 {
 	hotkey_handler_.reset(new hotkey_handler(*this, saved_game_)); //upgrade hotkey handler to the sp (whiteboard enabled) version
@@ -549,6 +550,7 @@ void playsingle_controller::play_ai_turn()
 		catch (fallback_ai_to_human_exception&) {
 			current_team().make_human();
 			player_type_changed_ = true;
+			ai_fallback_ = true;
 		}
 	}
 	catch(...) {
@@ -642,6 +644,11 @@ void playsingle_controller::sync_end_turn()
 
 	assert(end_turn_ == END_TURN_SYNCED);
 	skip_next_turn_ = false;
+
+	if(ai_fallback_) {
+		current_team().make_ai();
+		ai_fallback_ = false;
+	}
 }
 
 void playsingle_controller::update_viewing_player()

--- a/src/playsingle_controller.hpp
+++ b/src/playsingle_controller.hpp
@@ -94,7 +94,7 @@ protected:
 		END_TURN_SYNCED,
 	};
 	END_TURN_STATE end_turn_;
-	bool skip_next_turn_;
+	bool skip_next_turn_, ai_fallback_;
 	std::unique_ptr<replay_controller> replay_;
 	void linger();
 	void sync_end_turn() override;


### PR DESCRIPTION
Just like the FormulaAI fallback() function, this temporarily transfers control of the side to a human player.

I simply used the same exception that the FormulaAI uses for this, making it inherit from `lua_jailbreak_exception`. I have not tested it, however, which is part of why this is a PR rather than being pushed straight to master.