### PR TITLE
Fix highlighting reachable hexes when deselecting a moved unit.

### DIFF
--- a/src/game_display.cpp
+++ b/src/game_display.cpp
@@ -578,13 +578,13 @@ void game_display::highlight_another_reach(const pathfind::paths &paths_list)
 
 bool game_display::unhighlight_reach()
 {
-	reach_map_changed_ = !reach_map_.empty();
-
-	if(reach_map_changed_) {
+	if(!reach_map_.empty()) {
 		reach_map_.clear();
+		reach_map_changed_ = true;
+		return true;
+	} else {
+		return false;
 	}
-
-	return reach_map_changed_;
 }
 
 void game_display::invalidate_route()


### PR DESCRIPTION
If reach_map_ had been empty to begin with, reach_map_changed_ would
have been reset to false before display::process_reachmap_changes()
acted on it.

Fixes #2132.