### PR TITLE
HttT: Remove no longer needed trait_undead

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/05b_Isle_of_the_Damned.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/05b_Isle_of_the_Damned.cfg
@@ -369,7 +369,6 @@
             x={X}
             y={Y}
             [modifications]
-                {TRAIT_UNDEAD}
                 {TRAIT_LOYAL}
             [/modifications]
             {IS_LOYAL}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/15_The_Lost_General.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/15_The_Lost_General.cfg
@@ -444,7 +444,6 @@
             x=24
             y=28
             [modifications]
-                {TRAIT_UNDEAD}
                 {TRAIT_LOYAL}
             [/modifications]
             {IS_LOYAL}
@@ -463,7 +462,6 @@
             x=24
             y=28
             [modifications]
-                {TRAIT_UNDEAD}
                 {TRAIT_LOYAL}
             [/modifications]
             {IS_LOYAL}


### PR DESCRIPTION
This used to be needed here so trait order would be in harmony when other
undead units were made with LOYAL_UNDEAD_UNIT, but that macro has been
deprecated and replaced here with LOYAL_UNIT. Thus, the removal
restores the harmony.

Assigned to current maintainer.