### PR TITLE
Fix candidate visual bug in the announces system.

### DIFF
--- a/changelog
+++ b/changelog
@@ -3,6 +3,8 @@ Version 1.13.10+dev:
    * Updated translations: Chinese (Simplified)
  * User Interface:
    * Removed broken Unit Box and Widescreen themes.
+   * Fixed a bug that partially prevented movement feedback announce messages
+     to be displayed (UI regression bug #2130, affecting 1.13.8 and 1.13.10).
  * WML Engine:
    * File paths are now case sensitive even on Windows.
 

--- a/src/actions/move.cpp
+++ b/src/actions/move.cpp
@@ -1133,10 +1133,13 @@ namespace { // Private helpers for move_unit()
 			redraw = true;
 		}
 
+		display::announce_options announce_options;
+		announce_options.discard_previous = false;
+
 		// Failed teleport feedback?
 		if ( playing_team_is_viewing_  &&  teleport_failed_ ) {
 			std::string teleport_string = _("Failed teleport! Exit not empty");
-			disp.announce(message_prefix + teleport_string, font::BAD_COLOR);
+			disp.announce(message_prefix + teleport_string, font::BAD_COLOR, announce_options);
 			message_prefix += " \n";
 			redraw = true;
 		}
@@ -1166,7 +1169,7 @@ namespace { // Private helpers for move_unit()
 				msg_color = font::GOOD_COLOR;
 			}
 
-			disp.announce(message_prefix + message, msg_color);
+			disp.announce(message_prefix + message, msg_color, announce_options);
 			message_prefix += " \n";
 			redraw = true;
 		}
@@ -1179,7 +1182,7 @@ namespace { // Private helpers for move_unit()
 				utils::string_map symbols;
 				symbols["hotkey"] = name;
 				std::string message = vgettext("(press $hotkey to keep moving)", symbols);
-				disp.announce(message_prefix + message, font::NORMAL_COLOR);
+				disp.announce(message_prefix + message, font::NORMAL_COLOR, announce_options);
 				message_prefix += " \n";
 				redraw = true;
 			}

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1775,14 +1775,16 @@ void display::enable_menu(const std::string& item, bool enable)
 	}
 }
 
-void display::announce(const std::string& message, const color_t& color, int lifetime)
+void display::announce(const std::string& message, const color_t& color, const announce_options& options)
 {
-	font::remove_floating_label(prevLabel);
+	if(options.discard_previous) {
+		font::remove_floating_label(prevLabel);
+	}
 	font::floating_label flabel(message);
 	flabel.set_font_size(font::SIZE_XLARGE);
 	flabel.set_color(color);
 	flabel.set_position(map_outside_area().w/2, map_outside_area().h/3);
-	flabel.set_lifetime(lifetime);
+	flabel.set_lifetime(options.lifetime);
 	flabel.set_clip_rect(map_outside_area());
 
 	prevLabel = font::add_floating_label(flabel);

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -583,9 +583,30 @@ public:
 	map_labels& labels();
 	const map_labels& labels() const;
 
+	/** Holds options for calls to function 'announce' (@ref announce). */
+	struct announce_options
+	{
+		/** Lifetime measured in frames. */
+		int lifetime;
+
+		/**
+		 * An announcement according these options should replace the
+		 * previous announce (typical of fast announcing) or not
+		 * (typical of movement feedback).
+		 */
+		bool discard_previous;
+
+		announce_options()
+			: lifetime(100)
+			, discard_previous(false)
+		{
+		}
+	};
+
 	/** Announce a message prominently. */
 	void announce(const std::string& msg,
-		       const color_t& color = font::GOOD_COLOR, int lifetime = 100);
+	              const color_t& color = font::GOOD_COLOR,
+	              const announce_options& options = announce_options());
 
 	/**
 	 * Schedule the minimap for recalculation.

--- a/src/synced_commands.cpp
+++ b/src/synced_commands.cpp
@@ -392,7 +392,9 @@ namespace
 	{
 		utils::string_map symbols;
 		symbols["player"] = resources::controller->current_team().current_player();
-		resources::screen->announce(vgettext(message, symbols), font::NORMAL_COLOR, 1000);
+		display::announce_options announce_options;
+		announce_options.lifetime = 1000;
+		resources::screen->announce(vgettext(message, symbols), font::NORMAL_COLOR, announce_options);
 	}
 }
 SYNCED_COMMAND_HANDLER_FUNCTION(debug_unit, child,  use_undo, /*show*/, /*error_handler*/)


### PR DESCRIPTION
I suspect there might be a bug in `master` since rev ad809a87571f. About a label that I remember from when I was young, and I am missing now.

Compare `master` behavior at 'https://youtu.be/h_cA_UDTGKQ' with the intention of the feature branch at 'https://youtu.be/eVxK8uNWOsg'.

See also http://github.com/wesnoth/wesnoth/pull/999 to which this follows up.

Cheers and regards,