### PR TITLE
HttT: fix grammar in Moremirmu's farewell

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/05b_Isle_of_the_Damned.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/05b_Isle_of_the_Damned.cfg
@@ -550,7 +550,7 @@
             [then]
                 [message]
                     speaker=Moremirmu
-                    message= _ "Thank you for your assistance here brothers. I will stay to continue resisting the foul undead. May fate be with you in your noble quest, and may we meet again some day!"
+                    message= _ "Thank you for your assistance here, brothers. I will stay to continue resisting the foul undead. May fate be with you in your noble quest, and may we meet again some day!"
                 [/message]
             [/then]
         [/if]


### PR DESCRIPTION
Add missing comma.  Also remove the word "here" because it felt redundant.