### PR TITLE
Finish switch to MT19937 for randomness

### DIFF
--- a/projectfiles/VC12/wesnoth.vcxproj
+++ b/projectfiles/VC12/wesnoth.vcxproj
@@ -2580,7 +2580,6 @@
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Release|Win32'">$(IntDir)Preferences\</ObjectFileName>
     </ClCompile>
     <ClCompile Include="..\..\src\quit_confirmation.cpp" />
-    <ClCompile Include="..\..\src\random.cpp" />
     <ClCompile Include="..\..\src\random_deterministic.cpp" />
     <ClCompile Include="..\..\src\random_synced.cpp" />
     <ClCompile Include="..\..\src\recall_list_manager.cpp" />
@@ -3898,7 +3897,6 @@
     <ClInclude Include="..\..\src\preferences\general.hpp" />
     <ClInclude Include="..\..\src\preferences\lobby.hpp" />
     <ClInclude Include="..\..\src\quit_confirmation.hpp" />
-    <ClInclude Include="..\..\src\random.hpp" />
     <ClInclude Include="..\..\src\random_deterministic.hpp" />
     <ClInclude Include="..\..\src\random_synced.hpp" />
     <ClInclude Include="..\..\src\recall_list_manager.hpp" />

--- a/projectfiles/VC12/wesnoth.vcxproj.filters
+++ b/projectfiles/VC12/wesnoth.vcxproj.filters
@@ -1463,7 +1463,6 @@
     <ClCompile Include="..\..\src\playturn.cpp" />
     <ClCompile Include="..\..\src\playturn_network_adapter.cpp" />
     <ClCompile Include="..\..\src\quit_confirmation.cpp" />
-    <ClCompile Include="..\..\src\random.cpp" />
     <ClCompile Include="..\..\src\random_deterministic.cpp" />
     <ClCompile Include="..\..\src\random_synced.cpp" />
     <ClCompile Include="..\..\src\recall_list_manager.cpp" />
@@ -2889,7 +2888,6 @@
     <ClInclude Include="..\..\src\playturn.hpp" />
     <ClInclude Include="..\..\src\playturn_network_adapter.hpp" />
     <ClInclude Include="..\..\src\quit_confirmation.hpp" />
-    <ClInclude Include="..\..\src\random.hpp" />
     <ClInclude Include="..\..\src\random_deterministic.hpp" />
     <ClInclude Include="..\..\src\random_synced.hpp" />
     <ClInclude Include="..\..\src\recall_list_manager.hpp" />

--- a/projectfiles/VC12/wesnothlib.vcxproj
+++ b/projectfiles/VC12/wesnothlib.vcxproj
@@ -141,6 +141,7 @@
     <ClCompile Include="..\..\src\gettext_boost.cpp" />
     <ClCompile Include="..\..\src\log.cpp" />
     <ClCompile Include="..\..\src\log_windows.cpp" />
+    <ClCompile Include="..\..\src\random.cpp" />
     <ClCompile Include="..\..\src\serialization\binary_or_text.cpp">
       <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4706;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
@@ -170,6 +171,7 @@
     <ClInclude Include="..\..\src\libc_error.hpp" />
     <ClInclude Include="..\..\src\log.hpp" />
     <ClInclude Include="..\..\src\log_windows.hpp" />
+    <ClInclude Include="..\..\src\random.hpp" />
     <ClInclude Include="..\..\src\serialization\binary_or_text.hpp" />
     <ClInclude Include="..\..\src\serialization\parser.hpp" />
     <ClInclude Include="..\..\src\serialization\preprocessor.hpp" />

--- a/projectfiles/VC12/wesnothlib.vcxproj.filters
+++ b/projectfiles/VC12/wesnothlib.vcxproj.filters
@@ -53,6 +53,7 @@
     <ClCompile Include="..\..\src\gettext_boost.cpp" />
     <ClCompile Include="..\..\src\log.cpp" />
     <ClCompile Include="..\..\src\log_windows.cpp" />
+    <ClCompile Include="..\..\src\random.cpp" />
     <ClCompile Include="..\..\src\tstring.cpp" />
     <ClCompile Include="..\..\src\version.cpp" />
     <ClCompile Include="..\..\src\font\constants.cpp">
@@ -96,6 +97,7 @@
     <ClInclude Include="..\..\src\libc_error.hpp" />
     <ClInclude Include="..\..\src\log.hpp" />
     <ClInclude Include="..\..\src\log_windows.hpp" />
+    <ClInclude Include="..\..\src\random.hpp" />
     <ClInclude Include="..\..\src\tstring.hpp" />
     <ClInclude Include="..\..\src\version.hpp" />
     <ClInclude Include="..\..\src\wesconfig.h" />

--- a/source_lists/libwesnoth_core
+++ b/source_lists/libwesnoth_core
@@ -12,6 +12,7 @@ log.cpp
 map/location.cpp
 map/map.cpp
 mt_rng.cpp
+random.cpp
 seed_rng.cpp
 serialization/binary_or_text.cpp
 serialization/parser.cpp

--- a/source_lists/wesnoth
+++ b/source_lists/wesnoth
@@ -322,7 +322,6 @@ preferences/display.cpp
 preferences/editor.cpp
 preferences/game.cpp
 preferences/lobby.cpp
-random.cpp
 random_deterministic.cpp
 random_synced.cpp
 recall_list_manager.cpp

--- a/src/actions/advancement.cpp
+++ b/src/actions/advancement.cpp
@@ -183,7 +183,7 @@ namespace
 			}
 			else if(t.is_local_ai() || t.is_network_ai() || t.is_empty())
 			{
-				res = rand() % nb_options_;
+				res = randomness::generator->get_random_int(0, nb_options_-1);
 
 				//if ai_advancement_ is the default advancement the following code will
 				//have no effect because get_advancements returns an empty list.

--- a/src/addon/client.cpp
+++ b/src/addon/client.cpp
@@ -24,6 +24,7 @@
 #include "gui/dialogs/message.hpp"
 #include "gui/widgets/window.hpp"
 #include "log.hpp"
+#include "random.hpp"
 #include "serialization/parser.hpp"
 #include "serialization/string_utils.hpp"
 
@@ -132,7 +133,7 @@ bool addons_client::upload_addon(const std::string& id, std::string& response_me
 	if(passphrase.empty()) {
 		passphrase.resize(8);
 		for(size_t n = 0; n != 8; ++n) {
-			passphrase[n] = 'a' + (rand()%26);
+			passphrase[n] = randomness::generator->get_random_int('a', 'z');
 		}
 		cfg["passphrase"] = passphrase;
 		set_addon_pbl_info(id, cfg);

--- a/src/ai/default/recruitment.cpp
+++ b/src/ai/default/recruitment.cpp
@@ -1242,7 +1242,7 @@ const std::string recruitment::get_random_pattern_type_if_exists(const data& lea
 
 		if (!job_types.empty()) {
 			// Choose a random job_type.
-			choosen_type = job_types[rand() % job_types.size()];
+			choosen_type = job_types[randomness::generator->get_random_int(0, job_types.size()-1)];
 		}
 	}
 	return choosen_type;
@@ -1543,7 +1543,7 @@ void recruitment::do_randomness(std::vector<data>* leader_data) const {
 	for (data& data : *leader_data) {
 		for (score_map::value_type& entry : data.scores) {
 			double& score = entry.second;
-			score += (static_cast<double>(rand()) / RAND_MAX) * get_recruitment_randomness();
+			score += randomness::generator->get_random_double() * get_recruitment_randomness();
 		}
 	}
 }

--- a/src/ai/simulated_actions.cpp
+++ b/src/ai/simulated_actions.cpp
@@ -23,6 +23,7 @@
 #include "game_config.hpp"
 #include "log.hpp"
 #include "map/map.hpp"
+#include "random.hpp"
 #include "recall_list_manager.hpp"
 #include "resources.hpp"
 #include "team.hpp"
@@ -239,7 +240,7 @@ void helper_advance_unit(const map_location& loc){
 	std::vector<config> mod_options = advance_unit->get_modification_advances();
 	int options_num = unit_helper::number_of_possible_advances(*advance_unit);
 
-	size_t advance_choice = rand() % options_num;
+	size_t advance_choice = randomness::generator->get_random_int(0, options_num-1);
 	unit_ptr advanced_unit(new unit(*advance_unit));
 
 	if(advance_choice < options.size()){

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -351,7 +351,7 @@ void display::init_flags_for_side_internal(size_t n, const std::string& side_col
 	f = temp_anim;
 	auto time = f.get_end_time();
 	if (time > 0) {
-		f.start_animation(rand() % time, true);
+		f.start_animation(randomness::generator->get_random_int(0, time-1), true);
 	}
 	else {
 		// this can happen if both flag and game_config::images::flag are empty.

--- a/src/formula/formula.cpp
+++ b/src/formula/formula.cpp
@@ -762,11 +762,7 @@ private:
 	{
 		int res = 0;
 		while(faces > 0 && num_rolls-- > 0) {
-			if(randomness::generator) {
-				res += (randomness::generator->next_random() % faces) + 1;
-			} else {
-				res += (rand() % faces) + 1;
-			}
+			res += randomness::generator->get_random_int(1, faces);
 		}
 
 		return res;

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -43,6 +43,7 @@
 #include "log.hpp"
 #include "pathfind/teleport.hpp"
 #include "preferences/display.hpp"
+#include "random.hpp"
 #include "replay.hpp"
 #include "reports.hpp"
 #include "resources.hpp"
@@ -912,7 +913,7 @@ const std::string& play_controller::select_music(bool victory) const
 
 	if(music_list.empty())
 		return empty_str;
-	return music_list[rand() % music_list.size()];
+	return music_list[randomness::generator->get_random_int(0, music_list.size()-1)];
 }
 
 void play_controller::check_victory()

--- a/src/saved_game.cpp
+++ b/src/saved_game.cpp
@@ -70,6 +70,7 @@
 #include "game_config_manager.hpp"
 #include "generators/map_create.hpp"
 #include "log.hpp"
+#include "random.hpp"
 #include "serialization/binary_or_text.hpp"
 #include "statistics.hpp"
 #include "variable.hpp" // for config_variable_set
@@ -133,7 +134,7 @@ void saved_game::set_random_seed()
 		return;
 	}
 
-	carryover_["random_seed"] = rand();
+	carryover_["random_seed"] = randomness::generator->get_random_int(0, INT_MAX);
 	carryover_["random_calls"] = 0;
 }
 

--- a/src/server/user_handler.cpp
+++ b/src/server/user_handler.cpp
@@ -14,6 +14,7 @@
 
 #include "server/user_handler.hpp"
 #include "config.hpp"
+#include "random.hpp"
 #include "serialization/string_utils.hpp"
 
 #include <ctime>
@@ -43,7 +44,7 @@ std::string user_handler::create_salt(int length) {
 	std::stringstream ss;
 
 	for(int i = 0; i < length; i++) {
-		ss << (rand() % 10);
+		ss << randomness::generator->get_random_int(0, 9);
 	}
 
 	return  ss.str();

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -17,6 +17,7 @@
 #include "filesystem.hpp"
 #include "log.hpp"
 #include "preferences/game.hpp"
+#include "random.hpp"
 #include "serialization/string_utils.hpp"
 #include "sound_music_track.hpp"
 
@@ -323,7 +324,7 @@ static std::shared_ptr<sound::music_track> choose_track()
 
 		if(current_track_list.size() > 1) {
 			do {
-				track = rand() % current_track_list.size();
+				track = randomness::generator->get_random_int(0, current_track_list.size()-1);
 			} while(!track_ok(current_track_list[track]->file_path()));
 		}
 
@@ -352,14 +353,14 @@ static std::string pick_one(const std::string& files)
 	unsigned int choice;
 
 	if(prev_choices.find(files) != prev_choices.end()) {
-		choice = rand() % (ids.size() - 1);
+		choice = randomness::generator->get_random_int(0, ids.size()-1 - 1);
 		if(choice >= prev_choices[files]) {
 			++choice;
 		}
 
 		prev_choices[files] = choice;
 	} else {
-		choice = rand() % ids.size();
+		choice = randomness::generator->get_random_int(0, ids.size()-1);
 		prev_choices.emplace(files, choice);
 	}
 

--- a/src/soundsource.cpp
+++ b/src/soundsource.cpp
@@ -14,6 +14,7 @@
 
 #include "display.hpp"
 #include "log.hpp"
+#include "random.hpp"
 #include "serialization/string_utils.hpp"
 #include "sound.hpp"
 #include "soundsource.hpp"
@@ -134,7 +135,7 @@ void positional_source::update(unsigned int time, const display &disp)
 	if (time - last_played_ < unsigned(min_delay_) || sound::is_sound_playing(id_))
 		return;
 
-	int i = rand() % 100 + 1;
+	int i = randomness::generator->get_random_int(1, 100);
 
 	if(i <= chance_) {
 		last_played_ = time;

--- a/src/units/animation.cpp
+++ b/src/units/animation.cpp
@@ -24,6 +24,7 @@
 #include "units/animation_component.hpp"
 #include "units/filter.hpp"
 #include "variable.hpp"
+#include "random.hpp"
 
 #include <algorithm>
 
@@ -434,7 +435,7 @@ int unit_animation::matches(const display& disp, const map_location& loc, const 
 		return MATCH_FAIL;
 	}
 
-	if(frequency_ && !(rand()%frequency_)) {
+	if(frequency_ && !(randomness::generator->get_random_int(0, frequency_-1))) {
 		return MATCH_FAIL;
 	}
 

--- a/src/units/animation_component.cpp
+++ b/src/units/animation_component.cpp
@@ -18,6 +18,7 @@
 #include "display.hpp"
 #include "map/map.hpp"
 #include "preferences/general.hpp"
+#include "random.hpp"
 #include "units/unit.hpp"
 #include "units/types.hpp"
 
@@ -44,7 +45,7 @@ const unit_animation* unit_animation_component::choose_animation(const display& 
 	if(max_val == unit_animation::MATCH_FAIL) {
 		return nullptr;
 	}
-	return options[rand()%options.size()];
+	return options[randomness::generator->get_random_int(0, options.size()-1)];
 }
 
 void unit_animation_component::set_standing(bool with_bars)
@@ -116,7 +117,7 @@ void unit_animation_component::start_animation (int start_time, const unit_anima
 	frame_begin_time_ = anim_->get_begin_time() -1;
 	if (disp->idle_anim()) {
 		next_idling_ = get_current_animation_tick()
-			+ static_cast<int>((20000 + rand() % 20000) * disp->idle_anim_rate());
+			+ static_cast<int>(randomness::generator->get_random_int(20000, 39999) * disp->idle_anim_rate());
 	} else {
 		next_idling_ = INT_MAX;
 	}
@@ -140,7 +141,7 @@ void unit_animation_component::refresh()
 		// prevent all units animating at the same time
 		if (disp.idle_anim()) {
 			next_idling_ = get_current_animation_tick()
-				+ static_cast<int>((20000 + rand() % 20000) * disp.idle_anim_rate());
+				+ static_cast<int>(randomness::generator->get_random_int(20000, 39999) * disp.idle_anim_rate());
 		} else {
 			next_idling_ = INT_MAX;
 		}

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -437,7 +437,7 @@ unit::unit(const config& cfg, bool use_traits, const vconfig* vcfg)
 
 	random_traits_ = cfg["random_traits"].to_bool(true);
 	facing_ = map_location::parse_direction(cfg["facing"]);
-	if(facing_ == map_location::NDIRECTIONS) facing_ = static_cast<map_location::DIRECTION>(rand()%map_location::NDIRECTIONS);
+	if(facing_ == map_location::NDIRECTIONS) facing_ = static_cast<map_location::DIRECTION>(randomness::generator->get_random_int(0, map_location::NDIRECTIONS-1));
 
 	if(const config& mods = cfg.child("modifications")) {
 		modifications_ = mods;
@@ -668,7 +668,7 @@ unit::unit(const unit_type& u_type, int side, bool real_unit, unit_race::GENDER 
 	, overlays_()
 	, role_()
 	, attacks_()
-	, facing_(static_cast<map_location::DIRECTION>(rand() % map_location::NDIRECTIONS))
+	, facing_(static_cast<map_location::DIRECTION>(randomness::generator->get_random_int(0, map_location::NDIRECTIONS-1)))
 	, trait_names_()
 	, trait_descriptions_()
 	, unit_value_()


### PR DESCRIPTION
Coverity has been complaining about using rand() as an insecure function. As we're using it, this function is not insecure; but is also not a very good RNG. We're using MT19937 in a system-independant manner. But some uses of rand() were never converted. This converts them.

This closes the following Coverity issues:

CID 1356297
CID 1356299
CID 1356303
CID 1356304
CID 1356306
CID 1356312
CID 1356314
CID 1380163
CID 1380173
CID 1380179
CID 1380191
CID 1380198
CID 1380201
CID 1380210
CID 1380214
CID 1380215
CID 1380219
CID 1380230
CID 1380241