### PR TITLE
On Boost: update build scripts and documentation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,9 @@ src/**/*.vcproj
 !utils/umc_dev/org.wesnoth*/.settings/
 !utils/umc_dev/org.wesnoth*/.project
 
+# KDevelop caches (KDevelop 4.3.1, KDE Development Platform 4.8.4).
+*.kate-swp
+
 # autotools
 config.h
 config.h.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ else()
 endif()
 
 find_package(Crypto 1.0 REQUIRED)
-find_package(Boost 1.48 REQUIRED COMPONENTS iostreams program_options regex system thread random)
+find_package(Boost 1.50 REQUIRED COMPONENTS iostreams program_options regex system thread random)
 
 # no, gettext executables are not required when NLS is deactivated
 find_package(Gettext)
@@ -692,9 +692,9 @@ if(ENABLE_GAME)
 endif(ENABLE_GAME)
 
 if(ENABLE_GAME OR ENABLE_SERVER OR ENABLE_TOOLS OR ENABLE_TESTS)
-	find_package( Boost 1.48 REQUIRED COMPONENTS filesystem )
+	find_package(Boost 1.50 REQUIRED COMPONENTS filesystem)
 
-	find_package( Boost 1.48 REQUIRED COMPONENTS locale )
+	find_package(Boost 1.50 REQUIRED COMPONENTS locale)
 endif(ENABLE_GAME OR ENABLE_SERVER OR ENABLE_TOOLS OR ENABLE_TESTS)
 
 if(ENABLE_POT_UPDATE_TARGET)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,7 +16,7 @@ later, or Clang 3.3 and later.
 You'll need to have these libraries and their development headers installed in
 order to build Wesnoth:
 
- * Boost libraries             >= 1.48.0
+ * Boost libraries             >= 1.50.0
      Most headers plus the following binary libs:
    * Filesystem
    * Locale

--- a/SConstruct
+++ b/SConstruct
@@ -183,7 +183,7 @@ if 'TRAVIS' in os.environ:
 else:
     SDL2_version = '2.0.4'
 
-boost_version = '1.48.0'
+boost_version = '1.50.0'
 
 
 Help("""Arguments may be a mixture of switches and targets in any order.

--- a/projectfiles/VC12/README.md
+++ b/projectfiles/VC12/README.md
@@ -82,7 +82,10 @@ folders, all version numbers are minimal requirements:
       into the 'lib' *General Folder*.
 
 
-   3. libboost-1.48.0 ( http://www.boost.org/ )
+   3. libboost-1.50.0 ( http://www.boost.org/ )
+
+      Note these instructions are still referring to Boost 1.48.0, and are so
+      pending possible fixes to make it Boost >= 1.50.0 compliant.
 
       Download Boost and unpack it into the folder  
       	`C:\projects\`


### PR DESCRIPTION
At branch 'doc-from-discord-boost-discussion-20170926'.

The build documentation and scripts were slightly out of date about
Boost. This commit makes an interim update to them.

(CMakeLists.txt|SConstruct): `wesnoth` won't build using Boost lesser
than '1.50.0'. Boost 1.50.0 changed the location of version 3 of Boost
filesystem, from 'boost/filesystem/v3/' (e.g. for
'using boost::filesystem::v3::path;') to 'boost/filesystem/' (e.g. for
'using boost::filesystem::path;', enforced since the very introduction
of 'src/filesystem_boost.cpp'), making it incompatible unless using
precompiler directives for supporting backwards versions of Boost
filesystem prior than '1.50.0'. Using Boost 1.50.0 builds, but
segfaults on start up (in my mileage) (Valgrind hints about
'boost::detail::sp_counted_base'). I have not yet checked any more
than a single mileage, so I am not completely sure 1.50.0 is to be
discarded. In my mileage using Boost 1.51.0 makes the game boot and
saves able to load normally.

(INSTALL|projectfiles/VC12/README).md: Requirement of Boost libraries
 up to date.

.gitignore: Add KDevelop backup documents.