### PR TITLE
Unused expression result

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -291,7 +291,7 @@ void CVideo::setMode(int x, int y, const MODE_EVENT mode)
 int CVideo::getx() const
 {
 	if(!window) {
-		frameBuffer->w;
+		return frameBuffer->w;
 	}
 
 	return window->get_size().x;
@@ -300,7 +300,7 @@ int CVideo::getx() const
 int CVideo::gety() const
 {
 	if(!window) {
-		frameBuffer->h;
+		return frameBuffer->h;
 	}
 
 	return window->get_size().y;


### PR DESCRIPTION
clang reports a warning. This appears to be a missing return. Originally fell through resulting in null pointer reference.