### PR TITLE
Weight RGB values by alpha when blurring

### DIFF
--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -3834,6 +3834,12 @@ unplagueable: $wml_unit.status.unplagueable"
                         [/command]
                     [/option]
                     [option]
+                        label="Blur 100"
+                        [command]
+                            {SHOW_IMAGE_PATH_TEST "BL(100)"}
+                        [/command]
+                    [/option]
+                    [option]
                         label="More red!"
                         [command]
                             {SHOW_IMAGE_PATH_TEST "R(255)"}

--- a/src/sdl/utils.cpp
+++ b/src/sdl/utils.cpp
@@ -1603,7 +1603,7 @@ surface blur_alpha_surface(const surface &surf, int depth)
 		depth = max_blur;
 	}
 
-	boost::circular_buffer<Uint32> queue(max_blur);
+	boost::circular_buffer<Uint32> queue(depth*2+1);
 
 	const Uint32 ff = 0xff;
 

--- a/src/sdl/utils.cpp
+++ b/src/sdl/utils.cpp
@@ -1622,22 +1622,28 @@ surface blur_alpha_surface(const surface &surf, int depth)
 		Average() : alpha(), red(), green(), blue()
 		{}
 		Average& operator+=(const Pixel& pix){
-			red   += pix.red;
-			green += pix.green;
-			blue  += pix.blue;
+			red   += pix.alpha * pix.red;
+			green += pix.alpha * pix.green;
+			blue  += pix.alpha * pix.blue;
 			alpha += pix.alpha;
 			return *this;
 		}
 		Average& operator-=(const Pixel& pix){
-			red   -= pix.red;
-			green -= pix.green;
-			blue  -= pix.blue;
+			red   -= pix.alpha * pix.red;
+			green -= pix.alpha * pix.green;
+			blue  -= pix.alpha * pix.blue;
 			alpha -= pix.alpha;
 			return *this;
 		}
 		Uint32 operator()(unsigned num){
 			const Uint32 ff = 0xff;
-			return (std::min(alpha/num,ff) << 24) | (std::min(red/num,ff) << 16) | (std::min(green/num,ff) << 8) | std::min(blue/num,ff);
+			if(!alpha){
+				return 0;
+			}
+			return (std::min(alpha/num,ff) << 24)
+			    | (std::min(red/alpha,ff) << 16)
+			    | (std::min(green/alpha,ff) << 8)
+			    | std::min(blue/alpha,ff);
 		}
 	};
 

--- a/src/sdl/utils.cpp
+++ b/src/sdl/utils.cpp
@@ -1610,21 +1610,21 @@ surface blur_alpha_surface(const surface &surf, int depth)
 	surface_lock lock(res);
 	int x, y;
 	for(y = 0; y < res->h; ++y) {
-		Uint32 alpha=0, red = 0, green = 0, blue = 0, avg = 0;
+		Uint32 alpha=0, red = 0, green = 0, blue = 0;
 		Uint32* p = lock.pixels() + y*res->w;
 		for(x = 0; x <= depth && x < res->w; ++x, ++p) {
 			alpha += ((*p) >> 24)&0xFF;
 			red += ((*p) >> 16)&0xFF;
 			green += ((*p) >> 8)&0xFF;
 			blue += (*p)&0xFF;
-			++avg;
 			assert(!queue.full());
 			queue.push_back(*p);
 		}
 
 		p = lock.pixels() + y*res->w;
 		for(x = 0; x < res->w; ++x, ++p) {
-			*p = (std::min(alpha/avg,ff) << 24) | (std::min(red/avg,ff) << 16) | (std::min(green/avg,ff) << 8) | std::min(blue/avg,ff);
+			const Uint32 num = queue.size();
+			*p = (std::min(alpha/num,ff) << 24) | (std::min(red/num,ff) << 16) | (std::min(green/num,ff) << 8) | std::min(blue/num,ff);
 			if(x >= depth) {
 				{
 					const auto &front = queue.front();
@@ -1633,7 +1633,6 @@ surface blur_alpha_surface(const surface &surf, int depth)
 					green -= (front >> 8)&0xFF;
 					blue -= front&0xFF;
 				}
-				--avg;
 				assert(!queue.empty());
 				queue.pop_front();
 			}
@@ -1644,7 +1643,6 @@ surface blur_alpha_surface(const surface &surf, int depth)
 				red += ((*q) >> 16)&0xFF;
 				green += ((*q) >> 8)&0xFF;
 				blue += (*q)&0xFF;
-				++avg;
 				assert(!queue.full());
 				queue.push_back(*q);
 			}
@@ -1654,21 +1652,21 @@ surface blur_alpha_surface(const surface &surf, int depth)
 	}
 
 	for(x = 0; x < res->w; ++x) {
-		Uint32 alpha=0, red = 0, green = 0, blue = 0, avg = 0;
+		Uint32 alpha=0, red = 0, green = 0, blue = 0;
 		Uint32* p = lock.pixels() + x;
 		for(y = 0; y <= depth && y < res->h; ++y, p += res->w) {
 			alpha += ((*p) >> 24)&0xFF;
 			red += ((*p) >> 16)&0xFF;
 			green += ((*p) >> 8)&0xFF;
 			blue += *p&0xFF;
-			++avg;
 			assert(!queue.full());
 			queue.push_back(*p);
 		}
 
 		p = lock.pixels() + x;
 		for(y = 0; y < res->h; ++y, p += res->w) {
-			*p = (std::min(alpha/avg,ff) << 24) | (std::min(red/avg,ff) << 16) | (std::min(green/avg,ff) << 8) | std::min(blue/avg,ff);
+			const Uint32 num = queue.size();
+			*p = (std::min(alpha/num,ff) << 24) | (std::min(red/num,ff) << 16) | (std::min(green/num,ff) << 8) | std::min(blue/num,ff);
 			if(y >= depth) {
 				{
 					const auto &front = queue.front();
@@ -1677,7 +1675,6 @@ surface blur_alpha_surface(const surface &surf, int depth)
 					green -= (front >> 8)&0xFF;
 					blue -= front&0xFF;
 				}
-				--avg;
 				assert(!queue.empty());
 				queue.pop_front();
 			}
@@ -1688,7 +1685,6 @@ surface blur_alpha_surface(const surface &surf, int depth)
 				red += ((*q) >> 16)&0xFF;
 				green += ((*q) >> 8)&0xFF;
 				blue += (*q)&0xFF;
-				++avg;
 				assert(!queue.full());
 				queue.push_back(*q);
 			}

--- a/src/sdl/utils.hpp
+++ b/src/sdl/utils.hpp
@@ -212,7 +212,13 @@ surface submerge_alpha(const surface &surf, int depth, float alpha_base, float a
 */
 surface light_surface(const surface &surf, const surface &lightmap);
 
-/** Cross-fades a surface. */
+/**
+ * Cross-fades a surface.
+ *
+ * @param surf                    The source surface.
+ * @param depth                   The depth of the blurring.
+ * @return                        A new, blurred, neutral surface.
+ */
 surface blur_surface(const surface &surf, int depth = 1);
 
 /**
@@ -227,8 +233,9 @@ void blur_surface(surface& surf, SDL_Rect rect, int depth = 1);
 /**
  * Cross-fades a surface with alpha channel.
  *
- * @todo FIXME: This is just an adapted copy-paste
- * of the normal blur but with blur alpha channel too
+ * @param surf                    The source surface.
+ * @param depth                   The depth of the blurring.
+ * @return                        A new, blurred, neutral surface.
  */
 surface blur_alpha_surface(const surface &surf, int depth = 1);
 


### PR DESCRIPTION
Builds on PR #2172.

Pixel RGB values are weighted by their alpha channel. This means that fully transparent pixels do not contribute to the average, while partially transparent pixels contribute less than fully opaque ones.

Unlike PR #2172, this definitely does change the semantics of `~BL()` functor and `shadow_image` (used by `floating_label`).

Regarding performance, it adds a few integer multiplications, which are unlikely to have much effect.