### PR TITLE
Do not access non-existent unit

### DIFF
--- a/data/lua/wml/harm_unit.lua
+++ b/data/lua/wml/harm_unit.lua
@@ -176,7 +176,7 @@ function wml_actions.harm_unit(cfg)
 			end
 
 			if kill ~= false and unit_to_harm.hitpoints <= 0 then
-				wml_actions.kill { id = unit_to_harm.id, animate = toboolean( animate ), fire_event = fire_event }
+				wml_actions.kill { id = unit_to_harm.id, animate = toboolean( animate ), fire_event = fire_event, T.secondary_unit { id = harmer.id } }
 			end
 
 			if animate then

--- a/data/lua/wml/kill.lua
+++ b/data/lua/wml/kill.lua
@@ -11,7 +11,7 @@ function wesnoth.wml_actions.kill(cfg)
 		secondary_unit = wesnoth.get_units(secondary_unit)[1]
 		if cfg.fire_event then
 			if secondary_unit then
-				killer_loc = {secondary_unit.loc}
+				killer_loc = { x = tonumber(secondary_unit.x) or 0, y = tonumber(secondary_unit.y) or 0 }
 			else
 				wesnoth.log("warn", "failed to match [secondary_unit] in [kill] with a single on-board unit")
 			end
@@ -39,7 +39,7 @@ function wesnoth.wml_actions.kill(cfg)
 		if can_fire then
 			wesnoth.fire_event("last breath", death_loc, killer_loc)
 		end
-		if cfg.animate then
+		if cfg.animate and unit.valid == "map" then
 			wesnoth.scroll_to_tile(death_loc)
 			local anim = wesnoth.create_animator()
 			local primary = helper.get_child(cfg, "primary_attack")


### PR DESCRIPTION
The [kill] tag can run animations. But it can also fire the `last breath` event, which can call [kill]. When we get back to the original [kill], the unit is gone, causing an error attempting to run the animations.

Added a check to ensure the unit is still on the map before we attempt to run the animations.

The Issue also requested that [harm_unit] pass the unit causing the harm into the [kill] tag so that `last breath` could use the secondary (killing) unit available like it does elsewhere.

Closes #2298