### PR TITLE
Fixes to Code::Blocks compilation

### DIFF
--- a/projectfiles/CodeBlocks/wesnoth.cbp
+++ b/projectfiles/CodeBlocks/wesnoth.cbp
@@ -372,6 +372,8 @@
 		<Unit filename="../../src/formula/formula_fwd.hpp" />
 		<Unit filename="../../src/formula/function.cpp" />
 		<Unit filename="../../src/formula/function.hpp" />
+		<Unit filename="../../src/formula/function_gamestate.cpp" />
+		<Unit filename="../../src/formula/function_gamestate.hpp" />
 		<Unit filename="../../src/formula/string_utils.cpp" />
 		<Unit filename="../../src/formula/string_utils.hpp" />
 		<Unit filename="../../src/formula/tokenizer.cpp" />


### PR DESCRIPTION
I recently tried to compile Wesnoth using Code::Blocks and i got stuck due to a couple fo issues. 
Anyway, i'm not completely sure that replacing "strnlen" in this way is the best chioce.