### PR TITLE
Fix error: control may reach end of non-void lambda

### DIFF
--- a/src/game_initialization/lobby_info.cpp
+++ b/src/game_initialization/lobby_info.cpp
@@ -405,6 +405,8 @@ void lobby_info::sort_users(bool by_name, bool by_relation)
 		if(by_relation) {
 			return u1->relation < u2->relation;
 		}
+
+		return true;
 	});
 }
 

--- a/src/gui/dialogs/game_stats.cpp
+++ b/src/gui/dialogs/game_stats.cpp
@@ -76,7 +76,7 @@ unit_const_ptr game_stats::get_leader(const int side)
 
 static std::string controller_name(const team& t)
 {
-	static const std::array<t_string, 3> names {_("controller^Human"), _("controller^AI"), _("controller^Idle")};
+	static const std::array<t_string, 3> names {{_("controller^Human"), _("controller^AI"), _("controller^Idle")}};
 	return "<span color='#808080'><small>" + names[t.controller().v] + "</small></span>";
 }
 


### PR DESCRIPTION
If by_name and by_relation are both omitted, behave as if both were given: sort first by relation then by name.