### PR TITLE
Revert part of "GUI2 Textbox: Remove the other two emacs keybindings"

### DIFF
--- a/src/gui/widgets/text_box_base.cpp
+++ b/src/gui/widgets/text_box_base.cpp
@@ -539,6 +539,13 @@ void text_box_base::signal_handler_sdl_key_down(const event::ui_event event,
 			handle_key_backspace(modifier, handled);
 			break;
 
+		case SDLK_u:
+			if(!(modifier & KMOD_CTRL)) {
+				return;
+			}
+			handle_key_clear_line(modifier, handled);
+			break;
+
 		case SDLK_DELETE:
 			handle_key_delete(modifier, handled);
 			break;


### PR DESCRIPTION
This reverts part of commit 468c6e0f494793d57b0b1264894cd7f0b0383fa2.

Ctrl+A was removed because its emacs meaning is surprising to some
people.  Ctrl+E was removed because it was the counterpart of Ctrl+A.
Ctrl+U however doesn't conflict with anything else, and it's useful
to some people (me), so reinstate it.

Discussed with @CelticMinstrel.