### PR TITLE
Suppress unchecked return warning

### DIFF
--- a/src/gui/dialogs/message.cpp
+++ b/src/gui/dialogs/message.cpp
@@ -209,7 +209,7 @@ void show_error_message(CVideo& video,
 						bool message_use_markup)
 {
 	LOG_STREAM(err, lg::general()) << msg << '\n';
-	show_message(video,
+	(void) show_message(video,
 				 _("Error"),
 				 msg,
 				 message::ok_button,

--- a/src/gui/widgets/label.cpp
+++ b/src/gui/widgets/label.cpp
@@ -200,7 +200,7 @@ void label::signal_handler_right_button_click(const event::ui_event /* event */,
 
 	desktop::clipboard::copy_to_clipboard(link, false);
 
-	show_message(get_window()->video(), "", _("Copied link!"), dialogs::message::auto_close);
+	(void) show_message(get_window()->video(), "", _("Copied link!"), dialogs::message::auto_close);
 
 	handled = true;
 }

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -1370,7 +1370,7 @@ void menu_handler::do_search(const std::string& new_search)
 		const std::string msg = vgettext("Could not find label or unit "
 										 "containing the string ‘$search’.",
 				symbols);
-		gui2::show_message(gui_->video(), "", msg, gui2::dialogs::message::auto_close);
+		(void) gui2::show_message(gui_->video(), "", msg, gui2::dialogs::message::auto_close);
 	}
 }
 


### PR DESCRIPTION
Coverity has been complaining that a few uses of show_message do not have their return value checked.

Casting to void supresses these warning be documenting the value is intentionally not  checked.

This closes

CID 1380185
CID 1380186
CID 1380258