### PR TITLE
[store_unit_defense] WML tag

### DIFF
--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -944,3 +944,18 @@ end
 function wesnoth.wml_actions.cancel_action(cfg)
 	wesnoth.cancel_action()
 end
+
+function wesnoth.wml_actions.store_unit_defense(cfg)
+	local unit = wesnoth.get_units(cfg)[1] or helper.wml_error "[store_unit_defense]'s filter didn't match any unit"
+	local terrain = cfg.terrain
+	local defense
+	
+	if terrain then
+		defense = wesnoth.unit_defense(unit, terrain)
+	elseif cfg.loc_x and cfg.loc_y then
+		defense = wesnoth.unit_defense(unit, wesnoth.get_terrain(cfg.loc_x, cfg.loc_y))
+	else
+		defense = wesnoth.unit_defense(unit, wesnoth.get_terrain(unit.x, unit.y))
+	end
+	wesnoth.set_variable(cfg.variable or "terrain_defense", defense)
+end


### PR DESCRIPTION
Stores in variable the defense of a unit on a particular terrain. If terrain is not specified, the terrain on which the units currently stands is used. (Note: it is a WML defense, so the higher it is, the weaker unit's defense is.)

* StandardUnitFilter
* loc_x, loc_y: x and y of terrain location.
* terrain: alternatively, the character of terrain.
* variable: the name of the variable into which to store the defense. default: "terrain_defense"