### PR TITLE
wmlscope: Fix the output by --progress.

### DIFF
--- a/data/tools/wesnoth/wmltools3.py
+++ b/data/tools/wesnoth/wmltools3.py
@@ -683,7 +683,7 @@ class CrossRef:
             print("*** Beginning reference-gathering pass...")
         for (ns, fn) in all_in:
             if progress:
-                print(filename)
+                print(fn)
             if iswml(fn):
                 with codecs.open(fn, "r", "utf8") as rfp:
                     attack_name = None


### PR DESCRIPTION
Previously, this just printed the last file name again and again.
Now we are printing the file name we are currently looking at.

This can be observed e.g. by `wmlscope --progress`.
Potentially other WML tools are affected too.