### PR TITLE
[terrain_graphics] Castle neighbor bleed-through (sand, snow) 

### DIFF
--- a/data/core/terrain-graphics.cfg
+++ b/data/core/terrain-graphics.cfg
@@ -697,8 +697,8 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 {NEW:TRANSITION           !,Ket,Cd*,!,C*,Ke*   Cd*                         -360               flat/desert-road FLAG=inside}
 {NEW:TRANSITION           Cd*                  !,Ket,Cd*,!,C*,Ke*          -360               flat/desert-road}
 
-{NEW:TRANSITION           !,Ce*,Ke*,!,C*       !,Ket,!,Ce*,Ke*             -370               flat/dirt FLAG=inside}
-{NEW:TRANSITION           !,Ket,!,Ce*,Ke*      !,Ce*,Ke*,!,C*              -370               flat/dirt}
+{NEW:TRANSITION           !,Ce*,Ke*,Kme,!,C*       !,Ket,!,Ce*,Ke*,Kme             -370               flat/dirt FLAG=inside}
+{NEW:TRANSITION           !,Ket,!,Ce*,Ke*      !,Ce*,Ke*!,C*              -370               flat/dirt}
 
 {NEW:TRANSITION           !,Ket,Co*,Ker,Cer,!,C*,Ke*   Co*,Ker,Cer                         -380               flat/dirt-dark FLAG=inside}
 {NEW:TRANSITION           Ker,Cer,Co*                  !,Ket,Co*,Ker,Cer,!,C*,Ke*          -380               flat/dirt-dark}
@@ -708,6 +708,10 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 # 33% is an arbitrary magic number with which the transparency looks good
 {NEW:GENERIC_CORNER_TRANSITION Cme         (Cm,Km,Chw)   -330 castle/aquatic-camp/reef      masks/long "~O(33%)" FLAG=aquaticbasetrans}
 {NEW:GENERIC_CORNER_TRANSITION Cm,Km,Chw   (Cme)         -321 castle/aquatic-castle/cobbles masks/long "~O(33%)" FLAG=aquaticbasetrans}
+
+# this is to keep sand, snow, etc. from flowing in under the castle walls.  It may need to be adjusted for when such behavior is needed.
+# There should also be a pattern available for UMC, not sure what it would be though
+{NEW:DISABLE_TRANSITION 	(K*,C*)		(!,K*,C*)	}
 
 #
 # Cave

--- a/data/core/terrain-graphics.cfg
+++ b/data/core/terrain-graphics.cfg
@@ -698,7 +698,7 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 {NEW:TRANSITION           Cd*                  !,Ket,Cd*,!,C*,Ke*          -360               flat/desert-road}
 
 {NEW:TRANSITION           !,Ce*,Ke*,!,C*       !,Ket,!,Ce*,Ke*             -370               flat/dirt FLAG=inside}
-{NEW:TRANSITION           !,Ket,!,Ce*,Ke*      !,Ce*,Ke*!,C*              -370               flat/dirt}
+{NEW:TRANSITION           !,Ket,!,Ce*,Ke*      !,Ce*,Ke*,!,C*              -370               flat/dirt}
 
 {NEW:TRANSITION           !,Ket,Co*,Ker,Cer,!,C*,Ke*   Co*,Ker,Cer                         -380               flat/dirt-dark FLAG=inside}
 {NEW:TRANSITION           Ker,Cer,Co*                  !,Ket,Co*,Ker,Cer,!,C*,Ke*          -380               flat/dirt-dark}

--- a/data/core/terrain-graphics.cfg
+++ b/data/core/terrain-graphics.cfg
@@ -697,7 +697,7 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 {NEW:TRANSITION           !,Ket,Cd*,!,C*,Ke*   Cd*                         -360               flat/desert-road FLAG=inside}
 {NEW:TRANSITION           Cd*                  !,Ket,Cd*,!,C*,Ke*          -360               flat/desert-road}
 
-{NEW:TRANSITION           !,Ce*,Ke*,Kme,!,C*       !,Ket,!,Ce*,Ke*,Kme             -370               flat/dirt FLAG=inside}
+{NEW:TRANSITION           !,Ce*,Ke*,!,C*       !,Ket,!,Ce*,Ke*             -370               flat/dirt FLAG=inside}
 {NEW:TRANSITION           !,Ket,!,Ce*,Ke*      !,Ce*,Ke*!,C*              -370               flat/dirt}
 
 {NEW:TRANSITION           !,Ket,Co*,Ker,Cer,!,C*,Ke*   Co*,Ker,Cer                         -380               flat/dirt-dark FLAG=inside}

--- a/data/core/terrain-graphics/new-macros.cfg
+++ b/data/core/terrain-graphics/new-macros.cfg
@@ -168,6 +168,34 @@ transition#endarg
     [/terrain_graphics]
 #enddef
 
+#define NEW:DISABLE_TRANSITION TERRAINLIST ADJACENT
+
+#arg FLAG
+transition#endarg
+
+    [terrain_graphics]
+        map="
+, 2
+. , .
+, 1
+. , .
+, ."
+        [tile]
+            pos=1
+            type={ADJACENT}
+            set_flag={FLAG}-@R0
+        [/tile]
+        [tile]
+            pos=2
+            type={TERRAINLIST}
+            set_flag={FLAG}-@R3
+        [/tile]
+
+        rotations=n,ne,se,s,sw,nw
+    [/terrain_graphics]
+#enddef
+
+
 #define NEW:TRANSITION TERRAINLIST ADJACENT LAYER IMAGESTEM
 
 #arg FLAG


### PR DESCRIPTION
This should fix some graphics glitches, where neighbor terrain transitions bleed through under the castle walls.  Example in the attached image.
![castle_transitions_dust](https://user-images.githubusercontent.com/13510196/30794039-c58f0154-a17a-11e7-9bef-f6c230f1efdc.gif)

And yeah, the commits should be squashed.
