### PR TITLE
Further reworking of event iteration interface to try to fix #2312

### DIFF
--- a/data/test/scenarios/test_event_names_and_order.cfg
+++ b/data/test/scenarios/test_event_names_and_order.cfg
@@ -1,0 +1,48 @@
+{GENERIC_UNIT_TEST "order_of_variable_events1" (
+    [event]
+        name=start
+        {VARIABLE t 1}
+    [/event]
+    [event]
+        name="turn $t"
+        first_time_only=no
+        {VARIABLE_OP t add 1}
+        [end_turn][/end_turn]
+    [/event]
+    [event]
+        name=side 2 turn 1
+        {RETURN ({VARIABLE_CONDITIONAL t equals 2})}
+    [/event]
+)}
+
+{GENERIC_UNIT_TEST "order_of_variable_events2" (
+    [event]
+        name=start
+        {VARIABLE t 1}
+    [/event]
+    [event]
+        name=turn 1
+        {RETURN ({VARIABLE_CONDITIONAL t equals 2})}
+    [/event]
+    [event]
+        name="turn $t"
+        first_time_only=no
+        {VARIABLE_OP t add 1}
+        [end_turn][/end_turn]
+    [/event]
+)}
+
+{GENERIC_UNIT_TEST "event_name_variable_substitution" (
+    [event]
+        name=start
+        {VARIABLE t 1}
+    [/event]
+    [event]
+        name="turn 1"
+        [end_turn][/end_turn]
+    [/event]
+    [event]
+        name="side 1 turn $t end"
+        {RETURN ([true][/true])}
+    [/event]
+)}

--- a/src/game_events/handlers.hpp
+++ b/src/game_events/handlers.hpp
@@ -37,14 +37,17 @@ struct queued_event;
 class event_handler
 {
 public:
-	event_handler(config&& cfg, bool is_menu_item);
+	event_handler(config&& cfg, bool is_menu_item, const std::vector<std::string>& types);
+
+	const std::vector<std::string>& names() const
+	{
+		return types_;
+	}
 
 	bool disabled() const
 	{
 		return disabled_;
 	}
-
-	bool matches_name(const std::string& name, const game_data* data) const;
 
 	bool is_menu_item() const
 	{
@@ -71,6 +74,7 @@ private:
 	bool is_menu_item_;
 	bool disabled_;
 	config cfg_;
+	std::vector<std::string> types_;
 };
 
 }

--- a/src/game_events/manager_impl.hpp
+++ b/src/game_events/manager_impl.hpp
@@ -47,10 +47,10 @@ private:
 
 	void log_handlers();
 
+public:
 	/** Utility to standardize the event names used in by_name_. */
 	static std::string standardize_name(const std::string& name);
 
-public:
 	event_handlers()
 		: active_()
 		, by_name_()
@@ -67,6 +67,11 @@ public:
 
 	/** Read-only access to the active event handlers. Essentially gives all events. */
 	const handler_vec_t& get_active() const
+	{
+		return active_;
+	}
+
+	handler_vec_t& get_active()
 	{
 		return active_;
 	}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -195,3 +195,7 @@
 0 test_modify_ai_nested_facets
 0 test_modify_ai_composite_default_facets
 0 test_modify_ai_change_aspect
+# Event tests
+0 order_of_variable_events1
+1 order_of_variable_events2
+0 event_name_variable_substitution


### PR DESCRIPTION
Turns out constructing a list of matching handlers breaks some undocumented behavior, namely events being executed in the order they're added (usually the order in which they appear in the WML). It also broke certain variable substitution by moving variable interpolation wholly before any event execution, as opposed to between each event.

This commit is an experiment with an even simpler method: simply iterating through every registered handler in order, checking for a name match on each one, and if it passes, immediately executing the provided handler.

Not ready yet, still needs some polishing.