### PR TITLE
Eliminate use of string_view::at

### DIFF
--- a/src/font/text.cpp
+++ b/src/font/text.cpp
@@ -771,7 +771,7 @@ std::vector<std::string> pango_text::find_links(utils::string_view text) const {
 
 	int last_delim = -1;
 	for (size_t index = 0; index < text.size(); ++index) {
-		if (delim.find(text.at(index)) != std::string::npos) {
+		if (delim.find(text[index]) != std::string::npos) {
 			// want to include chars from range since last token, dont want to include any delimiters
 			utils::string_view token = text.substr(last_delim + 1, index - last_delim - 1);
 			if(looks_like_url(token)) {

--- a/src/serialization/string_view.hpp
+++ b/src/serialization/string_view.hpp
@@ -21,14 +21,7 @@ that class. */
 
 #include <boost/version.hpp>
 
-/*
- * Earlier versions already have string_view, but fail to compile on some
- * compilers. The problem is that in string_view::at's ternary expression,
- * BOOST_THROW_EXCEPTION is not seen as a throw-expression. If a ternary branch
- * is not a throw-expression, it must be of the same type as the other branch,
- * necessitating the ', res[0]' workaround.
- */
-#if BOOST_VERSION >= 106400
+#if BOOST_VERSION > 106100
 
 /* Boost string_view is available, so we can just use it. */
 #include <boost/utility/string_view.hpp>


### PR DESCRIPTION
We only use it in once place. At that point we can guarantee we stay in-bounds. So there is no need to use at() to check we remain in-bounds.

This eliminates a warning when building Debug for Windows (quieting Appveyor).

AI0886 had a similar issue building using GCC 6.3 on Boost 1.62

Reverting ca03818fa897a558d9ad5d9c3729404f5959029f and 0cbab6eeedff676a57191440c0b2b89b923bfaad since this changeset should correct both issues.