### PR TITLE
improve listbox::clear() performance.

### DIFF
--- a/src/gui/widgets/generator_private.hpp
+++ b/src/gui/widgets/generator_private.hpp
@@ -614,6 +614,7 @@ public:
 		{
 			delete item;
 		}
+		items_.clear();
 		order_dirty_ = true;
 		selected_item_count_ = 0;
 	}

--- a/src/gui/widgets/listbox.cpp
+++ b/src/gui/widgets/listbox.cpp
@@ -135,9 +135,7 @@ void listbox::remove_row(const unsigned row, unsigned count)
 
 void listbox::clear()
 {
-	// Due to the removing from the linked group, don't use
-	// generator_->clear() directly.
-	remove_row(0, 0);
+	generator_->clear();
 }
 
 unsigned listbox::get_item_count() const

--- a/src/gui/widgets/listbox.cpp
+++ b/src/gui/widgets/listbox.cpp
@@ -136,6 +136,7 @@ void listbox::remove_row(const unsigned row, unsigned count)
 void listbox::clear()
 {
 	generator_->clear();
+	update_content_size();
 }
 
 unsigned listbox::get_item_count() const


### PR DESCRIPTION
previously listbox::clear() removed all elements one by one.
This was quite ineffective since due to the listbox always-one-element-selected behviour this required calculating which is the next element in this list in the current order. Which then again requires resorting of the whole list since due to the list content change (removal) the order cache is cleared.

this could also fix https://gna.org/bugs/?25504