### PR TITLE
travis: switch to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: cpp
 sudo:     required
+distro: trusty
 
 services:
     - docker


### PR DESCRIPTION
Travis is going to migrate from ubuntu precise (current default) to ubuntu trusty (to-be default) soon.
Switch to trusty now to make sure nothing gets broken by accident.