### PR TITLE
Make the "Delay Shroud Updates" option apply to recalls.

### DIFF
--- a/changelog
+++ b/changelog
@@ -38,6 +38,8 @@ Version 1.13.10+dev:
    * Fixed ingame help showing units you haven't encountered (bug #2135)
    * Fixed the opacity IPF resetting to 0 if the value given was 100% or
      greater (bug #2185).
+   * Fix recalls updating shroud immediately when "Delay Shroud Updates" is set
+     (bug #2196)
 
 Version 1.13.10:
  * Add-ons client:

--- a/players_changelog
+++ b/players_changelog
@@ -13,6 +13,8 @@ Version 1.13.10+dev:
      CPU usage in fullscreen windows such as MP lobby by about 85 %.
  * Miscellaneous and bug fixes:
    * Fixed ingame help showing units you haven't encountered (bug #2135)
+   * Fix recalls updating shroud immediately when "Delay Shroud Updates" is set
+     (bug #2196)
 
 
 Version 1.13.10:

--- a/src/actions/create.cpp
+++ b/src/actions/create.cpp
@@ -639,6 +639,7 @@ place_recruit_result place_recruit(unit_ptr u, const map_location &recruit_locat
 	}
 
 	// Do some bookkeeping.
+	team& current_team = resources::gameboard->get_team(u->side());
 	recruit_checksums(*u, wml_triggered);
 	resources::whiteboard->on_gamestate_change();
 
@@ -655,7 +656,7 @@ place_recruit_result place_recruit(unit_ptr u, const map_location &recruit_locat
 		new_unit_itor->set_hidden(true);
 	}
 	preferences::encountered_units().insert(new_unit_itor->type_id());
-	resources::gameboard->get_team(u->side()).spend_gold(cost);
+	current_team.spend_gold(cost);
 
 	if ( show ) {
 		unit_display::unit_recruited(current_loc, leader_loc);
@@ -677,7 +678,7 @@ place_recruit_result place_recruit(unit_ptr u, const map_location &recruit_locat
 
 	// Fog clearing.
 	actions::shroud_clearer clearer;
-	if ( !wml_triggered ) // To preserve current WML behavior.
+	if ( !wml_triggered && current_team.auto_shroud_updates() ) // To preserve current WML behavior.
 		std::get<0>(res) |= clearer.clear_unit(current_loc, *new_unit_itor);
 
 	if ( fire_event ) {

--- a/src/synced_commands.cpp
+++ b/src/synced_commands.cpp
@@ -494,6 +494,7 @@ SYNCED_COMMAND_HANDLER_FUNCTION(debug_create_unit, child,  use_undo, /*show*/, e
 		actions::get_village(loc, created->side());
 
 	// Update fog/shroud.
+	// Not checking auto_shroud_updates() here since :create is not undoable. (#2196)
 	actions::shroud_clearer clearer;
 	clearer.clear_unit(loc, *created);
 	clearer.fire_events();


### PR DESCRIPTION
Fixes #2196 (in addition to ca0b5033f06ad83868dc569e973897083042f90b
which was HttT-specific).