### PR TITLE
Fix enemy [best] moves vanish on mouse move when mouse landed on unit

### DIFF
--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -454,6 +454,20 @@ void menu_handler::show_enemy_moves(bool ignore_units, int side_num)
 			gui_->highlight_another_reach(path);
 		}
 	}
+
+	// Find possible unit (no matter whether friend or foe) under the
+	// mouse cursor.
+	mouse_handler& mh = pc_.get_mouse_handler_base();
+	const map_location& hex_under_mouse = mh.hovered_hex();
+	const bool selected_hex_has_unit = mh.hex_hosts_unit(hex_under_mouse);
+
+	if(selected_hex_has_unit) {
+		// At this point, a single pixel move would remove the enemy
+		// [best possible] movements hex tiles highlights, so some
+		// prevention on normal unit mouseover movement highlight
+		// has to be toggled temporarily.
+		mh.disable_units_highlight();
+	}
 }
 
 void menu_handler::toggle_shroud_updates(int side_num)

--- a/src/mouse_events.hpp
+++ b/src/mouse_events.hpp
@@ -87,6 +87,31 @@ public:
 
 	void select_or_action(bool browse);
 
+	/**
+	 * Uses SDL and @ref game_display::hex_clicked_on
+	 * to fetch the hex the mouse is hovering, if applicable.
+	 */
+	const map_location hovered_hex() const;
+
+	/** Unit exists on the hex, no matter if friend or foe. */
+	bool hex_hosts_unit(const map_location& hex) const;
+
+	/**
+	 * Use this to disable hovering an unit from highlighting its movement
+	 * range.
+	 *
+	 * @see enable_units_highlight()
+	 */
+	void disable_units_highlight();
+
+	/**
+	 * When unit highlighting is disabled, call this when the mouse no
+	 * longer hovers any unit to enable highlighting again.
+	 *
+	 * @see disable_units_highlight()
+	 */
+	void enable_units_highlight();
+
 protected:
 	/**
 	 * Due to the way this class is constructed we can assume that the
@@ -146,6 +171,8 @@ private:
 	bool show_partial_move_;
 
 	static mouse_handler * singleton_;
+
+	bool preventing_units_highlight_;
 };
 
 }


### PR DESCRIPTION
When selecting in UI, using mouse, `show [best] enemy moves`, on a cluttered battlefield, probably mouse will land on an unit.

That be the case, when the user moves the mouse, even just a single pixel; best enemy moves highlights vanish.

This is a first try to cope with the problem. When cursor is landing on an unit, unit normal highlight gets prevented until mouse reaches an hex where there is no unit. The user can now be sure best enemy moves will not accidentally vanish when dealing with cluttered battles, while s/he can still de-highlight them straightforwardly whenever wanted.

There are field visibility and protection decisions here, that I decided not to take but delegate on the PR reviewer, that in the end of the day is more used to cope with these classes and will know better if the changes in field protection in 668363318d are desirable.

Cheers and regards,