### PR TITLE
SotA S21: Improve speed & readability of code

### DIFF
--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg
@@ -236,6 +236,9 @@ We finally made it out of the mountains. We crossed the Ford of Abez late this m
     [store_unit]
         [filter]
             side=1
+            [not]
+                x,y="recall","recall"
+            [/not]
         [/filter]
         variable=side1_units
     [/store_unit]
@@ -244,42 +247,36 @@ We finally made it out of the mountains. We crossed the Ford of Abez late this m
     # adjacent to the enemy leader to see if one matches one of those locations.
     [for]
         array=side1_units
-        variable=unit
+        variable=u
         [do]
             [store_reachable_locations]
                 [filter]
-                    id=$side1_units[$unit].id
+                    id=$side1_units[$u].id
                 [/filter]
                 moves=max
                 variable=reachable_locations
             [/store_reachable_locations]
             [for]
                 array=adjacent_to_leader
-                variable=adjacent
+                variable=a
                 [do]
                     [if]
                         [have_location]
                             # If an enemy unit can reach this hex...
-                            x=$adjacent_to_leader[$adjacent].x
-                            y=$adjacent_to_leader[$adjacent].y
+                            x=$adjacent_to_leader[$a].x
+                            y=$adjacent_to_leader[$a].y
                             find_in=reachable_locations
                         [/have_location]
-                        [and]
-                            # ...and we haven't already stored this unit...
-                            [have_unit]
-                                id=$side1_units[$unit].id
-                                [not]
-                                    find_in=close_units
-                                [/not]
-                            [/have_unit]
-                        [/and]
                         [then]
                             # ...then add it to the close_units list:
                             [set_variables]
                                 name=close_units
                                 mode=append
-                                to_variable=side1_units[$unit]
+                                to_variable=side1_units[$u]
                             [/set_variables]
+                            [break]
+                                # So we don't store the unit again.
+                            [/break]
                         [/then]
                     [/if]
                 [/do]
@@ -423,7 +420,7 @@ We finally made it out of the mountains. We crossed the Ford of Abez late this m
 
     # If the AI got just a couple units, they would go off to die one at a time. We
     # finish filling up the keep so that doesn't happen. Also, this will make leader
-    # assassination by backstabbing shadows or nightguants very difficult. We will
+    # assassination by backstabbing shadows or nightgaunts very difficult. We will
     # do nothing if side 1 wasn't nearby, and no extra units were added. In that case,
     # the leader will just recruit as normal.
     [store_unit]


### PR DESCRIPTION
The speed improvement comes from not storing recall list units.
Use of [break] is for readability, it doesn't seem to have a significant effect on speed.

See also https://github.com/wesnoth/wesnoth/issues/1706