### PR TITLE
addon_manager: fix append_tag usage

### DIFF
--- a/data/tools/wesnoth/campaignserver_client.py
+++ b/data/tools/wesnoth/campaignserver_client.py
@@ -311,7 +311,7 @@ class CampaignClient:
                     print(("Ignored dir", name))
                     return None
 
-            dataNode = append_tag("dir")
+            dataNode = append_tag(None, "dir")
             append_attributes(dataNode, name = name)
             for fn in glob.glob(path + "/*"):
                 if os.path.isdir(fn):


### PR DESCRIPTION
Note that this still doesn't allow the --upload
functionality to work. After this fix,
wesnoth still complaints about unordered WML.

It is believed that this is a separate issue though,
happened because of the latest simple_wml changes.