### PR TITLE
Use UTF8 length to decide if a TEXTINPUT is a hotkey (should fix #1855)

### DIFF
--- a/src/hotkey/command_executor.cpp
+++ b/src/hotkey/command_executor.cpp
@@ -29,7 +29,7 @@
 #include "display.hpp"
 #include "quit_confirmation.hpp"
 #include "show_dialog.hpp"
-#include "unicode.hpp"
+#include "serialization/unicode.hpp"
 
 #include "utils/functional.hpp"
 

--- a/src/hotkey/command_executor.cpp
+++ b/src/hotkey/command_executor.cpp
@@ -29,6 +29,7 @@
 #include "display.hpp"
 #include "quit_confirmation.hpp"
 #include "show_dialog.hpp"
+#include "unicode.hpp"
 
 #include "utils/functional.hpp"
 
@@ -520,10 +521,7 @@ static void event_execute( const SDL_Event& event, command_executor* executor)
 		if(!CKey::is_uncomposable(event.key) && !(mods & KMOD_CTRL) && !(mods & KMOD_ALT) && !(mods & KMOD_GUI)) {
 				return;
 		}
-	} else if(event.type == SDL_TEXTINPUT && (
-		static_cast<signed char>(event.text.text[0]) <= '\0' ||
-		(event.text.text[1] != '\0')))
-	{
+	} else if(event.type == SDL_TEXTINPUT && event.text.text[31] == 0 && utf8::size(utf8::string(event.text.text)) == 1) {
 		return;
 	}
 


### PR DESCRIPTION
This is an attempt to fix #1855 which is caused by non-ASCII characters being produced by single keys. I'm not entirely sure this is the right approach, however.