### PR TITLE
Reduce invisible units' transparency

### DIFF
--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -104,8 +104,8 @@ void unit_drawer::redraw_unit (const unit & u) const
 	params.submerge= is_flying ? -1.0 : terrain_info.unit_submerge();
 
 	if (u.invisible(loc, dc) &&
-			params.highlight_ratio > 0.5) {
-		params.highlight_ratio = 0.5;
+			params.highlight_ratio > 0.6) {
+		params.highlight_ratio = 0.6;
 	}
 	if (loc == sel_hex && params.highlight_ratio == 1.0) {
 		params.highlight_ratio = 1.5;


### PR DESCRIPTION
Units are rendered at 0.5 alpha when they are invisible (for example, Elvish Avengers' Ambush ability). An issue arises with the Shadow (and Nightgaunt) ghost unit which has the Nightstalker ability allowing it to be invisible at night time - in combination with its fluctuating alpha animation, it can be quite hard for the player to see at night time (https://gna.org/bugs/?14503). @beetlenaut suggests that the global alpha level for invisible units be slightly increased from 0.5 to 0.6.

So this is related to PR #984, but we are keeping this separate as this change affects more than just Shadows and I don't know the full implications of changing this value.