### PR TITLE
Add *.so to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ wesnoth.opt
 wesnoth.plg
 *.exe
 *.dll
+*.so
 
 # library files
 .libs


### PR DESCRIPTION
Shared Objects files should be ignored by git as well as DLL files.