### PR TITLE
Make Jarek from TSG loyal for consistency.

### DIFF
--- a/data/campaigns/The_South_Guard/scenarios/03_A_Desparate_Errand.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/03_A_Desparate_Errand.cfg
@@ -267,9 +267,11 @@
             x,y=41,33
             facing=sw
             [modifications]
-                {TRAIT_STRONG}
+                {TRAIT_LOYAL}
                 {TRAIT_QUICK}
+                {TRAIT_STRONG}
             [/modifications]
+            {IS_LOYAL}
         [/unit]
 
         [message]

--- a/data/campaigns/The_South_Guard/scenarios/03_A_Desparate_Errand.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/03_A_Desparate_Errand.cfg
@@ -269,7 +269,6 @@
             [modifications]
                 {TRAIT_LOYAL}
                 {TRAIT_QUICK}
-                {TRAIT_STRONG}
             [/modifications]
             {IS_LOYAL}
         [/unit]


### PR DESCRIPTION
All other units, which you get without recruiting in The South Guard are loyal. I think Jarek should be loyal too for consistency and because he is recalled by default in almost every single scenario. It should not affect difficulty significally.