### PR TITLE
HttT S17: Fix lava issues

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
@@ -682,37 +682,23 @@
     # Some volcanic ambiance
     #
     [event]
-        name=moveto
+        name=turn end
         first_time_only=no
-        [allow_undo]
-        [/allow_undo]
-        [filter]
-            side=1,4,5
-        [/filter]
-        {VARIABLE_OP rumble_test rand "1..35"}
+
+        {QUAKE "rumble.ogg"}
+        {VARIABLE_OP lava_count add 1}
+        {EXPAND_LAVA}
+
+        # Reset the counter if it gets too large (it slows things down)
         [if]
             [variable]
-                name=rumble_test
-                numerical_equals=1
+                name=lava_count
+                numerical_equals=3
             [/variable]
             [then]
-                {QUAKE "rumble.ogg"}
-                {VARIABLE_OP lava_count add 1}
-                {EXPAND_LAVA}
-
-                # Reset the counter if it gets too large (it slows things down)
-                [if]
-                    [variable]
-                        name=lava_count
-                        numerical_equals=3
-                    [/variable]
-                    [then]
-                        {NEXT_LAVA}
-                    [/then]
-                [/if]
+                {NEXT_LAVA}
             [/then]
         [/if]
-        {CLEAR_VARIABLE rumble_test}
     [/event]
 
     {campaigns/Heir_To_The_Throne/utils/deaths.cfg}


### PR DESCRIPTION
1. Undo now works again in the scenario.
2. Lava now works again.
3. Triggering on a moveto event was not good, as several shorter moves
   would make rate of lava grow much faster than fewer longer moves.