### PR TITLE
Attempt to implement experiment to fix edge-of-hex artifacts with fractional zooming

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -844,11 +844,17 @@ static surface get_hexed(const locator& i_locator)
 
 static surface get_scaled_to_hex(const locator& i_locator)
 {
-	surface img = get_image(i_locator, HEXED);
+	surface img = get_image(i_locator, UNSCALED); //HEXED);
 	// return scale_surface(img, zoom, zoom);
 
 	if(!img.null()) {
-		return scale_to_hex_func(img, zoom, zoom);
+		surface scaled = scale_surface(img, zoom, zoom);
+
+		bool is_empty = false;
+		surface cut = mask_surface(scaled, get_hexmask_scaled(), & is_empty, i_locator.get_filename());
+		i_locator.add_to_cache(is_empty_hex_, is_empty);
+
+		return cut;
 	}
 
 	return surface(nullptr);
@@ -1063,6 +1069,12 @@ surface get_hexmask()
 {
 	static const image::locator terrain_mask(game_config::images::terrain_mask);
 	return get_image(terrain_mask, UNSCALED);
+}
+
+surface get_hexmask_scaled()
+{
+	static const image::locator terrain_mask(game_config::images::terrain_mask);
+	return get_image(terrain_mask, SCALED_TO_ZOOM); //actually I think maybe its better for it always to be bilinear
 }
 
 bool is_in_hex(const locator& i_locator)

--- a/src/image.hpp
+++ b/src/image.hpp
@@ -199,6 +199,10 @@ namespace image {
 	///function to get the standard hex mask
 	surface get_hexmask();
 
+	///function to get scaled hex mask
+	///use this on images after scaling them, not the small one before, to avoid artifacts
+	surface get_hexmask_scaled();
+
 	///function to check if an image fit into an hex
 	///return false if the image has not the standard size.
 	bool is_in_hex(const locator& i_locator);


### PR DESCRIPTION
This is an adaptation of PR #318 by cbeck88 & my attempt to help close the pr.

However, I'm not sure what this is fixing if it is or if it is still relevant
I thought  it might fix the sceenshot I posted there, but my implementation does not. It is quite possible that I screwed up the implementation of #318



The idea is, when scaling a hex to zoom, instead of masking it
first and then scaling it up, it should be scaled to zoom and
then masked with a scaled up terrain mask image, because it will
be more precise.

I find that if this is done, and scale to hex algorithm is set to
nearest neighbor, then I no longer get any artifacts from this.