### PR TITLE
Fix base animation showing in zombie bats

### DIFF
--- a/changelog
+++ b/changelog
@@ -69,6 +69,8 @@ Version 1.13.7+dev:
    * New [zoom] tag allows changing the zoom level from an event
    * [kill]animate=yes now plays victory animations if applicable
    * Fix [volume] not accepting 100% as the new volume.
+ * Miscellaneous and bug fixes:
+   * Fixed base animation showing on walking corpse & soulless bats (bug #25673)
 
 Version 1.13.7:
  * AI:

--- a/data/core/units/undead/Corpse_Soulless.cfg
+++ b/data/core/units/undead/Corpse_Soulless.cfg
@@ -333,6 +333,10 @@
                 image="units/undead/soulless-bat-ne-[3,2,3].png:[50*2,40]"
             [/frame]
         [/attack_anim]
+        # Remove inherited third attack_anim tag from base unit
+        [attack_anim]
+            __remove=yes
+        [/attack_anim]
     [/variation]
 [/unit_type]
 

--- a/data/core/units/undead/Corpse_Walking.cfg
+++ b/data/core/units/undead/Corpse_Walking.cfg
@@ -333,6 +333,10 @@
                 image="units/undead/zombie-bat-ne-[3,2,3].png:[50*2,40]"
             [/frame]
         [/attack_anim]
+        # Remove inherited third attack_anim tag from base unit
+        [attack_anim]
+            __remove=yes
+        [/attack_anim]
     [/variation]
 [/unit_type]
 

--- a/players_changelog
+++ b/players_changelog
@@ -9,7 +9,8 @@ Version 1.13.7+dev:
  * User Interface:
    * Double-clicking an add-on now installs, updates, uninstalls or publishes it
      depending on the situation.
-
+ * Miscellaneous and bug fixes:
+   * Fixed base animation showing on walking corpse & soulless bats (bug #25673)
 
 Version 1.13.7:
  * AI:


### PR DESCRIPTION
Fixes https://gna.org/bugs/?25673


I figure it's either this fix, or I can split the bat's [attack_anim] into 3 tags instead of 2