### PR TITLE
Add strict warning options to the default build options.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,19 +199,16 @@ if(NOT DEFINED CXX_FLAGS_USER)
 
 endif(NOT DEFINED CXX_FLAGS_USER)
 
-set(COMPILER_FLAGS "-std=c++11 -Wall -Wextra -Werror=non-virtual-dtor")
+set(COMPILER_FLAGS "-std=c++11 -Wall -Wextra -Werror=non-virtual-dtor -Wno-unused-local-typedefs -Wno-maybe-uninitialized -Wold-style-cast")
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+	set(COMPILER_FLAGS "${COMPILER_FLAGS} -Qunused-arguments -Wno-unknown-warning-option -Wmismatched-tags -Wno-conditional-uninitialized")
+endif()
 
 ### Set strict compiler flags.
 
 if(ENABLE_STRICT_COMPILATION)
-	set(CXX_FLAGS_STRICT_COMPILATION "-Werror -Wno-unused-local-typedefs -Wno-maybe-uninitialized -Wold-style-cast")
-	
-	if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-		set(CXX_FLAGS_STRICT_COMPILATION "${CXX_FLAGS_STRICT_COMPILATION} -Wmismatched-tags -Wno-conditional-uninitialized")
-	endif()
-	
-	set(COMPILER_FLAGS "${COMPILER_FLAGS} ${CXX_FLAGS_STRICT_COMPILATION}")
-
+	set(COMPILER_FLAGS "${COMPILER_FLAGS} -Werror")
 endif(ENABLE_STRICT_COMPILATION)
 
 ### Set pedantic compiler flags.
@@ -229,10 +226,6 @@ if(ENABLE_PEDANTIC_COMPILATION)
 endif(ENABLE_PEDANTIC_COMPILATION)
 
 ### Set the final compiler flags.
-
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-	set(COMPILER_FLAGS "${COMPILER_FLAGS} -Qunused-arguments -Wno-unknown-warning-option")
-endif()
 
 set(COMPILER_FLAGS "${COMPILER_FLAGS} ${CXX_FLAGS_USER}")
 

--- a/SConstruct
+++ b/SConstruct
@@ -322,7 +322,7 @@ env.PrependENVPath('LD_LIBRARY_PATH', env["boostlibdir"])
 
 # Some tests require at least C++11
 if "gcc" in env["TOOLS"]:
-    env.AppendUnique(CCFLAGS = Split("-Wall -Wextra -Werror=non-virtual-dtor"), CFLAGS = ["-std=c99"])
+    env.AppendUnique(CCFLAGS = Split("-Wall -Wextra -Werror=non-virtual-dtor"))
     env.AppendUnique(CXXFLAGS = "-std=c++" + env["cxx_std"])
 
 if env["prereqs"]:
@@ -472,17 +472,16 @@ for env in [test_env, client_env, env]:
 
     if "clang" in env["CXX"]:
 # Silence warnings about unused -I options and unknown warning switches.
-        env.AppendUnique(CCFLAGS = Split("-Qunused-arguments -Wno-unknown-warning-option"))
-        if env['strict']:
-            env.AppendUnique(CCFLAGS = Split("-Wmismatched-tags -Wno-conditional-uninitialized"))
+        env.AppendUnique(CCFLAGS = Split("-Qunused-arguments -Wno-unknown-warning-option -Wmismatched-tags -Wno-conditional-uninitialized"))
 
     if "gcc" in env["TOOLS"]:
         if env['openmp']:
             env.AppendUnique(CXXFLAGS = ["-fopenmp"], LIBS = ["gomp"])
-
+        
+        env.AppendUnique(CCFLAGS = Split("-Wno-unused-local-typedefs -Wno-maybe-uninitialized -Wold-style-cast"))
+        
         if env['strict']:
-            env.AppendUnique(CCFLAGS = Split("-Werror -Wno-unused-local-typedefs -Wno-maybe-uninitialized"))
-            env.AppendUnique(CXXFLAGS = Split("-Wold-style-cast"))
+            env.AppendUnique(CCFLAGS = Split("-Werror"))
         if env['sanitize']:
             env.AppendUnique(CCFLAGS = ["-fsanitize=" + env["sanitize"]], LINKFLAGS = ["-fsanitize=" + env["sanitize"]])
         

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -206,22 +206,12 @@ add_library(lua ${LIBRARY_TYPE} EXCLUDE_FROM_ALL ${lua_STAT_SRC})
 # Disable the setting of -Wold-style-cast on some targets.
 # old style casts are not wanted by our coding style but some C based code
 # uses it. Force the flag off for these files.
-if(ENABLE_STRICT_COMPILATION)
-	set(CXX_FLAG_NO_OLD_STYLE_CAST "-Wno-old-style-cast")
-endif()
+set_target_properties(lua
+	PROPERTIES
+	COMPILE_FLAGS
+	"-Wno-old-style-cast -Wno-useless-cast"
+)
 
-if(ENABLE_PEDANTIC_COMPILATION)
-	set(CXX_FLAG_NO_USELESS_CAST "-Wno-useless-cast")
-endif()
-
-if(ENABLE_STRICT_COMPILATION OR ENABLE_PEDANTIC_COMPILATION)
-	MESSAGE("Adding flags to lua target: ${CXX_FLAG_NO_OLD_STYLE_CAST} ${CXX_FLAG_NO_USELESS_CAST}")
-	set_target_properties(lua
-		PROPERTIES
-		COMPILE_FLAGS
-		"${CXX_FLAG_NO_OLD_STYLE_CAST} ${CXX_FLAG_NO_USELESS_CAST}"
-	)
-endif()
 
 ########### Helper libraries ###############
 

--- a/src/SConscript
+++ b/src/SConscript
@@ -99,11 +99,14 @@ libwesnoth_client = client_env.Library("wesnoth-client", wesnoth_client_sources)
 lua_sources = GetSources("lua")
 
 env_lua = env.Clone(
-    # Silence some Clang-specific warnings due to extra parentheses in if statements when comparing.
-    CCFLAGS = ["$CCFLAGS", "clang" in env["CXX"] and Split("-Wno-parentheses-equality -Wno-pointer-bool-conversion") or [], "strict" in env and Split("-Wno-old-style-cast -Wno-useless-cast") or []],
     CCCOM = env["CXXCOM"],
     CPPPATH = ["$CPPPATH", Dir(".").srcnode()],
     CPPDEFINES = ["$CPPDEFINES", env["PLATFORM"] != "win32" and "LUA_USE_POSIX" or []])
+
+env_lua.AppendUnique(CCFLAGS = Split("-Wno-old-style-cast -Wno-useless-cast"))
+# Silence some Clang-specific warnings due to extra parentheses in if statements when comparing.
+if "clang" in env["CXX"]:
+    env_lua.AppendUnique(CCFLAGS = Split("-Wno-parentheses-equality"))
 
 if env_lua["enable_lto"] == True:
     env_lua["AR"] = 'gcc-ar'


### PR DESCRIPTION
This PR:
- Moves all the flags from the scons/cmake `strict` build into the regular build flags, except for `-Werror`.  This means that the only difference between `strict` builds and non-strict builds will be if warnings are turned into errors.
- Removes `-std=c99` from scons' `CFLAGS`, since cmake does not set that flag.  This affects `src/SDL_SavePNG/savepng.c`, since it's the only C source file Wesnoth has.
- Removes the `-Wno-pointer-bool-conversion` flag from scons' lua build, since cmake does not use that flag.

Additionally, cmake has another option used to add additional warning flags, `ENABLE_PEDANTIC_COMPILATION`:
- `-Wlogical-op` - Warn about suspicious uses of logical operators in expressions. This includes using logical operators in contexts where a bit-wise operator is likely to be expected. Also warns when the operands of a logical operator are the same.
- `-Wmissing-declarations` - Warn if a global function is defined without a previous declaration. Do so even if the definition itself provides a prototype. Use this option to detect global functions that are not declared in header files. In C, no warnings are issued for functions with previous non-prototype declarations; use -Wmissing-prototypes to detect missing prototypes. In C++, no warnings are issued for function templates, or for inline functions, or for functions in anonymous namespaces.
- `-Wredundant-decls` - Warn if anything is declared more than once in the same scope, even in cases where multiple declaration is valid and changes nothing.
- `-Wctor-dtor-privacy` - Warn when a class seems unusable because all the constructors or destructors in that class are private, and it has neither friends nor public static member functions. Also warn if there are no non-private methods, and there’s at least one private member function that isn’t a constructor or destructor.
- `-Wnon-virtual-dtor` - Scons and cmake already turn this specifically into an error for all builds.
- `-Wdouble-promotion` - Give a warning when a value of type float is implicitly promoted to double. CPUs with a 32-bit “single-precision” floating-point unit implement float in hardware, but emulate double in software. On such a machine, doing computations using double values is much more expensive because of the overhead required for software emulation.
- `-Wuseless-cast` - Warn when an expression is casted to its own type.
- `-Wnoexcept` - Warn when a noexcept-expression evaluates to false because of a call to a function that does not have a non-throwing exception specification (i.e. throw() or noexcept) but is known by the compiler to never throw an exception.

(Warning descriptions copied from [here](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html) and [here](https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html))

Are any of the pedantic flags useful/does anyone actually use `ENABLE_PEDANTIC_COMPILATION`?  If not, then there isn't any really point to keeping it around.  Alternatively, if any of the pedantic flags are worth keeping, then it seems to me like they should be added to the main build flags so they are warned about and fixed.