### PR TITLE
Add command line switch for printing info to be included in bug reports

### DIFF
--- a/changelog
+++ b/changelog
@@ -5,6 +5,9 @@ Version 1.13.8+dev:
    * Add wesnoth.format function to substitute variables into a string.
  * User Interface:
    * Enable the use of tab to switch between text fields in most dialogs.
+ * Miscellaneous and Bug Fixes:
+   * Add --report/-R command line switch for printing the same report from the
+     Game Version dialog's clipboard function to stdout.
 
 Version 1.13.8:
   * Campaigns:

--- a/doc/man/wesnoth.6
+++ b/doc/man/wesnoth.6
@@ -229,6 +229,9 @@ sets the screen resolution. Example:
 .BI --render-image \ image \  output
 takes a valid wesnoth 'image path string' with image path functions, and outputs to a windows .bmp file.
 .TP
+.BI -R,\ --report
+initializes game directories, prints build information suitable for use in bug reports, and exits.
+.TP
 .BI --rng-seed \ seed
 seeds the random number generator with number <arg>.
 Example:

--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -16,6 +16,9 @@
 
 #include "build_info.hpp"
 
+#include "desktop/version.hpp"
+#include "game_config.hpp"
+#include "filesystem.hpp"
 #include "formatter.hpp"
 #include "gettext.hpp"
 
@@ -341,6 +344,36 @@ std::string optional_features_report()
 
 		o << (f.enabled ? "yes" : "no") << '\n';
 	}
+
+	return o.str();
+}
+
+std::string full_build_report()
+{
+	std::ostringstream o;
+
+	o << "The Battle for Wesnoth version " << game_config::revision << '\n'
+	  << "Running on " << desktop::os_version() << '\n'
+	  << '\n'
+	  << "Game paths\n"
+	  << "==========\n"
+	  << '\n'
+	  << "Data dir:        " << game_config::path << '\n'
+	  << "User config dir: " << filesystem::get_user_config_dir() << '\n'
+	  << "User data dir:   " << filesystem::get_user_data_dir() << '\n'
+	  << "Saves dir:       " << filesystem::get_saves_dir() << '\n'
+	  << "Add-ons dir:     " << filesystem::get_addons_dir() << '\n'
+	  << "Cache dir:       " << filesystem::get_cache_dir() << '\n'
+	  << '\n'
+	  << "Libraries\n"
+	  << "=========\n"
+	  << '\n'
+	  << game_config::library_versions_report()
+	  << '\n'
+	  << "Features\n"
+	  << "========\n"
+	  << '\n'
+	  << game_config::optional_features_report();
 
 	return o.str();
 }

--- a/src/build_info.hpp
+++ b/src/build_info.hpp
@@ -75,4 +75,9 @@ const std::string& library_name(LIBRARY_ID lib);
  */
 std::string library_versions_report();
 
+/**
+ * Produce a bug report-style info dump.
+ */
+std::string full_build_report();
+
 } // end namespace game_config

--- a/src/commandline_options.cpp
+++ b/src/commandline_options.cpp
@@ -133,6 +133,7 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 	userdata_dir(),
 	validcache(false),
 	version(false),
+	report(false),
 	windowed(false),
 	with_replay(false),
 	args_(args.begin() + 1 , args.end()),
@@ -177,6 +178,7 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 		 " Implies --wconsole."
 #endif // _WIN32
 		 )
+		("report,R", "initializes game directories, prints build information suitable for use in bug reports, and exits.")
 		("rng-seed", po::value<unsigned int>(), "seeds the random number generator with number <arg>. Example: --rng-seed 0")
 		("screenshot", po::value<two_strings>()->multitoken(), "takes two arguments: <map> <output>. Saves a screenshot of <map> to <output> without initializing a screen. Editor must be compiled in for this to work."
 #ifdef _WIN32
@@ -435,6 +437,8 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 		username = vm["username"].as<std::string>();
 	if (vm.count("password"))
 		password = vm["password"].as<std::string>();
+	if (vm.count("report"))
+		report = true;
 	if (vm.count("side"))
 		multiplayer_side = parse_to_uint_string_tuples_(vm["side"].as<std::vector<std::string> >());
 	if (vm.count("test"))

--- a/src/commandline_options.hpp
+++ b/src/commandline_options.hpp
@@ -207,6 +207,8 @@ public:
 	bool validcache;
 	/// True if --version was given on the command line. Prints version and exits.
 	bool version;
+	/// True if --report was given on the command line. Prints a bug report-style info dump and exits.
+	bool report;
 	/// True if --windowed was given on the command line. Starts Wesnoth in windowed mode.
 	bool windowed;
 	/// True if --with-replay was given on the command line. Shows replay of the loaded file.

--- a/src/gui/dialogs/game_version.cpp
+++ b/src/gui/dialogs/game_version.cpp
@@ -310,32 +310,7 @@ void game_version::report_copy_callback()
 
 void game_version::generate_plain_text_report()
 {
-	std::ostringstream o;
-
-	o << "The Battle for Wesnoth version " << game_config::revision << '\n'
-	  << "Running on " << desktop::os_version() << '\n'
-	  << '\n'
-	  << "Game paths\n"
-	  << "==========\n"
-	  << '\n'
-	  << "Data dir:        " << path_map_["datadir"] << '\n'
-	  << "User config dir: " << path_map_["config"] << '\n'
-	  << "User data dir:   " << path_map_["userdata"] << '\n'
-	  << "Saves dir:       " << path_map_["saves"] << '\n'
-	  << "Add-ons dir:     " << path_map_["addons"] << '\n'
-	  << "Cache dir:       " << path_map_["cache"] << '\n'
-	  << '\n'
-	  << "Libraries\n"
-	  << "=========\n"
-	  << '\n'
-	  << game_config::library_versions_report()
-	  << '\n'
-	  << "Features\n"
-	  << "========\n"
-	  << '\n'
-	  << game_config::optional_features_report();
-
-	report_ = o.str();
+	report_ = game_config::full_build_report();
 }
 
 } // namespace dialogs

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -448,6 +448,11 @@ static int process_command_args(const commandline_options& cmdline_opts) {
 
 		return 0;
 	}
+	if(cmdline_opts.report) {
+		std::cout << "\n========= BUILD INFORMATION =========\n\n"
+				  << game_config::full_build_report();
+		return 0;
+	}
 
 	// Options changing their behavior dependent on some others should be checked below.
 


### PR DESCRIPTION
This add a new `--report`/`-R` switch that generate an info dump for bug reports.

This is intended to be used instead of the Game Version dialog's clipboard text report in the event that Wesnoth cannot reach the titlescreen or the dialog for some reason.

Unlike the `--version` info dump, it performs various calls to the filesystem API which have potential side-effects on the environment (namely, creating a user data directory structure if none existed before running the command). It seems highly improper for a program's `--version` switch to perform any actions other than printing text to its parent terminal, hence I thought it would be better to add a new switch with a more active phrasing, also reflected in its accompanying documentation.

Ultimately, this and its UI counterpart should be used by 1.14 players as part of the bug reporting process, preferably as a mandatory step before submitting new reports on GH or the forums.