### PR TITLE
Rewrite the link detection code

### DIFF
--- a/src/font/pango/hyperlink.hpp
+++ b/src/font/pango/hyperlink.hpp
@@ -14,19 +14,22 @@
 
 #pragma once
 
+#include "color.hpp"
+#include "serialization/string_utils.hpp"
+
 #include <string>
 
 namespace font {
 
 // Helper functions for link-aware text feature
 
-inline bool looks_like_url(const std::string & str)
+inline bool looks_like_url(utils::string_view str)
 {
 	return (str.size() >= 8) && ((str.substr(0,7) == "http://") || (str.substr(0,8) == "https://"));
 }
 
-inline std::string format_as_link(const std::string & link, const std::string & color) {
-	return "<span underline=\'single\' color=\'" + color + "\'>" + link + "</span>";
+inline std::string format_as_link(const std::string & link, color_t color) {
+	return "<span underline=\'single\' color=\'" + color.to_hex_string() + "\'>" + link + "</span>";
 }
 
 } // end namespace font

--- a/src/font/text.hpp
+++ b/src/font/text.hpp
@@ -407,7 +407,7 @@ private:
 	 */
 	bool set_markup(utils::string_view text, PangoLayout& layout);
 
-	bool set_markup_helper(utils::string_view text, PangoLayout& layout);
+	bool validate_markup(utils::string_view text, char** raw_text, std::string& semi_escaped) const;
 
 	/** Splits the text to two Cairo surfaces.
 	 *
@@ -430,9 +430,8 @@ private:
 
 	static void copy_layout_properties(PangoLayout& src, PangoLayout& dst);
 
-	std::string format_link_tokens(const std::string & text) const;
-
-	std::string handle_token(const std::string & token) const;
+	std::vector<std::string> find_links(utils::string_view text) const;
+	void format_links(std::string& text, const std::vector<std::string>& links) const;
 };
 
 } // namespace font

--- a/src/serialization/string_view.hpp
+++ b/src/serialization/string_view.hpp
@@ -127,7 +127,7 @@ public:
 	// element access
 	BOOST_CONSTEXPR const_reference operator[](size_type pos) const BOOST_NOEXCEPT { return ptr_[pos]; }
 
-	BOOST_CONSTEXPR const_reference at(size_t pos) const {
+	const_reference at(size_t pos) const {
 		return pos >= len_ ? BOOST_THROW_EXCEPTION(std::out_of_range("boost::string_view::at")), ptr_[0] : ptr_[pos];
 	}
 


### PR DESCRIPTION
As @Vultraz mentioned in Discord, the existing link detection code may sometimes detect Pango markup as parts of links and therefore produce invalid Pango markup. For example, if we have

\<span color='white'\>\<i\>Test **https://www.example.com/</i\>\</span\>**

automatic link detection will detect the part I bolded above as a link and add the following markup:

\<span color='white'\>\<i\>Test **\<span underline='single' color='#ffff00'\>** https://www.example.com/\</i\>\</span\>**\</span\>**

And that's invalid markup, because it attempts to open tags in the order `<span><i><span>` but close them in the order `</i></span></span>`.

To fix the problem, my code takes a completely different approach. Instead of scanning for links and replacing them in one go, the steps are performed separately... and with separate strings: the link scanning step uses the raw text **without markup**. Therefore markup can't be interpreted as a part of a link, and producing incorrect markup is no longer possible.

The code needs more testing before it can be merged. In particular, I'm worried about the possibility of memory leaks: it might be that the raw text that `pango_parse_markup()` gives us needs to be freed. (But when I tried that, the game crashed on startup because of a double-free. Still, I want to test with Address Sanitizer to be sure.)