### PR TITLE
UI: Sort the 'damage versus' tooltip by unit type.

### DIFF
--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -645,6 +645,14 @@ REPORT_GENERATOR(selected_unit_moves, rc)
 	return unit_moves(rc, u);
 }
 
+static inline const color_t attack_info_percent_color(int resistance)
+{
+	// Compare unit_helper::resistance_color()
+	if (resistance < 0) return font::BAD_COLOR;
+	if (resistance > 0) return font::GOOD_COLOR;
+	return font::YELLOW_COLOR;
+}
+
 static int attack_info(reports::context & rc, const attack_type &at, config &res, const unit &u, const map_location &displayed_unit_hex)
 {
 	std::ostringstream str, tooltip;
@@ -776,8 +784,11 @@ static int attack_info(reports::context & rc, const attack_type &at, config &res
 	for (const resist_units &resist : resistances) {
 		int damage_with_resistance = round_damage(specials_damage, damage_multiplier * resist.first, damage_divisor);
 		tooltip << "<b>" << damage_with_resistance << "</b>  "
-			<< "<i>(" << utils::signed_percent(resist.first-100) << ")</i> : "
-			<< utils::join(resist.second, ", ") << '\n';
+			<< "<span color='" << attack_info_percent_color(resist.first-100).to_hex_string() << "'>"
+			<< "<i>(" << utils::signed_percent(resist.first-100) << ")</i>"
+			<< naps
+			<< " :  \t" // spaces to align the tab to a multiple of 8
+			<< utils::join(resist.second, " " + font::unicode_bullet + " ") << '\n';
 	}
 	add_text(res, flush(str), flush(tooltip));
 


### PR DESCRIPTION
I have been using this locally but @Pentarctagon suggested to post it as a PR.  Here's the tooltip it changes, the image shows the listing both before and after the patch:

![damage-tooltip](https://user-images.githubusercontent.com/24784687/34451976-5b1e2eb8-ed2d-11e7-82ac-60951197a85a.png)

_edit_: The "by unit" code is commit 5af12fb6ca73bd75b598e019394cd3f592cbc6e.