### PR TITLE
add an "optional objective" caption

### DIFF
--- a/data/campaigns/The_South_Guard/scenarios/07a_Into_the_Depths.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/07a_Into_the_Depths.cfg
@@ -303,7 +303,7 @@
                         boolean_equals=yes
                     [/variable]
                 [/show_if]
-                {BONUS_OBJECTIVE_CAPTION}
+                {OPTIONAL_OBJECTIVE_CAPTION}
                 description= _ "Meet with and pay the troll leader $troll_help_cost gold to receive their help"
                 condition=win
             [/objective]

--- a/data/core/macros/objective-utils.cfg
+++ b/data/core/macros/objective-utils.cfg
@@ -26,6 +26,10 @@
     caption= _ "Bonus objective:"
 #enddef
 
+#define OPTIONAL_OBJECTIVE_CAPTION
+    caption= _ "Optional objective:"
+#enddef
+
 #define ALTERNATIVE_OBJECTIVE OBJECTIVE_TEXT
     [objective]
         {ALTERNATIVE_OBJECTIVE_CAPTION}


### PR DESCRIPTION
This adds one more caption macro for [objective]s

Currently there are:
 - no caption, shows under "Victory"
 - "alternative objective"
 - "bonus objective"

Scenario 7a in TSG is an example where none of them fits:
_"Meet with and pay the troll leader 100 gold to receive their help"_
- it's not a win condition (it was set up like this previously)
- nor an alternative to the win condition 
- bonus sounds like you should do this, everybody wants a "bonus".

Optional would be the right word. Though I'm not sure about the wording, if "optional objective" or just "objective". Into German I would translate it as just "optional".