### PR TITLE
Fix objectives with variables

### DIFF
--- a/data/lua/wml/objectives.lua
+++ b/data/lua/wml/objectives.lua
@@ -204,12 +204,19 @@ function wml_actions.objectives(cfg)
 	end
 end
 
+local function maybe_parsed(cfg)
+	if cfg.delayed_variable_substitution == false then
+		return helper.parsed(cfg)
+	end
+	return cfg
+end
+
 function wml_actions.show_objectives(cfg)
-	local cfg0 = scenario_objectives[0]
+	local cfg0 = maybe_parsed(scenario_objectives[0])
 	local function local_show_objectives(sides)
 		local objectives0 = cfg0 and generate_objectives(cfg0)
 		for i, team in ipairs(sides) do
-			cfg = scenario_objectives[team.side]
+			cfg = maybe_parsed(scenario_objectives[team.side])
 			local objectives = (cfg and generate_objectives(cfg)) or objectives0
 			if objectives then team.objectives = objectives end
 			team.objectives_changed = true

--- a/data/lua/wml/objectives.lua
+++ b/data/lua/wml/objectives.lua
@@ -178,7 +178,9 @@ local function remove_ssf_info_from(cfg)
 end
 
 function wml_actions.objectives(cfg)
-	cfg = helper.parsed(cfg)
+	if cfg.delayed_variable_substitution ~= true then
+		cfg = helper.parsed(cfg)
+	end
 
 	local sides = wesnoth.get_sides(cfg)
 	local silent = cfg.silent

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -1241,7 +1241,7 @@ void play_controller::show_objectives() const
 {
 	const team& t = gamestate().board_.teams()[gui_->viewing_team()];
 	static const std::string no_objectives(_("No objectives available"));
-	std::string objectives = t.objectives();
+	std::string objectives = interpolate_variables_into_string(t.objectives(), *gamestate_->get_game_data());
 	gui2::show_transient_message(gui_->video(), get_scenario_name(), (objectives.empty() ? no_objectives : objectives), "", true);
 	t.reset_objectives_changed();
 }

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -1241,7 +1241,7 @@ void play_controller::show_objectives() const
 {
 	const team& t = gamestate().board_.teams()[gui_->viewing_team()];
 	static const std::string no_objectives(_("No objectives available"));
-	std::string objectives = utils::interpolate_variables_into_string(t.objectives(), *gamestate_->get_game_data());
+	std::string objectives = t.objectives();
 	gui2::show_transient_message(gui_->video(), get_scenario_name(), (objectives.empty() ? no_objectives : objectives), "", true);
 	t.reset_objectives_changed();
 }

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -1241,7 +1241,7 @@ void play_controller::show_objectives() const
 {
 	const team& t = gamestate().board_.teams()[gui_->viewing_team()];
 	static const std::string no_objectives(_("No objectives available"));
-	std::string objectives = t.objectives();
+	std::string objectives = utils::interpolate_variables_into_string(t.objectives(), *gamestate_->get_game_data());
 	gui2::show_transient_message(gui_->video(), get_scenario_name(), (objectives.empty() ? no_objectives : objectives), "", true);
 	t.reset_objectives_changed();
 }

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -1241,7 +1241,7 @@ void play_controller::show_objectives() const
 {
 	const team& t = gamestate().board_.teams()[gui_->viewing_team()];
 	static const std::string no_objectives(_("No objectives available"));
-	std::string objectives = interpolate_variables_into_string(t.objectives(), *gamestate_->get_game_data());
+	std::string objectives = utils::interpolate_variables_into_string(t.objectives(), *gamestate_->get_game_data());
 	gui2::show_transient_message(gui_->video(), get_scenario_name(), (objectives.empty() ? no_objectives : objectives), "", true);
 	t.reset_objectives_changed();
 }


### PR DESCRIPTION
Apparently they're supposed to be able to resubstitute variables each time they're shown; even if that wasn't the original intent, it would be quite useful.

The way to do this is not parse the `[objectives]` config instantly, and then substitute variables later. There are two possible implementations of this:

* The first implementation (e9895f8a102f) runs before any time the objectives show, whether explicitly requested by the user or by simply setting `team.objectives_changed = true`. However, this has the disadvantage that `[insert_tag]` will not be reparsed, as the objectives have already been reduced to a string by this point.
* The second implementation (699853dfc3a1) instead resubstitutes the variables as part of `[show_objectives]`, which means the entire `[objectives]` config is reparsed whenever the objectives are explicitly viewed by the user. This has the advantage that `[insert_tag]` will also be reparsed, but means variables are not resubstituted if the objectives are shown naturally as a result of setting `team.objectives_changed = true`.

I'm not sure which is the better implementation. Also, there's the question of whether to support `delayed_variable_substitution` and, if so, what it should default to. In order for this to work at all, not supporting it would mean assuming it to be true; the current implementation effectively assumes it to be false.