### PR TITLE
Add revision info inside macOS releases.

### DIFF
--- a/projectfiles/Xcode/Wesnoth.xcodeproj/project.pbxproj
+++ b/projectfiles/Xcode/Wesnoth.xcodeproj/project.pbxproj
@@ -4682,6 +4682,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C01FCF4A08A954540054247B /* Build configuration list for PBXNativeTarget "Wesnoth" */;
 			buildPhases = (
+				46B626461D635BC900863502 /* Update Revision.h */,
 				8D11072C0486CEB800E47090 /* Sources */,
 				8D11072E0486CEB800E47090 /* Frameworks */,
 				8D1107290486CEB800E47090 /* Resources */,
@@ -4819,6 +4820,20 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		46B626461D635BC900863502 /* Update Revision.h */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Update Revision.h";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "cd \"$SOURCE_ROOT/../..\"\n./utils/autorevision.sh -t h > src/revision.h";
+		};
 		91C2A6EB1B843AA900346948 /* Copy Translations (if present) */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -6151,6 +6166,7 @@
 					"LUA_USE_MACOSX=1",
 					"HAVE_LIBPNG=1",
 					"HAVE_HISTORY=1",
+					"LOAD_REVISION=1",
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
@@ -6190,6 +6206,7 @@
 					"LUA_USE_MACOSX=1",
 					"HAVE_LIBPNG=1",
 					"HAVE_HISTORY=1",
+					"LOAD_REVISION=1",
 				);
 				GCC_WARN_UNUSED_VARIABLE = NO;
 				INFOPLIST_FILE = Info.plist;

--- a/projectfiles/Xcode/Wesnoth.xcodeproj/project.pbxproj
+++ b/projectfiles/Xcode/Wesnoth.xcodeproj/project.pbxproj
@@ -6206,7 +6206,6 @@
 					"LUA_USE_MACOSX=1",
 					"HAVE_LIBPNG=1",
 					"HAVE_HISTORY=1",
-					"LOAD_REVISION=1",
 				);
 				GCC_WARN_UNUSED_VARIABLE = NO;
 				INFOPLIST_FILE = Info.plist;


### PR DESCRIPTION
I added 'autorevision.sh' script inside Xcode project. Now all targets (Release and DEBUG) will contain revision number.
I can remove it for Release targets if you want.
This script is used in CMAKE 'project' and I just added it also to Xcode project.