### PR TITLE
[terrain_graphics] fill in Ke* gaps

### DIFF
--- a/data/core/terrain-graphics.cfg
+++ b/data/core/terrain-graphics.cfg
@@ -594,12 +594,12 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 
 # Aquatic camp
 
-{NEW:CASTLEWALL             (Kme,Cme)     (!,C*,K*,X*)           C*       castle/aquatic-camp/castle}
+{NEW:CASTLEWALL             (Kme,Cme)     (!,C*,K*,X*)           !,Ket,!,C*,Ke*       castle/aquatic-camp/castle}
 {AQUATIC:CAMPS              Kme           Cme,Cm,Km                       castle/aquatic-camp}
 
 # Aquatic castle
 
-{NEW:CASTLEWALL             Cm            (!,C*,K*,X*)           C*       castle/aquatic-castle/castle}
+{NEW:CASTLEWALL             Cm            (!,C*,K*,X*)           !,Ket,!,C*,Ke*       castle/aquatic-castle/castle}
 {NEW:CASTLEWALL2            Km            !,Ket,!,C*,Ke*    (!,C*,K*,X*)  castle/aquatic-castle/keep-castle}
 {NEW:CASTLEWALL             Km            (!,Km,X*)              K*       castle/aquatic-castle/keep}
 
@@ -614,29 +614,29 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 
 # Elven castle
 
-{NEW:CASTLEWALL             Cv            (!,C*,K*,X*)           C*       castle/elven/castle}
+{NEW:CASTLEWALL             Cv            (!,C*,K*,X*)           !,Ket,!,C*,Ke*       castle/elven/castle}
 {NEW:CASTLEWALL2            Kv            !,Ket,!,C*,Ke*    (!,C*,K*,X*)  castle/elven/keep-castle}
 {NEW:CASTLEWALL             Kv            (!,K*,X*)              K*       castle/elven/keep}
 
 
 # Orcish castles
 
-{NEW:CASTLEWALL             Co            (!,C*,K*,X*)           C*       castle/orcish/fort}
+{NEW:CASTLEWALL             Co            (!,C*,K*,X*)           !,Ket,!,C*,Ke*       castle/orcish/fort}
 {NEW:CASTLEWALL2            Ko            !,Ket,!,C*,Ke*    (!,C*,K*,X*)  castle/orcish/keep-fort}
 {NEW:CASTLEWALL             Ko            (!,K*,X*)              K*       castle/orcish/keep}
 
-{NEW:CASTLEWALL             Coa           (!,C*,K*,X*)           C*       castle/winter-orcish/fort}
+{NEW:CASTLEWALL             Coa           (!,C*,K*,X*)           !,Ket,!,C*,Ke*       castle/winter-orcish/fort}
 {NEW:CASTLEWALL2            Koa           !,Ket,!,C*,Ke*    (!,C*,K*,X*)  castle/winter-orcish/keep-fort}
 {NEW:CASTLEWALL             Koa           (Ke,Kea,!,K*,X*)       K*       castle/winter-orcish/keep}
 
 
 # Desert castles
 
-{NEW:CASTLEWALL             Cd            (!,C*,K*,X*)           C*       castle/sand/castle}
+{NEW:CASTLEWALL             Cd            (!,C*,K*,X*)           !,Ket,!,C*,Ke*       castle/sand/castle}
 {NEW:CASTLEWALL2            Kd            !,Ket,!,C*,Ke*    (!,C*,K*,X*)  castle/sand/keep-castle}
 {NEW:CASTLEWALL             Kd            (!,K*,X*)              K*       castle/sand/keep}
 
-{NEW:CASTLEWALL             Cdr           (!,C*,K*,X*)           C*       castle/sand/ruin-castle}
+{NEW:CASTLEWALL             Cdr           (!,C*,K*,X*)           !,Ket,!,C*,Ke*       castle/sand/ruin-castle}
 {NEW:CASTLEWALL2            Kdr           !,Ket,!,C*,Ke*    (!,C*,K*,X*)  castle/sand/ruin-keep-castle}
 {NEW:CASTLEWALL             Kdr           (Ke,Kea,!,K*,X*)       K*       castle/sand/ruin-keep}
 
@@ -644,11 +644,11 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 # Human castles
 #
 
-{NEW:CASTLEWALL             Ch            (!,C*,K*,X*)           C*       castle/castle}
+{NEW:CASTLEWALL             Ch            (!,C*,K*,X*)           !,Ket,!,C*,Ke*       castle/castle}
 {NEW:CASTLEWALL2            Kh            !,Ket,!,C*,Ke*    (!,C*,K*,X*)  castle/keep-castle}
 {NEW:CASTLEWALL             Kh            (!,K*,X*)              K*       castle/keep}
 
-{NEW:CASTLEWALL             Cha           (!,C*,K*,X*)           C*       castle/snowy/castle}
+{NEW:CASTLEWALL             Cha           (!,C*,K*,X*)           !,Ket,!,C*,Ke*       castle/snowy/castle}
 {NEW:CASTLEWALL2            Kha           !,Ket,!,C*,Ke*    (!,C*,K*,X*)  castle/snowy/keep-castle}
 {NEW:CASTLEWALL             Kha           (Ke,Kea,!,K*,X*)       K*       castle/snowy/keep}
 
@@ -659,7 +659,7 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 
 # (!,Chr,Chs,!,Ch*) is used to catch convex transitions between Chw and Ch*
 # without lots of additional rules
-{NEW:CASTLEWALL             (!,Chr,Chs,Ce*,Ke*,!,Ch*) (W*)       C*       castle/sunken-ruin}
+{NEW:CASTLEWALL             (!,Chr,Chs,Ce*,Ke*,!,Ch*) (W*)       !,Ket,!,C*,Ke*       castle/sunken-ruin}
 
 {NEW:CASTLEWALL2_P          Khw,Khs       Ch*          W*,Ss       75  castle/sunken-ruinkeep1-castle}
 {NEW:CASTLEWALL2            Khw,Khs       Ch*          W*,Ss           castle/sunkenkeep-castle}
@@ -671,7 +671,7 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 
 # There are no more human castles left, so we can just use Ch* here, which makes sure
 # that all ruin<->non-ruin transitions are drawn
-{NEW:CASTLEWALL             Ch*           (!,C*,K*,X*)           C*       castle/ruin}
+{NEW:CASTLEWALL             Ch*           (!,C*,K*,X*)           !,Ket,!,C*,Ke*       castle/ruin}
 
 {NEW:CASTLEWALL2_P          (Khr,Khw,Khs) (C*)         (!,Ch*,Kh*,X*) 75  castle/ruinkeep1-castle}
 {NEW:CASTLEWALL2            (Khr,Khw,Khs) (C*)         (!,Ch*,Kh*,X*)     castle/keep-castle}
@@ -681,9 +681,9 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 
 # Encampment
 
-{NEW:CASTLEWALL             Ce,Ke         (!,C*,K*,X*)           C*       castle/encampment/regular}
-{NEW:CASTLEWALL             Cer,Ker         (!,C*,K*,X*)           C*       castle/encampment-ruin/regular}
-{NEW:CASTLEWALL             Cea,Kea       (!,C*,K*,X*)           C*       castle/encampment/snow}
+{NEW:CASTLEWALL             Ce,Ke         (!,C*,K*,X*)           !,Ket,!,C*,Ke*       castle/encampment/regular}
+{NEW:CASTLEWALL             Cer,Ker         (!,C*,K*,X*)           !,Ket,!,C*,Ke*       castle/encampment-ruin/regular}
+{NEW:CASTLEWALL             Cea,Kea       (!,C*,K*,X*)           !,Ket,!,C*,Ke*       castle/encampment/snow}
 {NEW:CASTLEWALL2            Ket           (C*)              (!,C*,K*,X*)  castle/encampment/tall-keep-castle}
 {NEW:CASTLEWALL             Ket           (!,K*,X*)              K*       castle/encampment/tall-keep}
 


### PR DESCRIPTION
Fills in some gaps with Ke* terrains, so they are more like Ce*.  Basically replace C* filter with !,Ket,!,C*,Ke*
![screenshot_campwalls_fix](https://user-images.githubusercontent.com/13510196/31046757-5f692660-a5b3-11e7-971a-8f772f385e0b.gif)
