### PR TITLE
Fix Scons for SDL2_mixer 2.0.2

### DIFF
--- a/scons/sdl.py
+++ b/scons/sdl.py
@@ -93,17 +93,42 @@ def CheckSDL(context, sdl_lib = "SDL", require_version = None, header_file = Non
 
 def CheckOgg(context):
     test_program = '''
-    #include <SDL_mixer.h>
-    #include <stdlib.h>
+#include <stdlib.h>
+#include <stdio.h>
 
-    int main(int argc, char **argv)
-    {
-        Mix_Music* music = Mix_LoadMUS("$TESTFILE");
-        if (music == NULL) {
-            exit(1);
-        }
-        exit(0);
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_mixer.h>
+
+int main(int argc, char ** argv)
+{
+    if (SDL_Init(SDL_INIT_AUDIO) < 0) {
+        fprintf(stdout, "Cannot initialize SDL Audio: %s\\n", SDL_GetError());
+        return (EXIT_FAILURE);
     }
+
+    if (Mix_OpenAudio(44100, MIX_DEFAULT_FORMAT, 2, 1024) == -1) {
+        fprintf(stdout, "Cannot initialize SDL Mixer: %s\\n", Mix_GetError());
+        return (EXIT_FAILURE);
+    }
+
+    if (Mix_Init(MIX_INIT_OGG) != MIX_INIT_OGG) {
+        fprintf(stdout, "Cannot initialize OGG codec: %s\\n", Mix_GetError());
+        Mix_CloseAudio();
+        return (EXIT_FAILURE);
+    }
+
+    Mix_Music* music = Mix_LoadMUS("$TESTFILE");
+    if (music == NULL) {
+        fprintf(stdout, "Cannot load music file: %s\\n", Mix_GetError());
+        Mix_CloseAudio();
+        return (EXIT_FAILURE);
+    }
+
+    fprintf(stdout, "Success\\n");
+    Mix_FreeMusic(music);
+    Mix_CloseAudio();
+    return (EXIT_SUCCESS);
+}
 \n
 '''
     nodepath = File("data/core/music/main_menu.ogg").rfile().abspath.replace("\\", "\\\\")

--- a/scons/sdl.py
+++ b/scons/sdl.py
@@ -138,6 +138,7 @@ int main(int argc, char ** argv)
     if context.env["host"]:
         context.Result("n/a (cross-compile)")
         return True
+    context.env["ENV"]["SDL_AUDIODRIVER"] = "dummy"
     (result, output) = context.TryRun(test_program1, ".c")
     if result:
         context.Result("yes")


### PR DESCRIPTION
With the change from SDL_mixer 2.0.1 to 2.0.2, we cannot simply check if SDL_mixer can open an OGG/Vorbis file, we must first open an audio device. [This is probably a mistake, since the documentation implies simply initializing the codec should be enough.] To avoid future problems, upgrade the feature-test program to perform a full initialization and shut-down; everything except actually playing the sound.

Closes #2137