### PR TITLE
Fix Coverity Warning - Uninitialized

### DIFF
--- a/src/utils/irdya_datetime.cpp
+++ b/src/utils/irdya_datetime.cpp
@@ -21,7 +21,7 @@
 
 irdya_date irdya_date::read_date(const std::string& date)
 {
-	irdya_date date_result;
+	irdya_date date_result();
 
 	// Currently only supports a year and an epoch.
 	size_t year_start = date.find_first_not_of(' ');


### PR DESCRIPTION
Closes
    CID 1380147

Message was date_result.month was not initialized. Added initialization.