### PR TITLE
Made more use of std::isalnum, std::isalpha, and std::isdigit (std::l…

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -202,9 +202,7 @@ bool config::valid_attribute(config_key_type name)
 	}
 
 	for(char c : name) {
-		if((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_') {
-			// valid character.
-		} else {
+		if(!std::isalnum(c, std::locale::classic()) && c != '_') {
 			return false;
 		}
 	}

--- a/src/font/marked-up_text.cpp
+++ b/src/font/marked-up_text.cpp
@@ -31,6 +31,8 @@
 #include "wml_exception.hpp"
 #include "preferences/general.hpp"
 
+#include <locale>
+
 namespace font {
 
 // NOTE: if you add more markup characters below, you'll need to update
@@ -89,7 +91,7 @@ std::string::const_iterator parse_markup(std::string::const_iterator i1,
 				// should look like <213,14,151>
 				++i1;
 				uint8_t red=0, green=0, blue=0, temp=0;
-				while (i1 != i2 && *i1 >= '0' && *i1<='9') {
+				while (i1 != i2 && std::isdigit(*i1, std::locale::classic())) {
 					temp*=10;
 					temp += lexical_cast<int, char>(*i1);
 					++i1;
@@ -98,7 +100,7 @@ std::string::const_iterator parse_markup(std::string::const_iterator i1,
 				temp=0;
 				if (i1 != i2 && ',' == (*i1)) {
 					++i1;
-					while(i1 != i2 && *i1 >= '0' && *i1<='9'){
+					while(i1 != i2 && std::isdigit(*i1, std::locale::classic())){
 						temp*=10;
 						temp += lexical_cast<int, char>(*i1);
 						++i1;
@@ -108,7 +110,7 @@ std::string::const_iterator parse_markup(std::string::const_iterator i1,
 				}
 				if (i1 != i2 && ',' == (*i1)) {
 					++i1;
-					while(i1 != i2 && *i1 >= '0' && *i1<='9'){
+					while(i1 != i2 && std::isdigit(*i1, std::locale::classic())){
 						temp*=10;
 						temp += lexical_cast<int, char>(*i1);
 						++i1;

--- a/src/formula/tokenizer.cpp
+++ b/src/formula/tokenizer.cpp
@@ -12,9 +12,10 @@
    See the COPYING file for more details.
 */
 
-#include <sstream>
-
 #include "formula/tokenizer.hpp"
+
+#include <locale>
+#include <sstream>
 
 namespace wfl
 {
@@ -48,7 +49,7 @@ token get_token(iterator& i1, const iterator i2) {
 		// check if we parse now TOKEN_IDENTIFIER or TOKEN_OPERATOR/KEYWORD based on string
 		if( *i1 <= 'Z' || ( *i1 >= 'a' && *it <= 'z' ) || *i1 == '_' ) {
 
-			while( i1 != i2 && ( ( *i1 >= 'a' && *i1 <= 'z' ) || *i1 == '_' || ( *i1 >= 'A' && *i1 <= 'Z' ) ) )
+			while(i1 != i2 && (std::isalpha(*i1, std::locale::classic()) || *i1 == '_'))
 				++i1;
 
 			int diff = i1 - it;
@@ -139,7 +140,7 @@ token get_token(iterator& i1, const iterator i2) {
 				bool dot = false;
 
 				while( i1 != i2 ) {
-					if( *i1 >= '0' && *i1 <= '9' ) {
+					if(std::isdigit(*i1, std::locale::classic())) {
 						//do nothing
 					} else {
 						//look for '.' in case of decimal number

--- a/src/preferences/general.cpp
+++ b/src/preferences/general.cpp
@@ -34,6 +34,7 @@
 #include "utils/general.hpp"
 #include "video.hpp" // non_interactive()
 
+#include <locale>
 #include <sys/stat.h> // for setting the permissions of the preferences file
 #ifndef _WIN32
 #include <unistd.h>
@@ -293,7 +294,7 @@ void set_show_partial_orb(bool show_orb) {
 
 static std::string fix_orb_color_name(const std::string& color) {
 	if (color.substr(0,4) == "orb_") {
-		if(color[4] >= '0' && color[4] <= '9') {
+		if(std::isdigit(color[4], std::locale::classic())) {
 			return color.substr(5);
 		} else {
 			return color.substr(4);

--- a/src/serialization/tokenizer.cpp
+++ b/src/serialization/tokenizer.cpp
@@ -18,6 +18,7 @@
 #include "wesconfig.h"
 #include "serialization/tokenizer.hpp"
 
+#include <locale>
 
 tokenizer::tokenizer(std::istream& in) :
 	current_(EOF),
@@ -31,11 +32,11 @@ tokenizer::tokenizer(std::istream& in) :
 	for (int c = 0; c < 128; ++c)
 	{
 		int t = 0;
-		if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_') {
+		if(std::isalpha(c, std::locale::classic()) || c == '_') {
 			t = TOK_ALPHA;
-		} else if (c >= '0' && c <= '9') {
+		} else if(std::isdigit(c, std::locale::classic())) {
 			t = TOK_NUMERIC;
-		} else if (c == ' ' || c == '\t') {
+		} else if(c == ' ' || c == '\t') {
 			t = TOK_SPACE;
 		}
 		char_types_[c] = t;

--- a/src/server/ban.hpp
+++ b/src/server/ban.hpp
@@ -19,6 +19,7 @@
 #include <set>
 #include <map>
 #include <list>
+#include <locale>
 #include <queue>
 #include <ctime>
 
@@ -130,7 +131,7 @@ namespace wesnothd {
 		bool dirty_;
 
 		bool is_digit(const char& c) const
-		{ return c >= '0' && c <= '9'; }
+		{ return std::isdigit(c, std::locale::classic()); }
 		size_t to_digit(const char& c) const
 		{ return c - '0'; }
 

--- a/src/units/types.cpp
+++ b/src/units/types.cpp
@@ -34,6 +34,8 @@
 
 #include <boost/regex.hpp>
 
+#include <locale>
+
 static lg::log_domain log_config("config");
 #define ERR_CF LOG_STREAM(err, log_config)
 #define WRN_CF LOG_STREAM(warn, log_config)
@@ -1434,12 +1436,7 @@ void unit_type::check_id(std::string& id)
 
 	for(size_t pos = 0; pos < id.size(); ++pos) {
 		const char c = id[pos];
-		const bool valid =
-			c == '_' ||
-			c == ' ' ||
-			(c >= 'a' && c <= 'z') ||
-			(c >= 'A' && c <= 'Z') ||
-			(c >= '0' && c <= '9');
+		const bool valid = std::isalnum(c, std::locale::classic()) || c == '_' || c == ' ';
 
 		if(!valid) {
 			if(!gave_warning) {

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -18,6 +18,7 @@
 
 #include <cassert>
 #include <functional>
+#include <locale>
 
 #include <boost/algorithm/string.hpp>
 
@@ -58,7 +59,7 @@ version_info::version_info(const std::string& str)
 		const std::string right_side = v.substr(breakpoint_pos);
 		assert(right_side.empty() == false);
 
-		if((right_side[0] >= 'A' && right_side[0] <= 'Z') || (right_side[0] >= 'a' && right_side[0] <= 'z')) {
+		if(std::isalpha(right_side[0], std::locale::classic())) {
 			special_separator_ = '\0';
 			special_ = right_side;
 		}


### PR DESCRIPTION
…ocale versions)

I'm wondering if maybe I should make these util functions to avoid having to specify the classic locale constantly.