### PR TITLE
Allow paths with ".." in macro inclusions

### DIFF
--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -1379,18 +1379,11 @@ std::string get_binary_dir_location(const std::string &type, const std::string &
 	return std::string();
 }
 
-std::string get_wml_location(const std::string &filename_unresolved, const std::string &current_dir_abs)
+std::string get_wml_location(const std::string &filename_unresolved, const std::string &current_dir_input)
 {
 	std::string current_dir;
-	if(is_relative(current_dir_abs)) {
-		current_dir = current_dir_abs;
-	} else {
-		current_dir = get_short_wml_path(current_dir_abs);
-		if(current_dir == current_dir_abs && !is_relative(current_dir)) {
-			// Could happen if current_dir somehow pointed outside gamedata and userdata
-			// For example, if a Lua load() call set the chunk name
-			current_dir.clear();
-		}
+	if(is_relative(current_dir_input)) {
+		current_dir = current_dir_input;
 	}
 	// Special cases first:
 	if(filename_unresolved == "/") {

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -1379,15 +1379,21 @@ std::string get_binary_dir_location(const std::string &type, const std::string &
 	return std::string();
 }
 
-std::string get_wml_location(const std::string &filename_unresolved, const std::string &current_dir)
+std::string get_wml_location(const std::string &filename_unresolved, const std::string &current_dir_abs)
 {
+	std::string current_dir = get_short_wml_path(current_dir_abs);
+	if(current_dir == current_dir_abs) {
+		// Could happen if current_dir somehow pointed outside gamedata and userdata
+		// For example, if a Lua load() call set the chunk name
+		current_dir.clear();
+	}
 	// Special cases first:
 	if(filename_unresolved == "/") {
 		return game_config::path;
 	} else if(filename_unresolved == ".") {
 		return current_dir.empty() ? game_config::path : current_dir;
 	}
-	const std::string& filename = resolve_filename(filename_unresolved, get_short_wml_path(current_dir));
+	const std::string& filename = resolve_filename(filename_unresolved, current_dir);
 
 	if (!is_legal_file(filename))
 		return std::string();

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -1266,7 +1266,7 @@ static bool is_legal_file(const std::string& filename_str)
 		return false;
 	}
 
-	if (filename.size() >= 2 && filename[0] == '.' && filename[1] == '.') {
+	if(filename.find("..") != std::string::npos) {
 		ERR_FS << "Illegal path '" << filename << "' (initial \"..\" not allowed).\n";
 		return false;
 	}

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -1381,11 +1381,16 @@ std::string get_binary_dir_location(const std::string &type, const std::string &
 
 std::string get_wml_location(const std::string &filename_unresolved, const std::string &current_dir_abs)
 {
-	std::string current_dir = get_short_wml_path(current_dir_abs);
-	if(current_dir == current_dir_abs) {
-		// Could happen if current_dir somehow pointed outside gamedata and userdata
-		// For example, if a Lua load() call set the chunk name
-		current_dir.clear();
+	std::string current_dir;
+	if(is_relative(current_dir_abs)) {
+		current_dir = current_dir_abs;
+	} else {
+		current_dir = get_short_wml_path(current_dir_abs);
+		if(current_dir == current_dir_abs && !is_relative(current_dir)) {
+			// Could happen if current_dir somehow pointed outside gamedata and userdata
+			// For example, if a Lua load() call set the chunk name
+			current_dir.clear();
+		}
 	}
 	// Special cases first:
 	if(filename_unresolved == "/") {

--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -214,9 +214,9 @@ void game_config_manager::load_game_config(FORCE_RELOAD_CONFIG force_reload,
 			}
 
 			const std::string& path = core["path"];
-			if (!filesystem::file_exists(filesystem::get_wml_location(path))) {
-				events::call_in_main_thread([&]() {
-					gui2::dialogs::wml_error::display(
+			// get_wml_location() returns empty if the path does not exist
+			if(filesystem::get_wml_location(path).empty()) {
+				gui2::dialogs::wml_error::display(
 						_("Error validating data core."),
 						_("Core ID: ") + id
 						+ '\n' + _("Core Path: ") + path

--- a/src/scripting/lua_fileops.cpp
+++ b/src/scripting/lua_fileops.cpp
@@ -64,54 +64,13 @@ static std::string get_calling_file(lua_State* L)
 /// @returns true if the filename was successfully resolved.
 static bool resolve_filename(std::string& filename, std::string currentdir, std::string* rel = nullptr)
 {
-	if(filename.size() < 2) {
-		return false;
-	}
-	if(filename[0] == '.' && filename[1] == '/') {
-		filename = currentdir + filename.substr(1);
-	}
-	if(std::find(filename.begin(), filename.end(), '\\') != filename.end()) {
-		return false;
-	}
-	//resolve /./
-	while(true) {
-		std::size_t pos = filename.find("/./");
-		if(pos == std::string::npos) {
-			break;
-		}
-		filename = filename.replace(pos, 2, "");
-	}
-	//resolve //
-	while(true) {
-		std::size_t pos = filename.find("//");
-		if(pos == std::string::npos) {
-			break;
-		}
-		filename = filename.replace(pos, 1, "");
-	}
-	//resolve /../
-	while(true) {
-		std::size_t pos = filename.find("/..");
-		if(pos == std::string::npos) {
-			break;
-		}
-		std::size_t pos2 = filename.find_last_of('/', pos - 1);
-		if(pos2 == std::string::npos || pos2 >= pos) {
-			return false;
-		}
-		filename = filename.replace(pos2, pos- pos2 + 3, "");
-	}
-	if(filename.find("..") != std::string::npos) {
-		return false;
-	}
-	std::string p = filesystem::get_wml_location(filename);
-	if(p.empty()) {
+	filename = filesystem::get_wml_location(filename, currentdir);
+	if(filename.empty()) {
 		return false;
 	}
 	if(rel) {
-		*rel = filename;
+		*rel = filesystem::get_short_wml_path(filename);
 	}
-	filename = p;
 	return true;
 }
 

--- a/src/serialization/preprocessor.cpp
+++ b/src/serialization/preprocessor.cpp
@@ -804,7 +804,7 @@ preprocessor_data::preprocessor_data(preprocessor_streambuf& t,
 	: preprocessor(t)
 	, in_scope_(std::move(i))
 	, in_(*in_scope_)
-	, directory_(directory)
+	, directory_(filesystem::get_short_wml_path(directory))
 	, strings_()
 	, local_defines_(std::move(defines))
 	, tokens_()

--- a/src/tests/test_filesystem.cpp
+++ b/src/tests/test_filesystem.cpp
@@ -143,10 +143,13 @@ BOOST_AUTO_TEST_CASE( test_fs_binary_path )
 	BOOST_CHECK_EQUAL( get_binary_dir_location("images", "."), gamedata + "/images/." );
 
 	BOOST_CHECK_EQUAL( get_binary_file_location("images", "././././././"),
-	                   gamedata + "/images/././././././" );
+	                   gamedata + "/images/" );
 
 	BOOST_CHECK_EQUAL( get_binary_file_location("images", "wesnoth-icon.png"),
 	                   gamedata + "/data/core/images/wesnoth-icon.png" );
+
+	BOOST_CHECK_EQUAL(get_binary_file_location("images", "terrain/../scenery/dwarven-doors-closed.png"),
+					  gamedata + "/data/core/images/scenery/dwarven-doors-closed.png");
 
 	BOOST_CHECK_EQUAL( get_binary_file_location("music", "silence.ogg"),
 	                   gamedata + "/data/core/music/silence.ogg" );
@@ -157,14 +160,18 @@ BOOST_AUTO_TEST_CASE( test_fs_binary_path )
 	BOOST_CHECK_EQUAL( get_independent_image_path("wesnoth-icon.png"),
 	                   "data/core/images/wesnoth-icon.png" );
 
-	// Inexistent paths are resolved empty.
+	// Nonexistent paths are resolved empty.
 	BOOST_CHECK( get_binary_dir_location("images", "").empty() );
-	BOOST_CHECK( get_binary_dir_location("inexistent_resource_type", "").empty() );
+	BOOST_CHECK( get_binary_dir_location("nonexistent_resource_type", "").empty() );
 	BOOST_CHECK( get_binary_file_location("image", "wesnoth-icon.png").empty() );
 	BOOST_CHECK( get_binary_file_location("images", "bunnies_and_ponies_and_rainbows_oh_em_gee.psd").empty() );
 	BOOST_CHECK( get_binary_file_location("music", "this_track_does_not_exist.aiff").empty() );
 	BOOST_CHECK( get_binary_file_location("sounds", "rude_noises.aiff").empty() );
 	BOOST_CHECK( get_independent_image_path("dopefish.txt").empty() );
+
+	// Unsafe paths are resolved empty.
+	BOOST_CHECK(get_binary_file_location("images", "..").empty());
+	BOOST_CHECK(get_binary_file_location("images", "../sounds/bell.wav").empty())
 }
 
 BOOST_AUTO_TEST_CASE( test_fs_wml_path )
@@ -175,12 +182,24 @@ BOOST_AUTO_TEST_CASE( test_fs_wml_path )
 
 	BOOST_CHECK_EQUAL( get_wml_location("_main.cfg"), gamedata + "/data/_main.cfg" );
 	BOOST_CHECK_EQUAL( get_wml_location("core/_main.cfg"), gamedata + "/data/core/_main.cfg" );
-	BOOST_CHECK_EQUAL( get_wml_location("."), gamedata + "/data/." );
+	BOOST_CHECK_EQUAL(get_wml_location("core/units"), gamedata + "/data/core/units");
+	BOOST_CHECK_EQUAL( get_wml_location("."), gamedata + "/data" );
+	BOOST_CHECK_EQUAL(get_wml_location("/"), gamedata + "/data")
 
 	BOOST_CHECK_EQUAL( get_wml_location("~/"), userdata + "/data/" );
+	BOOST_CHECK_EQUAL(get_wml_lcation("~addons"), userdata + "/data/addons");
 
-	// Inexistent paths are resolved empty.
+	BOOST_CHECK_EQUAL(get_wml_location(".", get_wml_location("core/units")), gamedata + "/data/core/units");
+	BOOST_CHECK_EQUAL(get_wml_location("./bats", get_wml_location("core/units")), gamedata + "/data/core/units/bats");
+	BOOST_CHECK_EQUAL(get_wml_location("../macros/ai.cfg", get_wml_location("core/units")), gamedata + "data/core/macros/ai.cfg");
+
+	// Nonexistent paths are resolved empty.
 	BOOST_CHECK( get_wml_location("why_would_anyone_ever_name_a_file_like_this").empty() );
+
+	// Unsafe paths are resolved empty.
+	BOOST_CHECK(get_wml_location("..").empty());
+	BOOST_CHECK(get_wml_location("core/../..").empty());
+	BOOST_CHECK(get_wml_location("../..", get_wml_location("core")).empty());
 }
 
 BOOST_AUTO_TEST_CASE( test_fs_search )

--- a/src/tests/test_filesystem.cpp
+++ b/src/tests/test_filesystem.cpp
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_CASE( test_fs_binary_path )
 
 	// Unsafe paths are resolved empty.
 	BOOST_CHECK(get_binary_file_location("images", "..").empty());
-	BOOST_CHECK(get_binary_file_location("images", "../sounds/bell.wav").empty())
+	BOOST_CHECK(get_binary_file_location("images", "../sounds/bell.wav").empty());
 }
 
 BOOST_AUTO_TEST_CASE( test_fs_wml_path )
@@ -187,7 +187,7 @@ BOOST_AUTO_TEST_CASE( test_fs_wml_path )
 	BOOST_CHECK_EQUAL(get_wml_location("/"), gamedata + "/data")
 
 	BOOST_CHECK_EQUAL( get_wml_location("~/"), userdata + "/data/" );
-	BOOST_CHECK_EQUAL(get_wml_lcation("~addons"), userdata + "/data/addons");
+	BOOST_CHECK_EQUAL(get_wml_location("~addons"), userdata + "/data/addons");
 
 	BOOST_CHECK_EQUAL(get_wml_location(".", get_wml_location("core/units")), gamedata + "/data/core/units");
 	BOOST_CHECK_EQUAL(get_wml_location("./bats", get_wml_location("core/units")), gamedata + "/data/core/units/bats");


### PR DESCRIPTION
I have made this safe (I think) by resolving any ".." components manually while the path is still a relative path to the gamedata or userdata directory. If there are ".." components left over that can't be resolved (ie, at the beginning of the path), then it's an error. Otherwise, resolution then proceeds as normal, depending on whether it's a WML path (which is also used by Lua) or binary path.

I think this could use an audit to determine if it's truly safe. I did add some unit tests to make sure it would be safe, but I'm not sure if it covers every possible case.

With this it should be possible to make any addon not depend on the name of its folder.