### PR TITLE
Disallow backslashes in file paths

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -16,30 +16,24 @@ CHANGES
 
 [rasection="Campaigns"]
 [list]
-[*]The order of the beginner campaigns is now [i]A Tale of Two Brothers, An Orcish Incursion, The South Guard, & Heir to the Throne.[/i] It is hoped that this sequence will be friendlier to new players, encouraging them to start with the simpler AToTB, so they might be better prepared to enjoy HttT.
 [/list]
 [/rasection]
 
 [rasection="User Interface"]
 [list]
-[*]Most text boxes now support advanced Input Method Editors (in-game chat does not, however).
 [/list]
 [/rasection]
 
 
 [rawarn="Deprecations and breaking changes"]
 [list]
-[*] moveto and enter_hex, exit_hex event no longer abort the movement, [cancel_action] must be used to cancel the current move.
-[*] The allow_new_game= attribute in [scenario] now defaults to false (it still defaults to tru in [multiplayer]) 
-[*] In gui2 dialogs/widgets [resolution] window_width/height now specifies the minimum window size for that resolution ot be chosen 
+[*] File paths with backslashes are no longer accepted. Use forward slashes instead.
 [/list]
 [/rawarn]
 
 
  [rasection="New lua/wml features"]
  [list]
- [*] formula code is now supported in abilities and weapon specials
- [*] [multiplayer]/[scenario] now support mp_village_gold, mp_village_support, mp_fog and mp_shroud keys, which are useed as default values for the corresponding keys in [side], it is reccomended to use them instead of the keys in [side] for configurable multiplayer scenarios.
  [/list]
  [/rasection]
 

--- a/changelog
+++ b/changelog
@@ -1,5 +1,8 @@
 Version 1.13.11:
  * WML Engine:
+   * File paths with backslashes are no longer allowed. This ensures that a UMC
+     author can't accidentally use them and make an add-on that breaks on
+     GNU/Linux and macOS.
    * File paths are now case sensitive even on Windows.
 
 Version 1.13.10:

--- a/src/filesystem_boost.cpp
+++ b/src/filesystem_boost.cpp
@@ -1149,6 +1149,11 @@ static bool is_legal_file(const std::string &filename)
 		return false;
 	}
 
+	if (filename.find('\\') != std::string::npos) {
+		ERR_FS << "Illegal path '" << filename << R"end(' ("\" not allowed, for compatibility with GNU/Linux and macOS).)end" << std::endl;
+		return false;
+	}
+
 	if (looks_like_pbl(filename)) {
 		ERR_FS << "Illegal path '" << filename << "' (.pbl files are not allowed)." << std::endl;
 		return false;


### PR DESCRIPTION
The intent is to avoid UMC authors on Windows from accidentally using backslashes and making add-ons that won't work correctly on GNU/Linux and macOS.

IMO, this change is risky enough that we should merge it for 1.13.11, not 1.13.10.