### PR TITLE
Deprecation handling for the wesnoth preprocessor

### DIFF
--- a/data/core/macros/deprecated-utils.cfg
+++ b/data/core/macros/deprecated-utils.cfg
@@ -5,7 +5,7 @@
 
 #wmllint: markcheck off
 #define DEPRECATE MACRO_NAME VERSION_NAME
-    # Tag ActionWML macros for removal, where VERSION_NAME is the the next development series from the date of deprecation.
+    #deprecated 3 1.15 Use DEPRECATE_ACTION_MACRO instead.
     [deprecated_message]
         what={MACRO_NAME}
         level=2
@@ -25,32 +25,42 @@
 #wmllint: markcheck on
 
 #define MAGENTA_IS_THE_TEAM_COLOR
-    # This used to be used to set the default team colour for most unit types
-    # It's no longer needed, since the default is now set in the game_config.
+    #deprecated 3 1.15 This used to be used to set the default team colour for most unit types
+    #deprecated 3 1.15 It's no longer needed, since the default is now set in the game_config.
 #enddef
 
 #define ABILITY_LEADERSHIP_LEVEL_1
+    #deprecated 2 1.15 Leadership is now a single unified macro.
+    #deprecated 2 1.15 If you gave it to a unit other than its intended level, you'll need a custom macro.
     {ABILITY_LEADERSHIP}
 #enddef
 
 #define ABILITY_LEADERSHIP_LEVEL_2
+    #deprecated 2 1.15 Leadership is now a single unified macro.
+    #deprecated 2 1.15 If you gave it to a unit other than its intended level, you'll need a custom macro.
     {ABILITY_LEADERSHIP}
 #enddef
 
 #define ABILITY_LEADERSHIP_LEVEL_3
+    #deprecated 2 1.15 Leadership is now a single unified macro.
+    #deprecated 2 1.15 If you gave it to a unit other than its intended level, you'll need a custom macro.
     {ABILITY_LEADERSHIP}
 #enddef
 
 #define ABILITY_LEADERSHIP_LEVEL_4
+    #deprecated 2 1.15 Leadership is now a single unified macro.
+    #deprecated 2 1.15 If you gave it to a unit other than its intended level, you'll need a custom macro.
     {ABILITY_LEADERSHIP}
 #enddef
 
 #define ABILITY_LEADERSHIP_LEVEL_5
+    #deprecated 2 1.15 Leadership is now a single unified macro.
+    #deprecated 2 1.15 If you gave it to a unit other than its intended level, you'll need a custom macro.
     {ABILITY_LEADERSHIP}
 #enddef
 
 #define EARLY_FINISH_BONUS_CAPTION
-    # Deprecated; use the below EARLY_FINISH_BONUS_FOOTNOTE instead
+    #deprecated 3 1.15 Use EARLY_FINISH_BONUS_FOOTNOTE instead
 _"<small>(early finish bonus)</small>"#enddef
 
 #define EARLY_FINISH_BONUS_NOTE
@@ -80,6 +90,7 @@ _"No gold carried over to the next scenario."#enddef
 #enddef
 
 #define MESSAGE SPEAKER_ID IMAGE CAPTION_TEXT MESSAGE_TEXT
+    #deprecated 1 It's preferred to simply write out the message tag in full.
     # Displays a text message spoken by SPEAKER_ID.
     # Speaker can be any of: narrator, unit and second_unit
     # For example, let's have the narrator, which looks like a faery
@@ -119,6 +130,7 @@ _"No gold carried over to the next scenario."#enddef
 #enddef
 
 #define ON_SIGHTING ID SIGHTING_SIDE SIGHTED_FILTER ACTION_WML
+    #deprecated 1 Use an [event]name=sighted instead.
     # NOTE: As of version 1.11, this macro is unnecessary, since sighted
     # events now work as intended.
     #
@@ -267,6 +279,7 @@ _"No gold carried over to the next scenario."#enddef
 #enddef
 
 #define ANIMATED_CAMPFIRE X Y
+    # deprecated 2 1.15 Use the campfire terrain overlay (^Ecf) instead.
     # Embed this at scenario toplevel, not within an event.
     # Note that it will freeze while dialogue popups are onscreen.
     [terrain_graphics]
@@ -284,6 +297,7 @@ _"No gold carried over to the next scenario."#enddef
 #enddef
 
 #define ANIMATED_BRAZIER X Y
+    # deprecated 2 1.15 Use the campfire terrain overlay (^Eb) instead.
     # Embed this at scenario toplevel, not within an event.
     # Note that it will freeze while dialogue popups are onscreen.
     [terrain_graphics]
@@ -319,6 +333,7 @@ _"No gold carried over to the next scenario."#enddef
 
 # wmlindent: start ignoring
 #define FOREACH ARRAY_VALUE VAR
+#deprecated 1 You should use the [foreach] WML tag instead.
 # Macro to begin a WML clause that iterates over an array.
 {VARIABLE {VAR} 0}
 [while]
@@ -330,6 +345,7 @@ _"No gold carried over to the next scenario."#enddef
 #enddef
 
 #define NEXT VAR
+#deprecated 1 You should use the [foreach] WML tag instead of {FOREACH}.
 # Macro to end a WML clause that iterates over an array.
     [set_variable]
     name={VAR}
@@ -379,15 +395,15 @@ _"No gold carried over to the next scenario."#enddef
 #enddef
 
 #define SOUND:SLOW
-    # This was used to play a sound when slowing a unit, it had to
-    # be placed inside an attack animation. Now this sound is played
-    # automatically, there is no other use for this macro.
+    #deprecated 3 1.15 This was used to play a sound when slowing a unit, it had to
+    #deprecated 3 1.15 be placed inside an attack animation. Now this sound is played
+    #deprecated 3 1.15 automatically, there is no other use for this macro.
 #enddef
 
 #define SOUND:POISON
-    # This was used to play a sound when poisoning a unit, it had to
-    # be placed inside an attack animation. Now this sound is played
-    # automatically, there is no other use for this macro.
+    #deprecated 3 1.15 This was used to play a sound when poisoning a unit, it had to
+    #deprecated 3 1.15 be placed inside an attack animation. Now this sound is played
+    #deprecated 3 1.15 automatically, there is no other use for this macro.
 #enddef
 
 #define NO_INTERRUPT_NO_UNDO
@@ -398,5 +414,6 @@ _"No gold carried over to the next scenario."#enddef
 
 # TODO: remove for 1.15
 #define KHALIFATE_NAMES
+    #deprecated 3 1.15 Use DUNEFOLK_NAMES instead.
     {DUNEFOLK_NAMES}
 #enddef

--- a/projectfiles/VC12/wesnoth.vcxproj
+++ b/projectfiles/VC12/wesnoth.vcxproj
@@ -1095,13 +1095,6 @@
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Debug|Win32'">$(IntDir)Formula\</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Release|Win32'">$(IntDir)Formula\</ObjectFileName>
     </ClCompile>
-    <ClCompile Include="..\..\src\formula\string_utils.cpp">
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)Formula\</ObjectFileName>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='ReleaseDEBUG|Win32'">$(IntDir)Formula\</ObjectFileName>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)Formula\</ObjectFileName>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Debug|Win32'">$(IntDir)Formula\</ObjectFileName>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Release|Win32'">$(IntDir)Formula\</ObjectFileName>
-    </ClCompile>
     <ClCompile Include="..\..\src\formula\tokenizer.cpp">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)Formula\</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='ReleaseDEBUG|Win32'">$(IntDir)Formula\</ObjectFileName>
@@ -3663,7 +3656,6 @@
     <ClInclude Include="..\..\src\formula\formula_fwd.hpp" />
     <ClInclude Include="..\..\src\formula\function_gamestate.hpp" />
     <ClInclude Include="..\..\src\formula\function.hpp" />
-    <ClInclude Include="..\..\src\formula\string_utils.hpp" />
     <ClInclude Include="..\..\src\formula\tokenizer.hpp" />
     <ClInclude Include="..\..\src\formula\variant.hpp" />
     <ClInclude Include="..\..\src\formula\variant_value.hpp" />

--- a/projectfiles/VC12/wesnoth.vcxproj.filters
+++ b/projectfiles/VC12/wesnoth.vcxproj.filters
@@ -1322,9 +1322,6 @@
     <ClCompile Include="..\..\src\formula\function_gamestate.cpp">
       <Filter>Formula</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\formula\string_utils.cpp">
-      <Filter>Formula</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\formula\tokenizer.cpp">
       <Filter>Formula</Filter>
     </ClCompile>
@@ -1561,6 +1558,7 @@
     <ClCompile Include="..\..\src\gui\dialogs\surrender_quit.cpp">
       <Filter>Gui\Dialogs</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\deprecation.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\addon\client.hpp">
@@ -2745,9 +2743,6 @@
     <ClInclude Include="..\..\src\formula\function_gamestate.hpp">
       <Filter>Formula</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\formula\string_utils.hpp">
-      <Filter>Formula</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\src\formula\tokenizer.hpp">
       <Filter>Formula</Filter>
     </ClInclude>
@@ -3031,6 +3026,7 @@
     <ClInclude Include="..\..\src\gui\dialogs\surrender_quit.hpp">
       <Filter>Gui\Dialogs</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\deprecation.hpp" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\..\src\tests\test_sdl_utils.hpp">

--- a/projectfiles/VC12/wesnothlib.vcxproj
+++ b/projectfiles/VC12/wesnothlib.vcxproj
@@ -134,9 +134,15 @@
     <ClCompile Include="..\..\src\color_range.cpp" />
     <ClCompile Include="..\..\src\config.cpp" />
     <ClCompile Include="..\..\src\config_attribute_value.cpp" />
+    <ClCompile Include="..\..\src\deprecation.cpp" />
     <ClCompile Include="..\..\src\filesystem_boost.cpp" />
     <ClCompile Include="..\..\src\filesystem_common.cpp" />
     <ClCompile Include="..\..\src\font\constants.cpp" />
+    <ClCompile Include="..\..\src\formula\string_utils.cpp">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='ReleaseDEBUG|Win32'">$(IntDir)Formula\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)Formula\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)Formula\</ObjectFileName>
+    </ClCompile>
     <ClCompile Include="..\..\src\game_config.cpp" />
     <ClCompile Include="..\..\src\gettext_boost.cpp" />
     <ClCompile Include="..\..\src\log.cpp" />
@@ -162,8 +168,10 @@
     <ClInclude Include="..\..\src\color_range.hpp" />
     <ClInclude Include="..\..\src\config.hpp" />
     <ClInclude Include="..\..\src\config_attribute_value.hpp" />
+    <ClInclude Include="..\..\src\deprecation.hpp" />
     <ClInclude Include="..\..\src\filesystem.hpp" />
     <ClInclude Include="..\..\src\font\constants.hpp" />
+    <ClInclude Include="..\..\src\formula\string_utils.hpp" />
     <ClInclude Include="..\..\src\game_config.hpp" />
     <ClInclude Include="..\..\src\gettext.hpp" />
     <ClInclude Include="..\..\src\global.hpp" />

--- a/projectfiles/VC12/wesnothlib.vcxproj.filters
+++ b/projectfiles/VC12/wesnothlib.vcxproj.filters
@@ -17,6 +17,9 @@
     <Filter Include="Utils">
       <UniqueIdentifier>{dd5bcb3f-5af9-4dce-bcf3-9c23cec65372}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Formula">
+      <UniqueIdentifier>{89506bfd-cc4a-4db3-84f4-b90d70040b9c}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\serialization\binary_or_text.cpp">
@@ -59,6 +62,10 @@
     <ClCompile Include="..\..\src\font\constants.cpp">
       <Filter>Font</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\formula\string_utils.cpp">
+      <Filter>Formula</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\deprecation.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\serialization\binary_or_text.hpp">
@@ -140,5 +147,9 @@
     <ClInclude Include="..\..\src\utils\type_trait_aliases.hpp">
       <Filter>Utils</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\formula\string_utils.hpp">
+      <Filter>Formula</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\deprecation.hpp" />
   </ItemGroup>
 </Project>

--- a/source_lists/libwesnoth
+++ b/source_lists/libwesnoth
@@ -1,6 +1,7 @@
 arrow.cpp
 cursor.cpp
 desktop/clipboard.cpp
+deprecation.cpp
 display.cpp
 display_context.cpp
 events.cpp
@@ -14,6 +15,7 @@ font/text_cache.cpp
 font/text_formatting.cpp
 font/text_surface.cpp
 format_time_summary.cpp
+formula/string_utils.cpp
 game_end_exceptions.cpp
 generators/cave_map_generator.cpp
 generators/default_map_generator.cpp

--- a/source_lists/wesnoth
+++ b/source_lists/wesnoth
@@ -109,7 +109,6 @@ formula/debugger_fwd.cpp
 formula/formula.cpp
 formula/function.cpp
 formula/function_gamestate.cpp
-formula/string_utils.cpp
 formula/tokenizer.cpp
 formula/variant.cpp
 formula/variant_value.cpp

--- a/src/deprecation.cpp
+++ b/src/deprecation.cpp
@@ -1,0 +1,63 @@
+/*
+   Copyright (C) 2017 by the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#include "deprecation.hpp"
+
+#include "log.hpp"
+#include "gettext.hpp"
+#include "formula/string_utils.hpp"
+#include "tstring.hpp"
+#include "game_config.hpp"
+#include "version.hpp"
+
+static lg::log_domain log_wml("wml");
+
+// Note that these strings are all duplicated in data/lua/core.lua
+// Any changes here should also be reflected there.
+void deprecated_message(const std::string& elem_name, int level, const version_info& version, const std::string& detail) {
+	utils::string_map msg_params = {{"elem", elem_name}};
+	lg::logger* log_ptr = nullptr;
+	std::string message;
+	if(level == 1) {
+		log_ptr = &lg::info();
+		message = VGETTEXT("$elem has been deprecated indefinitely.", msg_params);
+	} else if(level == 2) {
+		log_ptr = &lg::warn();
+		if(game_config::wesnoth_version < version) {
+			msg_params["version"] = version.str();
+			message = VGETTEXT("$elem has been deprecated and may be removed in version $version.", msg_params);
+		} else {
+			message = VGETTEXT("$elem has been deprecated and may be removed at any time.", msg_params);
+		}
+	} else if(level == 3) {
+		log_ptr = &lg::err();
+		msg_params["version"] = version.str();
+		message = VGETTEXT("$elem has been deprecated and will be removed in the next version ($version).", msg_params);
+	} else if(level == 4) {
+		log_ptr = &lg::err();
+		message = VGETTEXT("$elem has been deprecated and removed.", msg_params);
+	} else {
+		utils::string_map err_params = {{"level", std::to_string(level)}};
+		LOG_STREAM(err, "general") << VGETTEXT("Invalid deprecation level $level (should be 1-4)", err_params);
+	}
+	// TODO: Decide when to dump to wml_error()
+	if(log_ptr && !log_ptr->dont_log(log_wml)) {
+		const lg::logger& out_log = *log_ptr;
+		out_log(log_wml) << message << '\n';
+		//lg::wml_error() << message << '\n';
+		if(!detail.empty()) {
+			out_log(log_wml) << detail << '\n';
+			//lg::wml_error() << detail << '\n';
+		}
+	}
+}

--- a/src/deprecation.hpp
+++ b/src/deprecation.hpp
@@ -1,0 +1,19 @@
+/*
+   Copyright (C) 2017 by the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#include <string>
+
+// Note: When using version (for level 2 or 3 deprecation), specify the first version
+// in which the feature could be removed... NOT the version at which it was deprecated.
+// For level 1 or 4 deprecation, it's fine to just pass an empty string, as the parameter will not be used.
+void deprecated_message(const std::string& elem_name, int level, const class version_info& version, const std::string& detail = "");

--- a/src/formula/formula.cpp
+++ b/src/formula/formula.cpp
@@ -16,12 +16,41 @@
 
 #include "formula/callable.hpp"
 #include "formula/function.hpp"
+#include "formula/string_utils.hpp"
 #include "random.hpp"
 #include "serialization/string_utils.hpp"
+#include "log.hpp"
 
 #include <cassert>
 #include <set>
 #include <sstream>
+
+// This is here only for the below initialization code.
+// If other logging is required in this file, it should use a different logdomain
+// (probably "scripting/formula" or something)
+static lg::log_domain log_engine("engine");
+#define ERR_NG LOG_STREAM(err, log_engine)
+
+namespace utils {
+	namespace detail {
+		std::string evaluate_formula_impl(const std::string& formula) {
+			try {
+				const wfl::formula form(formula);
+				return form.evaluate().string_cast();
+			} catch(wfl::formula_error& e) {
+				ERR_NG << "Formula in WML string cannot be evaluated due to "
+					<< e.type << "\n\t--> \"";
+				return "";
+			}
+		}
+
+		struct formula_initer {
+			formula_initer() {
+				evaluate_formula = &evaluate_formula_impl;
+			}
+		} init;
+	}
+}
 
 namespace wfl
 {

--- a/src/formula/string_utils.hpp
+++ b/src/formula/string_utils.hpp
@@ -21,6 +21,10 @@ class variable_set;
 
 namespace utils {
 
+	namespace detail {
+		extern std::string(* evaluate_formula)(const std::string& formula);
+	}
+
 /**
  * Determines if a string might contain variables to interpolate.
  * This can allow one to skip future interpolations (plural -- if there is only

--- a/src/scripting/lua_common.cpp
+++ b/src/scripting/lua_common.cpp
@@ -595,6 +595,17 @@ t_string luaW_checktstring(lua_State *L, int index)
 	return result;
 }
 
+bool luaW_isstring(lua_State* L, int index)
+{
+	if(lua_isstring(L, index)) {
+		return true;
+	}
+	if(lua_isuserdata(L, index) && luaL_testudata(L, index, tstringKey)) {
+		return true;
+	}
+	return false;
+}
+
 void luaW_filltable(lua_State *L, const config& cfg)
 {
 	if (!lua_checkstack(L, LUA_MINSTACK))

--- a/src/scripting/lua_common.hpp
+++ b/src/scripting/lua_common.hpp
@@ -78,6 +78,12 @@ bool luaW_totstring(lua_State *L, int index, t_string &str);
  */
 t_string luaW_checktstring(lua_State *L, int index);
 
+/*
+ * Test if a scalar is either a plain or translatable string.
+ * Also returns true if it's a number since that's convertible to string.
+ */
+bool luaW_isstring(lua_State* L, int index);
+
 /**
  * Converts a config object to a Lua table.
  * The destination table should be at the top of the stack on entry. It is

--- a/src/serialization/preprocessor.hpp
+++ b/src/serialization/preprocessor.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "exceptions.hpp"
+#include "version.hpp"
 
 class config_writer;
 class config;
@@ -56,13 +57,18 @@ struct preproc_define
 			const std::map<std::string, std::string>& optargs,
 			const std::string& domain,
 			int line,
-			const std::string& loc)
+			const std::string& loc,
+			const std::string& dep_msg,
+			int dep_lvl, const version_info& dep_ver)
 		: value(val)
 		, arguments(args)
 		, optional_arguments(optargs)
 		, textdomain(domain)
 		, linenum(line)
 		, location(loc)
+		, deprecation_message(dep_msg)
+		, deprecation_level(dep_lvl)
+		, deprecation_version(dep_ver)
 	{
 	}
 
@@ -77,6 +83,16 @@ struct preproc_define
 	int linenum;
 
 	std::string location;
+
+	std::string deprecation_message;
+
+	int deprecation_level = -1;
+
+	version_info deprecation_version;
+
+	bool is_deprecated() const {
+		return deprecation_level > 0;
+	}
 
 	void write(config_writer&, const std::string&) const;
 	void write_argument(config_writer&, const std::string&) const;


### PR DESCRIPTION
This extends the deprecation functionality (formerly implemented only in Lua) to the C++ core and adds a `#deprecated` preprocessor directive which, when used in a macro definition, will mark it deprecated so that a warning is printed on each use. (I'm not sure the implementation is quite the best; in particular, it doesn't currently give you the file and line number where it's used.) If used outside of a macro definition, the directive instead prints a deprecation warning applying to the entire file.

This is not ready to merge for one other reason: the second commit breaks the `$(...)` formula substitution syntax. The reason is that I need to be able to use string substitution syntax from the wesnothlib target (because the preprocessor is part of that target, and it depends on deprecation which depends on string substitution), but the formula engine is not part of the wesnothlib target. I'm not sure what the best course of action is here; moving the formula engine to wesnothlib seems like a poor choice as that would mean it's compiled into the servers.