### PR TITLE
[Don't Merge Yet] Fix unit_placed firing in lua put_unit

### DIFF
--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -2071,7 +2071,7 @@ int game_lua_kernel::intf_put_unit(lua_State *L)
 		return 0; // Don't fire event when unit is only erase
 	}
 
-	if(unit_arg != 1 || luaW_toboolean(L, 3)) {
+	if(luaW_toboolean(L, 3)) {
 		play_controller_.pump().fire("unit_placed", loc);
 	}
 	return 0;


### PR DESCRIPTION
wesnoth.put_unit(unit, cfg.x, cfg.y) will not trigger unit placed
wesnoth.put_unit(cfg.x, cfg.y, unit) will trigger unit placed (but is deprecated)

wiki says unit placed should fire for all uses of lua put_unit (except erase obviously)
However, the put_unit code makes a distinction between new units and already existing units (and seems to intend to fire unit_placed for only for existing units) so I'm thinking maybe the wiki should be changed slightly.

I'm not sure if this is the correct fix, & haven't tested it yet.

