### PR TITLE
help: Handle traits with empty names or descriptions.

### DIFF
--- a/src/help/help_impl.cpp
+++ b/src/help/help_impl.cpp
@@ -697,11 +697,19 @@ std::vector<topic> generate_trait_topics(const bool sort_generated)
 	for (std::map<t_string, const config>::iterator a = trait_list.begin(); a != trait_list.end(); ++a) {
 		std::string id = "traits_" + a->first;
 		const config trait = a->second;
+
+		std::string name = trait["male_name"].str();
+		if (name.empty()) name = trait["female_name"].str();
+		if (name.empty()) name = trait["name"].str();
+		if (name.empty()) continue; // Hidden trait
+
 		std::stringstream text;
-		if (trait["help_text"].empty()) {
+		if (!trait["help_text"].empty()) {
+			text << trait["help_text"];
+		} else if (!trait["description"].empty()) {
 			text << trait["description"];
 		} else {
-			text << trait["help_text"];
+			text << _("No description available.");
 		}
 		text << "\n\n";
 		if (trait["availability"] == "musthave") {
@@ -709,10 +717,6 @@ std::vector<topic> generate_trait_topics(const bool sort_generated)
 		} else if (trait["availability"] == "none") {
 			text << _("Availability: ") << _("Unavailable") << "\n";
 		}
-		std::string name = trait["male_name"].str();
-		if (name.empty()) name = trait["female_name"].str();
-		if (name.empty()) name = trait["name"].str();
-
 		topics.emplace_back(name, id, text.str());
 	}
 

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -224,6 +224,7 @@ static void print_trait_list(std::stringstream & ss, const std::vector<trait_dat
 	size_t i = 0;
 	ss << make_link(l[i].first, l[i].second);
 
+	// This doesn't skip traits with empty names
 	for(i++; i < l.size(); i++) {
 		ss << ", " << make_link(l[i].first,l[i].second);
 	}


### PR DESCRIPTION
Fixes #2108.

`print_trait_list` is used for "Traits (2): strong, quick, intelligent, resilient" listing in the unit help pages.