### PR TITLE
Fix insert index of the text edited by IME

### DIFF
--- a/src/gui/widgets/text_box_base.cpp
+++ b/src/gui/widgets/text_box_base.cpp
@@ -442,7 +442,7 @@ void text_box_base::handle_editing(bool& handled, const utf8::string& unicode, i
 		ime_cursor_ = start;
 		ime_length_ = new_len;
 		std::string new_text(text_cached_);
-		new_text.insert(ime_start_point_, unicode);
+		utf8::insert(new_text, ime_start_point_, unicode);
 		text_.set_text(new_text, false);
 
 		// Update status


### PR DESCRIPTION
First argument of std::string::insert() is byte index but ime_start_point_ is num of characters.
So, if multi-byte characters is included text_cached, the text edited by IME is inserted wrong position.

This fixes the problem above.