### PR TITLE
Invert alpha animation for Shadow (bug #14503)

### DIFF
--- a/data/core/units/undead/Spirit_Shadow.cfg
+++ b/data/core/units/undead/Spirit_Shadow.cfg
@@ -124,7 +124,7 @@ That is a question which is easily answered by a necromancer."+{SPECIAL_NOTES}+{
     [standing_anim]
         direction=s,se,sw
         start_time=0
-        alpha=0.8~0.4:1400,0.4~0.6:600,0.6~0.4:600,0.4~0.8:1400
+        alpha=0.4~0.8:1400,0.8~0.6:600,0.6~0.8:600,0.8~0.4:1400
         [frame]
             image="units/undead/shadow-s-[2,1~3,2,1~3,2,1~3,2,1~3].png:250"
         [/frame]
@@ -132,7 +132,7 @@ That is a question which is easily answered by a necromancer."+{SPECIAL_NOTES}+{
     [standing_anim]
         direction=n,ne,nw
         start_time=0
-        alpha=0.8~0.4:1400,0.4~0.6:600,0.6~0.4:600,0.4~0.8:1400
+        alpha=0.4~0.8:1400,0.8~0.6:600,0.6~0.8:600,0.8~0.4:1400
         [frame]
             image="units/undead/shadow-n-[2,1~3,2,1~3,2,1~3,2,1~3].png:250"
         [/frame]


### PR DESCRIPTION
Another adjustment as part of bug #14503. Idea is to make the Shadow alpha level spend more time between 0.6-0.8 instead of 0.4-0.6. So when the Shadow's Nightstalker ability becomes active at night time, the alpha level is mostly between 0.3-0.4 instead of 0.2-0.3, making it marginally more visible.