### PR TITLE
 	use a worker thread to send packages in wesnothd_connection, fixes #1674

### DIFF
--- a/src/game_initialization/multiplayer.cpp
+++ b/src/game_initialization/multiplayer.cpp
@@ -58,7 +58,7 @@ static wesnothd_connection_ptr open_connection(CVideo& video, const std::string&
 		dlg.show(video);
 
 		if(dlg.get_retval() != gui2::window::OK) {
-			return nullptr;
+			return wesnothd_connection_ptr();
 		}
 
 		h = preferences::network_host();
@@ -120,7 +120,7 @@ static wesnothd_connection_ptr open_connection(CVideo& video, const std::string&
 				throw wesnothd_error(_("Server-side redirect loop"));
 			}
 			shown_hosts.insert(hostpair(host, port));
-			sock.reset();
+			sock = wesnothd_connection_ptr();
 			sock = gui2::dialogs::network_transmission::wesnothd_connect_dialog(video, "redirect", host, port);
 			continue;
 		}
@@ -181,7 +181,7 @@ static wesnothd_connection_ptr open_connection(CVideo& video, const std::string&
 				warning_msg += _("Do you want to continue?");
 
 				if(gui2::show_message(video, _("Warning"), warning_msg, gui2::dialogs::message::yes_no_buttons) != gui2::window::OK) {
-					return 0;
+					return wesnothd_connection_ptr();
 				}
 			}
 
@@ -302,7 +302,7 @@ static wesnothd_connection_ptr open_connection(CVideo& video, const std::string&
 						break;
 					// Cancel
 					default:
-						return 0;
+						return wesnothd_connection_ptr();
 				}
 
 			// If we have got a new username we have to start all over again
@@ -323,7 +323,7 @@ static wesnothd_connection_ptr open_connection(CVideo& video, const std::string&
 		return sock;
 	}
 
-	return nullptr;
+	return wesnothd_connection_ptr();
 }
 
 /** Helper struct to manage the MP workflow arguments. */

--- a/src/game_initialization/multiplayer.cpp
+++ b/src/game_initialization/multiplayer.cpp
@@ -48,7 +48,7 @@ static lg::log_domain log_mp("mp/main");
 #define DBG_MP LOG_STREAM(debug, log_mp)
 
 /** Opens a new server connection and prompts the client for login credentials, if necessary. */
-static std::unique_ptr<wesnothd_connection> open_connection(CVideo& video, const std::string& original_host)
+static wesnothd_connection_ptr open_connection(CVideo& video, const std::string& original_host)
 {
 	DBG_MP << "opening connection" << std::endl;
 
@@ -64,7 +64,7 @@ static std::unique_ptr<wesnothd_connection> open_connection(CVideo& video, const
 		h = preferences::network_host();
 	}
 
-	std::unique_ptr<wesnothd_connection> sock;
+	wesnothd_connection_ptr sock;
 
 	const int colon_index = h.find_first_of(":");
 	std::string host;
@@ -120,7 +120,7 @@ static std::unique_ptr<wesnothd_connection> open_connection(CVideo& video, const
 				throw wesnothd_error(_("Server-side redirect loop"));
 			}
 			shown_hosts.insert(hostpair(host, port));
-			sock.release();
+			sock.reset();
 			sock = gui2::dialogs::network_transmission::wesnothd_connect_dialog(video, "redirect", host, port);
 			continue;
 		}
@@ -545,7 +545,7 @@ void start_client(CVideo& video, const config& game_config,	saved_game& state, c
 
 	preferences::admin_authentication_reset r;
 
-	std::unique_ptr<wesnothd_connection> connection = open_connection(video, host);
+	wesnothd_connection_ptr connection = open_connection(video, host);
 	if(!connection) {
 		return;
 	}

--- a/src/gui/dialogs/network_transmission.cpp
+++ b/src/gui/dialogs/network_transmission.cpp
@@ -125,7 +125,7 @@ struct read_wesnothd_connection_data : public network_transmission::connection_d
 	virtual size_t current()  override { return conn_.bytes_read(); }
 	virtual bool finished() override { return conn_.has_data_received(); }
 	virtual void cancel() override { }
-	virtual void poll() override { conn_.poll(); }
+	virtual void poll() override { }
 	wesnothd_connection& conn_;
 };
 
@@ -149,7 +149,7 @@ struct connect_wesnothd_connection_data : public network_transmission::connectio
 wesnothd_connection_ptr network_transmission::wesnothd_connect_dialog(CVideo& video, const std::string& msg, const std::string& hostname, int port)
 {
 	assert(!msg.empty());
-	wesnothd_connection_ptr res(new wesnothd_connection(hostname, std::to_string(port)));
+	wesnothd_connection_ptr res = wesnothd_connection::create(hostname, std::to_string(port));
 	connect_wesnothd_connection_data gui_data(*res);
 	wesnothd_dialog(video, gui_data, msg);
 	return res;

--- a/src/gui/dialogs/network_transmission.cpp
+++ b/src/gui/dialogs/network_transmission.cpp
@@ -146,10 +146,10 @@ struct connect_wesnothd_connection_data : public network_transmission::connectio
 	wesnothd_connection& conn_;
 };
 
-std::unique_ptr<wesnothd_connection> network_transmission::wesnothd_connect_dialog(CVideo& video, const std::string& msg, const std::string& hostname, int port)
+wesnothd_connection_ptr network_transmission::wesnothd_connect_dialog(CVideo& video, const std::string& msg, const std::string& hostname, int port)
 {
 	assert(!msg.empty());
-	std::unique_ptr<wesnothd_connection> res(new wesnothd_connection(hostname, std::to_string(port)));
+	wesnothd_connection_ptr res(new wesnothd_connection(hostname, std::to_string(port)));
 	connect_wesnothd_connection_data gui_data(*res);
 	wesnothd_dialog(video, gui_data, msg);
 	return res;

--- a/src/gui/dialogs/network_transmission.hpp
+++ b/src/gui/dialogs/network_transmission.hpp
@@ -50,7 +50,7 @@ public:
 	};
 
 	static bool wesnothd_receive_dialog(CVideo& video, const std::string& msg, config& cfg, wesnothd_connection& connection);
-	static std::unique_ptr<wesnothd_connection> wesnothd_connect_dialog(CVideo& video, const std::string& msg, const std::string& hostname, int port);
+	static std::shared_ptr<wesnothd_connection> wesnothd_connect_dialog(CVideo& video, const std::string& msg, const std::string& hostname, int port);
 
 private:
 	static void wesnothd_dialog(CVideo& video, connection_data& conn, const std::string& msg);

--- a/src/gui/dialogs/network_transmission.hpp
+++ b/src/gui/dialogs/network_transmission.hpp
@@ -19,8 +19,7 @@
 #include "network_asio.hpp"
 #include <boost/optional.hpp>
 #include "events.hpp"
-
-class wesnothd_connection;
+#include <wesnothd_connection.hpp>
 
 namespace gui2
 {
@@ -50,7 +49,7 @@ public:
 	};
 
 	static bool wesnothd_receive_dialog(CVideo& video, const std::string& msg, config& cfg, wesnothd_connection& connection);
-	static std::shared_ptr<wesnothd_connection> wesnothd_connect_dialog(CVideo& video, const std::string& msg, const std::string& hostname, int port);
+	static wesnothd_connection_ptr wesnothd_connect_dialog(CVideo& video, const std::string& msg, const std::string& hostname, int port);
 
 private:
 	static void wesnothd_dialog(CVideo& video, connection_data& conn, const std::string& msg);

--- a/src/tests/gui/test_gui2.cpp
+++ b/src/tests/gui/test_gui2.cpp
@@ -812,16 +812,16 @@ template<>
 struct dialog_tester<mp_lobby>
 {
 	config game_config;
-	wesnothd_connection connection;
+	wesnothd_connection_ptr connection;
 	wesnothd_connection_init init;
 	std::vector<std::string> installed_addons;
 	mp::lobby_info li;
-	dialog_tester() : connection("", ""), init(connection), li(game_config, installed_addons)
+	dialog_tester() : connection(wesnothd_connection::create("", "")), init(*connection), li(game_config, installed_addons)
 	{
 	}
 	mp_lobby* create()
 	{
-		return new mp_lobby(game_config, li, connection);
+		return new mp_lobby(game_config, li, *connection);
 	}
 };
 
@@ -838,13 +838,13 @@ struct dialog_tester<lobby_player_info>
 {
 	config c;
 	fake_chat_handler ch;
-	wesnothd_connection connection;
+	wesnothd_connection_ptr connection;
 	wesnothd_connection_init init;
 	mp::user_info ui;
 	std::vector<std::string> installed_addons;
 	mp::lobby_info li;
 	dialog_tester()
-		: connection("", ""), init(connection)
+		: connection(wesnothd_connection::create("", "")), init(*connection)
 		, ui(c), li(c, installed_addons)
 	{
 	}

--- a/src/wesnothd_connection.cpp
+++ b/src/wesnothd_connection.cpp
@@ -19,28 +19,55 @@
 #include "wesnothd_connection.hpp"
 #include "serialization/parser.hpp"
 
+#include <boost/thread.hpp>
+
 static lg::log_domain log_network("network");
 #define DBG_NW LOG_STREAM(debug, log_network)
 #define LOG_NW LOG_STREAM(info, log_network)
 #define WRN_NW LOG_STREAM(warn, log_network)
 #define ERR_NW LOG_STREAM(err, log_network)
 
+#if 0
+// code for the travis test
+#include <sys/types.h>
+#include <unistd.h>
+namespace {
+struct mptest_log
+{
+	mptest_log(const char* functionname)
+	{
+		WRN_NW << "Process:" << getpid() << " Thread:" << boost::this_thread::get_id() << " Function: " << functionname << " Start\n";
+	}
+};
+}
+
+
+#define MPTEST_LOG mptest_log mptest_log__( __func__)
+#else
+#define MPTEST_LOG ((void)0)
+#endif
+
 using boost::system::system_error;
 using boost::system::error_code;
 
+// main thread
 wesnothd_connection::wesnothd_connection(const std::string& host, const std::string& service)
-	: io_service_()
+	: worker_thread_()
+	, io_service_()
 	, resolver_(io_service_)
 	, socket_(io_service_)
 	, handshake_finished_(false)
 	, read_buf_()
 	, handshake_response_()
+	, recv_queue_()
+	, recv_queue_mutex_()
 	, payload_size_(0)
 	, bytes_to_write_(0)
 	, bytes_written_(0)
 	, bytes_to_read_(0)
 	, bytes_read_(0)
 {
+	MPTEST_LOG;
 	resolver_.async_resolve(
 		boost::asio::ip::tcp::resolver::query(host, service),
 		std::bind(&wesnothd_connection::handle_resolve, this, _1, _2)
@@ -48,27 +75,34 @@ wesnothd_connection::wesnothd_connection(const std::string& host, const std::str
 	LOG_NW << "Resolving hostname: " << host << '\n';
 }
 
+// main thread
 void wesnothd_connection::handle_resolve(const error_code& ec, resolver::iterator iterator)
 {
+	MPTEST_LOG;
 	if (ec) {
+		LOG_NW << __func__ << " Throwing: " << ec << "\n";
 		throw system_error(ec);
 	}
 	connect(iterator);
 }
 
+// main thread
 void wesnothd_connection::connect(resolver::iterator iterator)
 {
+	MPTEST_LOG;
 	socket_.async_connect(*iterator, std::bind(
 		&wesnothd_connection::handle_connect, this, _1, iterator)
 	);
 	LOG_NW << "Connecting to " << iterator->endpoint().address() << '\n';
 }
 
+// main thread
 void wesnothd_connection::handle_connect(
 		const boost::system::error_code& ec,
 		resolver::iterator iterator
 		)
 {
+	MPTEST_LOG;
 	if(ec) {
 		WRN_NW << "Failed to connect to " <<
 			iterator->endpoint().address() << ": " <<
@@ -86,9 +120,10 @@ void wesnothd_connection::handle_connect(
 		handshake();
 	}
 }
-
+// main thread
 void wesnothd_connection::handshake()
 {
+	MPTEST_LOG;
 	static const uint32_t handshake = 0;
 	boost::asio::async_write(socket_,
 		boost::asio::buffer(reinterpret_cast<const char*>(&handshake), 4),
@@ -100,29 +135,48 @@ void wesnothd_connection::handshake()
 	);
 }
 
+// main thread
 void wesnothd_connection::handle_handshake(const error_code& ec)
 {
+	MPTEST_LOG;
 	if (ec) {
+		LOG_NW << __func__ << " Throwing: " << ec << "\n";
 		throw system_error(ec);
 	}
 	handshake_finished_ = true;
+
 	recv();
+	worker_thread_.reset(new boost::thread( [this](){
+		// worker thread
+		std::shared_ptr<wesnothd_connection> this_ptr = this->shared_from_this();
+		io_service_.run();
+		WRN_NW << "Process:" << getpid() << " Thread:" << boost::this_thread::get_id() << " io_service_.run finished\n";		
+	} ));
 }
 
+// main thread
 void wesnothd_connection::send_data(const configr_of& request)
 {
-	poll();
-	send_queue_.emplace_back();
-
-	std::ostream os(&send_queue_.back());
+	MPTEST_LOG;
+	//C++11 doesnt allow lambda captuting by moving, this could maybe use std::unique_ptr in c++14;
+	std::shared_ptr<boost::asio::streambuf> buf_ptr( new boost::asio::streambuf());
+	std::ostream os(buf_ptr.get());
 	write_gz(os, request);
-	if (send_queue_.size() == 1) {
-		send();
-	}
+
+	//TODO: shoudl i capturea  shared_ptr for this?
+	io_service_.post([this, buf_ptr](){
+		DBG_NW << "In wesnothd_connection::send_data::lambda\n";		
+		send_queue_.push_back(buf_ptr);
+		if (send_queue_.size() == 1) {
+			send();
+		}
+	});
 }
 
+// main thread
 void wesnothd_connection::cancel()
 {
+	MPTEST_LOG;
 	if(socket_.is_open()) {
 		boost::system::error_code ec;
 		socket_.cancel(ec);
@@ -132,22 +186,37 @@ void wesnothd_connection::cancel()
 	}
 }
 
+// main thread
+void wesnothd_connection::stop()
+{
+	// TODO: wouldn't cancel() have the same effect?
+	MPTEST_LOG;
+	io_service_.stop();
+}
+
+//worker thread
 std::size_t wesnothd_connection::is_write_complete(const boost::system::error_code& ec, size_t bytes_transferred)
 {
-	if(ec)
+	MPTEST_LOG;
+	if(ec) {
+		LOG_NW << __func__ << " Throwing: " << ec << "\n";
 		throw system_error(ec);
+	}
 	bytes_written_ = bytes_transferred;
 	return bytes_to_write_ - bytes_transferred;
 }
 
+//worker thread
 void wesnothd_connection::handle_write(
 	const boost::system::error_code& ec,
 	std::size_t bytes_transferred
 	)
 {
+	MPTEST_LOG;
 	DBG_NW << "Written " << bytes_transferred << " bytes.\n";
 	send_queue_.pop_front();
 	if (ec) {
+		LOG_NW << __func__ << " Throwing: " << ec << "\n";
 		throw system_error(ec);
 	}
 	if (!send_queue_.empty()) {
@@ -155,12 +224,17 @@ void wesnothd_connection::handle_write(
 	}
 }
 
+//worker thread
 std::size_t wesnothd_connection::is_read_complete(
 		const boost::system::error_code& ec,
 		std::size_t bytes_transferred
 		)
 {
+	//We use custom is_write/read_complete function to be able to see the current progress of the upload/download
+	MPTEST_LOG;
+
 	if(ec) {
+		LOG_NW << __func__ << " Throwing: " << ec << "\n";
 		throw system_error(ec);
 	}
 	bytes_read_ = bytes_transferred;
@@ -180,26 +254,36 @@ std::size_t wesnothd_connection::is_read_complete(
 	}
 }
 
+//worker thread
 void wesnothd_connection::handle_read(
 	const boost::system::error_code& ec,
 	std::size_t bytes_transferred
 	)
 {
+	MPTEST_LOG;
 	DBG_NW << "Read " << bytes_transferred << " bytes.\n";
 	bytes_to_read_ = 0;
-	if(ec && ec != boost::asio::error::eof)
+	if(ec && ec != boost::asio::error::eof) {
+		LOG_NW << __func__ << " Throwing: " << ec << "\n";
 		throw system_error(ec);
+	}
 	std::istream is(&read_buf_);
-	recv_queue_.emplace_back();
-	read_gz(recv_queue_.back(), is);
+	config data;
+	read_gz(data, is);
+	{
+		std::lock_guard<std::mutex> lock(recv_queue_mutex_);
+		recv_queue_.emplace_back(std::move(data));
+	}
 	DBG_NW << "Received " << recv_queue_.back() << " bytes.\n";
 
 	recv();
 }
 
+//worker thread
 void wesnothd_connection::send()
 {
-	auto& buf = send_queue_.front();
+	MPTEST_LOG;
+	auto& buf = *send_queue_.front();
 	size_t buf_size = buf.size();
 	bytes_to_write_ = buf_size + 4;
 	bytes_written_ = 0;
@@ -213,32 +297,38 @@ void wesnothd_connection::send()
 		std::bind(&wesnothd_connection::handle_write, this, _1, _2)
 	);
 }
-
+//worker thread
 void wesnothd_connection::recv()
 {
+	MPTEST_LOG;
 	boost::asio::async_read(socket_, read_buf_,
 		std::bind(&wesnothd_connection::is_read_complete, this, _1, _2),
 		std::bind(&wesnothd_connection::handle_read, this, _1, _2)
 	);
 }
 
+// main thread, during handshake
 std::size_t wesnothd_connection::poll()
 {
+	MPTEST_LOG;
+	assert(!worker_thread_);
 	try {
 		return io_service_.poll();
 	}
 	catch (const boost::system::system_error& err) {
-		if(
-			err.code() == boost::asio::error::operation_aborted ||
-			err.code() == boost::asio::error::eof
-		)
+		if( err.code() == boost::asio::error::operation_aborted || err.code() == boost::asio::error::eof) {
 			return 1;
+		}
+		WRN_NW << __func__ << " Rehrowing: " << err.code() << "\n";
 		throw error(err.code());
 	}
 }
+
+// main thread
 bool wesnothd_connection::receive_data(config& result)
 {
-	poll();
+	MPTEST_LOG;
+	std::lock_guard<std::mutex> lock(recv_queue_mutex_);
 	if (recv_queue_.empty()) {
 		return false;
 	}
@@ -246,5 +336,38 @@ bool wesnothd_connection::receive_data(config& result)
 		result.swap(recv_queue_.front());
 		recv_queue_.pop_front();
 		return true;
+	}
+}
+
+wesnothd_connection::~wesnothd_connection()
+{
+	MPTEST_LOG;	
+}
+
+//  wesnothd_connection_ptr
+
+
+wesnothd_connection_ptr& wesnothd_connection_ptr::operator=(wesnothd_connection_ptr&& other)
+{
+	MPTEST_LOG;
+	if(ptr_) {
+		ptr_->stop();
+		ptr_.reset();
+	}
+	ptr_ = std::move(other.ptr_);
+	return *this;
+}	
+
+wesnothd_connection_ptr wesnothd_connection::create(const std::string& host, const std::string& service)
+{
+	//can't use make_shared becasue the ctor is private
+	return wesnothd_connection_ptr(std::shared_ptr<wesnothd_connection>(new wesnothd_connection(host, service)));
+}
+
+wesnothd_connection_ptr::~wesnothd_connection_ptr()
+{
+	MPTEST_LOG;
+	if(ptr_) {
+		ptr_->stop();
 	}
 }

--- a/src/wesnothd_connection.hpp
+++ b/src/wesnothd_connection.hpp
@@ -117,6 +117,7 @@ private:
 	socket socket_;
 
 	boost::system::error_code last_error_;
+	std::mutex last_error_mutex_;
 	bool handshake_finished_;
 
 	boost::asio::streambuf read_buf_;

--- a/src/wesnothd_connection.hpp
+++ b/src/wesnothd_connection.hpp
@@ -116,6 +116,7 @@ private:
 	typedef boost::asio::ip::tcp::socket socket;
 	socket socket_;
 
+	boost::system::error_code last_error_;
 	bool handshake_finished_;
 
 	boost::asio::streambuf read_buf_;
@@ -151,6 +152,7 @@ private:
 	std::list<config> recv_queue_;
 	std::mutex recv_queue_mutex_;
 	uint32_t payload_size_;
+	// TODO: do i need to guard the follwing 4 values with a mutex?
 	std::size_t bytes_to_write_;
 	std::size_t bytes_written_;
 	std::size_t bytes_to_read_;

--- a/src/wesnothd_connection.hpp
+++ b/src/wesnothd_connection.hpp
@@ -30,10 +30,18 @@
 #include <boost/asio.hpp>
 #include <deque>
 #include <list>
+#include <mutex>
+
 #include "exceptions.hpp"
 #include "wesnothd_connection_error.hpp"
 #include "configr_assign.hpp"
+namespace boost
+{
+	class thread;
+}
+
 class config;
+class wesnothd_connection_ptr;
 
 /** A class that represents a TCP/IP connection to the wesnothd server. */
 class wesnothd_connection : public std::enable_shared_from_this<wesnothd_connection>
@@ -43,14 +51,18 @@ public:
 
 	wesnothd_connection(const wesnothd_connection&) = delete;
 	wesnothd_connection& operator=(const wesnothd_connection&) = delete;
-
+	~wesnothd_connection();
+private:
 	/**
 	 * Constructor.
 	 *
+	 * May only be called via wesnothd_connection_ptr
 	 * @param host    Name of the host to connect to
 	 * @param service Service identifier such as "80" or "http"
 	 */
 	wesnothd_connection(const std::string& host, const std::string& service);
+public:
+	static wesnothd_connection_ptr create(const std::string& host, const std::string& service);
 
 	void send_data(const configr_of& request);
 
@@ -65,6 +77,8 @@ public:
 	 */
 
 	void cancel();
+	// Destroys this object.
+	void stop();
 
 	/** True if connected and no high-level operation is in progress */
 	bool handshake_finished() const { return handshake_finished_; }
@@ -94,6 +108,7 @@ public:
 		return !send_queue_.empty();
 	}
 private:
+	std::unique_ptr<boost::thread> worker_thread_;
 	boost::asio::io_service io_service_;
 	typedef boost::asio::ip::tcp::resolver resolver;
 	resolver resolver_;
@@ -132,9 +147,9 @@ private:
 	void send();
 	void recv();
 
-	std::list<boost::asio::streambuf> send_queue_;
+	std::list<std::shared_ptr<boost::asio::streambuf>> send_queue_;
 	std::list<config> recv_queue_;
-
+	std::mutex recv_queue_mutex_;
 	uint32_t payload_size_;
 	std::size_t bytes_to_write_;
 	std::size_t bytes_written_;
@@ -143,4 +158,44 @@ private:
 
 };
 
-using wesnothd_connection_ptr = std::shared_ptr<wesnothd_connection>;
+class wesnothd_connection_ptr
+{
+private:
+	friend class wesnothd_connection;
+	wesnothd_connection_ptr(std::shared_ptr<wesnothd_connection>&& ptr)
+		: ptr_(std::move(ptr))
+	{}
+public:
+	
+	wesnothd_connection_ptr() = default;
+	
+	wesnothd_connection_ptr(const wesnothd_connection_ptr&) = delete;
+	wesnothd_connection_ptr& operator=(const wesnothd_connection_ptr&) = delete;
+
+	wesnothd_connection_ptr(wesnothd_connection_ptr&&) = default;
+	wesnothd_connection_ptr& operator=(wesnothd_connection_ptr&&);
+	
+	~wesnothd_connection_ptr();
+
+	explicit operator bool() const {
+		return !!ptr_;
+	}
+	wesnothd_connection& operator*() {
+		return *ptr_;
+	}
+	const wesnothd_connection& operator*() const {
+		return *ptr_;
+	}
+	wesnothd_connection* operator->() {
+		return ptr_.get();
+	}
+	const wesnothd_connection* operator->() const {
+		return ptr_.get();
+	}
+	wesnothd_connection* get() const {
+		return ptr_.get();
+	}
+
+private:
+	std::shared_ptr<wesnothd_connection> ptr_;
+};

--- a/src/wesnothd_connection.hpp
+++ b/src/wesnothd_connection.hpp
@@ -36,7 +36,7 @@
 class config;
 
 /** A class that represents a TCP/IP connection to the wesnothd server. */
-class wesnothd_connection
+class wesnothd_connection : public std::enable_shared_from_this<wesnothd_connection>
 {
 public:
 	using error = wesnothd_connection_error;
@@ -142,3 +142,5 @@ private:
 	std::size_t bytes_read_;
 
 };
+
+using wesnothd_connection_ptr = std::shared_ptr<wesnothd_connection>;


### PR DESCRIPTION
TODO: remove the first commit ( testing just get erros from travis faster) before merging.

fixes #1674
This fixed a problem where at game start the host sends first a [scenario_diff]
and then a [start_game] but then the host loads the scenario config (during loadingscreen before game) and
wesnothd_connection::poll isn't called while the loadingscreen is showing. so
the other players receive the [start_game] with a lot delay since
wesnothd_connection won't send it before the the loadingscreen has finished.

At least for me this solution is also easier to implement than the alternative which would be calling poll() regulary form inside the drawing (gui2 and gamemap) code.