### PR TITLE
Tutorial - the player can't end turns after attacking

### DIFF
--- a/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
+++ b/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
@@ -425,6 +425,8 @@
 
         [disallow_end_turn][/disallow_end_turn]
 
+        {ALLOW_END_TURN_AFTER_ATTACK}
+
         {CLEAR_PRINT}
 
         [message]
@@ -471,6 +473,8 @@
         name=turn 3 refresh
 
         [disallow_end_turn][/disallow_end_turn]
+
+        {ALLOW_END_TURN_AFTER_ATTACK}
 
         {CLEAR_PRINT}
 
@@ -571,6 +575,8 @@
         [/filter_condition]
 
         [disallow_end_turn][/disallow_end_turn]
+
+        {ALLOW_END_TURN_AFTER_ATTACK}
 
         {CLEAR_PRINT}
 

--- a/data/campaigns/tutorial/utils/utils.cfg
+++ b/data/campaigns/tutorial/utils/utils.cfg
@@ -30,6 +30,24 @@
     [/if]
 #enddef
 
+#define ALLOW_END_TURN_AFTER_ATTACK
+    # for the case the player disobeys delfador's order and attacks
+    [event]
+        name=attack_end
+        id=prevent deadlock
+        [filter]
+            id=student
+        [/filter]
+        [allow_end_turn][/allow_end_turn]
+    [/event]
+    [event]
+        name=turn end
+        [remove_event]
+            id=prevent deadlock
+        [/remove_event]
+    [/event]
+#enddef
+
 #define UNDO_REMINDER
     [message]
         speaker=narrator


### PR DESCRIPTION
There are a few situations where the player ends up being unable to do anything when he attacked with the leader. He should't do that, but he can, and it may sometimes even look tempting to do that. Two solutions come to mind, either a) allowing him to end the turn or b) _somehow_ aborting the attack.

The related bugreport is [bug #25111](https://gna.org/bugs/?25111), the cases where the player has to reload. In the other cases the player could undo the moves _if he would know about that possibility._
