### PR TITLE
Allow showing [chat] to observers, fixes #1735

### DIFF
--- a/data/core/about.cfg
+++ b/data/core/about.cfg
@@ -1548,6 +1548,9 @@
         name = "Tommy (yobbo)"
     [/entry]
     [entry]
+        name = "Toom Lõhmus (Ravana)"
+    [/entry]
+    [entry]
         name = "tsr"
     [/entry]
     [entry]

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -75,9 +75,26 @@ function wml_actions.chat(cfg)
 	)
 
 	for index, side in ipairs(side_list) do
-		if side.controller == "human" then
+		if side.controller == "human" and side.is_local then
 			wesnoth.message(speaker, message)
 			break
+		end
+	end
+
+	local observable = cfg.observable ~= false
+
+	if observable then
+		local all_sides = wesnoth.get_sides()
+		local has_human_side = false
+		for index, side in ipairs(all_sides) do
+			if side.controller == "human" and side.is_local then
+				has_human_side = true
+				break
+			end
+		end
+
+		if not has_human_side then
+			wesnoth.message(speaker, message)
 		end
 	end
 end


### PR DESCRIPTION
Fixes https://github.com/wesnoth/wesnoth/issues/1735
Implements https://forums.wesnoth.org/viewtopic.php?f=12&t=46029
[chat] has key observable=yes/no, default yes, which controls, if the message should be visible to observers.