### PR TITLE
Tutorial part 2: resolving conflicting attack_end events

### DIFF
--- a/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
+++ b/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
@@ -71,6 +71,7 @@
         side=3
         controller=null
         team_name=player
+        user_team_name= _ "team_name^Student"
         no_leader=yes
         hidden=yes
 
@@ -92,11 +93,11 @@
 
         {VARIABLE low_hp_unit_message[0].value ( _ "I hope I have a chance to retreat after this!")}
         {VARIABLE low_hp_unit_message[1].value ( _ "One lucky attack by an Orcish Grunt, and I’m done for!")}
-        {VARIABLE low_hp_unit_message[2].value ( _ "Ouch! I could make use of some healing in a village.")}
+        {VARIABLE low_hp_unit_message[2].value ( _ "I could make use of some healing in a village.")}
         {VARIABLE low_hp_unit_message[3].value ( _ "I had better retreat, before I get caught out with such low health!")}
         {VARIABLE low_hp_unit_message_female[0].value ( _ "female^I hope I have a chance to retreat after this!")}
         {VARIABLE low_hp_unit_message_female[1].value ( _ "female^One lucky attack by an Orcish Grunt, and I’m done for!")}
-        {VARIABLE low_hp_unit_message_female[2].value ( _ "female^Ouch! I could make use of some healing in a village.")}
+        {VARIABLE low_hp_unit_message_female[2].value ( _ "female^I could make use of some healing in a village.")}
         {VARIABLE low_hp_unit_message_female[3].value ( _ "female^I had better retreat, before I get caught out with such low health!")}
 
         [objectives]
@@ -468,6 +469,27 @@ A full list of abilities and weapons specials, along with traits, may be found i
                 speaker=Galdrad
                 message= _ "If one of your Shamans stands just behind your wounded units, she will heal them each 4 hitpoints at the beginning of the next turn."
             [/message]
+
+            [event]
+                name=attack_end
+                first_time_only=no
+                [filter]
+                    side=1
+                    [not]
+                        id=student
+                    [/not]
+                [/filter]
+
+                [fire_event]
+                    name=warn_about_units_with_low_health
+                    [primary_unit]
+                        id=$unit.id
+                    [/primary_unit]
+                    [secondary_unit]
+                        id=$second_unit.id
+                    [/secondary_unit]
+                [/fire_event]
+            [/event]
         [/event]
     [/event]
 
@@ -690,14 +712,8 @@ A full list of abilities and weapons specials, along with traits, may be found i
     [/event]
 
     [event]
-        name=attack_end
+        name=warn_about_units_with_low_health
         first_time_only=no
-        [filter]
-            side=1
-            [not]
-                id=student
-            [/not]
-        [/filter]
         [filter_condition]
             [variable]
                 name=unit.hitpoints
@@ -707,23 +723,16 @@ A full list of abilities and weapons specials, along with traits, may be found i
                 name=unit.hitpoints
                 greater_than=0
             [/variable]
+            [variable]
+                name=second_unit.hitpoints
+                greater_than=0
+            [/variable]
 
             [variable]
                 name=lhpu_msg_i
                 less_than_equal_to=3
             [/variable]
         [/filter_condition]
-
-        [fire_event]
-            name=warn_about_units_with_low_health
-            [primary_unit]
-                id=$unit.id
-            [/primary_unit]
-        [/fire_event]
-    [/event]
-
-    [event]
-        name=warn_about_units_with_low_health
 
         [message]
             speaker=unit


### PR DESCRIPTION
There are two conflicting attack_end events in the 2nd part of the tutorial, one of them is first_time_only. 
The way it was first the dumbo event was triggered, and afterwards an _Ouch, I got retaliation damage_  event.

In the hope to keep the code more readable I moved some filters to the manually fired event.