### PR TITLE
test: Use a better error message when code.lua doesn't exist

### DIFF
--- a/data/core/about.cfg
+++ b/data/core/about.cfg
@@ -167,6 +167,10 @@
         wikiuser = "lao"
     [/entry]
     [entry]
+        name = "Luther Thompson"
+        email = "lutheroto_AT_gmail.com"
+    [/entry]
+    [entry]
         name = "Mark de Wever (Mordante/SkeletonCrew)"
         comment = "coder, bug fixes, various features, multi-letter terrain system, gui system."
         wikiuser = "SkeletonCrew"

--- a/data/core/about.cfg
+++ b/data/core/about.cfg
@@ -167,10 +167,6 @@
         wikiuser = "lao"
     [/entry]
     [entry]
-        name = "Luther Thompson"
-        email = "lutheroto_AT_gmail.com"
-    [/entry]
-    [entry]
         name = "Mark de Wever (Mordante/SkeletonCrew)"
         comment = "coder, bug fixes, various features, multi-letter terrain system, gui system."
         wikiuser = "SkeletonCrew"
@@ -1289,6 +1285,10 @@
     [/entry]
     [entry]
         name = "Luiz Fernando de Faria Pereira (lfernando)"
+    [/entry]
+    [entry]
+        name = "Luther Thompson"
+        email = "lutheroto_AT_gmail.com"
     [/entry]
     [entry]
         name = "lv-zheng"

--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -1398,22 +1398,17 @@ My best advancement costs $next_cost gold and I’m $experience|% there."
             [command]
                 [lua]
                     code=<<
-                      local success, codeTable =
-                        pcall(wesnoth.dofile, "lua/code.lua")
-                      if success then
-                        if type(codeTable) == 'table' and
-                           type(codeTable.main) == 'function'
-                        then
-                          codeTable.main()
+                        local codeFile = "lua/code.lua"
+                        if wesnoth.have_file(codeFile) then
+                            local code = wesnoth.dofile(codeFile)
+                            if type(code) == "table" and type(code.main) == "function" then
+                                code.main()
+                            else
+                                wesnoth.message(codeFile.." must return a table with a 'main' function.")
+                            end
                         else
-                          wesnoth.message(
-                            "code.lua must return a table with a main function.")
+                            wesnoth.message("To use this command, create a file 'data/lua/code.lua' in the wesnoth source directory that returns a table with a 'main' function.")
                         end
-                      else
-                        wesnoth.message(
-                          codeTable ..
-                          " (To use this command, create a file 'data/lua/code.lua' in the wesnoth source directory that returns a table with a main function.)")
-                      end
                     >>
                 [/lua]
             [/command]

--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -1397,7 +1397,15 @@ My best advancement costs $next_cost gold and I’m $experience|% there."
             # The file is not in the repository to allow adding custom stuff to it.
             [command]
                 [lua]
-                    code=<< wesnoth.dofile("lua/code.lua").main() >>
+                    code=<<
+                      if not pcall(
+                        function()
+                          wesnoth.dofile("lua/code.lua").main()
+                        end)
+                      then
+                        wesnoth.message("To use this command, create a file 'data/lua/code.lua' in the wesnoth source directory that returns a table with a main function.")
+                      end
+                    >>
                 [/lua]
             [/command]
         [/set_menu_item]

--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -1398,12 +1398,21 @@ My best advancement costs $next_cost gold and I’m $experience|% there."
             [command]
                 [lua]
                     code=<<
-                      if not pcall(
-                        function()
-                          wesnoth.dofile("lua/code.lua").main()
-                        end)
-                      then
-                        wesnoth.message("To use this command, create a file 'data/lua/code.lua' in the wesnoth source directory that returns a table with a main function.")
+                      local success, codeTable =
+                        pcall(wesnoth.dofile, "lua/code.lua")
+                      if success then
+                        if type(codeTable) == 'table' and
+                           type(codeTable.main) == 'function'
+                        then
+                          codeTable.main()
+                        else
+                          wesnoth.message(
+                            "code.lua must return a table with a main function.")
+                        end
+                      else
+                        wesnoth.message(
+                          codeTable ..
+                          " (To use this command, create a file 'data/lua/code.lua' in the wesnoth source directory that returns a table with a main function.)")
                       end
                     >>
                 [/lua]


### PR DESCRIPTION
Bug #1690. This is hopefully a better error message when the user clicks "Reload and execute Lua code", and lua/code.lua doesn't exist.