### PR TITLE
Bump min Pango version to a saner value

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -539,23 +539,23 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fprofile-generate=${CMAKE_SOURCE_DIR}/pgo_data/" CACHE STRING "Release build flags generating PGO data" FORCE)
 		set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -fprofile-generate=${CMAKE_SOURCE_DIR}/pgo_data/" CACHE STRING "Release build flags generating PGO data" FORCE)
 	endif()
-	
+
 	if(PGO_DATA STREQUAL "use")
 		MESSAGE("Using PGO data from previous runs")
 		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fprofile-correction -fprofile-use=${CMAKE_SOURCE_DIR}/pgo_data/" CACHE STRING "Release build flags for using PGO data" FORCE)
 		set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -fprofile-correction -fprofile-use=${CMAKE_SOURCE_DIR}/pgo_data/" CACHE STRING "Release build flags for using PGO data" FORCE)
 	endif()
-	
+
 	if(ENABLE_LTO)
 		if(NOT LTO_JOBS)
 			MESSAGE("LTO_JOBS not set, defaulting to 1")
 			set(LTO_JOBS "1" CACHE STRING "Number of threads to use for LTO with gcc" FORCE)
 		endif(NOT LTO_JOBS)
-		
+
 		MESSAGE("added -flto=${LTO_JOBS} to Release build")
 		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -flto=${LTO_JOBS}" CACHE STRING "Release build flags with LTO" FORCE)
 		set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -flto=${LTO_JOBS}" CACHE STRING "Release build flags with LTO" FORCE)
-		
+
 		MESSAGE("Using GCC gold linker")
 		set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} -fuse-ld=gold" CACHE STRING "" FORCE)
 	endif(ENABLE_LTO)
@@ -568,18 +568,18 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fprofile-instr-generate=${CMAKE_SOURCE_DIR}/pgo_data/wesnoth-%p.profraw" CACHE STRING "Release build flags generating PGO data" FORCE)
 		set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -fprofile-instr-generate=${CMAKE_SOURCE_DIR}/pgo_data/wesnoth-%p.profraw" CACHE STRING "Release build flags generating PGO data" FORCE)
 	endif()
-	
+
 	if(PGO_DATA STREQUAL "use")
 		MESSAGE("Using PGO data from previous runs")
 		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fprofile-instr-use=${CMAKE_SOURCE_DIR}/pgo_data/wesnoth.profdata" CACHE STRING "Release build flags for using PGO data" FORCE)
 		set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -fprofile-instr-use=${CMAKE_SOURCE_DIR}/pgo_data/wesnoth.profdata" CACHE STRING "Release build flags for using PGO data" FORCE)
 	endif()
-	
+
 	if(ENABLE_LTO)
 		MESSAGE("added -flto=thin to Release build")
 		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -flto=thin" CACHE STRING "Release build flags with LTO" FORCE)
 		set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -flto=thin" CACHE STRING "Release build flags with LTO" FORCE)
-		
+
 		MESSAGE("Using Clang LLD linker")
 		set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} -fuse-ld=lld" CACHE STRING "Linker flag for building with LTO and clang" FORCE)
 	endif(ENABLE_LTO)
@@ -712,7 +712,7 @@ if(ENABLE_GAME OR ENABLE_TESTS)
 		find_package(VorbisFile REQUIRED)
 		find_package( PkgConfig REQUIRED )
 		pkg_check_modules( CAIRO REQUIRED cairo>=1.10 )
-		pkg_check_modules( PANGOCAIRO REQUIRED pangocairo>=1.21.3 )
+		pkg_check_modules( PANGOCAIRO REQUIRED pangocairo>=1.36.8 )
 		pkg_check_modules( FONTCONFIG REQUIRED fontconfig>=2.4.1 )
 		pkg_check_modules( SYSTEMD systemd )
 	endif(NOT MSVC)
@@ -751,7 +751,7 @@ if(ENABLE_GAME)
 	if(ENABLE_LIBPNG AND PNG_FOUND)
 		add_definitions(-DHAVE_LIBPNG)
 	else(ENABLE_LIBPNG AND PNG_FOUND)
-		message("Could not find lib PNG. Disabling support for writing PNG images.")	
+		message("Could not find lib PNG. Disabling support for writing PNG images.")
 	endif(ENABLE_LIBPNG AND PNG_FOUND)
 
 	find_package( History )

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,7 +33,7 @@ order to build Wesnoth:
    * SDL2_ttf                  >= 2.0.12
  * Fontconfig                  >= 2.4.1
  * Cairo                       >= 1.10.0
- * Pango                       >= 1.21.3 (with Cairo backend)
+ * Pango                       >= 1.36.8 (with Cairo backend)
  * Vorbisfile
  * libbz2
  * libz

--- a/SConstruct
+++ b/SConstruct
@@ -95,7 +95,7 @@ opts.AddVariables(
     PathVariable('boostdir', 'Directory of boost installation.', "", OptionalPath),
     PathVariable('boostlibdir', 'Directory where boost libraries are installed.', "", OptionalPath),
     ('boost_suffix', 'Suffix of boost libraries.'),
-    PathVariable('gettextdir', 'Root directory of Gettext\'s installation.', "", OptionalPath), 
+    PathVariable('gettextdir', 'Root directory of Gettext\'s installation.', "", OptionalPath),
     PathVariable('gtkdir', 'Directory where GTK SDK is installed.', "", OptionalPath),
     PathVariable('luadir', 'Directory where Lua binary package is unpacked.', "", OptionalPath),
     ('host', 'Cross-compile host.', ''),
@@ -171,7 +171,7 @@ if env['jobs'] > 1:
 else:
     env['jobs'] = 1
 
-if env['distcc']: 
+if env['distcc']:
     env.Tool('distcc')
 
 if env['ccache']: env.Tool('ccache')
@@ -387,7 +387,7 @@ if env["prereqs"]:
         conf.CheckPNG() & \
         conf.CheckJPG() & \
         conf.CheckCairo(min_version = "1.10") & \
-        conf.CheckPango("cairo", require_version = "1.21.3") & \
+        conf.CheckPango("cairo", require_version = "1.36.8") & \
         conf.CheckPKG("fontconfig") & \
         conf.CheckBoost("program_options", require_version = boost_version) & \
         conf.CheckBoost("thread") & \
@@ -479,43 +479,43 @@ for env in [test_env, client_env, env]:
             env.AppendUnique(CXXFLAGS = Split("-Wold-style-cast"))
         if env['sanitize']:
             env.AppendUnique(CCFLAGS = ["-fsanitize=" + env["sanitize"]], LINKFLAGS = ["-fsanitize=" + env["sanitize"]])
-        
+
 # #
 # Start determining options for debug build
 # #
-        
+
         debug_flags = "-O0 -DDEBUG -ggdb3"
-        
+
         if env["glibcxx_debug"] == True:
             glibcxx_debug_flags = "_GLIBCXX_DEBUG _GLIBCXX_DEBUG_PEDANTIC"
         else:
             glibcxx_debug_flags = ""
-        
+
 # #
 # End determining options for debug build
 # Start setting options for release build
 # #
-        
+
 # default compiler flags
         rel_comp_flags = "-O3"
         rel_link_flags = ""
-        
+
 # use the arch if provided, or if on Windows and no arch was passed in then default to pentiumpro
 # without setting to pentiumpro, compiling on Windows with 64-bit tdm-gcc and -O3 currently fails
         if env["arch"]:
             env["arch"] = " -march=" + env["arch"]
-        
+
         if env["PLATFORM"] == "win32" and not env["arch"]:
             env["arch"] = " -march=pentiumpro"
-        
+
         rel_comp_flags = rel_comp_flags + env["arch"]
-        
+
 # PGO and LTO setup
         if env["CC"] == "gcc":
             if env["pgo_data"] == "generate":
                 rel_comp_flags = rel_comp_flags + " -fprofile-generate=pgo_data/"
                 rel_link_flags = "-fprofile-generate=pgo_data/"
-            
+
             if env["pgo_data"] == "use":
                 rel_comp_flags = rel_comp_flags + " -fprofile-correction -fprofile-use=pgo_data/"
                 rel_link_flags = "-fprofile-correction -fprofile-use=pgo_data/"
@@ -527,7 +527,7 @@ for env in [test_env, client_env, env]:
             if env["pgo_data"] == "generate":
                 rel_comp_flags = rel_comp_flags + " -fprofile-instr-generate=pgo_data/wesnoth-%p.profraw"
                 rel_link_flags = "-fprofile-instr-generate=pgo_data/wesnoth-%p.profraw"
-            
+
             if env["pgo_data"] == "use":
                 rel_comp_flags = rel_comp_flags + " -fprofile-instr-use=pgo_data/wesnoth.profdata"
                 rel_link_flags = "-fprofile-instr-use=pgo_data/wesnoth.profdata"
@@ -540,23 +540,23 @@ for env in [test_env, client_env, env]:
 # End setting options for release build
 # Start setting options for profile build
 # #
-        
+
         if env["profiler"] == "gprof":
             prof_comp_flags = "-pg"
             prof_link_flags = "-pg"
-        
+
         if env["profiler"] == "gcov":
             prof_comp_flags = "-fprofile-arcs -ftest-coverage"
             prof_link_flags = "-fprofile-arcs"
-        
+
         if env["profiler"] == "gperftools":
             prof_comp_flags = ""
             prof_link_flags = "-Wl,--no-as-needed,-lprofiler"
-        
+
         if env["profiler"] == "perf":
             prof_comp_flags = "-ggdb -Og"
             prof_link_flags = ""
-        
+
 # #
 # End setting options for profile build
 # #
@@ -656,7 +656,7 @@ if os.path.isabs(env["localedirname"]):
     env["localedir"] = env["localedirname"]
 else:
     env["localedir"] = "$datadir/$localedirname"
-        
+
 pythontools = Split("wmlscope wmllint wmlindent wesnoth_addon_manager")
 pythonmodules = Split("wmltools.py wmlparser.py wmldata.py wmliterator.py campaignserver_client.py __init__.py")
 

--- a/src/font/text.cpp
+++ b/src/font/text.cpp
@@ -41,12 +41,7 @@
 namespace font {
 
 pango_text::pango_text()
-#if PANGO_VERSION_CHECK(1,22,0)
 	: context_(pango_font_map_create_context(pango_cairo_font_map_get_default()), g_object_unref)
-#else
-	: context_(pango_cairo_font_map_create_context((
-		reinterpret_cast<PangoCairoFontMap*>(pango_cairo_font_map_get_default()))), g_object_unref)
-#endif
 	, layout_(pango_layout_new(context_.get()), g_object_unref)
 	, rect_()
 	, sublayouts_()


### PR DESCRIPTION
The previous min version (1.21.3) is almost 10 years old at this point (release archives indicate a
release date of June 2008). The current pangocairo package available in Debian oldstable (Jessie,
which we still support since we're still supporting GCC 4.8...) is 1.36.8 (from September 2014), so
I made that the new minimum.