### PR TITLE
Issue #1738: Changed unit_recall dialogue box 

### DIFF
--- a/src/gui/dialogs/unit_recall.cpp
+++ b/src/gui/dialogs/unit_recall.cpp
@@ -249,7 +249,7 @@ void unit_recall::pre_show(window& window)
 
 	list.register_sorting_option(0, [this](const int i) { return recall_list_[i]->type_name().str(); });
 	list.register_sorting_option(1, [this](const int i) { return recall_list_[i]->name().str(); });
-    list.register_sorting_option(2, [this](const int i) { return recall_list_[i]->level()*1000 - recall_list_[i]->experience_to_advance(); });
+    list.register_sorting_option(2, [this](const int i) { return recall_list_[i]->level()*1000 - static_cast<int>(recall_list_[i]->experience_to_advance()); });
 	list.register_sorting_option(3, [this](const int i) { return recall_list_[i]->experience(); });
 	list.register_sorting_option(4, [this](const int i) {
 		return !recall_list_[i]->trait_names().empty() ? recall_list_[i]->trait_names().front().str() : "";

--- a/src/gui/dialogs/unit_recall.cpp
+++ b/src/gui/dialogs/unit_recall.cpp
@@ -146,11 +146,10 @@ static std::string get_title_suffix(int side_num)
 	return msg.str();
 }
 
-void unit_recall:unit_recall_default_compare(unit &first, unit &second) {
-	if ( first.level() > second.level() ) return true;
-	if ( first.experience_to_advance() > second.experience_to_advance() ) return true;
-	if ( first.experience() > second.experience() ) return true;
-	if ( first.max_hitpoints() > second.max_hitpoints() ) return true;
+bool unit_recall::unit_recall_default_compare(const unit_const_ptr first, const unit_const_ptr second)
+{
+	if (first->level() > second->level()) return true;
+	if (first->experience_to_advance() < second->experience_to_advance()) return true;
 	return false;
 }
 

--- a/src/gui/dialogs/unit_recall.cpp
+++ b/src/gui/dialogs/unit_recall.cpp
@@ -181,6 +181,13 @@ void unit_recall::pre_show(window& window)
 		find_widget<button>(&window, "show_help", false),
 		std::bind(&unit_recall::show_help, this, std::ref(window)));
 
+	list.register_sorting_option(0, [this](const int i) { return recall_list_[i]->level(); });
+	list.register_sorting_option(1, [this](const int i) { return recall_list_[i]->experience_to_advance(); });
+	list.register_sorting_option(2, [this](const int i) { return recall_list_[i]->experience(); });
+	list.register_sorting_option(3, [this](const int i) { return recall_list_[i]->max_experience(); });
+
+	list.set_active_sorting_option(sort_last.first >= 0 ? sort_last	: sort_default);
+
 	for(const unit_const_ptr& unit : recall_list_) {
 		std::map<std::string, string_map> row_data;
 		string_map column;
@@ -240,7 +247,7 @@ void unit_recall::pre_show(window& window)
 	list.register_sorting_option(0, [this](const int i) { return recall_list_[i]->type_name().str(); });
 	list.register_sorting_option(1, [this](const int i) { return recall_list_[i]->name().str(); });
 	list.register_sorting_option(2, [this](const int i) { return recall_list_[i]->level(); });
-	list.register_sorting_option(3, [this](const int i) { return recall_list_[i]->experience(); });
+	list.register_sorting_option(3, [this](const int i) { return recall_list_[i]->experience_to_advance(); });
 	list.register_sorting_option(4, [this](const int i) {
 		return !recall_list_[i]->trait_names().empty() ? recall_list_[i]->trait_names().front().str() : "";
 	});

--- a/src/gui/dialogs/unit_recall.cpp
+++ b/src/gui/dialogs/unit_recall.cpp
@@ -146,6 +146,14 @@ static std::string get_title_suffix(int side_num)
 	return msg.str();
 }
 
+void unit_recall:unit_recall_default_compare(unit &first, unit &second) {
+	if ( first.level() > second.level() ) return true;
+	if ( first.experience_to_advance() > second.experience_to_advance() ) return true;
+	if ( first.experience() > second.experience() ) return true;
+	if ( first.max_hitpoints() > second.max_hitpoints() ) return true;
+	return false;
+}
+
 void unit_recall::pre_show(window& window)
 {
 	label& title = find_widget<label>(&window, "title", true);
@@ -181,12 +189,7 @@ void unit_recall::pre_show(window& window)
 		find_widget<button>(&window, "show_help", false),
 		std::bind(&unit_recall::show_help, this, std::ref(window)));
 
-	list.register_sorting_option(0, [this](const int i) { return recall_list_[i]->level(); });
-	list.register_sorting_option(1, [this](const int i) { return recall_list_[i]->experience_to_advance(); });
-	list.register_sorting_option(2, [this](const int i) { return recall_list_[i]->experience(); });
-	list.register_sorting_option(3, [this](const int i) { return recall_list_[i]->max_experience(); });
-
-	list.set_active_sorting_option(sort_last.first >= 0 ? sort_last	: sort_default);
+	std::sort(recall_list_.begin(), recall_list_.end(), unit_recall_default_compare);
 
 	for(const unit_const_ptr& unit : recall_list_) {
 		std::map<std::string, string_map> row_data;
@@ -247,7 +250,7 @@ void unit_recall::pre_show(window& window)
 	list.register_sorting_option(0, [this](const int i) { return recall_list_[i]->type_name().str(); });
 	list.register_sorting_option(1, [this](const int i) { return recall_list_[i]->name().str(); });
 	list.register_sorting_option(2, [this](const int i) { return recall_list_[i]->level(); });
-	list.register_sorting_option(3, [this](const int i) { return recall_list_[i]->experience_to_advance(); });
+	list.register_sorting_option(3, [this](const int i) { return recall_list_[i]->experience(); });
 	list.register_sorting_option(4, [this](const int i) {
 		return !recall_list_[i]->trait_names().empty() ? recall_list_[i]->trait_names().front().str() : "";
 	});

--- a/src/gui/dialogs/unit_recall.cpp
+++ b/src/gui/dialogs/unit_recall.cpp
@@ -149,6 +149,7 @@ static std::string get_title_suffix(int side_num)
 bool unit_recall::unit_recall_default_compare(const unit_const_ptr first, const unit_const_ptr second)
 {
 	if (first->level() > second->level()) return true;
+	if (first->level() < second->level()) return false;
 	if (first->experience_to_advance() < second->experience_to_advance()) return true;
 	return false;
 }
@@ -248,7 +249,7 @@ void unit_recall::pre_show(window& window)
 
 	list.register_sorting_option(0, [this](const int i) { return recall_list_[i]->type_name().str(); });
 	list.register_sorting_option(1, [this](const int i) { return recall_list_[i]->name().str(); });
-	list.register_sorting_option(2, [this](const int i) { return recall_list_[i]->level(); });
+    list.register_sorting_option(2, [this](const int i) { return recall_list_[i]->level()*1000 - recall_list_[i]->experience_to_advance(); });
 	list.register_sorting_option(3, [this](const int i) { return recall_list_[i]->experience(); });
 	list.register_sorting_option(4, [this](const int i) {
 		return !recall_list_[i]->trait_names().empty() ? recall_list_[i]->trait_names().front().str() : "";

--- a/src/gui/dialogs/unit_recall.cpp
+++ b/src/gui/dialogs/unit_recall.cpp
@@ -249,7 +249,7 @@ void unit_recall::pre_show(window& window)
 
 	list.register_sorting_option(0, [this](const int i) { return recall_list_[i]->type_name().str(); });
 	list.register_sorting_option(1, [this](const int i) { return recall_list_[i]->name().str(); });
-    list.register_sorting_option(2, [this](const int i) { return recall_list_[i]->level()*1000 - static_cast<int>(recall_list_[i]->experience_to_advance()); });
+	list.register_sorting_option(2, [this](const int i) { return recall_list_[i]->level()*1000 - static_cast<int>(recall_list_[i]->experience_to_advance()); });
 	list.register_sorting_option(3, [this](const int i) { return recall_list_[i]->experience(); });
 	list.register_sorting_option(4, [this](const int i) {
 		return !recall_list_[i]->trait_names().empty() ? recall_list_[i]->trait_names().front().str() : "";

--- a/src/gui/dialogs/unit_recall.hpp
+++ b/src/gui/dialogs/unit_recall.hpp
@@ -62,7 +62,7 @@ private:
 	void show_help(window& window);
 
 	/** Function to sort recall_list_ by default. */
-	bool unit_recall_default_compare(const unit &first, const unit &second);
+	static bool unit_recall_default_compare(const unit_const_ptr first, const unit_const_ptr second);
 
 	/** Inherited from modal_dialog, implemented by REGISTER_DIALOG. */
 	virtual const std::string& window_id() const override;

--- a/src/gui/dialogs/unit_recall.hpp
+++ b/src/gui/dialogs/unit_recall.hpp
@@ -61,6 +61,9 @@ private:
 	void dismiss_unit(window& window);
 	void show_help(window& window);
 
+	/** Function to sort recall_list_ by default. */
+	bool unit_recall_default_compare(const unit &first, const unit &second);
+
 	/** Inherited from modal_dialog, implemented by REGISTER_DIALOG. */
 	virtual const std::string& window_id() const override;
 


### PR DESCRIPTION
Changed unit_recall dialogue box to sort by
1. Level
2. Experience to advance
