### PR TITLE
use clang for c++14 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
       env: OPT=-O2 CXXSTD=11 NLS=false
     - compiler: gcc
       env: NLS=true
-    - compiler: clang
+    - compiler: gcc
       env: OPT=-O2 CXXSTD=1y NLS=false
     - compiler: clang
       env: OPT=-O0 CXXSTD=11 NLS=false


### PR DESCRIPTION
the used clang version supports more c++14 features than the used gcc version so its better suited for testing whether the code still works with those features enabled.