### PR TITLE
appdata file for appstream software centers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,10 @@ if(UNIX AND NOT APPLE AND NOT CYGWIN)
 	option(ENABLE_DESKTOP_ENTRY "enable installation of desktop entry files" ON)
 endif(UNIX AND NOT APPLE AND NOT CYGWIN)
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+	option(ENABLE_APPDATA_FILE "enable installation of an appdata file for appstream" ON)
+endif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+
 option(ENABLE_STRICT_COMPILATION "Sets the strict compilation mode" OFF)
 option(ENABLE_PEDANTIC_COMPILATION "Sets the pedantic compilation mode" OFF)
 option(ENABLE_DEBUG_WINDOW_LAYOUT "Add the debug option to allow the generation of debug layout files in dot format" OFF)
@@ -561,6 +565,9 @@ if(ENABLE_DESKTOP_ENTRY AND ENABLE_GAME)
 	install(DIRECTORY packaging/icons/hicolor DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons )
 endif(ENABLE_DESKTOP_ENTRY AND ENABLE_GAME)
 
+if(ENABLE_APPDATA_FILE AND ENABLE_GAME)
+	install(FILES packaging/wesnoth.appdata.xml DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo )
+endif(ENABLE_APPDATA_FILE AND ENABLE_GAME)
 
 if(ENABLE_SERVER AND FIFO_DIR)
 	install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory \$ENV{DESTDIR}/${FIFO_DIR})")

--- a/SConstruct
+++ b/SConstruct
@@ -65,11 +65,13 @@ opts.AddVariables(
     PathVariable('fifodir', 'directory for the wesnothd fifo socket file', "/var/run/wesnothd", PathVariable.PathAccept),
     BoolVariable('fribidi','Clear to disable bidirectional-language support', True),
     BoolVariable('desktop_entry','Clear to disable desktop-entry', True),
+    BoolVariable('appdata_file','Clear to not install appdata file', True),
     BoolVariable('systemd','Install systemd unit file for wesnothd', bool(WhereIs("systemd"))),
     PathVariable('datarootdir', 'sets the root of data directories to a non-default location', "share", PathVariable.PathAccept),
     PathVariable('datadirname', 'sets the name of data directory', "wesnoth$version_suffix", PathVariable.PathAccept),
     PathVariable('desktopdir', 'sets the desktop entry directory to a non-default location', "$datarootdir/applications", PathVariable.PathAccept),
     PathVariable('icondir', 'sets the icons directory to a non-default location', "$datarootdir/icons", PathVariable.PathAccept),
+    PathVariable('appdatadir', 'sets the appdata directory to a non-default location', "$datarootdir/metainfo", PathVariable.PathAccept),
     BoolVariable('internal_data', 'Set to put data in Mac OS X application fork', False),
     PathVariable('localedirname', 'sets the locale data directory to a non-default location', "translations", PathVariable.PathAccept),
     PathVariable('mandir', 'sets the man pages directory to a non-default location', "$datarootdir/man", PathVariable.PathAccept),
@@ -576,7 +578,7 @@ for env in [test_env, client_env, env]:
         env.Append(CPPDEFINES = "_X11")
 
 # Simulate autools-like behavior of prefix on various paths
-    installdirs = Split("bindir datadir fifodir icondir desktopdir mandir docdir python_site_packages_dir")
+    installdirs = Split("bindir datadir fifodir icondir desktopdir appdatadir mandir docdir python_site_packages_dir")
     for d in installdirs:
         env[d] = os.path.join(env["prefix"], env[d])
 
@@ -691,6 +693,8 @@ InstallManpages(env, "wesnoth")
 if have_client_prereqs and have_X and env["desktop_entry"]:
      env.InstallData("icondir", "wesnoth", "packaging/icons")
      env.InstallData("desktopdir", "wesnoth", "packaging/wesnoth.desktop")
+if have_client_prereqs and "linux" in sys.platform and env["appdata_file"]:
+     env.InstallData("appdatadir", "wesnoth", "packaging/wesnoth.appdata.xml")
 
 # Python tools
 env.InstallData("bindir", "pytools", [os.path.join("data", "tools", tool) for tool in pythontools])

--- a/packaging/wesnoth.appdata.xml
+++ b/packaging/wesnoth.appdata.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2017 The Battle for Wesnoth Project -->
+<component type="desktop">
+  <id>wesnoth.desktop</id>
+  <launchable type="desktop-id">wesnoth.desktop</launchable>
+  <metadata_license>GFDL-1.3</metadata_license>
+  <project_license>GPL-2.0+</project_license>
+  <name>Battle for Wesnoth</name>
+  <name xml:lang="de">Battle for Wesnoth</name>
+  <name xml:lang="es">La batalla por Wesnoth</name>
+  <name xml:lang="fr">La Bataille pour Wesnoth</name>
+  <name xml:lang="hu">Harc Wesnothért</name>
+  <name xml:lang="pl">Bitwa o Wesnoth</name>
+  <name xml:lang="ru">Битва за Веснот</name>
+  <summary>A turn-based strategy game with a high fantasy theme</summary>
+  <summary xml:lang="de">Ein rundenbasierendes Strategiespiel mit Fantasy-Thematik</summary>
+  <summary xml:lang="es">Un juego de estrategia basado en turnos con un tema de fantasía</summary>
+  <summary xml:lang="fr">Un jeu de stratégie au tour par tour dans un univers fantastique</summary>
+  <summary xml:lang="hu">Fantasy stílusú, körökre osztott, stratégiai játék</summary>
+  <summary xml:lang="pl">Bitwa o Wesnoth to turowa strategia w klimatach fantasy</summary>
+  <summary xml:lang="ru">Фантастическая пошаговая стратегия</summary>
+  <description>
+    <p>
+      Build up a great army, gradually turning raw recruits into hardened
+      veterans.
+      In later games, recall your toughest warriors and form a deadly host that
+      no one can stand against! Choose units from a large pool of specialists,
+      and hand-pick a force with the right strengths to fight well on different
+      terrains against all manner of opposition.
+    </p>
+    <p xml:lang="de">Stelle eine mächtige Armee zusammen, indem du aus einfachen Rekruten gestählte Veteranen machst. Später kannst du deine härtesten Krieger wieder einberufen, und niemand wird sich dir mehr in den Weg stellen können! Wähle deine Mitstreiter aus einer Anzahl von spezialisierten Einheitentypen und erstelle eine handverlesene Kriegsmacht, mit deren Stärken du dich auf verschiedenem Gelände gegen jede Art von Widerstand behaupten kannst.</p>
+    <p xml:lang="es">Reúne un gran ejercito y convierte progresivamente los reclutas en duros veteranos. ¡Posteriormente reincorpora a tus guerreros más poderosos formando un batallón mortal al que nadie se pueda oponer!. Selecciona unidades entre un gran número de perfiles construyendo un ejercito equilibrado para luchar en diferentes terrenos contra todo tipo de rivales.</p>
+    <p xml:lang="fr">Construisez une grande armée, transformant progressivement de simples recrues en vétérans aguerris. Dans les parties ultérieures, rappelez vos combattants les plus forts et formez une faction meurtrière contre laquelle il est impossible de lutter ! Choisissez des unités parmi un large éventail de spécialistes, et sélectionnez méticuleusement des troupes avec les atouts adéquats pour combattre efficacement sur différents terrains et contre toute sorte d'opposition.</p>
+    <p xml:lang="hu">Építs óriási seregeket, zöldfülű újoncaidat harcedzett veteránokká változtatva! Legkeményebb harcosaidat későbbi pályákon is visszahívhatod, így szinte legyőzhetetlen csapatot alkothatsz. Egységeidet rengeteg típus közül választhatod ki, hogy bármilyen terepen bármilyen ellenfél ellen sikerrel küzdhess meg.</p>
+    <p xml:lang="pl">Stwórz wspaniałą armię, stopniowo rozwijając rekrutów w doświadczonych żołnierzy. W późniejszych grach przywołuj najlepszych wojowników, aby stworzyć niszczycielską drużynę, której nikt nie będzie mógł się przeciwstawić. Wybieraj podwładnych z szerokiej puli wyspecjalizowanych jednostek i stwórz armię, która będzie w stanie skutecznie walczyć na zróżnicowanym terenie z dowolnym wrogiem.</p>
+    <p xml:lang="ru">Создайте великую армию, постепенно превращая неотесанных новобранцев в закаленных ветеранов. В последующих играх призывайте ваших сильнейших воинов и сформируйте из них смертоносный тандем, против которого никто не сможет выстоять! Выбирайте юниты с различными специализациями, подбирайте бойцов с правильными особенностями, чтобы хорошо сражаться на различных территориях и дать отпор против любых маневров врага. </p>
+    <p>
+      Wesnoth has many different sagas waiting to be played.
+      Fight to regain the throne of Wesnoth, of which you are the legitimate
+      heir... lead a brutal quest to unite the orcish tribes... vanquish a horde
+      of undead warriors... Guide a band of elvish survivors in an epic quest to
+      find a new home...
+    </p>
+    <p xml:lang="de">Viele Sagen warten darauf, von dir gespielt zu werden. Kämpfe um den Thron von Wesnoth, dessen legitimer Erbe du bist... schlüpfe in die Rolle eines jungen Offiziers, der ausgesandt wurde, um einen nicht allzu ruhigen Außenposten zu verteidigen... führe einen brutalen Feldzug, um die orkischen Stämme zu vereinigen... besiege eine Gruppe untoter Krieger, die von einem Totenbeschwörer beschworen wurden, der auch deinen Bruder in seiner Gewalt hat... führe eine Gruppe elfischer Überlebender auf ihrer Suche nach einer neuen Heimat...</p>
+    <p xml:lang="es">Wesnoth cuenta con un gran número de campañas esperando a ser jugadas. Lucha por recuperar el trono de Wesnoth del cual eres legítimo heredero... ponte en la piel de un joven oficial enviado a protejer un puesto fronterizo no tan tranquilo como esperaba... lidera la brutal aventura de unir las tribus orcas... derrota una horda de guerreros no muertos invocados por un infecto nigromante que ha raptado a tu hermano... guía a un grupo de supervivientes elfos en su épica búsqueda de un nuevo hogar...</p>
+    <p xml:lang="fr">Wesnoth comporte de nombreuses sagas qui n'attendent que d'être jouées. Luttez pour regagner le trône de Wesnoth, dont vous êtes l'héritier légitime… incarnez un jeune officier envoyé en mission pour garder un avant-poste frontalier pas si paisible… dirigez une quête brutale pour unifier les tribus orcs… surmontez une horde de guerriers morts-vivants contrôlés par un vil nécromancien, qui a par ailleurs pris votre frère en otage… guidez une troupe de survivants elfes dans une quête épique pour trouver une nouvelle terre d'accueil...</p>
+    <p xml:lang="hu">Wesnoth világa számos történetet tartogat. Harcolj Wesnoth trónjáért, amelynek te vagy a jogos örököse... bújj egy fiatal tiszt bőrébe, és vedd át egy nem is annyira nyugodt helyőrség parancsnokságát... egyesítsd az ork törzseket egy kegyetlen hadjáratban... irtsd ki a gonosz holtidéző élőholt seregét, akik mellesleg a bátyádat is túszul ejtették... vezesd tünde túlélők egy kicsiny csoportját egy új haza felé...</p>
+    <p xml:lang="pl">Wesnoth posiada wiele historii gotowych do rozegrania. Walcz aby odzyskać tron Wesnoth, którego jesteś prawowitym spadkobiercą... zasmakuj życia młodego oficera, wysłanego by bronić nie-tak-spokojnej granicy... zniszcz hordę nieumarłych przywołanych przez zuchwałego nekromantę, który porwał też twego brata... poprowadź grupę ocalałych elfów w epickiej wyprawie poszukiwania nowego domu.</p>
+    <p xml:lang="ru">Веснот содержит множество различных саг, которые только и ждут, чтобы быть сыгранными. Сражайтесь за возвращение трона Веснота как его истинный наследник... почувствуйте себя молодым офицером, отправленным на охрану неспокойного передового аванпоста... возглавьте брутальный квест по объединению орочьих племен... сокрушите орду мертвецов, поднятую отвратительным некромантом, который также берет вашего брата в заложники... ведите отряд выживших эльфов в эпическом квесте по поиску нового дома...</p>
+    <p>
+      There are at least two hundred unit types, sixteen races, six major
+      factions, and hundreds of years of history.
+      The world of Wesnoth is absolutely huge and only limited by your
+      creativity.
+      You can also challenge up to eight friends — or strangers — and fight in
+      epic multiplayer fantasy battles.
+    </p>
+    <p xml:lang="de">Mehr als 200 Einheitentypen. 16 Rassen. 6 Hauptfraktionen. Hunderte von Geschichtsjahren. Die Welt Wesnoths ist gigantisch und nur von den Grenzen deiner Vorstellungskraft begrenzt — erstelle deine eigenen Einheiten, Karten, Szenarien oder gleich ganze Kampagnen. Du kannst auch bis zu 8 Personen in epischen Mehrspielerschlachten herausfordern.</p>
+    <p xml:lang="es">Existen más de doscientos tipos de unidades, dieciseis razas, seis facciones principales y cientos de años de historia. El mundo de Wesnoth es absolutamente gigante y sólo está limitado por tu creatividad — construye tus propias unidades personalizadas, elabora tus propios mapas, crea tus propios escenarios o incluso campañas completas. Puedes también retar hasta ocho amigos — o estraños — y luchar en épicas batallas multijugador.</p>
+    <p xml:lang="fr">Plus de 200 types d'unités. 16 races. 6 factions majeures. Des siècles d'histoire. Le monde de Wesnoth est gigantesque et ses seules limites sont votre créativité : créez vos propres unités personnalisées, réalisez vos propres cartes, et écrivez vos propres scénarios voire des campagnes complètes ! Vous pouvez également défier jusqu'à 8 amis — ou inconnus — et les combattre dans d'épiques batailles en mode multijoueur.</p>
+    <p xml:lang="hu">Több, mint kétszáz fajta egység, hatvan faj, hat nagy szövetség és több száz évnyi történelem vár felfedezésre. Wesnoth világa hatalmas és csak a saját képzeleted jelenti a határt. Egyedi egységeket és térképeket készíthetsz, saját küldetéseket vagy akkár hadjáratokat írhatsz. Többjátékos küzdelemre hívhatod ki legfeljebb nyolc barátodat vagy idegeneket.</p>
+    <p xml:lang="pl">Ponad 200 jednostek. 16 ras. 6 głównych frakcji. Setki lat historii. Świat Wesnoth jest niezwykle wielki, ograniczony tylko Twoją wyobraźnią - stwórz własne jednostki, zbuduj własne mapy i napisz własne scenariusze, a nawet całe kampanie. Możesz wyzwać nawet do 8 przyjaciół — lub nieznajomych — aby toczyć epickie bitwy w trybie gry wieloosobowej.</p>
+    <p xml:lang="ru">В игре есть по крайней мере две сотни типов юнитов, шестнадцать рас, шесть крупных фракций и сотни лет истории. Мир Веснота огромен и ограничен только вашей креативностью — создавайте собственные юниты, карты, пишите собственные сценарии или даже полноценные кампании. Вы также можете соревноваться с друзьями или незнакомцами (до 8 человек), сражаясь с ними в эпических многопользовательских фэнтезийных баталиях.</p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image type="source" width="1280" height="768">https://www.wesnoth.org/images/sshots/wesnoth-1.13.2-1.jpg</image>
+    </screenshot>
+    <screenshot>
+      <image type="source" width="1280" height="768">https://www.wesnoth.org/images/sshots/wesnoth-1.13.2-4.jpg</image>
+    </screenshot>
+    <screenshot>
+      <image type="source" width="1280" height="768">https://www.wesnoth.org/images/sshots/wesnoth-1.13.6-4.jpg</image>
+    </screenshot>
+    <screenshot>
+      <image type="source" width="1280" height="768">https://www.wesnoth.org/images/sshots/wesnoth-1.13.7-2.jpg</image>
+    </screenshot>
+    <screenshot>
+      <image type="source" width="1280" height="768">https://www.wesnoth.org/images/sshots/wesnoth-1.13.6-1.jpg</image>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://www.wesnoth.org</url>
+  <url type="faq">https://wiki.wesnoth.org/Play</url>
+  <url type="help">https://wiki.wesnoth.org/WesnothManual</url>
+  <url type="translate">https://wiki.wesnoth.org/WesnothTranslations</url>
+  <url type="bugtracker">https://bugs.wesnoth.org</url>
+  <project_group>Wesnoth</project_group>
+  <developer_name>The Battle for Wesnoth Project</developer_name>
+  <update_contact>Please fill a bug at bugs.wesnoth.org</update_contact>
+  <kudos>
+    <kudo>HiDpiIcon<kudo>
+    <kudo>ModernToolkit</kudo>
+    <kudo>Notifications</kudo>
+    <kudo>UserDocs</kudo>
+  </kudos>
+  <provides>
+    <binary>wesnoth</binary>
+    <binary>wesnothd</binary>
+  </provides>
+</component>


### PR DESCRIPTION
With the adition of this wesnoth will show more information in software centers on linux.
Here an example from gnome-software:

![bildschirmfoto von 2017-10-13 06-15-52](https://user-images.githubusercontent.com/21158813/33972967-a10d1f38-e080-11e7-999a-b5001dc6bd2a.png)

The text shown is from the wiki (and thus the file is under GFDL license)
We would still need an email for the `update_contact` field, it should be an valid email address.

The 'Localized in your Language' is not properly detected for languages other than English, I wonder if it is related to #2213 or some other black magic.

As for the id:
It should ideally be of the scheme tld.developer.product
It seems like the comments and the rating in the software centres are bound to the id, so, if the id would be org.wesnoth.wesnoth-1.xy then each new release will start from scratch again.
Linux packagers will need more than one, maybe this is an alternative:
org.wesnoth.wesnoth (in the default repository)
org.wesnoth.wesnoth-devel (not in repos)
org.wesnoth.wesnoth-new (for backports of the new release)