### PR TITLE
Atttempt to fix repeated fireing of first_time_only=yes events

### DIFF
--- a/src/game_events/manager.hpp
+++ b/src/game_events/manager.hpp
@@ -129,7 +129,7 @@ public:
 
 	void write_events(config& cfg) const;
 
-	using event_func_t = std::function<void(game_events::manager&, handler_ptr)>;
+	using event_func_t = std::function<void(game_events::manager&, handler_ptr&)>;
 	void execute_on_events(const std::string& event_id, event_func_t func);
 
 	game_events::wml_event_pump& pump();

--- a/src/game_events/menu_item.cpp
+++ b/src/game_events/menu_item.cpp
@@ -329,7 +329,7 @@ void wml_menu_item::update_command(const config& new_command)
 	if(!command_.empty()) {
 		assert(resources::game_events);
 
-		resources::game_events->execute_on_events(event_name_, [&](game_events::manager& man, handler_ptr ptr) {
+		resources::game_events->execute_on_events(event_name_, [&](game_events::manager& man, handler_ptr& ptr) {
 			if(ptr->is_menu_item()) {
 				LOG_NG << "Removing command for " << event_name_ << ".\n";
 				man.remove_event_handler(command_["id"].str());

--- a/src/game_events/pump.cpp
+++ b/src/game_events/pump.cpp
@@ -574,7 +574,7 @@ bool wml_event_pump::operator()()
 
 		if(event_id.empty()) {
 			// Handle events of this name.
-			impl_->my_manager->execute_on_events(event_name, [&](game_events::manager&, handler_ptr ptr) {
+			impl_->my_manager->execute_on_events(event_name, [&](game_events::manager&, handler_ptr& ptr) {
 				DBG_EH << "processing event " << event_name << " with id=" << ptr->get_config()["id"] << "\n";
 
 				// Let this handler process our event.


### PR DESCRIPTION
fixup be665e29f111ad6c8ef1e8410a08608a405554cc

This isn't the best fix, ideally the code wouldn't use weak_ptr::expired to check whether an event was already handled.