### PR TITLE
Updated links to wesnoth.org to use https

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ More Information
 For extensive documentation about all aspects of the game, see the
 official Battle for Wesnoth web site.
 
-  <http://www.wesnoth.org/>
+  <https://www.wesnoth.org/>
 
 A (translated) description of how to play the game can be found in
 doc/manual/manual.*.html, or online at:
@@ -47,4 +47,4 @@ doc/manual/manual.*.html, or online at:
 The official Battle for Wesnoth Forums (with over 400,000 posts from more than
 20,000 registered members) can be found at:
 
-  <http://forums.wesnoth.org/>
+  <https://forums.wesnoth.org/>


### PR DESCRIPTION
I just changed URLs to the wesnoth.org webpages to use https instead of http.

This will make users go directly to the webpages linked, instead of automatically being redirected to the https version by the website. 

Should be very slightly better for user experience! 😊

Please note: http://manual.wesnoth.org/ redirects to https://wiki.wesnoth.org/WesnothManual, but https://manual.wesnoth.org/ breaks, so I left it unchanged.

PS: Thank you for making an awesome game!