### PR TITLE
Minor code cleanup.

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -65,7 +65,7 @@ libwesnoth_core_sources = GetSources("libwesnoth_core")
 if env["PLATFORM"] == "win32":
     libwesnoth_core_sources.append("log_windows.cpp")
 
-libwesnoth_core = [env.Library("wesnoth_core", libwesnoth_core_sources)]
+libwesnoth_core = env.Library("wesnoth_core", libwesnoth_core_sources)
 
 #---libwesnoth---
 libwesnoth_sources = GetSources("libwesnoth")

--- a/src/SConscript
+++ b/src/SConscript
@@ -147,11 +147,11 @@ for env in [test_env, client_env, env]:
     env.AddMethod(WesnothProgram)
 
 #---wesnoth---
-wesnoth_objects = libwesnoth_extras + libwesnoth_core + libwesnoth + libwesnoth_sdl + libwesnoth_extras
+libwesnoth_objects = libwesnoth_extras + libwesnoth_core + libwesnoth + libwesnoth_sdl + libwesnoth_extras
 if env["PLATFORM"] == 'darwin':
-    client_env.WesnothProgram("wesnoth", ["wesnoth.cpp"] + wesnoth_objects + ["macosx/SDLMain.mm"], have_client_prereqs)
+    client_env.WesnothProgram("wesnoth", ["wesnoth.cpp"] + libwesnoth_objects + ["macosx/SDLMain.mm"], have_client_prereqs)
 else:
-    client_env.WesnothProgram("wesnoth", ["wesnoth.cpp"] + wesnoth_objects, have_client_prereqs)
+    client_env.WesnothProgram("wesnoth", ["wesnoth.cpp"] + libwesnoth_objects, have_client_prereqs)
 
 #---wesnothd---
 wesnothd_sources = GetSources("wesnothd")
@@ -163,7 +163,7 @@ env.WesnothProgram("campaignd", campaignd_sources + libwesnoth_core, have_server
 
 #---boost_unit_tests---
 test_sources = GetSources("boost_unit_tests")
-boost_unit_tests = test_env.WesnothProgram("boost_unit_tests", test_sources + wesnoth_objects, have_test_prereqs)
+boost_unit_tests = test_env.WesnothProgram("boost_unit_tests", test_sources + libwesnoth_objects, have_test_prereqs)
 #---end of getting sources---
 
 sources = []

--- a/src/SConscript
+++ b/src/SConscript
@@ -147,23 +147,23 @@ for env in [test_env, client_env, env]:
     env.AddMethod(WesnothProgram)
 
 #---wesnoth---
-wesnoth_objects = ["wesnoth.cpp", libwesnoth_extras, libwesnoth_core, libwesnoth,
-                   libwesnoth_sdl, libwesnoth_extras, env["wesnoth_res"]]
+wesnoth_objects = libwesnoth_extras + libwesnoth_core + libwesnoth + libwesnoth_sdl + libwesnoth_extras
 if env["PLATFORM"] == 'darwin':
-	wesnoth_objects.append("macosx/SDLMain.mm")
-client_env.WesnothProgram("wesnoth", wesnoth_objects, have_client_prereqs)
+    client_env.WesnothProgram("wesnoth", ["wesnoth.cpp"] + wesnoth_objects + ["macosx/SDLMain.mm"], have_client_prereqs)
+else:
+    client_env.WesnothProgram("wesnoth", ["wesnoth.cpp"] + wesnoth_objects, have_client_prereqs)
 
 #---wesnothd---
 wesnothd_sources = GetSources("wesnothd")
-env.WesnothProgram("wesnothd", wesnothd_sources + [libwesnoth_core, env["wesnothd_res"]], have_server_prereqs)
+env.WesnothProgram("wesnothd", wesnothd_sources + libwesnoth_core, have_server_prereqs)
 
 #---campaignd---
 campaignd_sources = GetSources("campaignd")
-env.WesnothProgram("campaignd", campaignd_sources + [libwesnoth_core], have_server_prereqs, OBJPREFIX = "campaignd_")
+env.WesnothProgram("campaignd", campaignd_sources + libwesnoth_core, have_server_prereqs, OBJPREFIX = "campaignd_")
 
 #---boost_unit_tests---
 test_sources = GetSources("boost_unit_tests")
-boost_unit_tests = test_env.WesnothProgram("boost_unit_tests", test_sources +  [libwesnoth_extras, libwesnoth_core, libwesnoth, libwesnoth_sdl, libwesnoth_extras], have_test_prereqs)
+boost_unit_tests = test_env.WesnothProgram("boost_unit_tests", test_sources + wesnoth_objects, have_test_prereqs)
 #---end of getting sources---
 
 sources = []


### PR DESCRIPTION
- Removes some unnecessary lists.
- Removes `env["wesnoth_res"]` and `env["wesnothd_res"]`, since neither of those are referenced anywhere else.
- Changes how `SDLMain.mm` is added so the `wesnoth_objects` variable can be reused between `wesnoth` and `boost_unit_tests`.