### PR TITLE
add hidden_amla option in amlas

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/_main.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/_main.cfg
@@ -211,60 +211,6 @@
     {ABILITY_FORMATION_EVENTS}
     {ABILITY_DISENGAGE_EVENTS}
     {ABILITY_SUPPORT_EVENTS}
-
-    # Quenoth Youths have a non-null advances_to= in order to prevent them from
-    # having purple xp bars (until all advancements have been gained); these
-    # events make sure that they've nullified before advancement (to prevent the
-    # unit type from appearing in the advancement menu) and restored afterwards.
-    [event]
-        name=pre advance
-        first_time_only=no
-
-        [filter]
-            type=Quenoth Youth,Quenoth Youth 2,Quenoth Youth 3
-        [/filter]
-
-        {VARIABLE unit.advances_to null}
-
-        [unstore_unit]
-            variable=unit
-            find_vacant=no
-            advance=no
-        [/unstore_unit]
-    [/event]
-    [event]
-        name=post advance
-        first_time_only=no
-
-        [filter]
-            type=Quenoth Youth 3
-
-            [not]
-                [filter_wml]
-                    [modifications]
-                        [advancement]
-                            exclude_amla=warrior_2_1,warrior_2_2
-                        [/advancement]
-                        [advancement]
-                            exclude_amla=hunter_2_1,hunter_2_2
-                        [/advancement]
-                        [advancement]
-                            exclude_amla=leader_2_1,leader_2_2
-                        [/advancement]
-                    [/modifications]
-                [/filter_wml]
-            [/not]
-        [/filter]
-
-        {VARIABLE unit.advances_to "Quenoth Youth 3"}
-
-        [unstore_unit]
-            variable=unit
-            find_vacant=no
-            advance=no
-        [/unstore_unit]
-    [/event]
-
     # On recruit, this switches the higher-recruit-cost units to the normal
     # types, so that the different cost variations don't need to be taken into
     # account for example in unit filters.

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Kaleh.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Kaleh.cfg
@@ -11,7 +11,8 @@
 
 #define KALEH_ADVANCEMENT HP_INCREMENT XP_INCREMENT EFFECT_WML VARIATION_NAME
     [advancement]
-        max_times=1
+        max_times=1 
+        hidden_amla=yes
         always_display=yes
         [effect]
             apply_to=hitpoints

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Kaleh.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Kaleh.cfg
@@ -11,7 +11,7 @@
 
 #define KALEH_ADVANCEMENT HP_INCREMENT XP_INCREMENT EFFECT_WML VARIATION_NAME
     [advancement]
-        max_times=1 
+        max_times=1
         hidden_amla=yes
         always_display=yes
         [effect]

--- a/data/campaigns/Under_the_Burning_Suns/units/elves/Kaleh.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/elves/Kaleh.cfg
@@ -12,7 +12,7 @@
 #define KALEH_ADVANCEMENT HP_INCREMENT XP_INCREMENT EFFECT_WML VARIATION_NAME
     [advancement]
         max_times=1
-        hidden_amla=yes
+        major_amla=yes
         always_display=yes
         [effect]
             apply_to=hitpoints

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
@@ -1,7 +1,7 @@
 #textdomain wesnoth-utbs
 
 #define HEAL_EFFECTS
-   major_amla=yes
+major_amla=yes
     [effect]
         apply_to=hitpoints
         heal_full=yes

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
@@ -1,7 +1,7 @@
 #textdomain wesnoth-utbs
 
 #define HEAL_EFFECTS
-hidden_amla=yes
+major_amla=yes
     [effect]
         apply_to=hitpoints
         heal_full=yes

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
@@ -1,6 +1,7 @@
 #textdomain wesnoth-utbs
 
-#define HEAL_EFFECTS
+#define HEAL_EFFECTS 
+hidden_amla=yes
     [effect]
         apply_to=hitpoints
         heal_full=yes
@@ -412,7 +413,7 @@
     level=1
     profile=portraits/kaleh.png
     alignment=lawful
-    advances_to=Quenoth Youth
+    advances_to=null
     cost=14
     usage=fighter
     description= _ "Kaleh is still a young Elf of the Quenoth, on the verge of adulthood. He trained with his father with the bow and sword, joining him in lighter expeditions and raids. When his father was lost, Kaleh became more serious and solemn than is usual for those who walk under the two suns. He turned inwards for answers and guidance, not knowing how much his people would look towards him for guidance in times to come."
@@ -464,7 +465,7 @@
     level=2
     profile=portraits/kaleh.png
     alignment=lawful
-    advances_to=Quenoth Youth 2
+    advances_to=null
     cost=14
     usage=fighter
     description= _ "Kaleh is still a young Elf of the Quenoth, on the verge of adulthood. He trained with his father with the bow and sword, joining him in lighter expeditions and raids. When his father was lost, Kaleh became more serious and solemn than is usual for those who walk under the two suns. He turned inwards for answers and guidance, not knowing how much his people would look towards him for guidance in times to come."
@@ -518,7 +519,7 @@
     level=3
     profile=portraits/kaleh.png
     alignment=lawful
-    advances_to=Quenoth Youth 3
+    advances_to=null
     cost=14
     usage=fighter
     description= _ "Kaleh is still a young Elf of the Quenoth, on the verge of adulthood. He trained with his father with the bow and sword, joining him in lighter expeditions and raids. When his father was lost, Kaleh became more serious and solemn than is usual for those who walk under the two suns. He turned inwards for answers and guidance, not knowing how much his people would look towards him for guidance in times to come."

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
@@ -1,7 +1,7 @@
 #textdomain wesnoth-utbs
 
 #define HEAL_EFFECTS
-major_amla=yes
+   major_amla=yes
     [effect]
         apply_to=hitpoints
         heal_full=yes

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
@@ -1,7 +1,7 @@
 #textdomain wesnoth-utbs
 
 #define HEAL_EFFECTS
-major_amla=yes
+    major_amla=yes
     [effect]
         apply_to=hitpoints
         heal_full=yes

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
@@ -1,6 +1,6 @@
 #textdomain wesnoth-utbs
 
-#define HEAL_EFFECTS 
+#define HEAL_EFFECTS
 hidden_amla=yes
     [effect]
         apply_to=hitpoints

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1096,14 +1096,14 @@ color_t unit::xp_color() const
 	const bool far_advance  = static_cast<int>(experience_to_advance()) <= game_config::kill_experience*3;
 
 	color_t color = normal_color;
-	bool hidden_amla = false;
+	bool major_amla = false;
 	for(const config& adv:get_modification_advances()){
-		if(adv["hidden_amla"].to_bool ()){
-hidden_amla=true;
+		if(adv["major_amla"].to_bool ()){
+major_amla=true;
 		}
 	}
 	
-		if(advances_to().size() || hidden_amla == true){
+		if(advances_to().size() || major_amla == true){
 		if(near_advance){
 			color=near_advance_color;
 		} else if(mid_advance){

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1097,11 +1097,12 @@ color_t unit::xp_color() const
 
 	color_t color = normal_color;
 	bool hidden_amla = false;
-	for (const config& adv : get_modification_advances()){
+	for(const config& adv:get_modification_advances()){
 if(adv[ "hidden_amla" ].to_bool ()){
-hidden_amla = true;
+hidden_amla=true;
 }
-	}
+}
+
 if(advances_to().size() || hidden_amla == true){
 		if(near_advance){
 			color=near_advance_color;

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1098,10 +1098,12 @@ color_t unit::xp_color() const
 	color_t color = normal_color;
 	bool hidden_amla = false;
 	for(const config& adv:get_modification_advances()){
-if(adv[ "hidden_amla" ].to_bool ()){
+		if(adv["hidden_amla"].to_bool ()){
 hidden_amla=true;
-}
-}
+		}
+	}
+		
+
 
 if(advances_to().size() || hidden_amla == true){
 		if(near_advance){

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1099,7 +1099,7 @@ color_t unit::xp_color() const
 	bool major_amla = false;
 	for(const config& adv:get_modification_advances()){
 		if(adv["major_amla"].to_bool ()){
-major_amla=true;
+			major_amla = true;
 		}
 	}
 	if(advances_to().size() || major_amla == true){

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1102,8 +1102,7 @@ color_t unit::xp_color() const
 major_amla=true;
 		}
 	}
-	
-		if(advances_to().size() || major_amla == true){
+	if(advances_to().size() || major_amla == true){
 		if(near_advance){
 			color=near_advance_color;
 		} else if(mid_advance){

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1096,8 +1096,11 @@ color_t unit::xp_color() const
 	const bool far_advance  = static_cast<int>(experience_to_advance()) <= game_config::kill_experience*3;
 
 	color_t color = normal_color;
+	bool major_amla;
 	for(const config& adv:get_modification_advances()){
-	if(advances_to().size() || adv["major_amla"].to_bool()){
+		major_amla = adv["major_amla"].to_bool();
+	}
+	if(advances_to().size() ||major_amla){
 		if(near_advance){
 			color=near_advance_color;
 		} else if(mid_advance){
@@ -1115,7 +1118,6 @@ color_t unit::xp_color() const
 		} else {
 			color=amla_color;
 		}
-	}
 	}
 
 	return(color);

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1102,10 +1102,8 @@ color_t unit::xp_color() const
 hidden_amla=true;
 		}
 	}
-		
-
-
-if(advances_to().size() || hidden_amla == true){
+	
+		if(advances_to().size() || hidden_amla == true){
 		if(near_advance){
 			color=near_advance_color;
 		} else if(mid_advance){

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1097,8 +1097,8 @@ color_t unit::xp_color() const
 
 	color_t color = normal_color;
 	bool hidden_amla = false;
-	for (const config& adv : get_modification_advances()) {
-if(adv[ "hidden_amla" ]. to_bool ()){
+	for (const config& adv : get_modification_advances()){
+if(adv[ "hidden_amla" ].to_bool ()){
 hidden_amla = true;
 }
 	}

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1096,13 +1096,8 @@ color_t unit::xp_color() const
 	const bool far_advance  = static_cast<int>(experience_to_advance()) <= game_config::kill_experience*3;
 
 	color_t color = normal_color;
-	bool major_amla = false;
 	for(const config& adv:get_modification_advances()){
-		if(adv["major_amla"].to_bool ()){
-			major_amla = true;
-		}
-	}
-	if(advances_to().size() || major_amla == true){
+	if(advances_to().size() || adv["major_amla"].to_bool()){
 		if(near_advance){
 			color=near_advance_color;
 		} else if(mid_advance){
@@ -1120,6 +1115,7 @@ color_t unit::xp_color() const
 		} else {
 			color=amla_color;
 		}
+	}
 	}
 
 	return(color);

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1096,8 +1096,13 @@ color_t unit::xp_color() const
 	const bool far_advance  = static_cast<int>(experience_to_advance()) <= game_config::kill_experience*3;
 
 	color_t color = normal_color;
-
-	if(advances_to().size()){
+	bool hidden_amla = false;
+	for (const config& adv : get_modification_advances()) {
+if(adv[ "hidden_amla" ]. to_bool ()){
+hidden_amla = true;
+}
+	}
+if(advances_to().size() || hidden_amla == true){
 		if(near_advance){
 			color=near_advance_color;
 		} else if(mid_advance){

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1096,9 +1096,9 @@ color_t unit::xp_color() const
 	const bool far_advance  = static_cast<int>(experience_to_advance()) <= game_config::kill_experience*3;
 
 	color_t color = normal_color;
-	bool major_amla;
+	bool major_amla = false;
 	for(const config& adv:get_modification_advances()){
-		major_amla = adv["major_amla"].to_bool();
+		major_amla |= adv["major_amla"].to_bool();
 	}
 	if(advances_to().size() ||major_amla){
 		if(near_advance){


### PR DESCRIPTION
With the apply_to=type in effect the amla allow an unit to upgrade without specifing in advances_to. Different amlas can be associate with upgrade but color xp bar remain purple.
In utbs the wml is use for hide this but is no perfect when the youth upgrade( purple is briefly seeing). I propose an change in source for simplify the work of addons developer who want create an unit line similar.