### PR TITLE
ignore Xcode 9 Index storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ buildlog.txt
 # XCode
 projectfiles/Xcode/**/build
 projectfiles/Xcode/**/Headers
+projectfiles/Xcode/**/Index
 projectfiles/Xcode/**/Wesnoth.dmgCanvas
 projectfiles/Xcode/**/*.mode1v3
 projectfiles/Xcode/**/*.pbxuser


### PR DESCRIPTION
New Xcode 9 creates Index storage inside project dir. This commit makes this index ignored by GIT