### PR TITLE
Remove the scons workaround for Travis only having SDL 2.0.2

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -176,11 +176,6 @@ if env['distcc']:
 
 if env['ccache']: env.Tool('ccache')
 
-if 'TRAVIS' in os.environ:
-    SDL2_version = '2.0.2'
-else:
-    SDL2_version = '2.0.4'
-
 boost_version = '1.50.0'
 
 
@@ -356,7 +351,7 @@ if env["prereqs"]:
 
     def have_sdl_other():
         return \
-            conf.CheckSDL(require_version = SDL2_version) & \
+            conf.CheckSDL(require_version = '2.0.4') & \
             conf.CheckSDL("SDL2_ttf", header_file = "SDL_ttf") & \
             conf.CheckSDL("SDL2_mixer", header_file = "SDL_mixer") & \
             conf.CheckSDL("SDL2_image", header_file = "SDL_image")


### PR DESCRIPTION
This is no longer needed, as Travis now has SDL 2.0.4 available via the docker image.