### PR TITLE
less unit copying

### DIFF
--- a/src/actions/advancement.cpp
+++ b/src/actions/advancement.cpp
@@ -346,13 +346,15 @@ void advance_unit(map_location loc, const advancement_option &advance_to, bool f
 	bool use_amla = boost::get<std::string>(&advance_to) == nullptr;
 	unit_ptr new_unit = use_amla ? get_amla_unit(*u, *boost::get<const config*>(advance_to)) :
 	                           get_advanced_unit(*u, boost::get<std::string>(advance_to));
+	new_unit->set_location(loc);
 	if ( !use_amla )
 	{
 		statistics::advance_unit(*new_unit);
 		preferences::encountered_units().insert(new_unit->type_id());
 		LOG_CF << "Added '" << new_unit->type_id() << "' to the encountered units.\n";
 	}
-	u = resources::gameboard->units().replace(loc, *new_unit).first;
+	resources::gameboard->units().erase(loc);
+	u = resources::gameboard->units().insert(new_unit).first;
 
 	// Update fog/shroud.
 	actions::shroud_clearer clearer;

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1154,10 +1154,9 @@ namespace {
 			if (reanimator)
 			{
 				LOG_NG << "found unit type:" << reanimator->id() << '\n';
-				unit newunit(*reanimator, attacker.get_unit().side(),
-					true, unit_race::MALE);
-				newunit.set_attacks(0);
-				newunit.set_movement(0, true);
+				unit_ptr newunit(new unit(*reanimator, attacker.get_unit().side(), true, unit_race::MALE));
+				newunit->set_attacks(0);
+				newunit->set_movement(0, true);
 				// Apply variation
 				if (undead_variation != "null")
 				{
@@ -1165,15 +1164,16 @@ namespace {
 					config &variation = mod.add_child("effect");
 					variation["apply_to"] = "variation";
 					variation["name"] = undead_variation;
-					newunit.add_modification("variation",mod);
-					newunit.heal_fully();
+					newunit->add_modification("variation",mod);
+					newunit->heal_fully();
 				}
-				units_.add(death_loc, newunit);
+				newunit->set_location(death_loc);
+				units_.insert(newunit);
 
-				game_events::entity_location reanim_loc(defender.loc_, newunit.underlying_id());
+				game_events::entity_location reanim_loc(defender.loc_, newunit->underlying_id());
 				resources::game_events->pump().fire("unit_placed", reanim_loc);
 
-				preferences::encountered_units().insert(newunit.type_id());
+				preferences::encountered_units().insert(newunit->type_id());
 				if (update_display_) {
 					resources::screen->invalidate(death_loc);
 				}

--- a/src/actions/unit_creator.cpp
+++ b/src/actions/unit_creator.cpp
@@ -170,7 +170,8 @@ void unit_creator::add_unit(const config &cfg, const vconfig* vcfg)
 		map_location loc = find_location(temp_cfg, new_unit.get());
 		if ( loc.valid() ) {
 			//add the new unit to map
-			board_->units().replace(loc, *new_unit);
+			new_unit->set_location(loc);
+			board_->units().insert(new_unit);
 			LOG_NG << "inserting unit for side " << new_unit->side() << "\n";
 			post_create(loc,*(board_->units().find(loc)),animate);
 		}
@@ -184,7 +185,8 @@ void unit_creator::add_unit(const config &cfg, const vconfig* vcfg)
 		//get unit from recall list
 		map_location loc = find_location(temp_cfg, recall_list_element.get());
 		if ( loc.valid() ) {
-			board_->units().replace(loc, *recall_list_element);
+			recall_list_element->set_location(loc);
+			board_->units().insert(recall_list_element);
 			LOG_NG << "inserting unit from recall list for side " << recall_list_element->side()<< " with id="<< id << "\n";
 			post_create(loc,*(board_->units().find(loc)),animate);
 			//if id is not empty, delete units with this ID from recall list

--- a/src/ai/simulated_actions.cpp
+++ b/src/ai/simulated_actions.cpp
@@ -209,12 +209,13 @@ void helper_check_village(const map_location& loc, int side){
 }
 
 void helper_place_unit(const unit& u, const map_location& loc){
-	unit new_unit = u;
-	new_unit.set_movement(0, true);
-	new_unit.set_attacks(0);
-	new_unit.heal_fully();
+	unit_ptr new_unit(new unit(u));
+	new_unit->set_movement(0, true);
+	new_unit->set_attacks(0);
+	new_unit->heal_fully();
+	new_unit->set_location(loc);
 
-	std::pair<unit_map::iterator, bool> add_result = resources::gameboard->units().add(loc, new_unit);
+	std::pair<unit_map::iterator, bool> add_result = resources::gameboard->units().insert(new_unit);
 	assert(add_result.second);
 	unit_map::iterator& new_unit_itor = add_result.first;
 
@@ -239,7 +240,7 @@ void helper_advance_unit(const map_location& loc){
 	int options_num = unit_helper::number_of_possible_advances(*advance_unit);
 
 	size_t advance_choice = rand() % options_num;
-	unit advanced_unit(*advance_unit);
+	unit_ptr advanced_unit(new unit(*advance_unit));
 
 	if(advance_choice < options.size()){
 		std::string advance_unit_typename = options[advance_choice];
@@ -248,20 +249,22 @@ void helper_advance_unit(const map_location& loc){
 			ERR_AI_SIM_ACTIONS << "Simulating advancing to unknown unit type: " << advance_unit_typename;
 			assert(false && "simulating to unknown unit type");
 		}
-		advanced_unit.set_experience(advanced_unit.experience() - advanced_unit.max_experience());
-		advanced_unit.advance_to(*advanced_type);
-		advanced_unit.heal_fully();
-		advanced_unit.set_state(unit::STATE_POISONED, false);
-		advanced_unit.set_state(unit::STATE_SLOWED, false);
-		advanced_unit.set_state(unit::STATE_PETRIFIED, false);
+		advanced_unit->set_experience(advanced_unit->experience() - advanced_unit->max_experience());
+		advanced_unit->advance_to(*advanced_type);
+		advanced_unit->heal_fully();
+		advanced_unit->set_state(unit::STATE_POISONED, false);
+		advanced_unit->set_state(unit::STATE_SLOWED, false);
+		advanced_unit->set_state(unit::STATE_PETRIFIED, false);
 	}else{
 		const config &mod_option = mod_options[advance_choice-options.size()];
-		advanced_unit.set_experience(advanced_unit.experience()-advanced_unit.max_experience());
-		advanced_unit.add_modification("advancement", mod_option);
+		advanced_unit->set_experience(advanced_unit->experience()-advanced_unit->max_experience());
+		advanced_unit->add_modification("advancement", mod_option);
 	}
 
-	resources::gameboard->units().replace(loc, advanced_unit);
-	LOG_AI_SIM_ACTIONS << advance_unit->type_name() << " at " << loc << " advanced to " << advanced_unit.type_name() << std::endl;
+	advanced_unit->set_location(loc);
+	resources::gameboard->units().erase(loc);
+	resources::gameboard->units().insert(advanced_unit);
+	LOG_AI_SIM_ACTIONS << advance_unit->type_name() << " at " << loc << " advanced to " << advanced_unit->type_name() << std::endl;
 }
 
 }// End namespace

--- a/src/scripting/lua_unit.cpp
+++ b/src/scripting/lua_unit.cpp
@@ -84,7 +84,8 @@ bool lua_unit::put_map(const map_location &loc)
 		if (it) {
 			side = 0;
 			// uid may be changed by unit_map on insertion
-			uid = resources::gameboard->units().replace(loc, *it).first->underlying_id();
+			it->set_location(loc);
+			uid = resources::gameboard->units().insert(it).first->underlying_id();
 		} else {
 			ERR_LUA << "Could not find unit " << uid << " on recall list of side " << side << '\n';
 			return false;


### PR DESCRIPTION
we use unit_map::insert instead of unit_map::add/unit_map::replace, to minimize copying of units.