### PR TITLE
Fix Coverity divide-by-zero warning

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -347,7 +347,11 @@ void display::init_flags_for_side_internal(size_t n, const std::string& side_col
 	animated<image::locator>& f = flags_[n];
 
 	f = temp_anim;
-	assert(f.get_end_time() != 0);
+	if (f.get_end_time() <= 0) {
+		std::stringstream msg;
+		msg << "Invalid animation duration (<= 0) found when constructing flag for side " << n;
+		throw std::domain_error(msg.str());
+	}
 	f.start_animation(rand() % f.get_end_time(), true);
 }
 


### PR DESCRIPTION
Closes CID 1380221

Instead of assert() simply skip the animation.