### PR TITLE
Remove MSVC support from cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,6 @@ set(FIFO_DIR "/var/run/wesnothd" CACHE STRING "Directory for the wesnothd fifo s
 option(ENABLE_GAME "Enable compilation of the game" ON)
 option(ENABLE_CAMPAIGN_SERVER "Enable compilation of campaign server")
 option(ENABLE_SERVER "Enable compilation of server" ON)
-option(ENABLE_TOOLS "Enable building and installation of tools for artists and WML maintainers")
-option(ENABLE_SDL2_TOOLS "Enable building and installation of tools for testing with SDL2" OFF)
 option(ENABLE_TESTS "Build unit tests")
 option(ENABLE_NLS "Enable building of translations" ON)
 option(ENABLE_OMP "Enables OpenMP, and has additional dependencies" OFF)
@@ -466,9 +464,9 @@ endif(ENABLE_DEBUG_WINDOW_LAYOUT)
 # Libraries that are only required by some targets
 #
 
-if(ENABLE_TOOLS OR ENABLE_GAME OR ENABLE_TESTS)
+if(ENABLE_GAME OR ENABLE_TESTS)
 	find_package( SDL2_image 2.0.0 REQUIRED )
-endif(ENABLE_TOOLS OR ENABLE_GAME OR ENABLE_TESTS)
+endif(ENABLE_GAME OR ENABLE_TESTS)
 
 if(ENABLE_GAME OR ENABLE_TESTS)
 	find_package( SDL2_mixer 2.0.0 REQUIRED )
@@ -480,10 +478,7 @@ if(ENABLE_GAME OR ENABLE_TESTS)
 	pkg_check_modules( FONTCONFIG REQUIRED fontconfig>=2.4.1 )
 	pkg_check_modules( SYSTEMD systemd )
 endif(ENABLE_GAME OR ENABLE_TESTS)
-if(ENABLE_TOOLS)
-	find_package( ZLIB REQUIRED )
-	find_package( PNG REQUIRED )
-endif(ENABLE_TOOLS)
+
 if(ENABLE_TESTS)
 	find_package( Boost 1.36 REQUIRED COMPONENTS unit_test_framework )
 endif(ENABLE_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,3 @@
-# most stuff should be implemented so far, what is not working so far:
-# * some other smaller stuff
-# * nice INSTALL howto
-# * Detect Python and install Python tools
-# * Rewrite the po4a-update
-# * Test everything
-# * install .desktop files taking binary prefix and suffix into account
 
 # set minimum version
 cmake_minimum_required(VERSION 2.8.5)
@@ -95,23 +88,15 @@ find_package(Gettext)
 
 find_package(X11)
 
-if(NOT MSVC)
-	#needed to get some SDL2 defines in... (as of rev31694 -D_GNU_SOURCE=1 is required!)
-	set(SDL2_CONFIG "sdl2-config" CACHE STRING "Path to sdl2-config script")
-	exec_program(${SDL2_CONFIG} ARGS "--cflags" OUTPUT_VARIABLE SDL2_CFLAGS)
-	add_definitions(${SDL2_CFLAGS})
-endif(NOT MSVC)
+# needed to get some SDL2 defines in... (as of rev31694 -D_GNU_SOURCE=1 is required!)
+set(SDL2_CONFIG "sdl2-config" CACHE STRING "Path to sdl2-config script")
+exec_program(${SDL2_CONFIG} ARGS "--cflags" OUTPUT_VARIABLE SDL2_CFLAGS)
+add_definitions(${SDL2_CFLAGS})
 
 if(NOT WIN32)
 	# Use the safer `mkstemp' instead of `tmpnam' on POSIX systems.
 	add_definitions(-DLUA_USE_POSIX)
 endif(NOT WIN32)
-
-if(MSVC)
-	add_definitions(-D_SCL_SECURE_NO_WARNINGS)
-	add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-	add_definitions(-DNOMINMAX)
-endif(MSVC)
 
 #check for some compiler/arch specific things and export defines accordingly...
 include(SearchForStuff)
@@ -120,7 +105,7 @@ include(SearchForStuff)
 # optimization (c.f. bug #23445), work around this by enforcing "release" type
 # if nothing was selected
 if(NOT CMAKE_BUILD_TYPE)
-	set( CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release Profile RelWithDebInfo MinSizeRel." FORCE)
+	set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release Profile RelWithDebInfo MinSizeRel." FORCE)
 endif(NOT CMAKE_BUILD_TYPE)
 
 if(NOT DEFINED ENABLE_DISPLAY_REVISION)
@@ -175,12 +160,7 @@ option(ENABLE_DEBUG_WINDOW_LAYOUT "Add the debug option to allow the generation 
 option(ENABLE_DESIGN_DOCUMENTS "Enables the generation of design documents, and has additional dependencies" OFF)
 option(ENABLE_LTO "Sets Link Time Optimization for Release builds" OFF)
 option(GLIBCXX_DEBUG "Whether to define _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC" OFF)
-
-#misc options
-if(NOT MSVC)
-	# Pot updates don't work at Windows so no reason to even try
-	option(ENABLE_POT_UPDATE_TARGET "Enables the tools to update the pot files and manuals. This target has extra dependencies." OFF)
-endif(NOT MSVC)
+option(ENABLE_POT_UPDATE_TARGET "Enables the tools to update the pot files and manuals. This target has extra dependencies." OFF)
 
 if(UNIX AND NOT APPLE AND NOT CYGWIN)
 	option(ENABLE_NOTIFICATIONS "Enable Window manager notification messages" ON)
@@ -221,28 +201,7 @@ if(NOT DEFINED CXX_FLAGS_USER)
 
 endif(NOT DEFINED CXX_FLAGS_USER)
 
-
-### Set default Wesnoth project compiler flags
-if(MSVC AND NOT DEFINED CXX_FLAGS_MSVC)
-	# MSVC sets some initial compilation flags, these need to
-	# be preserved.
-	set(CXX_FLAGS_MSVC
-		"${CMAKE_CXX_FLAGS_INIT}"
-		CACHE
-		STRING
-		"The initial CXX flags for MSVC"
-		FORCE
-	)
-endif(MSVC AND NOT DEFINED CXX_FLAGS_MSVC)
-
-set(CXX_FLAGS_PROJECT "-std=c++11 -Wextra -Werror=non-virtual-dtor")
-
-# MSVC's -Wall is not like gcc's, it really enables *all* warnings which include zillions for system headers and doesn't make sense.
-if(NOT MSVC)
-	set(CXX_FLAGS_PROJECT "${CXX_FLAGS_PROJECT} -Wall")
-endif(NOT MSVC)
-
-set(COMPILER_FLAGS "${CXX_FLAGS_PROJECT}")
+set(COMPILER_FLAGS "-std=c++11 -Wall -Wextra -Werror=non-virtual-dtor")
 
 ### Set strict compiler flags.
 
@@ -272,10 +231,6 @@ if(ENABLE_PEDANTIC_COMPILATION)
 endif(ENABLE_PEDANTIC_COMPILATION)
 
 ### Set the final compiler flags.
-
-if(MSVC)
-	set(COMPILER_FLAGS "${CXX_FLAGS_MSVC} ${COMPILER_FLAGS}")
-endif(MSVC)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 	set(COMPILER_FLAGS "${COMPILER_FLAGS} -Qunused-arguments -Wno-unknown-warning-option")
@@ -514,18 +469,16 @@ endif(ENABLE_DEBUG_WINDOW_LAYOUT)
 if(ENABLE_TOOLS OR ENABLE_GAME OR ENABLE_TESTS)
 	find_package( SDL2_image 2.0.0 REQUIRED )
 endif(ENABLE_TOOLS OR ENABLE_GAME OR ENABLE_TESTS)
+
 if(ENABLE_GAME OR ENABLE_TESTS)
 	find_package( SDL2_mixer 2.0.0 REQUIRED )
 	find_package( SDL2_ttf 2.0.12 REQUIRED )
-	if(NOT MSVC)
-		find_package(VorbisFile REQUIRED)
-		find_package( PkgConfig REQUIRED )
-		pkg_check_modules( CAIRO REQUIRED cairo>=1.10 )
-		pkg_check_modules( PANGOCAIRO REQUIRED pangocairo>=1.21.3 )
-		pkg_check_modules( FONTCONFIG REQUIRED fontconfig>=2.4.1 )
-		pkg_check_modules( SYSTEMD systemd )
-	endif(NOT MSVC)
-
+	find_package(VorbisFile REQUIRED)
+	find_package( PkgConfig REQUIRED )
+	pkg_check_modules( CAIRO REQUIRED cairo>=1.10 )
+	pkg_check_modules( PANGOCAIRO REQUIRED pangocairo>=1.21.3 )
+	pkg_check_modules( FONTCONFIG REQUIRED fontconfig>=2.4.1 )
+	pkg_check_modules( SYSTEMD systemd )
 endif(ENABLE_GAME OR ENABLE_TESTS)
 if(ENABLE_TOOLS)
 	find_package( ZLIB REQUIRED )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,22 +8,7 @@ function(GetSources source_list store_in_var)
 endfunction()
 
 ## some includes ##
-if(MSVC)
-	# This seems to break on some Linux systems in combination with strict
-	# compilation, so disabled for now. The problem occurred on Gentoo with
-	# boost 1.37. Debian with boost 1.34, 1.35 and 1.38 works properly.
-	include_directories(SYSTEM ${Boost_INCLUDE_DIR} )
-
-	#additional MSVC includes
-	include_directories(SYSTEM ${PANGO_INCLUDE_DIR} )
-	include_directories(SYSTEM ${CAIRO_INCLUDE_DIR} )
-	include_directories(SYSTEM ${GLIB_INCLUDE_DIR} )
-	include_directories(SYSTEM ${GLIBCONFIG_INCLUDE_PATH} )
-else(MSVC)
-	include_directories(SYSTEM ${FONTCONFIG_INCLUDE_DIRS} )
-endif(MSVC)
-
-
+include_directories(SYSTEM ${FONTCONFIG_INCLUDE_DIRS} )
 include_directories(SYSTEM ${PANGOCAIRO_INCLUDE_DIRS} )
 include_directories(SYSTEM ${GETTEXT_INCLUDE_DIR} )
 include_directories(SYSTEM ${LIBDBUS_INCLUDE_DIRS} )
@@ -63,23 +48,12 @@ link_directories(
 	${LIBDBUS_LIBRARY_DIRS}
 )
 
-if(MSVC)
-	# Since MSVC does autolinking of boost adding those files will duplicate
-	# the includes and cause build errors.
-	set(common-external-libs
-		${sdl-lib}
-		${sdlmain-lib}
-		ws2_32.lib
-		shlwapi.lib
-	)
-else(MSVC)
-	set(common-external-libs
-		${sdl-lib}
-		${Boost_IOSTREAMS_LIBRARY}
-		${Boost_REGEX_LIBRARY}
-		${Boost_PROGRAM_OPTIONS_LIBRARY}
-	)
-endif(MSVC)
+set(common-external-libs
+	${sdl-lib}
+	${Boost_IOSTREAMS_LIBRARY}
+	${Boost_REGEX_LIBRARY}
+	${Boost_PROGRAM_OPTIONS_LIBRARY}
+)
 
 set(common-external-libs
 	${common-external-libs}
@@ -116,16 +90,6 @@ if(ENABLE_HISTORY AND HISTORY_FOUND)
 	)
 endif(ENABLE_HISTORY AND HISTORY_FOUND)
 
-if(MSVC)
-	set(game-external-libs
-		${game-external-libs}
-		${PANGO_LIBRARY}
-		${PANGOCAIRO_LIBRARY}
-		${CAIRO_LIBRARY}
-		${GOBJECT_LIBRARY}
-	)
-endif(MSVC)
-
 set(server-external-libs
 	${common-external-libs}
 	${Boost_SYSTEM_LIBRARIES}
@@ -148,48 +112,6 @@ if(X11_FOUND)
 	include_directories(SYSTEM ${X11_INCLUDE_DIR} )
 	set(game-external-libs ${game-external-libs} ${X11_LIBRARIES})
 endif(X11_FOUND)
-
-if(MSVC)
-	SOURCE_GROUP("src" REGULAR_EXPRESSION ".*")
-	SOURCE_GROUP("src ai" REGULAR_EXPRESSION "ai/.*")
-	SOURCE_GROUP("src ai composite" REGULAR_EXPRESSION "ai/composite/.*")
-	SOURCE_GROUP("src ai default" REGULAR_EXPRESSION "ai/default/.*")
-	SOURCE_GROUP("src ai dfool" REGULAR_EXPRESSION "ai/dfool/.*")
-	SOURCE_GROUP("src ai formula" REGULAR_EXPRESSION "ai/formula/.*")
-	SOURCE_GROUP("src ai testing" REGULAR_EXPRESSION "ai/testing/.*")
-	SOURCE_GROUP("src campaign_server" REGULAR_EXPRESSION "campaign_server/.*")
-	SOURCE_GROUP("src editor" REGULAR_EXPRESSION "editor/.*")
-	SOURCE_GROUP("src editor action" REGULAR_EXPRESSION "editor/action/.*")
-	SOURCE_GROUP("src editor action mouse" REGULAR_EXPRESSION "editor/action/mouse/.*")
-	SOURCE_GROUP("src editor palette" REGULAR_EXPRESSION "editor/palette/.*")
-	SOURCE_GROUP("src editor toolkit" REGULAR_EXPRESSION "editor/toolkit/.*")
-	SOURCE_GROUP("src editor map" REGULAR_EXPRESSION "editor/map/.*")
-	SOURCE_GROUP("src gui" REGULAR_EXPRESSION "gui/.*")
-	SOURCE_GROUP("src gui auxiliary" REGULAR_EXPRESSION "gui/auxiliary/.*")
-	SOURCE_GROUP("src gui auxiliary event" REGULAR_EXPRESSION "gui/core/event/.*")
-	SOURCE_GROUP("src gui auxiliary widget_definition" REGULAR_EXPRESSION "gui/core/widget_definition/.*")
-	SOURCE_GROUP("src gui auxiliary window_builder" REGULAR_EXPRESSION "gui/core/window_builder/.*")
-	SOURCE_GROUP("src gui dialogs" REGULAR_EXPRESSION "gui/dialogs/.*")
-	SOURCE_GROUP("src gui dialogs lobby" REGULAR_EXPRESSION "gui/dialogs/lobby/.*")
-	SOURCE_GROUP("src lua" REGULAR_EXPRESSION "lua/.*")
-	SOURCE_GROUP("src widgets" REGULAR_EXPRESSION "widgets/.*")
-	SOURCE_GROUP("src gui widgets" REGULAR_EXPRESSION "gui/widgets/.*")
-	SOURCE_GROUP("src pathfind" REGULAR_EXPRESSION "pathfind/.*")
-	SOURCE_GROUP("src scripting" REGULAR_EXPRESSION "scripting/.*")
-	SOURCE_GROUP("src serialization" REGULAR_EXPRESSION "serialization/.*")
-	SOURCE_GROUP("src server" REGULAR_EXPRESSION "server/.*")
-	SOURCE_GROUP("src storyscreen" REGULAR_EXPRESSION "storyscreen/.*")
-	SOURCE_GROUP("src tests" REGULAR_EXPRESSION "tests/.*")
-	SOURCE_GROUP("src tests gui" REGULAR_EXPRESSION "tests/gui/.*")
-	SOURCE_GROUP("src tests utils" REGULAR_EXPRESSION "tests/utils/.*")
-	SOURCE_GROUP("src tools" REGULAR_EXPRESSION "tools/.*")
-	SOURCE_GROUP("src tools schema" REGULAR_EXPRESSION "tools/schema/.*")
-	SOURCE_GROUP("src utils" REGULAR_EXPRESSION "utils/.*")
-	SOURCE_GROUP("src whiteboard" REGULAR_EXPRESSION "whiteboard/.*")
-
-endif(MSVC)
-
-
 
 ########### Set Library mode ###############
 


### PR DESCRIPTION
This PR:
- Removes MSVC support from cmake.
- Removes the two unused options `ENABLE_TOOLS` and `ENABLE_SDL2_TOOLS`.