### PR TITLE
Translate damage types in the unit_preview_pane tooltip.

### DIFF
--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -125,7 +125,7 @@ static inline std::string get_hp_tooltip(const utils::string_map& res, const std
 	bool att_def_diff = false;
 	for(const utils::string_map::value_type &resist : res) {
 		std::ostringstream line;
-		line << translation::gettext(resist.first.c_str()) << ": ";
+		line << translation::dgettext("wesnoth", resist.first.c_str()) << ": ";
 
 		// Some units have different resistances when attacking or defending.
 		const int res_att = 100 - get(resist.first, true);


### PR DESCRIPTION
To reproduce:

1. Run `wesnoth -t`
2. Open the 'recruit' dialog
3. Mouseover the green "HP:" value
4. Observe that the attack types ("arcane", "blade", etc.) appear in English.

With this patch, the attack types are translated.