### PR TITLE
Addon client: close connection if the player cancels the download

### DIFF
--- a/changelog
+++ b/changelog
@@ -56,6 +56,7 @@ Version 1.13.10+dev:
    * Macro SCEPTRE_OF_FIRE_EFFECT damage increased to 15x4 so Sceptre is an
      improvement over the uncut ruby of fire (14x4) in TRoW.
  * Miscellaneous and bug fixes:
+   * Fixed crash after canceling add-on download (bug #2203)
    * Fixed ingame help showing units you haven't encountered (bug #2135)
    * Fixed the opacity IPF resetting to 0 if the value given was 100% or
      greater (bug #2185).

--- a/players_changelog
+++ b/players_changelog
@@ -21,6 +21,7 @@ Version 1.13.10+dev:
    * Miscellaneous low-level optimizations in game rendering code, improving
      performance ingame by up to 50 %.
  * Miscellaneous and bug fixes:
+   * Fixed crash after canceling add-on download (bug #2203)
    * Fixed ingame help showing units you haven't encountered (bug #2135)
    * Fix recalls updating shroud immediately when "Delay Shroud Updates" is set
      (bug #2196)

--- a/src/addon/client.cpp
+++ b/src/addon/client.cpp
@@ -574,6 +574,10 @@ void addons_client::wait_for_transfer_done(const std::string& status_message, tr
 
 	if(!stat.show()) {
 		// Notify the caller chain that the user aborted the operation.
-		throw user_exit();
+		if(mode == transfer_mode::connect) {
+			throw user_disconnect();
+		} else {
+			throw user_exit();
+		}
 	}
 }

--- a/src/addon/client.hpp
+++ b/src/addon/client.hpp
@@ -40,6 +40,7 @@ public:
 	struct invalid_server_address {};
 	struct not_connected_to_server {};
 	struct user_exit {};
+	struct user_disconnect {};
 
 	addons_client(const addons_client&) = delete;
 	addons_client& operator=(const addons_client&) = delete;

--- a/src/addon/client.hpp
+++ b/src/addon/client.hpp
@@ -122,7 +122,6 @@ private:
 	std::string host_;
 	std::string port_;
 	std::unique_ptr<network_asio::connection> conn_;
-	std::unique_ptr<gui2::dialogs::network_transmission> stat_;
 	std::string last_error_;
 	std::string last_error_data_;
 

--- a/src/addon/client.hpp
+++ b/src/addon/client.hpp
@@ -56,11 +56,19 @@ public:
 	 */
 	void connect();
 
+	/**
+	 * Disconnect from the add-on server.
+	 */
+	void disconnect() { conn_.reset(); }
+
 	/** Returns the last error message sent by the server, or an empty string. */
 	const std::string& get_last_server_error() const { return last_error_; }
 
 	/** Returns the last error message extra data sent by the server, or an empty string. */
 	const std::string& get_last_server_error_data() const { return last_error_data_; }
+
+	/** Returns true if the client is connected to the server. */
+	bool is_connected() { return conn_ != nullptr; }
 
 	/**
 	 * Request the add-ons list from the server.
@@ -118,6 +126,8 @@ public:
 	bool delete_remote_addon(const std::string& id, std::string& response_message);
 
 private:
+	enum class transfer_mode {download, connect, upload};
+
 	std::string addr_;
 	std::string host_;
 	std::string port_;
@@ -198,7 +208,7 @@ private:
 	 * will throw a @a user_exit exception if the user cancels the
 	 * transfer by canceling the status window.
 	 */
-	void wait_for_transfer_done(const std::string& status_message, bool track_upload = false);
+	void wait_for_transfer_done(const std::string& status_message, transfer_mode mode = transfer_mode::download);
 
 	bool update_last_error(config& response_cfg);
 };

--- a/src/addon/manager_ui.cpp
+++ b/src/addon/manager_ui.cpp
@@ -99,6 +99,8 @@ bool addons_manager_ui(const std::string& remote_address)
 		e.show();
 	} catch(const addons_client::user_exit&) {
 		LOG_AC << "initial connection canceled by user\n";
+	} catch(const addons_client::user_disconnect&) {
+		LOG_AC << "attempt to reconnect canceled by user\n";
 	} catch(const addons_client::invalid_server_address&) {
 		gui2::show_error_message(_("The add-ons server address specified is not valid."));
 	}

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -598,6 +598,10 @@ void addon_manager::execute_action_on_selected_addon(window& window)
 		(this->*fptr)(*addon, window);
 	} catch(const addons_client::user_exit&) {
 		// User canceled the op.
+		if(!client_.is_connected()) {
+			// User also canceled reconnecting to server, the addon manager is no longer usable.
+			throw;
+		}
 	}
 }
 

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -598,10 +598,6 @@ void addon_manager::execute_action_on_selected_addon(window& window)
 		(this->*fptr)(*addon, window);
 	} catch(const addons_client::user_exit&) {
 		// User canceled the op.
-		if(!client_.is_connected()) {
-			// User also canceled reconnecting to server, the addon manager is no longer usable.
-			throw;
-		}
 	}
 }
 

--- a/src/gui/dialogs/network_transmission.cpp
+++ b/src/gui/dialogs/network_transmission.cpp
@@ -73,11 +73,6 @@ network_transmission::network_transmission(
 	set_restore(true);
 }
 
-void network_transmission::set_subtitle(const std::string& subtitle)
-{
-	subtitle_ = subtitle;
-}
-
 void network_transmission::pre_show(window& window)
 {
 	// ***** ***** ***** ***** Set up the widgets ***** ***** ***** *****
@@ -94,7 +89,10 @@ void network_transmission::pre_show(window& window)
 void network_transmission::post_show(window& /*window*/)
 {
 	pump_monitor_.window_.reset();
-	connection_->cancel();
+
+	if(get_retval() == window::retval::CANCEL) {
+		connection_->cancel();
+	}
 }
 
 } // namespace dialogs

--- a/src/gui/dialogs/network_transmission.hpp
+++ b/src/gui/dialogs/network_transmission.hpp
@@ -69,12 +69,6 @@ public:
 						  const std::string& title,
 						  const std::string& subtitle);
 
-	void set_subtitle(const std::string&);
-	void set_connection_data(connection_data& connection)
-	{
-		connection_ = &connection;
-	}
-
 protected:
 	/** Inherited from modal_dialog. */
 	virtual void pre_show(window& window) override;


### PR DESCRIPTION
This pull request is a fix for bug #2203.

The approach is to close the connection when the player cancels the download. This is the same thing that Wesnoth was doing before the GUI2 port of the addon manager, and it has zero overhead if the player *doesn't* cancel the download (unlike some other options which were suggested).