### PR TITLE
Fix editor help incomplete sentence.

### DIFF
--- a/data/core/editor/help.cfg
+++ b/data/core/editor/help.cfg
@@ -67,7 +67,7 @@ This tool utilizes the brushes."
     title= _ "Starting Tool"
     text= "<img>src=icons/action/editor-tool-starting-position_60.png align=left box=yes</img>" + _"Defines the side leader starting position
 
-This tool gives only limited control over the start locations of certain."
+This tool sets the side leaders' default starting locations, and named special locations."
 [/topic]
 # wmllint: markcheck on
 


### PR DESCRIPTION
Replace the sentence to make it clear the Starting Tool marks both the team leader, and named special, locations.

Closes #2085.

[ci skip]