### PR TITLE
whiteboard: Don't clear the undo stack in SP mode.

### DIFF
--- a/changelog
+++ b/changelog
@@ -61,6 +61,8 @@ Version 1.13.10+dev:
      greater (bug #2185).
    * Fix recalls updating shroud immediately when "Delay Shroud Updates" is set
      (bug #2196)
+   * Fixed not being able to undo previous moves after entering planning mode 
+     (bug #2303)
 
 Version 1.13.10:
  * Add-ons client:

--- a/players_changelog
+++ b/players_changelog
@@ -24,6 +24,8 @@ Version 1.13.10+dev:
    * Fixed ingame help showing units you haven't encountered (bug #2135)
    * Fix recalls updating shroud immediately when "Delay Shroud Updates" is set
      (bug #2196)
+   * Fixed not being able to undo previous moves after entering planning mode 
+     (bug #2303)
 
 
 Version 1.13.10:

--- a/src/whiteboard/manager.cpp
+++ b/src/whiteboard/manager.cpp
@@ -1076,6 +1076,11 @@ int manager::get_spent_gold_for(int side)
 	return resources::gameboard->get_team(side).get_side_actions()->get_gold_spent();
 }
 
+bool manager::should_clear_undo() const
+{
+	return resources::controller->is_networked_mp();
+}
+
 void manager::options_dlg()
 {
 	int v_side = viewer_side();

--- a/src/whiteboard/manager.hpp
+++ b/src/whiteboard/manager.hpp
@@ -181,8 +181,8 @@ public:
 	int get_spent_gold_for(int side);
 
 	/** Determines whether or not the undo_stack should be cleared.
-	 *  @todo Only when there are networked allies and we have set a preferences option */
-	bool should_clear_undo() const {return true;}
+	 *  @todo When there are network allies, only clear the undo stack when we have set a preferences option */
+	bool should_clear_undo() const;
 
 	/** Displays the whiteboard options dialog. */
 	void options_dlg();


### PR DESCRIPTION
Fixes #2303.

I left the preferences as a todo since this patch as it stands is already an improvement for SP.