### PR TITLE
Fix a few messages from VC static analysis

### DIFF
--- a/src/attack_prediction.cpp
+++ b/src/attack_prediction.cpp
@@ -275,7 +275,7 @@ public:
 	// Returns the index of the plane with the given slow statuses.
 	static unsigned int plane_index(bool a_slowed, bool b_slowed)
 	{
-		return a_slowed * 1u + b_slowed * 2u;
+		return (a_slowed ? 1 : 0) + (b_slowed ? 2 : 0);
 	}
 
 	/// What is the chance that an indicated combatant (one of them) is at zero?

--- a/src/log_windows.cpp
+++ b/src/log_windows.cpp
@@ -430,15 +430,15 @@ void log_file_manager::enable_native_console_output()
 	DBG_LS << "stderr to console\n";
 	fflush(stderr);
 	std::cerr.flush();
-	freopen("CONOUT$", "wb", stderr);
+	assert(freopen("CONOUT$", "wb", stderr) == stderr);
 
 	DBG_LS << "stdout to console\n";
 	fflush(stdout);
 	std::cout.flush();
-	freopen("CONOUT$", "wb", stdout);
+	assert(freopen("CONOUT$", "wb", stdout) == stdout);
 
 	DBG_LS << "stdin from console\n";
-	freopen("CONIN$",  "rb", stdin);
+	assert(freopen("CONIN$",  "rb", stdin) == stdin);
 
 	// At this point the log file has been closed and it's no longer our
 	// responsibility to clean up anything; Windows will figure out what to do

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -961,20 +961,21 @@ static config unit_weapons(reports::context & rc, const unit *attacker, const ma
 
 static config unit_weapons(reports::context & rc, const unit *u)
 {
-	if (!u || u->attacks().empty()) return config();
-	map_location displayed_unit_hex = rc.screen().displayed_unit_hex();
-	config res;
+	config res = config();
+	if ((u != nullptr) && (!u->attacks().empty())) {
+		map_location displayed_unit_hex = rc.screen().displayed_unit_hex();
 
-	//TODO enable after the string frezze is lifted
-	//const std::string attack_headline =
-	//		( u->attacks().size() > 1 ) ? N_("Attacks") : N_("Attack");
+		//TODO enable after the string frezze is lifted
+		//const std::string attack_headline =
+		//		( u->attacks().size() > 1 ) ? N_("Attacks") : N_("Attack");
 
-	//add_text(res,  /*span_color(font::weapon_details_color)
-	//		+*/ attack_headline /*+ "</span>\n"*/ + '\n', "");
+		//add_text(res,  /*span_color(font::weapon_details_color)
+		//		+*/ attack_headline /*+ "</span>\n"*/ + '\n', "");
 
-	for (const attack_type &at : u->attacks())
-	{
-		attack_info(rc, at, res, *u, displayed_unit_hex);
+		for (const attack_type &at : u->attacks())
+		{
+			attack_info(rc, at, res, *u, displayed_unit_hex);
+		}
 	}
 	return res;
 }

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -965,12 +965,11 @@ static config unit_weapons(reports::context & rc, const unit *u)
 	if ((u != nullptr) && (!u->attacks().empty())) {
 		map_location displayed_unit_hex = rc.screen().displayed_unit_hex();
 
-		//TODO enable after the string frezze is lifted
-		//const std::string attack_headline =
-		//		( u->attacks().size() > 1 ) ? N_("Attacks") : N_("Attack");
+		const std::string attack_headline =
+				( u->attacks().size() > 1 ) ? N_("Attacks") : N_("Attack");
 
-		//add_text(res,  /*span_color(font::weapon_details_color)
-		//		+*/ attack_headline /*+ "</span>\n"*/ + '\n', "");
+		add_text(res,  span_color(font::weapon_details_color)
+				+ attack_headline + "</span>" + '\n', "");
 
 		for (const attack_type &at : u->attacks())
 		{

--- a/src/serialization/string_utils.cpp
+++ b/src/serialization/string_utils.cpp
@@ -48,7 +48,7 @@ bool portable_isspace(const char c)
 	// returns true only on ASCII spaces
 	if (static_cast<unsigned char>(c) >= 128)
 		return false;
-	return isnewline(c) || isspace(c);
+	return isnewline(c) || isspace(static_cast<unsigned char>(c));
 }
 
 // Make sure we regard '\r' and '\n' as a space, since Mac, Unix, and DOS


### PR DESCRIPTION
Using "Microsoft All Rules" but not enabling lifetime evaluation results in just a few warnings which can be fixed.

The remaining messages are in the upstream Lua and Boost packages. A couple are related to Visual C/C++ static analysis bypassing checks on OpenMP-specific code.