### PR TITLE
remove 'allow_failures' from c++14 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ matrix:
     - os: osx
       compiler: clang
       env: opt=-O0 CXXSTD=11 NLS=false
-  allow_failures:
-    - env: OPT=-O2 CXXSTD=1y NLS=false
 
 before_install:
     - export TARGETS="wesnoth wesnothd campaignd test"


### PR DESCRIPTION
this was intially added brecause it didnt compile whne it was added.