### PR TITLE
Respect lua_next constraints

### DIFF
--- a/src/scripting/lua_common.cpp
+++ b/src/scripting/lua_common.cpp
@@ -745,8 +745,9 @@ bool luaW_toconfig(lua_State *L, int index, config &cfg)
 	// Then convert the attributes (string indices).
 	for (lua_pushnil(L); lua_next(L, index); lua_pop(L, 1))
 	{
-		if (lua_isnumber(L, -2)) continue;
-		if (!lua_isstring(L, -2)) return_misformed();
+		int indextype = lua_type(L, -2);
+		if (indextype == LUA_TNUMBER) continue;
+		if (indextype != LUA_TSTRING) return_misformed();
 		config::attribute_value &v = cfg[lua_tostring(L, -2)];
 		if (lua_istable(L, -1)) {
 			int subindex = lua_absindex(L, -1);
@@ -760,7 +761,7 @@ bool luaW_toconfig(lua_State *L, int index, config &cfg)
 			}
 			// If there are any string keys, it's misformed
 			for (lua_pushnil(L); lua_next(L, subindex); lua_pop(L, 1)) {
-				if (!lua_isnumber(L, -2)) return_misformed();
+				if (lua_type(L, -2) != LUA_TNUMBER) return_misformed();
 			}
 			v = str.str();
 		} else if (!luaW_toscalar(L, -1, v)) return_misformed();

--- a/src/scripting/lua_formula_bridge.cpp
+++ b/src/scripting/lua_formula_bridge.cpp
@@ -70,7 +70,10 @@ public:
 		add_input(inputs, "__list");
 		add_input(inputs, "__map");
 		for(lua_pushnil(mState); lua_next(mState, table_i); lua_pop(mState,1)) {
-			if(lua_isstring(mState, -2) && !lua_isnumber(mState, -2)) {
+			lua_pushvalue(mState, -2);
+			bool is_valid_key = (lua_type(mState, -1) == LUA_TSTRING) && !lua_isnumber(mState, -1);
+			lua_pop(mState, 1);
+			if(is_valid_key) {
 				std::string key = lua_tostring(mState, -2);
 				if(key.find_first_not_of(formula::id_chars) != std::string::npos) {
 					add_input(inputs, key);

--- a/src/scripting/lua_kernel_base.cpp
+++ b/src/scripting/lua_kernel_base.cpp
@@ -178,7 +178,7 @@ static int intf_name_generator(lua_State *L)
 			if(lua_istable(L, 2)) {
 				std::map<std::string, std::vector<std::string>> data;
 				for(lua_pushnil(L); lua_next(L, 2); lua_pop(L, 1)) {
-					if(!lua_isstring(L, -2)) {
+					if(lua_type(L, -2) != LUA_TSTRING) {
 						lua_pushstring(L, "CFG generator: invalid nonterminal name (must be a string)");
 						return lua_error(L);
 					}
@@ -914,7 +914,7 @@ std::vector<std::string> lua_kernel_base::get_attribute_names(const std::string 
 			lua_settop(L, top);
 			// Metafunction not found, so use lua_next to enumerate the table
 			for(lua_pushnil(L); lua_next(L, obj); lua_pop(L, 1)) {
-				if(lua_isstring(L, -2)) {
+				if(lua_type(L, -2) == LUA_TSTRING) {
 					std::string attr = lua_tostring(L, -2);
 					if(attr.empty()) {
 						continue;

--- a/src/scripting/lua_kernel_base.cpp
+++ b/src/scripting/lua_kernel_base.cpp
@@ -910,6 +910,10 @@ std::vector<std::string> lua_kernel_base::get_attribute_names(const std::string 
 			lua_pushlstring(L, partial_name.c_str(), partial_name.size());
 			luaW_pcall(L, 2, 1);
 			ret = lua_check<std::vector<std::string>>(L, -1);
+		} else if(lua_type(L, -1) != LUA_TTABLE) {
+			LOG_LUA << "Userdata missing __tab_enum meta-function for tab completion";
+			lua_settop(L, save_stack);
+			return ret;
 		} else {
 			lua_settop(L, top);
 			// Metafunction not found, so use lua_next to enumerate the table


### PR DESCRIPTION
The key value returned by lua_next, on the Lua stack, cannot be modified.

Certain tests such as lua_isstring will convert the value.

The solution is, instead of testing if they key can be converted to a string, test if it actually is a string by using lua_type.