### PR TITLE
Macros: Tweak sceptre damage for story reasons

### DIFF
--- a/data/core/macros/items.cfg
+++ b/data/core/macros/items.cfg
@@ -552,7 +552,7 @@
         [specials]
             {WEAPON_SPECIAL_MAGICAL}
         [/specials]
-        damage=14
+        damage=15
         number=4
     [/effect]
 


### PR DESCRIPTION
Sceptre (15x4) is now stronger than the uncut ruby of fire (14x4) for
regular mainline users Thursagan and Konard II. Level 3 Konrad & Li'sar
in HttT are still exceptional users of the sceptre (18x4 & 16x4).

From discussions with zookeeper in irc.