### PR TITLE
Fix #2135: Honour the show_all_units_in_help preference during scenarios

### DIFF
--- a/src/hotkey/hotkey_command.cpp
+++ b/src/hotkey/hotkey_command.cpp
@@ -320,6 +320,11 @@ void set_active_scopes(hk_scopes s)
 	scope_active_ = s;
 }
 
+bool is_scope_active(scope s)
+{
+	return scope_active_[s];
+}
+
 bool is_scope_active(hk_scopes s)
 {
 	// s is a copy because we need one

--- a/src/hotkey/hotkey_command.cpp
+++ b/src/hotkey/hotkey_command.cpp
@@ -322,6 +322,7 @@ void set_active_scopes(hk_scopes s)
 
 bool is_scope_active(scope s)
 {
+	assert(s < SCOPE_COUNT);
 	return scope_active_[s];
 }
 

--- a/src/hotkey/hotkey_command.hpp
+++ b/src/hotkey/hotkey_command.hpp
@@ -280,6 +280,7 @@ const hotkey_command& get_hotkey_null();
 void deactivate_all_scopes();
 void set_scope_active(scope s, bool set = true);
 void set_active_scopes(hk_scopes s);
+bool is_scope_active(scope s);
 bool is_scope_active(hk_scopes s);
 
 ///


### PR DESCRIPTION
Adding this overload removes a silent type conversion from 'enum scope'
to 'hk_scopes' (std::bitset<3>) in the src/help/help_impl.cpp callsite.

Fixes #2135.