### PR TITLE
fix cmake compile error on macOS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -360,6 +360,16 @@ if(WIN32)
 	)
 endif(WIN32)
 
+# On apple only
+if(APPLE)
+	set(libwesnoth-game_STAT_SRC
+		${libwesnoth-game_STAT_SRC}
+		desktop/apple_notification.hpp
+		desktop/apple_notification.mm
+	)
+endif(APPLE)
+
+
 # For libdbus (essentially just for linux), this file needs to be linked, as its header is included #ifdef HAVE_LIBDBUS
 if(LIBDBUS_FOUND)
 	set(libwesnoth-game_STAT_SRC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -364,7 +364,6 @@ endif(WIN32)
 if(APPLE)
 	set(libwesnoth-game_STAT_SRC
 		${libwesnoth-game_STAT_SRC}
-		desktop/apple_notification.hpp
 		desktop/apple_notification.mm
 	)
 endif(APPLE)


### PR DESCRIPTION
https://github.com/wesnoth/wesnoth/issues/1613
fix this error.
https://forums.wesnoth.org/viewtopic.php?f=5&t=44455

before this commit:
```
[  3%] Built target wesnoth-core
[  7%] Built target wesnothd
[ 13%] Built target wesnoth-lua
[ 24%] Built target wesnoth-game
[ 25%] Built target wesnoth-sdl
[ 25%] Linking CXX executable ../wesnoth
Undefined symbols for architecture x86_64:
  "apple_notifications::send_notification(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, desktop::notifications::type)", referenced from:
      desktop::notifications::send(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, desktop::notifications::type) in notifications.cpp.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [wesnoth] Error 1
make[1]: *** [src/CMakeFiles/wesnoth.dir/all] Error 2
make: *** [all] Error 2
```

after fix:
```
[  3%] Built target wesnoth-core
[  7%] Built target wesnothd
[ 13%] Built target wesnoth-lua
Scanning dependencies of target wesnoth-game
[ 13%] Building CXX object src/CMakeFiles/wesnoth-game.dir/desktop/apple_notification.mm.o
[ 13%] Linking CXX static library libwesnoth-game.a
[ 24%] Built target wesnoth-game
[ 25%] Built target wesnoth-sdl
[ 25%] Linking CXX executable ../wesnoth
[100%] Built target wesnoth
```