### PR TITLE
Filter refactor

### DIFF
--- a/src/ai/lua/lua_object.cpp
+++ b/src/ai/lua/lua_object.cpp
@@ -47,8 +47,7 @@ namespace ai {
 		}
 		lua_getfield(L, n, "own");
 		if(lua_istable(L, -1)) {
-			config cfg;
-			vconfig vcfg(cfg, true);
+			vconfig vcfg(config(), true);
 			if(luaW_tovconfig(L, -1, vcfg)) {
 				att->filter_own_.reset(new unit_filter(vcfg, resources::filter_con));
 			}
@@ -59,8 +58,7 @@ namespace ai {
 		}
 		lua_getfield(L, n, "enemy");
 		if(lua_istable(L, -1)) {
-			config cfg;
-			vconfig vcfg(cfg, true);
+			vconfig vcfg(config(), true);
 			if(luaW_tovconfig(L, -1, vcfg)) {
 				att->filter_enemy_.reset(new unit_filter(vcfg, resources::filter_con));
 			}

--- a/src/scripting/lua_common.cpp
+++ b/src/scripting/lua_common.cpp
@@ -799,7 +799,7 @@ bool luaW_tovconfig(lua_State *L, int index, vconfig &vcfg)
 			config cfg;
 			bool ok = luaW_toconfig(L, index, cfg);
 			if (!ok) return false;
-			vcfg = vconfig(cfg, true);
+			vcfg = vconfig(std::move(cfg));
 			break;
 		}
 		case LUA_TUSERDATA:

--- a/src/side_filter.cpp
+++ b/src/side_filter.cpp
@@ -124,7 +124,7 @@ bool side_filter::match_internal(const team &t) const
 	if(cfg_.has_child("has_unit")) {
 		const vconfig & ufilt_cfg = cfg_.child("has_unit");
 		if (!ufilter_) {
-			ufilter_.reset(new unit_filter(ufilt_cfg, fc_));
+			ufilter_.reset(new unit_filter(ufilt_cfg.make_safe(), fc_));
 			ufilter_->set_use_flat_tod(flat_);
 		}
 		bool found = false;

--- a/src/side_filter.cpp
+++ b/src/side_filter.cpp
@@ -123,8 +123,10 @@ bool side_filter::match_internal(const team &t) const
 	//Allow filtering on units
 	if(cfg_.has_child("has_unit")) {
 		const vconfig & ufilt_cfg = cfg_.child("has_unit");
-		if (!ufilter_)
-			ufilter_.reset(new unit_filter(ufilt_cfg, fc_, flat_));
+		if (!ufilter_) {
+			ufilter_.reset(new unit_filter(ufilt_cfg, fc_));
+			ufilter_->set_use_flat_tod(flat_);
+		}
 		bool found = false;
 		for(const unit &u : fc_->get_disp_context().units()) {
 			if (u.side() != t.side()) {

--- a/src/terrain/filter.cpp
+++ b/src/terrain/filter.cpp
@@ -165,8 +165,10 @@ bool terrain_filter::match_internal(const map_location& loc, const unit* ref_uni
 		const unit_map::const_iterator u = fc_->get_disp_context().units().find(loc);
 		if (!u.valid())
 			return false;
-		if (!cache_.ufilter_)
-			cache_.ufilter_.reset(new unit_filter(cfg_.child("filter"), fc_, flat_));
+		if (!cache_.ufilter_) {
+			cache_.ufilter_.reset(new unit_filter(cfg_.child("filter"), fc_));
+			cache_.ufilter_->set_use_flat_tod(flat_);
+		}
 		if (!cache_.ufilter_->matches(*u, loc))
 			return false;
 	}

--- a/src/terrain/filter.cpp
+++ b/src/terrain/filter.cpp
@@ -166,7 +166,7 @@ bool terrain_filter::match_internal(const map_location& loc, const unit* ref_uni
 		if (!u.valid())
 			return false;
 		if (!cache_.ufilter_) {
-			cache_.ufilter_.reset(new unit_filter(cfg_.child("filter"), fc_));
+			cache_.ufilter_.reset(new unit_filter(cfg_.child("filter").make_safe(), fc_));
 			cache_.ufilter_->set_use_flat_tod(flat_);
 		}
 		if (!cache_.ufilter_->matches(*u, loc))

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -306,7 +306,7 @@ bool unit::ability_active(const std::string& ability,const config& cfg,const map
 	bool illuminates = ability == "illuminates";
 
 	if (const config &afilter = cfg.child("filter"))
-		if ( !unit_filter(vconfig(afilter), resources::filter_con, illuminates).matches(*this, loc) )
+		if ( !unit_filter(vconfig(afilter), resources::filter_con).set_use_flat_tod(illuminates).matches(*this, loc) )
 			return false;
 
 	map_location adjacent[6];
@@ -318,7 +318,8 @@ bool unit::ability_active(const std::string& ability,const config& cfg,const map
 	for (const config &i : cfg.child_range("filter_adjacent"))
 	{
 		size_t count = 0;
-		const unit_filter ufilt(vconfig(i), resources::filter_con, illuminates);
+		unit_filter ufilt(vconfig(i), resources::filter_con);
+		ufilt.set_use_flat_tod(illuminates);
 		std::vector<map_location::DIRECTION> dirs = map_location::parse_directions(i["adjacent"]);
 		for (const map_location::DIRECTION index : dirs)
 		{
@@ -389,7 +390,7 @@ bool unit::ability_affects_adjacent(const std::string& ability, const config& cf
 		}
 		const config &filter = i.child("filter");
 		if (!filter || //filter tag given
-			unit_filter(vconfig(filter), resources::filter_con, illuminates).matches(*this, loc, from) ) {
+			unit_filter(vconfig(filter), resources::filter_con).set_use_flat_tod(illuminates).matches(*this, loc, from) ) {
 			return true;
 		}
 	}
@@ -401,7 +402,7 @@ bool unit::ability_affects_self(const std::string& ability,const config& cfg,con
 	const config &filter = cfg.child("filter_self");
 	bool affect_self = cfg["affect_self"].to_bool(true);
 	if (!filter || !affect_self) return affect_self;
-	return unit_filter(vconfig(filter), resources::filter_con, ability == "illuminates").matches(*this, loc);
+	return unit_filter(vconfig(filter), resources::filter_con).set_use_flat_tod(ability == "illuminates").matches(*this, loc);
 }
 
 bool unit::has_ability_type(const std::string& ability) const

--- a/src/units/filter.hpp
+++ b/src/units/filter.hpp
@@ -98,7 +98,6 @@ public:
 		, impl_(cfg_)
 		, max_matches_(-1)
 	{
-		cfg_.make_safe();
 	}
 
 	unit_filter(const unit_filter&) = default;

--- a/src/units/filter.hpp
+++ b/src/units/filter.hpp
@@ -91,10 +91,10 @@ namespace unit_filter_impl
 class unit_filter
 {
 public:
-	unit_filter(vconfig cfg, const filter_context * fc, bool use_flat_tod = false)
+	unit_filter(vconfig cfg, const filter_context * fc)
 		: cfg_(cfg)
 		, fc_(fc)
-		, use_flat_tod_(use_flat_tod)
+		, use_flat_tod_(false)
 		, impl_(cfg_)
 		, max_matches_(-1)
 	{
@@ -106,6 +106,11 @@ public:
 
 	unit_filter& operator=(const unit_filter&) = default;
 	unit_filter& operator=(unit_filter&&) = default;
+
+	unit_filter& set_use_flat_tod(bool value) {
+		use_flat_tod_ = value;
+		return *this;
+	}
 
 	/// Determine if *this matches @a filter at a specified location.
 	/// Use this for units on a recall list, or to test for a match if

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -124,16 +124,17 @@ vconfig vconfig::unconstructed_vconfig()
  * It is perfectly safe to call this for a vconfig that already manages its memory.
  * This does not work on a null() vconfig.
  */
-void vconfig::make_safe() const
+const vconfig& vconfig::make_safe() const
 {
 	// Nothing to do if we already manage our own memory.
 	if ( memory_managed() )
-		return;
+		return *this;
 
 	// Make a copy of our config.
 	cache_.reset(new config(*cfg_));
 	// Use our copy instead of the original.
 	cfg_ = cache_.get();
+	return *this;
 }
 
 config vconfig::get_parsed_config() const

--- a/src/variable.hpp
+++ b/src/variable.hpp
@@ -60,6 +60,7 @@ public:
 	/// Equivalent to vconfig(cfg, false).
 	/// Do not use if the vconfig will persist after @a cfg is destroyed!
 	explicit vconfig(const config &cfg) : cache_(), cfg_(&cfg) {}
+	explicit vconfig(config &&cfg) : cache_(new config(std::move(cfg))), cfg_(cache_.get()) { }
 	vconfig(const config &cfg, bool manage_memory);
 	~vconfig();
 
@@ -70,7 +71,7 @@ public:
 	explicit operator bool() const	{ return !null(); }
 
 	bool null() const { assert(cfg_); return cfg_ == &default_empty_config; }
-	void make_safe() const; //!< instruct the vconfig to make a private copy of its underlying data.
+	const vconfig& make_safe() const; //!< instruct the vconfig to make a private copy of its underlying data.
 	const config& get_config() const { return *cfg_; }
 	config get_parsed_config() const;
 


### PR DESCRIPTION
This refactors the unit filter so that it now parses as much as possible when the filter is created to speed up the filter::matches function. This also make the provious optimisation of havign a 'nil' filter unnecessary.

Also i did comepletey reworite these files so looking at the diff probably won't be handy.
