### PR TITLE
wmlxgettext: fix UTF-8 issue: #1785

### DIFF
--- a/utils/pywmlx/state/machine.py
+++ b/utils/pywmlx/state/machine.py
@@ -414,22 +414,6 @@ def run(*, filebuf, fileref, fileno, startstate, waitwml=True):
             'Text preceding the invalid byte (line ' + str(errlineno) + 
             '):\n' + splituntil[-1] + '\n'   
         )
-        '''
-        xbytes = None
-        xbytes = []
-        for i in range ((errpos -100), errpos):
-            xbytes.append(e.object[i])
-        errmsg2 = "".join(map(chr, xbytes))
-        errmsg = errmsg + errmsg2 + '\n\n'
-        '''
-        with open('debuglogf.log', 'w', encoding='utf-8') as debff:
-            print('encoding =', e.encoding, file=debff)
-            print('end =', e.end, file=debff)
-            print('reason =', e.reason, file=debff)
-            print('start =', e.start, file=debff)
-            xstart = int(e.start)
-            print('\n\nobj[', xstart, '] =', hex(e.object[xstart]), file=debff)
-            print('\n\nsplituntil = ', splituntil, file=debff)
         wmlerr(finfo, errmsg)
     pywmlx.nodemanip.closefile(_dictionary, _current_lineno)
 

--- a/utils/pywmlx/state/machine.py
+++ b/utils/pywmlx/state/machine.py
@@ -388,7 +388,7 @@ def run(*, filebuf, fileref, fileno, startstate, waitwml=True):
     except UnicodeDecodeError as e:
         errpos = int(e.start)  # error position on file object with UTF-8 error
         errbval = hex(e.object[errpos]) # value of byte wich causes UTF-8 error
-        # well... when exception occurred, the _current_lineno valie 
+        # well... when exception occurred, the _current_lineno value 
         # was not updated at all due to the failure of the try block. 
         # (it is = 0)
         # this means we need to make a workaround to obtain in what line of the
@@ -409,10 +409,13 @@ def run(*, filebuf, fileref, fileno, startstate, waitwml=True):
         errmsg = ( 
             "UTF-8 Format error.\nCan't decode byte " + str(errbval) + ' (' +
             e.reason + ').\n' +
-            'You must edit the file, replacing that byte with a valid ' +
-            'UTF-8 character.\n\n' +
-            'Text preceding the invalid byte (line ' + str(errlineno) + 
-            '):\n' + splituntil[-1] + '\n'   
+            'Probably your file is not encoded with UTF-8 encoding: you ' + 
+            'should open the file with an advanced text editor, and re-save ' +
+            'it with UTF-8 encoding.\n' +
+            'To avoid this problem in the future, you might want to set ' +
+            'the default encoding of your editor to UTF-8.\n\n' +
+            'Text preceding the invalid byte (source file, line ' + 
+            str(errlineno) + '):\n' + splituntil[-1] + '\n'   
         )
         wmlerr(finfo, errmsg)
     pywmlx.nodemanip.closefile(_dictionary, _current_lineno)

--- a/utils/wmlxgettext
+++ b/utils/wmlxgettext
@@ -61,10 +61,11 @@ def commandline(args):
         required=True,
         default=None,
         dest='outfile',
-        help= ('Destination file. In some special situation you could want to '
-               'write the output to STDOUT write an actual file. In that case '
-               'you can use "-o -" to write the pot file to STDOUT on purpose '
-               '(wich it is something you normally would avoid, becouse it can '
+        help= ('Destination file. In some special situation you you might want '
+               'to write the output to STDOUT instead of writing '
+               'an actual file. In that case, you can use "-o -" to write '
+               'the pot file to STDOUT on purpose '
+               '(wich is something you would normally avoid, becouse it can '
                'lead to encoding problems). [**REQUIRED ARGUMENT**]')
     )
     parser.add_argument(

--- a/utils/wmlxgettext
+++ b/utils/wmlxgettext
@@ -61,12 +61,12 @@ def commandline(args):
         required=True,
         default=None,
         dest='outfile',
-        help= ('Destination file. In some special situation you you might want '
+        help= ('Destination file. In some special situations you might want '
                'to write the output to STDOUT instead of writing '
-               'an actual file. In that case, you can use "-o -" to write '
-               'the pot file to STDOUT on purpose '
-               '(wich is something you would normally avoid, becouse it can '
-               'lead to encoding problems). [**REQUIRED ARGUMENT**]')
+               'an actual file (using "-o -"). On a standard usage, however, '
+               'you should avoid to write the output to STDOUT (or you can'
+               'face some issues related to text encoding '
+               '[**REQUIRED ARGUMENT**]')
     )
     parser.add_argument(
         '--domain', 

--- a/utils/wmlxgettext
+++ b/utils/wmlxgettext
@@ -44,23 +44,28 @@ import pywmlx
 def commandline(args):
     parser = argparse.ArgumentParser(
         description='Generate .po from WML/lua file list.',
-        usage='''wmlxgettext --domain=DOMAIN [--directory=START_PATH]
+        usage='''wmlxgettext --domain=DOMAIN -o OUTPUT_FILE
+                   [--directory=START_PATH]
                    [--recursive] [--initialdomain=INITIALDOMAIN]
                    [--package-version=PACKAGE_VERSION]
-                   [--no-text-colors] [--fuzzy] [--warnall] [-o OUTPUT_FILE]
+                   [--no-text-colors] [--fuzzy] [--warnall]
                    FILE1 FILE2 ... FILEN'''
     )
     parser.add_argument(
         '--version',
         action='version',
-        version='wmlxgettext 2016.10.03.py3'
+        version='wmlxgettext 2017.06.25.py3'
     )
     parser.add_argument(
         '-o',
+        required=True,
         default=None,
         dest='outfile',
-        help= ('Destination file. By default the output '
-               'will be printed on stdout')
+        help= ('Destination file. In some special situation you could want to '
+               'write the output to STDOUT write an actual file. In that case '
+               'you can use "-o -" to write the pot file to STDOUT on purpose '
+               '(wich it is something you normally would avoid, becouse it can '
+               'lead to encoding problems). [**REQUIRED ARGUMENT**]')
     )
     parser.add_argument(
         '--domain', 
@@ -156,16 +161,12 @@ def main():
     sentlist = dict()
     fileno = 0
     fdebug = None
+    if args.outfile == '-':
+        args.outfile = None
     if args.debugmode:
         fdebug = open('debug.txt', 'w', encoding='utf-8')
     pywmlx.statemachine.setup(sentlist, args.initdom, args.domain, 
                               args.warnall, fdebug)
-    if args.warnall is True and args.outfile is None:
-        pywmlx.wmlwarn('command line warning', 'Writing the output to stdout '
-                       '(and then eventually redirect that output to a file) '
-                       'is a deprecated usage. Please, consider to use the '
-                       '"-o <outfile.po>" option, instead of using the '
-                       'output redirection')
     filelist = None
     if args.recursive is False and args.filelist is None:
         pywmlx.wmlerr("bad command line", "FILELIST must not be empty. "


### PR DESCRIPTION
This code should fix the issue reported at
https://github.com/wesnoth/wesnoth/issues/1785

I tested my code with an older file of my own campaign wich contained an invalid UTF-8 byte 

https://github.com/AncientLich/wmlxgettext-unoff/blob/master/wmlxgettext/test/reports/2017.06.15/05_The_Underground_Path.cfg

The invalid byte is located on the comment at line 272

>  \# da modificare - devo aggiungerci la condizione "se il turno 23 non è stato raggiunto"

That is an italian comment (the meaning is not important). What it is import is that the 'è' character wasn't UTF-8 compatible, becouse I wrote that file with a wrong text encoding while I was a windows user (now I use Ubuntu).

Now the code manage the UTF-8 decode error, and will show a proper error message, wich is, in this case:

> error: DrakeStory/scenarios/05_The_Underground_Path.cfg:272: UTF-8 Format error.
> Can't decode byte 0xe8 (invalid continuation byte).
> You must edit the file, replacing that byte with a valid UTF-8 character.
> 
> Text preceding the invalid byte (line 272):
> 	\# da modificare - devo aggiungerci la condizione "se il turno 23 non 

You can notice 2 commits. On the first one I forgot to delete some debugging code (create a temporary file wich I used to understand how to display all the informations I need from the exception class). This file should never be created on an actual usage of wmlxgettext.