### PR TITLE
Remove Solaris support, improve glibcxx_debug support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,8 @@ option(ENABLE_STRICT_COMPILATION "Sets the strict compilation mode" OFF)
 option(ENABLE_PEDANTIC_COMPILATION "Sets the pedantic compilation mode" OFF)
 option(ENABLE_DEBUG_WINDOW_LAYOUT "Add the debug option to allow the generation of debug layout files in dot format" OFF)
 option(ENABLE_DESIGN_DOCUMENTS "Enables the generation of design documents, and has additional dependencies" OFF)
-option(ENABLE_LTO "Sets Link Time Optimization" OFF)
+option(ENABLE_LTO "Sets Link Time Optimization for Release builds" OFF)
+option(GLIBCXX_DEBUG "Whether to define _GLIBCXX_DEBUG _GLIBCXX_DEBUG_PEDANTIC" OFF)
 
 #misc options
 if(NOT MSVC)
@@ -579,6 +580,13 @@ MARK_AS_ADVANCED(LTO_AR LTO_RANLIB NON_LTO_AR NON_LTO_RANLIB)
 MESSAGE("Replacing flags used for Debug build")
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -DDEBUG -ggdb3" CACHE STRING "change cmake's Debug flags to match scons' flags" FORCE)
 set(CMAKE_C_FLAGS_DEBUG "-O0 -DDEBUG -ggdb3" CACHE STRING "change cmake's Debug flags to match scons' flags" FORCE)
+
+# adds GLIBCXX_DEBUG definitions
+if(GLIBCXX_DEBUG)
+  MESSAGE("Defining _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC")
+  add_definitions(-D_GLIBCXX_DEBUG)
+  add_definitions(-D_GLIBCXX_DEBUG_PEDANTIC)
+endif(GLIBCXX_DEBUG)
 
 # #
 # End setting options for Debug build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ option(ENABLE_PEDANTIC_COMPILATION "Sets the pedantic compilation mode" OFF)
 option(ENABLE_DEBUG_WINDOW_LAYOUT "Add the debug option to allow the generation of debug layout files in dot format" OFF)
 option(ENABLE_DESIGN_DOCUMENTS "Enables the generation of design documents, and has additional dependencies" OFF)
 option(ENABLE_LTO "Sets Link Time Optimization for Release builds" OFF)
-option(GLIBCXX_DEBUG "Whether to define _GLIBCXX_DEBUG _GLIBCXX_DEBUG_PEDANTIC" OFF)
+option(GLIBCXX_DEBUG "Whether to define _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC" OFF)
 
 #misc options
 if(NOT MSVC)

--- a/SConstruct
+++ b/SConstruct
@@ -192,7 +192,7 @@ Important switches include:
                         in build/release and copy resulting binaries
                         into distribution/working copy root.
     build=debug     same for debug build variant, binaries will be copied with -debug suffix
-    build=profile   
+    build=profile   build with instrumentation for gprof
 
 With no arguments, the recipe builds wesnoth and wesnothd.  Available
 build targets include the individual binaries:

--- a/SConstruct
+++ b/SConstruct
@@ -56,7 +56,7 @@ opts.AddVariables(
     ('extra_flags_profile', 'Extra compiler and linker flags to use for profile builds', ""),
     BoolVariable('enable_lto', 'Whether to enable Link Time Optimization for build=release', False),
     ('arch', 'What -march option to use for build=release, will default to pentiumpro on Windows', ""),
-    BoolVariable('glibcxx_debug', 'Whether to define _GLIBCXX_DEBUG _GLIBCXX_DEBUG_PEDANTIC for build=debug', False),
+    BoolVariable('glibcxx_debug', 'Whether to define _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for build=debug', False),
     PathVariable('bindir', 'Where to install binaries', "bin", PathVariable.PathAccept),
     ('cachedir', 'Directory that contains a cache of derived files.', ''),
     PathVariable('datadir', 'read-only architecture-independent game data', "$datarootdir/$datadirname", PathVariable.PathAccept),
@@ -191,8 +191,10 @@ Important switches include:
     build=release   build the release build variant with appropriate flags
                         in build/release and copy resulting binaries
                         into distribution/working copy root.
-    build=debug     same for debug build variant, binaries will be copied with -debug suffix
+    build=debug     same for debug build variant
+                    binaries will be copied with -debug suffix
     build=profile   build with instrumentation for gprof
+                    binaries will be copied with -profile suffix
 
 With no arguments, the recipe builds wesnoth and wesnothd.  Available
 build targets include the individual binaries:
@@ -482,9 +484,9 @@ for env in [test_env, client_env, env]:
         env["DEBUG_FLAGS"] = Split("-O0 -DDEBUG -ggdb3")
         
         if env["glibcxx_debug"] == True:
-            env["GLIBCXX_DEBUG"] = Split("_GLIBCXX_DEBUG _GLIBCXX_DEBUG_PEDANTIC")
+            glibcxx_debug_flags = Split("_GLIBCXX_DEBUG _GLIBCXX_DEBUG_PEDANTIC")
         else:
-            env["GLIBCXX_DEBUG"] = ""
+            glibcxx_debug_flags = ""
         
 # #
 # End determining options for debug build
@@ -554,10 +556,10 @@ SConscript(dirs = Split("po doc packaging/windows packaging/systemd"))
 
 binaries = Split("wesnoth wesnothd campaignd test")
 builds = {
-    "base"          : dict(CCFLAGS    = Split("$OPT_COMP_FLAGS"), LINKFLAGS=Split("$OPT_LINK_FLAGS")),    # Don't build in subdirectory
-    "debug"         : dict(CCFLAGS    = Split("$DEBUG_FLAGS")   , CPPDEFINES=env["GLIBCXX_DEBUG"]),
-    "release"       : dict(CCFLAGS    = Split("$OPT_COMP_FLAGS"), LINKFLAGS=Split("$OPT_LINK_FLAGS")),
-    "profile"       : dict(CCFLAGS    = "-pg", LINKFLAGS = "-pg")
+    "base"    : dict(CCFLAGS = Split("$OPT_COMP_FLAGS"), LINKFLAGS=Split("$OPT_LINK_FLAGS")),
+    "debug"   : dict(CCFLAGS = Split("$DEBUG_FLAGS")   , CPPDEFINES=glibcxx_debug_flags),
+    "release" : dict(CCFLAGS = Split("$OPT_COMP_FLAGS"), LINKFLAGS=Split("$OPT_LINK_FLAGS")),
+    "profile" : dict(CCFLAGS = "-pg", LINKFLAGS = "-pg")
     }
 build = env["build"]
 

--- a/src/SConscript
+++ b/src/SConscript
@@ -132,7 +132,10 @@ def WesnothProgram(env, target, source, can_build, **kw):
         env["RANLIB"] = 'gcc-ranlib'
     
     if can_build:
-        bin = env.Program("#/" + target + build_suffix, source, **kw)
+        if env["build"] == "base":
+            bin = env.Program(target, source, **kw)
+        else:
+            bin = env.Program("#/" + target + build_suffix, source, **kw)
         env.Alias(target, bin)
     else:
         bin = env.Alias(target, [], error_action)
@@ -162,6 +165,12 @@ env.WesnothProgram("campaignd", campaignd_sources + [libwesnoth_core], have_serv
 test_sources = GetSources("test")
 test = test_env.WesnothProgram("test", test_sources +  [libwesnoth_extras, libwesnoth_core, libwesnoth, libwesnoth_sdl, libwesnoth_extras], have_test_prereqs)
 #---end of getting sources---
+
+sources = []
+if "TAGS" in COMMAND_LINE_TARGETS:
+    sources = [ Glob(os.path.join(dir, pattern)) for dir in ["", "*", "*/*"] for pattern in ["*.cpp", "*.hpp"] ]
+
+Export("sources")
 
 # Local variables:
 # mode: python

--- a/src/SConscript
+++ b/src/SConscript
@@ -132,10 +132,7 @@ def WesnothProgram(env, target, source, can_build, **kw):
         env["RANLIB"] = 'gcc-ranlib'
     
     if can_build:
-        if env["build"] == "base":
-            bin = env.Program(target, source, **kw)
-        else:
-            bin = env.Program("#/" + target + build_suffix, source, **kw)
+        bin = env.Program("#/" + target + build_suffix, source, **kw)
         env.Alias(target, bin)
     else:
         bin = env.Alias(target, [], error_action)
@@ -165,12 +162,6 @@ env.WesnothProgram("campaignd", campaignd_sources + [libwesnoth_core], have_serv
 test_sources = GetSources("test")
 test = test_env.WesnothProgram("test", test_sources +  [libwesnoth_extras, libwesnoth_core, libwesnoth, libwesnoth_sdl, libwesnoth_extras], have_test_prereqs)
 #---end of getting sources---
-
-sources = []
-if "TAGS" in COMMAND_LINE_TARGETS:
-    sources = [ Glob(os.path.join(dir, pattern)) for dir in ["", "*", "*/*"] for pattern in ["*.cpp", "*.hpp"] ]
-
-Export("sources")
 
 # Local variables:
 # mode: python


### PR DESCRIPTION
This PR:
- Removes support for building on Solaris from scons.  This support is currently non-functional.
- Replaces the `glibcxx_debug` separate build with a `glibcxx_debug=yes|no` option for the existing `debug` build.
- Adds building with the `glibcxx_debug` option to cmake.
- Adds a description of what the `profile` build is for to scons.