### PR TITLE
fix mp depckeck (#1887, #2092)

### DIFF
--- a/src/game_initialization/create_engine.cpp
+++ b/src/game_initialization/create_engine.cpp
@@ -230,7 +230,6 @@ create_engine::create_engine(CVideo& v, saved_game& state)
 	: current_level_type_()
 	, current_level_index_(0)
 	, current_era_index_(0)
-	, current_mod_index_(0)
 	, level_name_filter_()
 	, player_count_filter_(1)
 	, type_map_()
@@ -519,12 +518,9 @@ level& create_engine::current_level() const
 	return *type_map_.at(current_level_type_.v).games[current_level_index_];
 }
 
-const create_engine::extras_metadata& create_engine::current_extra(const MP_EXTRA extra_type) const
+const create_engine::extras_metadata& create_engine::current_era() const
 {
-	const size_t index = (extra_type == ERA) ?
-		current_era_index_ : current_mod_index_;
-
-	return *get_const_extras_by_type(extra_type)[index];
+	return *get_const_extras_by_type(ERA)[current_era_index_];
 }
 
 void create_engine::set_current_level(const size_t index)
@@ -556,10 +552,10 @@ void create_engine::set_current_era_index(const size_t index, bool force)
 	dependency_manager_->try_era_by_index(index, force);
 }
 
-bool create_engine::toggle_current_mod(bool force)
+bool create_engine::toggle_mod(int index, bool force)
 {
-	bool is_active = dependency_manager_->is_modification_active(current_mod_index_);
-	dependency_manager_->try_modification_by_index(current_mod_index_, !is_active, force);
+	bool is_active = dependency_manager_->is_modification_active(index);
+	dependency_manager_->try_modification_by_index(index, !is_active, force);
 
 	state_.mp_settings().active_mods = dependency_manager_->get_modifications();
 

--- a/src/game_initialization/create_engine.cpp
+++ b/src/game_initialization/create_engine.cpp
@@ -290,10 +290,8 @@ create_engine::create_engine(CVideo& v, saved_game& state)
 		}
 	}
 
-	if(current_level_type_ != level::TYPE::CAMPAIGN &&
-		current_level_type_ != level::TYPE::SP_CAMPAIGN) {
-		dependency_manager_->try_modifications(state_.mp_settings().active_mods, true);
-	}
+
+	dependency_manager_->try_modifications(state_.mp_settings().active_mods, true);
 
 	reset_level_filters();
 }
@@ -548,11 +546,7 @@ void create_engine::set_current_level(const size_t index)
 		generator_.reset(nullptr);
 	}
 
-	if(current_level_type_ != level::TYPE::CAMPAIGN &&
-		current_level_type_ != level::TYPE::SP_CAMPAIGN) {
-
-		dependency_manager_->try_scenario(current_level().id());
-	}
+	dependency_manager_->try_scenario(current_level().id());
 }
 
 void create_engine::set_current_era_index(const size_t index, bool force)
@@ -564,7 +558,6 @@ void create_engine::set_current_era_index(const size_t index, bool force)
 
 bool create_engine::toggle_current_mod(bool force)
 {
-	force |= (current_level_type_ == ng::level::TYPE::CAMPAIGN || current_level_type_ == ng::level::TYPE::SP_CAMPAIGN);
 	bool is_active = dependency_manager_->is_modification_active(current_mod_index_);
 	dependency_manager_->try_modification_by_index(current_mod_index_, !is_active, force);
 
@@ -588,23 +581,21 @@ void create_engine::generator_user_config()
 	generator_->user_config();
 }
 
-int create_engine::find_level_by_id(const std::string& id) const
+std::pair<level::TYPE, int> create_engine::find_level_by_id(const std::string& id) const
 {
-	int i = 0;
-
 	for(const auto& type : type_map_) {
-		i = 0;
+		int i = 0;
 
 		for(const auto game : type.second.games) {
 			if(game->id() == id) {
-				return i;
+				return {type.first, i};
 			}
 
 			i++;
 		}
 	}
 
-	return -1;
+	return {level::TYPE::SP_CAMPAIGN, -1};
 }
 
 int create_engine::find_extra_by_id(const MP_EXTRA extra_type, const std::string& id) const
@@ -618,19 +609,6 @@ int create_engine::find_extra_by_id(const MP_EXTRA extra_type, const std::string
 	}
 
 	return -1;
-}
-
-level::TYPE create_engine::find_level_type_by_id(const std::string& id) const
-{
-	for(const auto& type : type_map_) {
-		for(const auto game : type.second.games) {
-			if(game->id() == id) {
-				return type.first;
-			}
-		}
-	}
-
-	return level::TYPE::SP_CAMPAIGN;
 }
 
 void create_engine::init_active_mods()

--- a/src/game_initialization/create_engine.hpp
+++ b/src/game_initialization/create_engine.hpp
@@ -384,9 +384,8 @@ public:
 	bool generator_has_settings() const;
 	void generator_user_config();
 
-	int find_level_by_id(const std::string& id) const;
+	std::pair<level::TYPE, int> find_level_by_id(const std::string& id) const;
 	int find_extra_by_id(const MP_EXTRA extra_type, const std::string& id) const;
-	level::TYPE find_level_type_by_id(const std::string& id) const;
 
 	const depcheck::manager& dependency_manager() const
 	{

--- a/src/game_initialization/create_engine.hpp
+++ b/src/game_initialization/create_engine.hpp
@@ -343,7 +343,7 @@ public:
 	std::vector<size_t> get_filtered_level_indices(level::TYPE type) const;
 
 	level& current_level() const;
-	const extras_metadata& current_extra(const MP_EXTRA extra_type) const;
+	const extras_metadata& current_era() const;
 
 	void set_current_level_type(const level::TYPE type)
 	{
@@ -358,19 +358,10 @@ public:
 	void set_current_level(const size_t index);
 
 	void set_current_era_index(const size_t index, bool force = false);
-	void set_current_mod_index(const size_t index)
-	{
-		current_mod_index_ = index;
-	}
 
 	size_t current_era_index() const
 	{
 		return current_era_index_;
-	}
-
-	size_t current_mod_index() const
-	{
-		return current_mod_index_;
 	}
 
 	const config& curent_era_cfg() const;
@@ -378,7 +369,7 @@ public:
 	const std::vector<extras_metadata_ptr>& get_const_extras_by_type(const MP_EXTRA extra_type) const;
 	std::vector<extras_metadata_ptr>& get_extras_by_type(const MP_EXTRA extra_type);
 
-	bool toggle_current_mod(bool force = false);
+	bool toggle_mod(int index, bool force = false);
 
 	bool generator_assigned() const;
 	bool generator_has_settings() const;
@@ -418,7 +409,6 @@ private:
 	size_t current_level_index_;
 
 	size_t current_era_index_;
-	size_t current_mod_index_;
 
 	std::string level_name_filter_;
 	int player_count_filter_;

--- a/src/game_initialization/depcheck.cpp
+++ b/src/game_initialization/depcheck.cpp
@@ -110,6 +110,18 @@ manager::manager(const config& gamecfg, bool mp, CVideo& video)
 			depinfo_.add_child("scenario", info);
 		}
 	}
+
+	for(const config& cfg : gamecfg.child_range("campaign")) {
+		config info;
+		info["id"] = cfg["id"];
+		info["name"] = cfg["name"];
+		info["allow_era_choice"] = cfg["allow_era_choice"];
+
+		copy_keys(info, cfg, "era");
+		copy_keys(info, cfg, "modification", true);
+
+		depinfo_.add_child("scenario", info);
+	}
 }
 
 void manager::save_state()
@@ -234,6 +246,10 @@ bool manager::conflicts(const elem& elem1, const elem& elem2, bool directonly) c
 		if(utils::contains(ignored, elem1.id)) {
 			return false;
 		}
+	}
+
+	if((elem1.type == "era" && data2["allow_era_choice"].to_bool(false)) ||(elem2.type == "era" && data1["allow_era_choice"].to_bool(false))) {
+		return false;
 	}
 
 	bool result = false;

--- a/src/gui/dialogs/campaign_selection.cpp
+++ b/src/gui/dialogs/campaign_selection.cpp
@@ -358,8 +358,7 @@ void campaign_selection::mod_toggled(window& window)
 
 	for(unsigned i = 0; i < mod_states_.size(); i++) {
 		if(mod_states_[i]) {
-			engine_.set_current_mod_index(i);
-			engine_.toggle_current_mod();
+			engine_.toggle_mod(i);
 		}
 	}
 

--- a/src/gui/dialogs/multiplayer/mp_create_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.cpp
@@ -42,6 +42,7 @@
 #include "gui/widgets/toggle_panel.hpp"
 #include "gui/widgets/text_box.hpp"
 #include "game_config.hpp"
+#include "log.hpp"
 #include "savegame.hpp"
 #include "settings.hpp"
 #include "formatter.hpp"
@@ -51,6 +52,13 @@
 #endif
 
 #include <boost/algorithm/string.hpp>
+
+
+static lg::log_domain log_mp_create("mp/create");
+
+#define DBG_MP LOG_STREAM(debug, log_mp_create)
+#define WRN_MP LOG_STREAM(warn, log_mp_create)
+#define ERR_MP LOG_STREAM(err, log_mp_create)
 
 namespace gui2
 {
@@ -405,6 +413,7 @@ void mp_create_game::sync_with_depcheck(window& window)
 {
 	if (static_cast<int>(create_engine_.current_era_index()) != create_engine_.dependency_manager().get_era_index()) {
 
+		DBG_MP << "sync_with_depcheck: correcting era\n";
 		int new_era_index = create_engine_.dependency_manager().get_era_index();
 		
 		create_engine_.set_current_era_index(new_era_index, true);
@@ -412,6 +421,7 @@ void mp_create_game::sync_with_depcheck(window& window)
 	}
 
 	if (create_engine_.current_level().id() != create_engine_.dependency_manager().get_scenario()) {
+		DBG_MP << "sync_with_depcheck: correcting scenario\n";
 
 		// Match scenario and scenario type
 		auto new_level_index = create_engine_.find_level_by_id(create_engine_.dependency_manager().get_scenario());
@@ -431,6 +441,7 @@ void mp_create_game::sync_with_depcheck(window& window)
 	}
 	
 	if(get_active_mods() != create_engine_.dependency_manager().get_modifications()) {
+		DBG_MP << "sync_with_depcheck: correcting modifications\n";
 		set_active_mods(create_engine_.dependency_manager().get_modifications());
 	}
 	create_engine_.init_active_mods();
@@ -515,9 +526,9 @@ void mp_create_game::on_tab_select(window& window)
 
 void mp_create_game::on_mod_toggle(window& window, const int index, toggle_button* sender)
 {
-	(void)sender;
 	if(sender && (sender->get_value_bool() == create_engine_.dependency_manager().is_modification_active(index))) {
-		assert(false);
+		ERR_MP << "ignoring on_mod_toggle that is already set\n";
+		return;
 	}
 	create_engine_.toggle_mod(index);
 

--- a/src/gui/dialogs/multiplayer/mp_create_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.cpp
@@ -403,7 +403,7 @@ void mp_create_game::pre_show(window& win)
 
 void mp_create_game::sync_with_depcheck(window& window)
 {
-	if (create_engine_.current_era_index() != create_engine_.dependency_manager().get_era_index()) {
+	if (static_cast<int>(create_engine_.current_era_index()) != create_engine_.dependency_manager().get_era_index()) {
 
 		int new_era_index = create_engine_.dependency_manager().get_era_index();
 		

--- a/src/gui/dialogs/multiplayer/mp_create_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.cpp
@@ -515,8 +515,7 @@ void mp_create_game::on_tab_select(window& window)
 
 void mp_create_game::on_mod_toggle(window& window, const int index)
 {
-	create_engine_.set_current_mod_index(index);
-	create_engine_.toggle_current_mod();
+	create_engine_.toggle_mod(index);
 
 	sync_with_depcheck(window);
 
@@ -527,7 +526,7 @@ void mp_create_game::on_era_select(window& window)
 {
 	create_engine_.set_current_era_index(find_widget<menu_button>(&window, "eras", false).get_value());
 
-	find_widget<menu_button>(&window, "eras", false).set_tooltip(create_engine_.current_extra(ng::create_engine::ERA).description);
+	find_widget<menu_button>(&window, "eras", false).set_tooltip(create_engine_.current_era().description);
 
 	sync_with_depcheck(window);
 
@@ -812,7 +811,7 @@ void mp_create_game::post_show(window& window)
 		prefs::set_modifications(create_engine_.active_mods());
 		prefs::set_level_type(create_engine_.current_level_type().v);
 		prefs::set_level(create_engine_.current_level().id());
-		prefs::set_era(create_engine_.current_extra(ng::create_engine::ERA).id);
+		prefs::set_era(create_engine_.current_era().id);
 
 		create_engine_.prepare_for_era_and_mods();
 

--- a/src/gui/dialogs/multiplayer/mp_create_game.hpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.hpp
@@ -31,6 +31,8 @@ namespace gui2
 class toggle_button;
 class toggle_panel;
 class widget;
+class listbox;
+class menu_button;
 
 namespace dialogs
 {
@@ -107,6 +109,9 @@ private:
 	field_integer* turn_bonus_;
 	field_integer* reservoir_;
 	field_integer* action_bonus_;
+	
+	listbox* mod_list_;
+	menu_button* eras_menu_button_;
 
 	template<typename widget>
 	void on_filter_change(window& window, const std::string& id, bool do_select);
@@ -117,8 +122,8 @@ private:
 	void on_mod_toggle(window& window, const int index, toggle_button* sender);
 	void on_random_faction_mode_select(window& window);
 	
-	std::vector<std::string> get_active_mods(window& window);
-	void set_active_mods(window& window, const std::vector<std::string>& val);
+	std::vector<std::string> get_active_mods();
+	void set_active_mods(const std::vector<std::string>& val);
 	
 	void sync_with_depcheck(window& window);
 	

--- a/src/gui/dialogs/multiplayer/mp_create_game.hpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.hpp
@@ -109,12 +109,12 @@ private:
 	field_integer* action_bonus_;
 
 	template<typename widget>
-	void on_filter_change(window& window, const std::string& id);
+	void on_filter_change(window& window, const std::string& id, bool do_select);
 
 	void on_game_select(window& window);
 	void on_tab_select(window& window);
 	void on_era_select(window& window);
-	void on_mod_toggle(window& window, const int index);
+	void on_mod_toggle(window& window, const int index, toggle_button* sender);
 	void on_random_faction_mode_select(window& window);
 	
 	std::vector<std::string> get_active_mods(window& window);

--- a/src/gui/dialogs/multiplayer/mp_create_game.hpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.hpp
@@ -114,9 +114,14 @@ private:
 	void on_game_select(window& window);
 	void on_tab_select(window& window);
 	void on_era_select(window& window);
-	void on_mod_toggle(const int index);
+	void on_mod_toggle(window& window, const int index);
 	void on_random_faction_mode_select(window& window);
-
+	
+	std::vector<std::string> get_active_mods(window& window);
+	void set_active_mods(window& window, const std::vector<std::string>& val);
+	
+	void sync_with_depcheck(window& window);
+	
 	void show_description(window& window, const std::string& new_description);
 
 	void update_details(window& window);

--- a/src/gui/widgets/menu_button.cpp
+++ b/src/gui/widgets/menu_button.cpp
@@ -143,7 +143,7 @@ void menu_button::signal_handler_left_button_click(const event::ui_event event, 
 			return;
 		}
 
-		set_selected(selected);
+		set_selected(selected, true);
 
 		if(retval_ != 0) {
 			if(window* window = get_window()) {
@@ -171,7 +171,7 @@ void menu_button::set_values(const std::vector<::config>& values, int selected)
 	set_label(values_[selected_]["label"]);
 }
 
-void menu_button::set_selected(int selected)
+void menu_button::set_selected(int selected, bool fire_event)
 {
 	assert(static_cast<size_t>(selected) < values_.size());
 	assert(static_cast<size_t>(selected_) < values_.size());
@@ -183,8 +183,9 @@ void menu_button::set_selected(int selected)
 	selected_ = selected;
 
 	set_label(values_[selected_]["label"]);
-
-	fire(event::NOTIFY_MODIFIED, *this, nullptr);
+	if (fire_event) {
+		fire(event::NOTIFY_MODIFIED, *this, nullptr);
+	}
 }
 
 // }---------- DEFINITION ---------{

--- a/src/gui/widgets/menu_button.hpp
+++ b/src/gui/widgets/menu_button.hpp
@@ -75,13 +75,13 @@ public:
 
 	void set_values(const std::vector<::config>& values, int selected = 0);
 
-	void set_selected(int selected);
+	void set_selected(int selected, bool fire_event = true);
 
 	/** Inherited from selectable_item */
 	virtual unsigned get_value() const override { return selected_; }
 
 	/** Inherited from selectable_item */
-	virtual void set_value(const unsigned value ) override { set_selected(value); }
+	virtual void set_value(unsigned value, bool fire_event = false) override { set_selected(value, fire_event); }
 
 	/** Inherited from selectable_item */
 	virtual unsigned num_states() const override { return values_.size(); }

--- a/src/gui/widgets/selectable_item.hpp
+++ b/src/gui/widgets/selectable_item.hpp
@@ -39,7 +39,7 @@ public:
 	virtual unsigned get_value() const = 0;
 
 	/** Select the styled_widget. */
-	virtual void set_value(const unsigned) = 0;
+	virtual void set_value(unsigned value, bool fire_event = false) = 0;
 
 	/** The number of states, that is 2 for normal buttons, 3 for tristate buttons. */
 	virtual unsigned num_states() const = 0;
@@ -50,10 +50,10 @@ public:
 		return get_value() != 0;
 	}
 
-	void set_value_bool(const bool value)
+	void set_value_bool(bool value, bool fire_event = false)
 	{
 		assert(num_states() == 2);
-		return set_value(value);
+		return set_value(value, fire_event);
 	}
 };
 

--- a/src/gui/widgets/toggle_button.cpp
+++ b/src/gui/widgets/toggle_button.cpp
@@ -110,12 +110,13 @@ void toggle_button::update_canvas()
 	set_is_dirty(true);
 }
 
-void toggle_button::set_value(const unsigned selected)
+void toggle_button::set_value(unsigned selected, bool fire_event)
 {
+	selected = selected % num_states();
 	if(selected == get_value()) {
 		return;
 	}
-	state_num_ = selected % num_states();
+	state_num_ = selected;
 	set_is_dirty(true);
 
 	// Check for get_window() is here to prevent the callback from
@@ -123,8 +124,9 @@ void toggle_button::set_value(const unsigned selected)
 	if(!get_window()) {
 		return;
 	}
-
-	fire(event::NOTIFY_MODIFIED, *this, nullptr);
+	if (fire_event) {
+		fire(event::NOTIFY_MODIFIED, *this, nullptr);
+	}
 }
 
 void toggle_button::set_retval(const int retval)
@@ -168,7 +170,7 @@ void toggle_button::signal_handler_left_button_click(const event::ui_event event
 
 	sound::play_UI_sound(settings::sound_toggle_button_click);
 
-	set_value(get_value() + 1);
+	set_value(get_value() + 1, true);
 
 	handled = true;
 }

--- a/src/gui/widgets/toggle_button.hpp
+++ b/src/gui/widgets/toggle_button.hpp
@@ -62,7 +62,7 @@ public:
 	/** Inherited from selectable_item */
 	unsigned num_states() const override;
 	/** Inherited from selectable_item */
-	void set_value(const unsigned selected) override;
+	void set_value(unsigned selected, bool fire_event = false) override;
 
 	/***** ***** ***** setters / getters for members ***** ****** *****/
 

--- a/src/gui/widgets/toggle_panel.cpp
+++ b/src/gui/widgets/toggle_panel.cpp
@@ -159,15 +159,15 @@ point toggle_panel::border_space() const
 	return point(conf->left_border + conf->right_border, conf->top_border + conf->bottom_border);
 }
 
-void toggle_panel::set_value(const unsigned selected)
+void toggle_panel::set_value(unsigned selected, bool fire_event)
 {
+	selected = selected % num_states();
 	if(selected == get_value()) {
 		return;
 	}
-	state_num_ = selected % num_states();
+	state_num_ = selected;
 	set_is_dirty(true);
 
-#if 0
 	/*
 	 * Disabled since this causes problems all over the place.
 	 * This was added in acea15c312f178b2b6fe4556ca6b190b00866557 but clashes with the
@@ -185,12 +185,9 @@ void toggle_panel::set_value(const unsigned selected)
 
 	// Check for get_window() is here to prevent the callback from
 	// being called when the initial value is set.
-	if(!get_window()) {
-		return;
+	if(get_window() && fire_event) {
+		fire(event::NOTIFY_MODIFIED, *this, nullptr);
 	}
-
-	fire(event::NOTIFY_MODIFIED, *this, nullptr);
-#endif
 }
 
 void toggle_panel::set_retval(const int retval)
@@ -252,7 +249,7 @@ toggle_panel::signal_handler_pre_left_button_click(const event::ui_event event)
 {
 	DBG_GUI_E << get_control_type() << "[" << id() << "]: " << event << ".\n";
 
-	set_value(1);
+	set_value(1, true);
 
 #if 0
 	/*
@@ -281,10 +278,7 @@ void toggle_panel::signal_handler_left_button_click(const event::ui_event event,
 
 	sound::play_UI_sound(settings::sound_toggle_panel_click);
 
-	set_value(get_value() + 1);
-
-	/** @todo remove. See comment in @ref set_value. */
-	fire(event::NOTIFY_MODIFIED, *this, nullptr);
+	set_value(get_value() + 1, true);
 
 	handled = true;
 }

--- a/src/gui/widgets/toggle_panel.hpp
+++ b/src/gui/widgets/toggle_panel.hpp
@@ -96,7 +96,7 @@ public:
 	}
 
 	/** Inherited from selectable_item */
-	void set_value(const unsigned selected) override;
+	void set_value(const unsigned selected, bool fire_event = false) override;
 
 	/** Inherited from selectable_item */
 	unsigned num_states() const override;


### PR DESCRIPTION
just like in the gui1 version opf mp create we just call a 'sync'
function whenever the user changed the selected era/scenario/mod. This
commit currently only fixes the check for era/scenario compability not
for mods.

it might also create an ininite recursion sometimes, have to investigate that.