### PR TITLE
multiplayer maps: descriptions: cleanup

### DIFF
--- a/data/multiplayer/scenarios/3p_Island_of_the_Horatii.cfg
+++ b/data/multiplayer/scenarios/3p_Island_of_the_Horatii.cfg
@@ -3,7 +3,7 @@
 [multiplayer]
     id=multiplayer_Island_of_the_Horatii
     name= _ "3p — Island of the Horatii"
-    description= _ "Controlling the central island is often the key to victory in this 21x21hex 3 player free for all map." + _ " Recommended setting of 2 gold per village."
+    description= _ "Controlling the central island is often the key to victory in this 3 player free for all map." + _ " Recommended setting of 2 gold per village."
     map_data="{multiplayer/maps/3p_Island_of_the_Horatii.map}"
 
     {DEFAULT_SCHEDULE}

--- a/data/multiplayer/scenarios/4p_Isars_Cross.cfg
+++ b/data/multiplayer/scenarios/4p_Isars_Cross.cfg
@@ -6,7 +6,7 @@
     id=multiplayer_Isars_Cross
     name= _ "4p — Isar’s Cross"
     map_data="{multiplayer/maps/4p_Isars_Cross.map}"
-    description= _ "A very small 2 vs. 2 map. Close quarters fighting means the successful rotation of units and planning of moves is important. Teams set for players 1&4 vs. 2&3 (northeast vs. southwest). Designed for 75 starting gold, 20 villages."
+    description= _ "A very small 2 vs. 2 map. Close quarters fighting means the successful rotation of units and planning of moves is important. Teams set for players 1+4 vs. 2+3 (northeast vs. southwest). Designed for 75 starting gold, 20 villages."
 
     {DEFAULT_SCHEDULE}
     {DEFAULT_MUSIC_PLAYLIST}

--- a/data/multiplayer/scenarios/4p_King_of_the_Hill.cfg
+++ b/data/multiplayer/scenarios/4p_King_of_the_Hill.cfg
@@ -6,7 +6,7 @@
     id=multiplayer_King_of_the_Hill
     name= _ "4p — King of the Hill"
     map_data="{multiplayer/maps/4p_King_of_the_Hill.map}"
-    description= _ "Controlling the area around the central keep is very lucrative in this 36X36 4 player FFA map. Works fine 2 vs. 2 as well. There are 36 villages." + _ " Recommended setting of 2 gold per village and 150 starting gold."
+    description= _ "Controlling the area around the central keep is very lucrative in this 4 player FFA map. Works fine 2 vs. 2 as well. There are 36 villages." + _ " Recommended setting of 2 gold per village and 150 starting gold."
 
     {DEFAULT_SCHEDULE}
     {DEFAULT_MUSIC_PLAYLIST}

--- a/data/multiplayer/scenarios/4p_Loris_River.cfg
+++ b/data/multiplayer/scenarios/4p_Loris_River.cfg
@@ -6,7 +6,7 @@
     id=multiplayer_Loris_River
     name= _ "4p — Loris River"
     map_data="{multiplayer/maps/4p_Loris_River.map}"
-    description= _ "A 25x25 2 vs. 2 map centered around a river with keeps in opposite corners. Designed for players 1&4 vs. 2&3. There are 28 villages." + _ " Recommended setting of 2 gold per village."
+    description= _ "2 vs. 2 map centered around a river with keeps in opposite corners. Designed for players 1+4 vs. 2+3. There are 28 villages." + _ " Recommended setting of 2 gold per village."
 
     {DEFAULT_SCHEDULE_SECOND_WATCH}
 

--- a/data/multiplayer/scenarios/4p_Paths_of_Daggers.cfg
+++ b/data/multiplayer/scenarios/4p_Paths_of_Daggers.cfg
@@ -6,7 +6,7 @@
     id=multiplayer_Paths_of_Daggers
     name= _ "4p — Paths of Daggers"
     map_data="{multiplayer/maps/4p_Paths_of_Daggers.map}"
-    description= _ "A 35X27 2 vs. 2 map with 5 separate paths of engagement. Balanced to be played east vs. west (1&4 vs. 2&3), but works well with any teams or FFA." + _ " Recommended setting of 2 gold per village, 28 villages."
+    description= _ "A 2 vs. 2 map with 5 separate paths of engagement. Balanced to be played east vs. west (1+4 vs. 2+3), but works well with any teams or FFA." + _ " Recommended setting of 2 gold per village, 28 villages."
 
     {DEFAULT_SCHEDULE}
     {DEFAULT_MUSIC_PLAYLIST}

--- a/data/multiplayer/scenarios/4p_Ruins_of_Terra-Dwelve.cfg
+++ b/data/multiplayer/scenarios/4p_Ruins_of_Terra-Dwelve.cfg
@@ -4,7 +4,7 @@
 [multiplayer]
     id=multiplayer_Ruins_of_Terra-Dwelve
     name= _ "4p — Ruins of Terra-Dwelve"
-    description= _ "Battle over the legendary treasures of the ancient ruins of Terra-Dwelve. Large multi-fronted 2vs2 set in a vast underground complex." + _ " Recommended setting of 2 gold per village."
+    description= _ "Battle over the legendary treasures of the ancient ruins of Terra-Dwelve. Large multi-fronted 2 vs. 2 set in a vast underground complex." + _ " Recommended setting of 2 gold per village."
     map_data="{multiplayer/maps/4p_Ruins_of_Terra-Dwelve.map}"
 
     {DEFAULT_SCHEDULE}

--- a/data/multiplayer/scenarios/4p_Siege_Castles.cfg
+++ b/data/multiplayer/scenarios/4p_Siege_Castles.cfg
@@ -6,7 +6,7 @@
     id=multiplayer_Siege_Castles
     name= _ "4p — Siege Castles"
     map_data="{multiplayer/maps/4p_Siege_Castles.map}"
-    description= _ "36X36 4 player map where 4 mighty castles face off at the convergence of two rivers. Works well as 2 vs. 2 or FFA. There are approximately 45 villages." + _ " Recommended setting of 2 gold per village and 150 starting gold."
+    description= _ "A 4 player map where 4 mighty castles face off at the convergence of two rivers. Works well as 2 vs. 2 or FFA. There are approximately 45 villages." + _ " Recommended setting of 2 gold per village and 150 starting gold."
 
     {DEFAULT_SCHEDULE}
     {DEFAULT_MUSIC_PLAYLIST}

--- a/data/multiplayer/scenarios/4p_Xanthe_Chaos.cfg
+++ b/data/multiplayer/scenarios/4p_Xanthe_Chaos.cfg
@@ -6,7 +6,7 @@
     id=multiplayer_Xanthe_Chaos
     name= _ "4p — Xanthe Chaos"
     map_data="{multiplayer/maps/4p_Xanthe_Chaos.map}"
-    description= _ "A 24X28 2 vs. 2 map with auxiliary keeps, and a large messy battle in the center common."
+    description= _ "A 2 vs. 2 map with auxiliary keeps, and a large messy battle in the center common."
 
     {DEFAULT_SCHEDULE}
     {DEFAULT_MUSIC_PLAYLIST}

--- a/data/multiplayer/scenarios/5p_Auction-X.cfg
+++ b/data/multiplayer/scenarios/5p_Auction-X.cfg
@@ -4,7 +4,7 @@
     id=multiplayer_Auction-X
     name= _ "5p — Auction-X"
     map_data="{multiplayer/maps/5p_Auction-X.map}"
-    description= _ "4 players surround a central keep, play vs the AI survival style, or as a FFA or 4 vs. 1. The center player will need more gold in a 4 vs. 1 or FFA, and the best way to determine how much is an auction, LOWEST bid wins. It is a very small map so 75 gold is recommended for the other players."
+    description= _ "4 players surround a central keep, play vs. the AI survival style, or as a FFA or 4 vs. 1. The center player will need more gold in a 4 vs. 1 or FFA, and the best way to determine how much is an auction, LOWEST bid wins. It is a very small map so 75 gold is recommended for the other players."
 
     {DEFAULT_SCHEDULE}
     {DEFAULT_MUSIC_PLAYLIST}

--- a/data/multiplayer/scenarios/6p_The_Manzivan_Traps.cfg
+++ b/data/multiplayer/scenarios/6p_The_Manzivan_Traps.cfg
@@ -7,7 +7,7 @@
     name= _ "6p — The Manzivan Traps"
     map_data="{multiplayer/maps/6p_The_Manzivan_Traps.map}"
     # wmllint: local spelling Manzivan
-    description= _ "A 40X20 3 vs. 3 map. The Manzivan Traps are widely known as a difficult and confusing area of terrain where it is easy to end up out of position or over extended. Teams set for players 145 vs. 236 (east vs west). Designed for 100 starting gold, has 33 villages."
+    description= _ "A 3 vs. 3 map. The Manzivan Traps are widely known as a difficult and confusing area of terrain where it is easy to end up out of position or over extended. Teams set for players 145 vs. 236 (east vs. west). Designed for 100 starting gold, has 33 villages."
 
     {DEFAULT_SCHEDULE}
     {DEFAULT_MUSIC_PLAYLIST}

--- a/data/multiplayer/scenarios/6p_Volcano.cfg
+++ b/data/multiplayer/scenarios/6p_Volcano.cfg
@@ -6,7 +6,7 @@
     id=multiplayer_Volcano
     name= _ "6p — Volcano"
     map_data="{multiplayer/maps/6p_Volcano.map}"
-    description= _ "A 3vs3 battle to control the ashes of a kingdom long ago collapsed from a volcanic eruption. It has 36 villages."
+    description= _ "A 3 vs. 3 battle to control the ashes of a kingdom long ago collapsed from a volcanic eruption. It has 36 villages."
 
     {DEFAULT_SCHEDULE}
     {DEFAULT_MUSIC_PLAYLIST}

--- a/data/multiplayer/scenarios/6p_Waterloo_Sunset.cfg
+++ b/data/multiplayer/scenarios/6p_Waterloo_Sunset.cfg
@@ -6,7 +6,7 @@
     id=multiplayer_Waterloo_Sunset
     name= _ "6p — Waterloo Sunset"
     map_data="{multiplayer/maps/6p_Waterloo_Sunset.map}"
-    description= _ "A 40X30 3 vs. 3 map. Flexible coordination of your alliance is required to avoid being outnumbered. Teams set for players 145 vs. 236 (north vs. south), but having players 146 or 136 as a team is also interesting. Designed for 150 starting gold, has 44 villages."
+    description= _ "A 3 vs. 3 map. Flexible coordination of your alliance is required to avoid being outnumbered. Teams set for players 145 vs. 236 (north vs. south), but having players 146 or 136 as a team is also interesting. Designed for 150 starting gold, has 44 villages."
 
     {DEFAULT_SCHEDULE}
     {DEFAULT_MUSIC_PLAYLIST}


### PR DESCRIPTION
don't include mape size in the description since map selection screen already displays map size by itself.
canonicalize "XvsY" and "X vs Y" to "X vs. Y".
work around pango_text::set_markup_helper warnings about unescaped ampersands.