### PR TITLE
extent fix for use team_color default without use numeric palette IDs.

### DIFF
--- a/data/core/team-colors.cfg
+++ b/data/core/team-colors.cfg
@@ -230,63 +230,6 @@
     name= _ "Shroud"
 [/color_range]
 
-# Old-style numeric palette IDs for backwards compatibility
-# The C++ code uses this form heavily in generated RC() markup;
-# these can't be removed until all of those are fixed.
-[color_range]
-    id=1
-    rgb=FF0000,FFFFFF,000000,FF0000
-    name= _ "Red"
-[/color_range]
-
-[color_range]
-    id=2
-    rgb=2E419B,FFFFFF,0F0F0F,0000FF
-    name= _ "Blue"
-[/color_range]
-
-[color_range]
-    id=3
-    rgb=62B664,FFFFFF,000000,00FF00
-    name= _ "Green"
-[/color_range]
-
-[color_range]
-    id=4
-    rgb=93009D,FFFFFF,000000,FF00FF
-    name= _ "Purple"
-[/color_range]
-
-[color_range]
-    id=7
-    rgb=FF7E00,FFFFFF,0F0F0F,FFAA00
-    name= _ "Orange"
-[/color_range]
-
-[color_range]
-    id=5
-    rgb=5A5A5A,FFFFFF,000000,000000
-    name= _ "Black"
-[/color_range]
-
-[color_range]
-    id=8
-    rgb=E1E1E1,FFFFFF,1E1E1E,FFFFFF
-    name= _ "White"
-[/color_range]
-
-[color_range]
-    id=6
-    rgb=945027,FFFFFF,000000,AA4600
-    name= _ "Brown"
-[/color_range]
-
-[color_range]
-    id=9
-    rgb=30CBC0,FFFFFF,000000,00F0C8
-    name= _ "Teal"
-[/color_range]
-
 # Colors in the palette are used for recoloring parts of images, such as unit
 # clothing to match each team color. The names should not clash with
 # color_range id's above.

--- a/src/save_index.cpp
+++ b/src/save_index.cpp
@@ -403,11 +403,10 @@ void extract_summary_from_config(config& cfg_save, config& cfg_summary)
 				std::vector<std::string> color_options_;
 				color_options_ = game_config::default_colors;
 				color_id_ = color_options_[color_];
-
-			if(u["color"].to_int()) {
+				if(u["color"].to_int()) {
 			color_ = u["color"].to_int() - 1;
 			color_id_ = color_options_[color_];
-			}
+				}
 			
 
 

--- a/src/save_index.cpp
+++ b/src/save_index.cpp
@@ -405,9 +405,11 @@ void extract_summary_from_config(config& cfg_save, config& cfg_summary)
 				color_options_ = game_config::default_colors;
 				color_id_ = color_options_[color_];
 				
-				if(u["color"].to_int()){
-				color_ = u["color"].to_int() - 1;
-				color_id_ = color_options_[color_];
+				if (!cfg[ "color" ]. empty ()) {
+					if(u["color"].to_int()){
+						color_ = u["color"].to_int() - 1;
+						color_id_ = color_options_[color_];
+					}
 				}
 			
 

--- a/src/save_index.cpp
+++ b/src/save_index.cpp
@@ -372,6 +372,7 @@ void extract_summary_from_config(config& cfg_save, config& cfg_summary)
 			std::string leader;
 			std::string leader_image;
 			std::string leader_image_tc_modifier;
+			std::string leader_image_tc_modifier_alt;
 			std::string leader_name;
 			int gold = side["gold"];
 			int units = 0, recall_units = 0;
@@ -395,13 +396,27 @@ void extract_summary_from_config(config& cfg_save, config& cfg_summary)
 				if(!leader.empty() || !u["canrecruit"].to_bool()) {
 					continue;
 				}
+				int color_=u["side"].to_int(1)-1;
+				std::string color_id_;
+				std::string flag_rgb_;
+				flag_rgb_="magenta";
+				std::vector<std::string> color_options_;
+				color_options_ = game_config::default_colors;
+				color_id_ = color_options_[color_];
+
+				if(u["color"].to_int()) {
+			color_ = u["color"].to_int() - 1;
+			color_id_ = color_options_[color_];
+			}
+
 
 				// Don't count it among the troops
 				units--;
 				leader = u["id"].str();
 				leader_name = u["name"].str();
 				leader_image = u["image"].str();
-				leader_image_tc_modifier = "~RC(" + u["flag_rgb"].str() + ">" + u["side"].str() + ")";
+				leader_image_tc_modifier = "~RC(" + u["flag_rgb"].str() + ">" + color_id_ + ")";
+				leader_image_tc_modifier_alt="~RC(" + flag_rgb_ + ">" + color_id_ + ")";
 			}
 
 			// We need a binary path-independent path to the leader image here so it can be displayed
@@ -421,7 +436,7 @@ void extract_summary_from_config(config& cfg_save, config& cfg_summary)
 			leader_config["leader"] = leader;
 			leader_config["leader_name"] = leader_name;
 			leader_config["leader_image"] = leader_image;
-			leader_config["leader_image_tc_modifier"] = leader_image_tc_modifier;
+			leader_config["leader_image_tc_modifier"] = leader_image_tc_modifier_alt;
 			leader_config["gold"] = gold;
 			leader_config["units"] = units;
 			leader_config["recall_units"] = recall_units;

--- a/src/save_index.cpp
+++ b/src/save_index.cpp
@@ -404,10 +404,11 @@ void extract_summary_from_config(config& cfg_save, config& cfg_summary)
 				color_options_ = game_config::default_colors;
 				color_id_ = color_options_[color_];
 
-				if(u["color"].to_int()) {
+			if(u["color"].to_int()) {
 			color_ = u["color"].to_int() - 1;
 			color_id_ = color_options_[color_];
 			}
+			
 
 
 				// Don't count it among the troops

--- a/src/save_index.cpp
+++ b/src/save_index.cpp
@@ -396,6 +396,7 @@ void extract_summary_from_config(config& cfg_save, config& cfg_summary)
 				if(!leader.empty() || !u["canrecruit"].to_bool()) {
 					continue;
 				}
+				
 				int color_=u["side"].to_int(1)-1;
 				std::string color_id_;
 				std::string flag_rgb_;
@@ -403,6 +404,7 @@ void extract_summary_from_config(config& cfg_save, config& cfg_summary)
 				std::vector<std::string> color_options_;
 				color_options_ = game_config::default_colors;
 				color_id_ = color_options_[color_];
+				
 				if(u["color"].to_int()) {
 			color_ = u["color"].to_int() - 1;
 			color_id_ = color_options_[color_];

--- a/src/save_index.cpp
+++ b/src/save_index.cpp
@@ -405,7 +405,7 @@ void extract_summary_from_config(config& cfg_save, config& cfg_summary)
 				color_options_ = game_config::default_colors;
 				color_id_ = color_options_[color_];
 				
-				if (u.has_attribute("color")){
+				if (u.has_attribute("color")) {
 					color_ = u["color"].to_int() - 1;
 					color_id_ = color_options_[color_];
 				}

--- a/src/save_index.cpp
+++ b/src/save_index.cpp
@@ -405,11 +405,9 @@ void extract_summary_from_config(config& cfg_save, config& cfg_summary)
 				color_options_ = game_config::default_colors;
 				color_id_ = color_options_[color_];
 				
-				if (!u[ "color" ]. empty ()) {
-					if(u["color"].to_int()){
-						color_ = u["color"].to_int() - 1;
-						color_id_ = color_options_[color_];
-					}
+				if (u.has_attribute("color)"{
+					color_ = u["color"].to_int() - 1;
+					color_id_ = color_options_[color_];
 				}
 			
 

--- a/src/save_index.cpp
+++ b/src/save_index.cpp
@@ -405,7 +405,7 @@ void extract_summary_from_config(config& cfg_save, config& cfg_summary)
 				color_options_ = game_config::default_colors;
 				color_id_ = color_options_[color_];
 				
-				if (!cfg[ "color" ]. empty ()) {
+				if (!u[ "color" ]. empty ()) {
 					if(u["color"].to_int()){
 						color_ = u["color"].to_int() - 1;
 						color_id_ = color_options_[color_];

--- a/src/save_index.cpp
+++ b/src/save_index.cpp
@@ -405,7 +405,7 @@ void extract_summary_from_config(config& cfg_save, config& cfg_summary)
 				color_options_ = game_config::default_colors;
 				color_id_ = color_options_[color_];
 				
-				if (u.has_attribute("color)"{
+				if (u.has_attribute("color")){
 					color_ = u["color"].to_int() - 1;
 					color_id_ = color_options_[color_];
 				}

--- a/src/save_index.cpp
+++ b/src/save_index.cpp
@@ -405,9 +405,9 @@ void extract_summary_from_config(config& cfg_save, config& cfg_summary)
 				color_options_ = game_config::default_colors;
 				color_id_ = color_options_[color_];
 				
-				if(u["color"].to_int()) {
-			color_ = u["color"].to_int() - 1;
-			color_id_ = color_options_[color_];
+				if(u["color"].to_int()){
+				color_ = u["color"].to_int() - 1;
+				color_id_ = color_options_[color_];
 				}
 			
 

--- a/src/team.cpp
+++ b/src/team.cpp
@@ -195,11 +195,24 @@ void team::team_info::read(const config &cfg)
 	carryover_gold = cfg["carryover_gold"].to_int(0);
 	variables = cfg.child_or_empty("variables");
 	is_local = cfg["is_local"].to_bool(true);
+	int color_=side-1;
+	std::string color_id_;
+	std::vector<std::string> color_options_;
+	color_options_ = game_config::default_colors;
+	color_id_ = color_options_[color_];
+
+	if(!cfg["color"].empty()) {
+		if(cfg["color"].to_int()) {
+			color_ = cfg["color"].to_int() - 1;
+			color_id_ = color_options_[color_];
+		}
+		}
+
 
 	if(cfg.has_attribute("color")) {
 		color = cfg["color"].str();
 	} else {
-		color = cfg["side"].str();
+		color = color_id_;
 	}
 
 	// If arel starting new scenario override settings from [ai] tags

--- a/src/team.cpp
+++ b/src/team.cpp
@@ -206,7 +206,9 @@ void team::team_info::read(const config &cfg)
 			color_ = cfg["color"].to_int() - 1;
 			color_id_ = color_options_[color_];
 		}
-		}
+	}
+	
+	
 
 
 	if(cfg.has_attribute("color")) {


### PR DESCRIPTION
I know, a fix has be commits in game_initialisation\connect_engine.cpp but when i reload a scenario start save after delete numeric palette
	then i have not anymore default color but base color(magenta for image unit, green for flags).
	I propose to complete this fix in team.cpp.
	Save_index.cpp is modified equally for the same reason, but if i add leader_image_tc_modifier_alt,it's in case to leader image team_color is not magenta
	Then, as unknow-unit.png team color is always magenta i duplicate leader_image_tc_modifier.
