### PR TITLE
[don't merge] [animate_unit] Insure a direction is returned if locations are identical

### DIFF
--- a/data/lua/wml/animate_unit.lua
+++ b/data/lua/wml/animate_unit.lua
@@ -76,6 +76,9 @@ local function add_animation(anim, cfg)
 			local facing_loc = wesnoth.get_locations(facing)[1]
 			if facing_loc then
 				local dir = wesnoth.map.get_relative_dir(unit.x, unit.y, facing_loc[1], facing_loc[2])
+				if dir == "" then
+					dir = "nw"
+				end
 				unit.facing = dir
 				facing = wesnoth.map.get_direction(unit.x, unit.y, dir)
 			else


### PR DESCRIPTION
This is to fix an issue with SotA S10 & S15 and likely other campaigns or add-ons, by restoring 1.12 behavior. (providing a direction if locations are the same)

S 15_Mountain_Pass.cfg line
if Ardonna (line 190) is located at 16,21 (line 194)
This error happens: https://forums.wesnoth.org/viewtopic.php?f=4&t=46480

There's also a version in S10.

This may not be the best way to fix this.

