### PR TITLE
Replace base build with use_srcdir option.

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -132,8 +132,8 @@ def WesnothProgram(env, target, source, can_build, **kw):
         env["RANLIB"] = 'gcc-ranlib'
     
     if can_build:
-        if env["build"] == "base":
-            bin = env.Program(target, source, **kw)
+        if env["use_srcdir"] == True:
+            bin = env.Program(target + build_suffix, source, **kw)
         else:
             bin = env.Program("#/" + target + build_suffix, source, **kw)
         env.Alias(target, bin)


### PR DESCRIPTION
This PR replaces the `base` build with the `use_srcdir` option, which can then be applied to all of the remaining build types.  It also replaces the use of `env` for the compiler/linker flag variables to make it consistent with what was initially requested [here](https://github.com/wesnoth/wesnoth/pull/2081#discussion_r143444015).