### PR TITLE
allow multi_page to contienr differnt type of pages

### DIFF
--- a/data/gui/schema.cfg
+++ b/data/gui/schema.cfg
@@ -1892,7 +1892,7 @@
                                     [tag]
                                         name="page_definition"
                                         min="0"
-                                        max="1"
+                                        max="-1"
                                         super="gui/window/resolution/grid"
                                     [/tag]
                                     [key]

--- a/src/actions/move.cpp
+++ b/src/actions/move.cpp
@@ -247,7 +247,7 @@ namespace { // Private helpers for move_unit()
 		bool post_wml(const route_iterator & step);
 		bool post_wml() { return post_wml(full_end_); }
 		/// Fires the sighted events that were raised earlier.
-		bool pump_sighted(const route_iterator & from);
+		void pump_sighted(const route_iterator & from);
 		/// Returns the ambush alert (if any) for the given unit.
 		static std::string read_ambush_string(const unit & ambusher);
 		/// Reveals the unit at the indicated location.
@@ -842,9 +842,9 @@ namespace { // Private helpers for move_unit()
 	 *
 	 * @param[in]  from  Points to the hex the sighting unit currently occupies.
 	 *
-	 * @return true if this event should interrupt movement.
+	 * @return sets event_mutated_ to true if this event should interrupt movement.
 	 */
-	bool unit_mover::pump_sighted(const route_iterator & from)
+	void unit_mover::pump_sighted(const route_iterator & from)
 	{
 		const size_t track = resources::game_events->pump().wml_tracking();
 		bool valid = true;
@@ -857,8 +857,6 @@ namespace { // Private helpers for move_unit()
 
 		if ( event || !valid )
 			event_mutated_ = true;
-
-		return event || !valid;
 	}
 
 
@@ -1010,8 +1008,9 @@ namespace { // Private helpers for move_unit()
 				// us out of the loop if needed.)
 				fire_hex_event(enter_hex_str, real_end_, step_from);
 				// Sighted events only fire if we could stop due to sighting.
-				if ( is_reasonable_stop(*real_end_) )
+				if (is_reasonable_stop(*real_end_)) {
 					pump_sighted(real_end_);
+				}
 			}//for
 			// Make sure any remaining sighted events get fired.
 			pump_sighted(real_end_-1);

--- a/src/actions/move.cpp
+++ b/src/actions/move.cpp
@@ -405,8 +405,10 @@ namespace { // Private helpers for move_unit()
 		{
 			// Only set the goto if movement was not complete and was not
 			// interrupted.
-			if ( real_end_ != full_end_  &&  !interrupted(false) ) // End-of-move-events do not cancel a goto. (Use case: tutorial S2.)
+			if (real_end_ != full_end_  &&  !interrupted(false)) {
+				// End-of-move-events do not cancel a goto. (Use case: tutorial S2.)
 				move_it_->set_goto(goto_);
+			}
 		}
 	}
 
@@ -452,8 +454,9 @@ namespace { // Private helpers for move_unit()
 		const unit_map::const_iterator blocking_unit = resources::gameboard->units().find(hex);
 
 		// If no unit, then the path is not obstructed.
-		if ( blocking_unit == resources::gameboard->units().end() )
+		if (blocking_unit == resources::gameboard->units().end()) {
 			return false;
+		}
 
 		// Check for units blocking a teleport exit. This can now only happen
 		// if these units are not visible to the current side, as otherwise no
@@ -589,8 +592,9 @@ namespace { // Private helpers for move_unit()
 	{
 		// We cannot reasonably stop if move_it_ could not be moved to this
 		// hex (the hex was occupied by someone else).
-		if ( *move_loc_ != hex )
+		if (*move_loc_ != hex) {
 			return false;
+		}
 
 		// We can reasonably stop if the hex is not an unowned village.
 		return !resources::gameboard->map().is_village(hex) ||
@@ -608,18 +612,18 @@ namespace { // Private helpers for move_unit()
 	inline void unit_mover::reveal_ambushers()
 	{
 		// Reveal the blocking unit.
-		if ( blocked() )
+		if (blocked()) {
 			reveal_ambusher(blocked_loc_, false);
-
+		}
 		// Reveal ambushers.
 		for(const map_location & reveal : ambushers_) {
 			reveal_ambusher(reveal, true);
 		}
 
 		// Default "Ambushed!" message?
-		if ( ambush_string_.empty() )
+		if (ambush_string_.empty()) {
 			ambush_string_ = _("Ambushed!");
-
+		}
 		// Update the display.
 		resources::screen->draw();
 	}
@@ -635,9 +639,10 @@ namespace { // Private helpers for move_unit()
 		// Loop through the previously-detected ambushers.
 		size_t i = 0;
 		while ( i != ambushers_.size() ) {
-			if ( units.count(ambushers_[i]) == 0 )
+			if (units.count(ambushers_[i]) == 0) {
 				// Ambusher is gone.
 				ambushers_.erase(ambushers_.begin() + i);
+			}
 			else {
 				// Proceed to the next ambusher.
 				++i;
@@ -728,13 +733,13 @@ namespace { // Private helpers for move_unit()
 		const game_events::entity_location mover(*move_it_, *current);
 		const bool event = resources::game_events->pump().fire(event_name, mover, *other);
 
-		if ( track != resources::game_events->pump().wml_tracking() )
+		if (track != resources::game_events->pump().wml_tracking()) {
 			// Some WML fired, so update our status.
 			valid = post_wml(current);
-
-		if ( event || !valid )
+		}
+		if (event || !valid) {
 			event_mutated_ = true;
-
+		}
 		return event || !valid;
 	}
 
@@ -753,9 +758,9 @@ namespace { // Private helpers for move_unit()
 		const gamemap &map = resources::gameboard->map();
 
 		// Handle null routes.
-		if ( start == stop )
+		if (start == stop) {
 			return start;
-
+		}
 
 		int remaining_moves = move_it_->movement_left();
 		zoc_stop_ = map_location::null_location();
@@ -786,17 +791,17 @@ namespace { // Private helpers for move_unit()
 			moves_left_.push_back(remaining_moves);
 
 			// Check for being unable to leave this hex.
-			if ( !move_it_->get_ability_bool("skirmisher", *end, *resources::gameboard) &&
-			      pathfind::enemy_zoc(*current_team_, *end, *current_team_) )
+			if (!move_it_->get_ability_bool("skirmisher", *end, *resources::gameboard) &&
+				pathfind::enemy_zoc(*current_team_, *end, *current_team_))
+			{
 				zoc_stop_ = *end;
+			}
 		}
 
-		if ( true ) {
-			// Avoiding stopping on a (known) unit.
-			route_iterator min_end =  start == begin_ ? start : start + 1;
-			while ( end != min_end  &&  resources::gameboard->has_visible_unit(*(end-1), *current_team_) )
-				// Backtrack.
-				--end;
+		route_iterator min_end =  start == begin_ ? start : start + 1;
+		while (end != min_end  &&  resources::gameboard->has_visible_unit(*(end - 1), *current_team_)) {
+			// Backtrack.
+			--end;
 		}
 
 		return end;
@@ -829,8 +834,9 @@ namespace { // Private helpers for move_unit()
 			const route_iterator new_limit = plot_turn(step, expected_end_);
 			cache_hidden_units(step, new_limit);
 			// Just in case: length 0 paths become length 1 paths.
-			if ( ambush_limit_ == step )
+			if (ambush_limit_ == step) {
 				++ambush_limit_;
+			}
 		}
 
 		return found;
@@ -849,14 +855,15 @@ namespace { // Private helpers for move_unit()
 		const size_t track = resources::game_events->pump().wml_tracking();
 		bool valid = true;
 
-		const bool event = clearer_.fire_events();
+		const bool non_undoable_events_happened = clearer_.fire_events();
 
-		if ( track != resources::game_events->pump().wml_tracking() )
+		if (track != resources::game_events->pump().wml_tracking()) {
 			// Some WML fired, so update our status.
 			valid = post_wml(from);
-
-		if ( event || !valid )
+		}
+		if (non_undoable_events_happened || !valid) {
 			event_mutated_ = true;
+		}
 	}
 
 
@@ -868,8 +875,9 @@ namespace { // Private helpers for move_unit()
 		for(const unit_ability &hide : ambusher.get_abilities("hides"))
 		{
 			const std::string & ambush_string = (*hide.first)["alert"].str();
-			if ( !ambush_string.empty() )
+			if (!ambush_string.empty()) {
 				return ambush_string;
+			}
 		}
 
 		// No string found.
@@ -898,17 +906,18 @@ namespace { // Private helpers for move_unit()
 			ambusher->set_state(unit::STATE_UNCOVERED, true);
 
 			// Record this in the move spectator.
-			if ( spectator_ )
+			if (spectator_) {
 				spectator_->set_ambusher(ambusher);
-
+			}
 			// Override the default ambushed messge?
 			if ( update_alert ) {
 				// Observers don't get extra information.
 				if ( playing_team_is_viewing_ || !disp.fogged(hex) ) {
 					show_ambush_alert_ = true;
 					// We only support one custom ambush message; use the first one.
-					if ( ambush_string_.empty() )
+					if (ambush_string_.empty()) {
 						ambush_string_ = read_ambush_string(*ambusher);
+					}
 				}
 			}
 
@@ -1026,8 +1035,9 @@ namespace { // Private helpers for move_unit()
 		// Some flags were set to indicate why we might stop.
 		// Update those to reflect whether or not we got to them.
 		ambushed_ = ambushed_ && real_end_ == ambush_limit_;
-		if ( !obstructed_stop )
+		if (!obstructed_stop) {
 			blocked_loc_ = map_location::null_location();
+		}
 		teleport_failed_ = teleport_failed_ && obstructed_stop;
 		// event_mutated_ does not get unset, regardless of other reasons
 		// for stopping, but we do save its current value.
@@ -1047,10 +1057,12 @@ namespace { // Private helpers for move_unit()
 		bool action_time_bonus = false;
 
 		// Reveal ambushers?
-		if ( ambushed_ || blocked() )
+		if (ambushed_ || blocked()) {
 			reveal_ambushers();
-		else if ( teleport_failed_ && spectator_ )
+		}
+		else if (teleport_failed_ && spectator_) {
 			spectator_->set_failed_teleport(resources::gameboard->units().find(*obstructed_));
+		}
 		unit::clear_status_caches();
 
 		if ( move_it_.valid() ) {
@@ -1059,8 +1071,9 @@ namespace { // Private helpers for move_unit()
 				sighted_stop_ && !resources::whiteboard->is_executing_actions() ?
 					*(full_end_-1) :
 					map_location::null_location());
-			if ( ambushed_ || final_loc == zoc_stop_ )
+			if (ambushed_ || final_loc == zoc_stop_) {
 				move_it_->set_movement(0, true);
+			}
 
 			// Village capturing.
 			if ( resources::gameboard->map().is_village(final_loc) ) {
@@ -1080,8 +1093,9 @@ namespace { // Private helpers for move_unit()
 		post_wml();
 
 		// Record keeping.
-		if ( spectator_ )
+		if (spectator_) {
 			spectator_->set_unit(move_it_);
+		}
 		if ( undo_stack ) {
 			const bool mover_valid = move_it_.valid();
 
@@ -1179,8 +1193,9 @@ namespace { // Private helpers for move_unit()
 		}
 
 		// Update the screen.
-		if ( redraw )
+		if (redraw) {
 			disp.draw();
+		}
 	}
 
 }//end anonymous namespace
@@ -1193,8 +1208,9 @@ static size_t move_unit_internal(undo_list* undo_stack,
 {
 	const events::command_disabler disable_commands;
 	// Default return value.
-	if ( interrupted )
+	if (interrupted) {
 		*interrupted = false;
+	}
 
 	// Attempt moving.
 	mover.try_actual_movement(show_move);
@@ -1216,12 +1232,14 @@ static size_t move_unit_internal(undo_list* undo_stack,
 	// Bookkeeping, etc.
 	// also fires the moveto event
 	mover.post_move(undo_stack);
-	if ( show_move )
+	if (show_move) {
 		mover.feedback();
+	}
 
 	// Set return value.
-	if ( interrupted )
+	if (interrupted) {
 		*interrupted = mover.interrupted();
+	}
 
 	return mover.steps_travelled();
 }

--- a/src/gui/widgets/multi_page.hpp
+++ b/src/gui/widgets/multi_page.hpp
@@ -55,6 +55,7 @@ public:
 	 * @returns                   The grid of the newly added page.
 	 */
 	grid& add_page(const string_map& item);
+	grid& add_page(const std::string& type, int insert_pos, const string_map& item);
 
 	/**
 	 * Adds single page to the grid.
@@ -74,6 +75,7 @@ public:
 	 * @returns                   The grid of the newly added page.
 	 */
 	grid& add_page(const std::map<std::string /* widget id */, string_map>& data);
+	grid& add_page(const std::string& type, int insert_pos, const std::map<std::string /* widget id */, string_map>& data);
 
 	/**
 	 * Removes a page in the multi page.
@@ -137,9 +139,10 @@ public:
 
 	/***** ***** ***** setters / getters for members ***** ****** *****/
 
-	void set_page_builder(builder_grid_ptr page_builder)
+	void set_page_builders(const std::map<std::string, builder_grid_const_ptr>& page_builders)
 	{
-		page_builder_ = page_builder;
+		assert(!page_builders.empty());
+		page_builders_ = page_builders;
 	}
 
 private:
@@ -160,7 +163,7 @@ private:
 	generator_base* generator_;
 
 	/** Contains the builder for the new items. */
-	builder_grid_const_ptr page_builder_;
+	std::map<std::string, builder_grid_const_ptr> page_builders_;
 
 	/** See @ref widget::impl_draw_background. */
 	virtual void impl_draw_background(surface& frame_buffer,
@@ -201,7 +204,7 @@ struct builder_multi_page : public builder_styled_widget
 
 	widget* build() const;
 
-	builder_grid_ptr builder;
+	std::map<std::string, builder_grid_const_ptr> builders;
 
 	/**
 	 * Multi page data.

--- a/src/scripting/lua_gui2.cpp
+++ b/src/scripting/lua_gui2.cpp
@@ -840,16 +840,19 @@ int intf_add_dialog_tree_node(lua_State *L)
 	const int insert_pos = luaL_checkinteger(L, 2);
 	static const std::map<std::string, string_map> data;
 	gui2::widget *w = find_widget(L, 3, false);
-	gui2::tree_view_node *twn = dynamic_cast<gui2::tree_view_node *>(w);
-	if (!twn) {
-		if(gui2::tree_view* tw = dynamic_cast<gui2::tree_view *>(w)) {
-			twn = &tw->get_root_node();
-		}
-		else {
-			return luaL_argerror(L, lua_gettop(L), "unsupported widget");
-		}
+
+	if (gui2::tree_view_node *twn = dynamic_cast<gui2::tree_view_node *>(w)) {
+		twn->add_child(node_type, data, insert_pos);
 	}
-	twn->add_child(node_type, data, insert_pos);
+	else if (gui2::tree_view* tw = dynamic_cast<gui2::tree_view *>(w)) {
+		tw->get_root_node().add_child(node_type, data, insert_pos);
+	}
+	else if (gui2::multi_page *mp = dynamic_cast<gui2::multi_page *>(w)) {
+		mp->add_page(node_type, insert_pos, data);
+	}
+	else {
+		return luaL_argerror(L, lua_gettop(L), "unsupported widget");
+	}
 	return 0;
 }
 


### PR DESCRIPTION
 	

although stacked_widget supports similar functionality this is currently
not easily doable from the lua gui2 api. In particular
1) stacked_widget cannot add pages dynamically
2) multi_page can only contain one type of widget.
3) a stacked_widget inside a multi_page is ineffective since it
generates many unused widgets
4) a multi_page inside a stacked_widget is just unhandy to use

this also contains some unrelates commits in actions/move.cpp that just happend to be on that branch.