### PR TITLE
add clear_halo in erase_unit to prevent halo reamain after animate [kill]

### DIFF
--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -2103,6 +2103,7 @@ int game_lua_kernel::intf_erase_unit(lua_State *L)
 			if (!map().on_board(loc)) {
 				return luaL_argerror(L, 1, "invalid location");
 			}
+			u->anim_comp().clear_haloes();
 		} else if (int side = u.on_recall_list()) {
 			team &t = board().get_team(side);
 			// Should it use underlying ID instead?


### PR DESCRIPTION
When function clear_halo supress, halo persist after kill an unit after dialog