### PR TITLE
support container variables in [options]

### DIFF
--- a/src/saved_game.cpp
+++ b/src/saved_game.cpp
@@ -372,7 +372,14 @@ void saved_game::expand_mp_options()
 			{
 				for(const config& option : cfg.child_range("option"))
 				{
-					variables[option["id"]] = option["value"];
+					try
+					{
+						variable_access_create(option["id"], variables).as_scalar() = option["value"];
+					}
+					catch(const invalid_variablename_exception&)
+					{
+						ERR_NG << "variable " << option["id"] << "cannot be set to " << option["value"] << std::endl;
+					}
 				}
 			}
 			else


### PR DESCRIPTION
options settigns attributes in a contianer like
```
[options]
  [slider]
    id="container.attribute"
    ....
  [/slider]
[/options]
```
were broken in  a previous refactor in 1.13.0. This commit should restore them.