### PR TITLE
fix -Winconsistent-missing-override warnings by clang.

### DIFF
--- a/src/scripting/game_lua_kernel.hpp
+++ b/src/scripting/game_lua_kernel.hpp
@@ -193,7 +193,7 @@ public:
 
 	void set_game_display(game_display * gd);
 
-	virtual std::string my_name() { return "Game Lua Kernel"; }
+	virtual std::string my_name() override { return "Game Lua Kernel"; }
 
 	std::string apply_effect(const std::string& name, unit& u, const config& cfg, bool need_apply);
 	void initialize(const config& level);
@@ -210,7 +210,7 @@ public:
 	bool run_filter(char const *name, int nArgs);
 	bool run_wml_conditional(const std::string&, vconfig const &);
 
-	virtual void log_error(char const* msg, char const* context = "Lua error");
+	virtual void log_error(char const* msg, char const* context = "Lua error") override;
 
 	ai::lua_ai_context* create_lua_ai_context(char const *code, ai::engine_lua *engine);
 	ai::lua_ai_action_handler* create_lua_ai_action_handler(char const *code, ai::lua_ai_context &context);


### PR DESCRIPTION
was:
````
[  0%/4/4/515,14.101] Building CXX object src/CMakeFiles/wesnoth-game.dir/ai/composite/aspect.cpp.o
In file included from ../src/ai/composite/aspect.cpp:19:
In file included from ../src/ai/composite/aspect.hpp:25:
../src/scripting/game_lua_kernel.hpp:196:22: warning: 'my_name' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
        virtual std::string my_name() { return "Game Lua Kernel"; }
                            ^
../src/scripting/lua_kernel_base.hpp:56:22: note: overridden virtual function is here
        virtual std::string my_name() { return "Basic Lua Kernel"; }
                            ^
In file included from ../src/ai/composite/aspect.cpp:19:
In file included from ../src/ai/composite/aspect.hpp:25:
../src/scripting/game_lua_kernel.hpp:213:15: warning: 'log_error' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
        virtual void log_error(char const* msg, char const* context = "Lua error");
                     ^
../src/scripting/lua_kernel_base.hpp:66:15: note: overridden virtual function is here
        virtual void log_error(char const* msg, char const* context = "Lua error");
                     ^
2 warnings generated.
````