### PR TITLE
Fix Coverity Uninitialized Scalar Warnings

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -18,6 +18,7 @@
 #include "log.hpp"
 #include "quit_confirmation.hpp"
 #include "video.hpp"
+#include "sdl/userevent.hpp"
 
 #if defined _WIN32
 #include "desktop/windows_tray_notification.hpp"
@@ -548,12 +549,7 @@ void pump()
 						&& std::abs(event.button.x - last_click_x) < DoubleClickMaxMove
 						&& std::abs(event.button.y - last_click_y) < DoubleClickMaxMove
 				) {
-					SDL_UserEvent user_event;
-					user_event.type = DOUBLE_CLICK_EVENT;
-					user_event.code = 0;
-					user_event.data1 = reinterpret_cast<void*>(event.button.x);
-					user_event.data2 = reinterpret_cast<void*>(event.button.y);
-					user_event.timestamp = std::time(nullptr);
+					sdl::UserEvent user_event(DOUBLE_CLICK_EVENT, event.button.x, event.button.y);
 					::SDL_PushEvent(reinterpret_cast<SDL_Event*>(&user_event));
 				}
 
@@ -755,13 +751,7 @@ void call_in_main_thread(const std::function<void(void)>& f)
 	invoked_function_data fdata{false, f};
 
 	SDL_Event sdl_event;
-	SDL_UserEvent sdl_userevent;
-
-	sdl_userevent.type = INVOKE_FUNCTION_EVENT;
-	sdl_userevent.code = 0;
-	sdl_userevent.data1 = &fdata;
-	sdl_userevent.data2 = nullptr;
-	sdl_userevent.timestamp = std::time(nullptr);
+	sdl::UserEvent sdl_userevent(INVOKE_FUNCTION_EVENT, &fdata);
 
 	sdl_event.type = INVOKE_FUNCTION_EVENT;
 	sdl_event.user = sdl_userevent;

--- a/src/gui/core/event/distributor.cpp
+++ b/src/gui/core/event/distributor.cpp
@@ -23,6 +23,7 @@
 #include "gui/widgets/widget.hpp"
 #include "gui/widgets/window.hpp"
 #include "gui/widgets/text_box_base.hpp"
+#include "sdl/userevent.hpp"
 
 #include "utils/functional.hpp"
 
@@ -60,13 +61,7 @@ static Uint32 popup_callback(Uint32 /*interval*/, void* /*param*/)
 	DBG_GUI_E << "Pushing popup removal event in queue.\n";
 
 	SDL_Event event;
-	SDL_UserEvent data;
-
-	data.type = HOVER_REMOVE_POPUP_EVENT;
-	data.code = 0;
-	data.data1 = 0;
-	data.data2 = 0;
-	data.timestamp = std::time(nullptr);
+	sdl::UserEvent data(HOVER_REMOVE_POPUP_EVENT);
 
 	event.type = HOVER_REMOVE_POPUP_EVENT;
 	event.user = data;

--- a/src/gui/core/event/handler.cpp
+++ b/src/gui/core/event/handler.cpp
@@ -25,6 +25,7 @@
 #include "hotkey/hotkey_item.hpp"
 #include "video.hpp"
 #include "serialization/unicode_cast.hpp"
+#include "sdl/userevent.hpp"
 
 #include <cassert>
 
@@ -79,13 +80,7 @@ static Uint32 timer_sdl_draw_event(Uint32, void*)
 	// DBG_GUI_E << "Pushing draw event in queue.\n";
 
 	SDL_Event event;
-	SDL_UserEvent data;
-
-	data.type = DRAW_EVENT;
-	data.code = 0;
-	data.data1 = nullptr;
-	data.data2 = nullptr;
-	data.timestampt = std::time(nullptr);
+	sdl::UserEvent data(DRAW_EVENT);
 
 	event.type = DRAW_EVENT;
 	event.user = data;

--- a/src/gui/widgets/window.cpp
+++ b/src/gui/widgets/window.cpp
@@ -61,6 +61,7 @@
 #include "formula/variant.hpp"
 #include "video.hpp"
 #include "wml_exception.hpp"
+#include "sdl/userevent.hpp"
 
 #include "utils/functional.hpp"
 
@@ -136,13 +137,7 @@ static Uint32 draw_timer(Uint32, void*)
 	//	DBG_GUI_E << "Pushing draw event in queue.\n";
 
 	SDL_Event event;
-	SDL_UserEvent data;
-
-	data.type = DRAW_EVENT;
-	data.code = 0;
-	data.data1 = nullptr;
-	data.data2 = nullptr;
-	data.timestamp = std::time(nullptr);
+	sdl::UserEvent data(DRAW_EVENT);
 
 	event.type = DRAW_EVENT;
 	event.user = data;
@@ -189,13 +184,7 @@ static bool helptip()
 	DBG_GUI_E << "Pushing SHOW_HELPTIP_EVENT event in queue.\n";
 
 	SDL_Event event;
-	SDL_UserEvent data;
-
-	data.type = SHOW_HELPTIP_EVENT;
-	data.code = 0;
-	data.data1 = nullptr;
-	data.data2 = nullptr;
-	data.timestamp = std::time(nullptr);
+	sdl::UserEvent data(SHOW_HELPTIP_EVENT);
 
 	event.type = SHOW_HELPTIP_EVENT;
 	event.user = data;
@@ -600,13 +589,7 @@ int window::show(const bool restore, const unsigned auto_close_timeout)
 		draw();
 
 		SDL_Event event;
-		SDL_UserEvent data;
-
-		data.type = CLOSE_WINDOW_EVENT;
-		data.code = manager::instance().get_id(*this);
-		data.data1 = nullptr;
-		data.data2 = nullptr;
-		data.timestamp = std::time(nullptr);
+		sdl::UserEvent data(CLOSE_WINDOW_EVENT, manager::instance().get_id(*this));
 
 		event.type = CLOSE_WINDOW_EVENT;
 		event.user = data;

--- a/src/sdl/userevent.hpp
+++ b/src/sdl/userevent.hpp
@@ -1,0 +1,43 @@
+/*
+   Copyright (C) 2017 the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#pragma once
+
+#include <SDL_events.h>
+
+namespace sdl
+{
+    class UserEvent : public SDL_UserEvent
+    {
+        public:
+            UserEvent() : SDL_UserEvent() {
+            }
+
+            UserEvent(int type) : UserEvent() {
+                this->type = type;
+            }
+
+            UserEvent(int type, int code) : UserEvent(type) {
+                this->code = code;
+            }
+
+            UserEvent(int type, int data1, int data2) : UserEvent(type) {
+                this->data1 = reinterpret_cast<void*>(data1);
+                this->data2 = reinterpret_cast<void*>(data2);
+            }
+
+            UserEvent(int type, void* data1) : UserEvent(type) {
+                this->data1 = data1;
+            }
+    };
+}

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -20,6 +20,7 @@
 #include "log.hpp"
 #include "preferences/general.hpp"
 #include "sdl/window.hpp"
+#include "sdl/userevent.hpp"
 
 #include <cassert>
 #include <vector>
@@ -66,13 +67,7 @@ void trigger_full_redraw() {
 	}
 
 	SDL_Event drawEvent;
-	SDL_UserEvent data;
-
-	data.type = DRAW_ALL_EVENT;
-	data.code = 0;
-	data.data1 = nullptr;
-	data.data2 = nullptr;
-	data.timestamp = std::time(nullptr);
+	sdl::UserEvent data(DRAW_ALL_EVENT);
 
 	drawEvent.type = DRAW_ALL_EVENT;
 	drawEvent.user = data;
@@ -153,13 +148,7 @@ void CVideo::video_event_handler::handle_window_event(const SDL_Event &event)
 				//if(display::get_singleton())
 					//display::get_singleton()->redraw_everything();
 				SDL_Event drawEvent;
-				SDL_UserEvent data;
-
-				data.type = DRAW_ALL_EVENT;
-				data.code = 0;
-				data.data1 = nullptr;
-				data.data2 = nullptr;
-				data.timestamp = std::time(nullptr);
+				sdl::UserEvent data(DRAW_ALL_EVENT);
 
 				drawEvent.type = DRAW_ALL_EVENT;
 				drawEvent.user = data;


### PR DESCRIPTION
Coverity notes that SDL_UserEvent.windowID is never initialized. Initializing to 0 on the assumption that it means 'no window' (SDL comment says 'if any', which indicates there may be a 'none' value and zero is a good guess for that).

This closes

    CID 1380246
    CID 1380234
    CID 1380159
    CID 1380152
    CID 1356356

Earlier commit for these warnings only fixed the timestamp. Checked there are no additional scalars for this commit and it should not expose additional warnings.