### PR TITLE
Allow negative maximum slider values

### DIFF
--- a/src/gui/widgets/slider.cpp
+++ b/src/gui/widgets/slider.cpp
@@ -14,6 +14,8 @@
 
 #define GETTEXT_DOMAIN "wesnoth-lib"
 
+#include <limits>
+
 #include "gui/widgets/slider.hpp"
 
 #include "formatter.hpp"
@@ -40,7 +42,7 @@ REGISTER_WIDGET(slider)
 slider::slider()
 	: scrollbar_base()
 	, best_slider_length_(0)
-	, minimum_value_(0)
+	, minimum_value_(std::numeric_limits<int>::min())
 	, minimum_value_label_()
 	, maximum_value_label_()
 	, value_labels_()


### PR DESCRIPTION
Previously, the initialization of minimum_value to 0 prevented
setting negative maximum values, since the negative value would
always be less than 0, triggering an assert. Initializing it to the
least int possible avoids this.

This fixes https://gna.org/bugs/?25618.

If someone only calls slider::set_maximum_value() and not slider::set_minimum_value(), this would obviously lead to unexpected results (previous value of 0 was probably a saner default in that aspect), but there are currently no such place in the code base. I pondered whether I should add a function for setting both the min and the max in the same call (it's somewhat awkward to be unable to set minimum unless maximum is already set), but I went for the simpler solution.