### PR TITLE
Fix for error: unused typedef in Xcode builds

### DIFF
--- a/projectfiles/Xcode/Wesnoth.xcodeproj/project.pbxproj
+++ b/projectfiles/Xcode/Wesnoth.xcodeproj/project.pbxproj
@@ -6314,6 +6314,10 @@
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/lib";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				OTHER_CFLAGS = (
+					"-Wno-unused-local-typedefs",
+					"-Wno-unused-private-field",
+				);
 				OTHER_LDFLAGS = (
 					"-lz",
 					"-lbz2",


### PR DESCRIPTION
This PR fixes this:
```
10:43:06 In file included from /Users/user/.jenkins/workspace/Wesnoth/src/color_range.cpp:24:
10:43:06 In file included from ../../src/map/map.hpp:22:
10:43:06 In file included from ../../src/terrain/translation.hpp:29:
10:43:06 In file included from Headers/boost/multi_array.hpp:21:
10:43:06 In file included from Headers/boost/multi_array/base.hpp:28:
10:43:06 Headers/boost/multi_array/concept_checks.hpp:42:43: error: unused typedef 'index_range' [-Werror,-Wunused-local-typedef]
10:43:06       typedef typename Array::index_range index_range;
10:43:06                                           ^
10:43:06 Headers/boost/multi_array/concept_checks.hpp:43:37: error: unused typedef 'index' [-Werror,-Wunused-local-typedef]
10:43:06       typedef typename Array::index index;
10:43:06                                     ^
10:43:06 Headers/boost/multi_array/concept_checks.hpp:53:43: error: unused typedef 'index_range' [-Werror,-Wunused-local-typedef]
10:43:06       typedef typename Array::index_range index_range;
10:43:06                                           ^
10:43:06 Headers/boost/multi_array/concept_checks.hpp:54:37: error: unused typedef 'index' [-Werror,-Wunused-local-typedef]
10:43:06       typedef typename Array::index index;
10:43:06                                     ^
10:43:06 4 errors generated.
```