### PR TITLE
fix code problems found by luacheck

### DIFF
--- a/data/lua/wml/endlevel.lua
+++ b/data/lua/wml/endlevel.lua
@@ -25,7 +25,7 @@ function wesnoth.wml_actions.endlevel(cfg)
 	if end_credits ~= nil then
 		wesnoth.set_end_campaign_credits(end_credits)
 	end
-	
+
 	local side_results = {}
 	for result in helper.child_range(parsed, "result") do
 		local side = result.side or helper.wml_error("[result] in [endlevel] missing required side= key")
@@ -82,7 +82,7 @@ function wesnoth.wml_actions.endlevel(cfg)
 		end
 	end
 
-	local proceed_to_next_level = there_is_a_human_victory or (not there_is_a_human_defeat and cfg.result ~= "defeat") 
+	local proceed_to_next_level = there_is_a_human_victory or (not there_is_a_human_defeat and cfg.result ~= "defeat")
 	local victory = there_is_a_local_human_victory or (not there_is_a_local_human_defeat and proceed_to_next_level)
 
 	if cfg.music then

--- a/data/lua/wml/find_path.lua
+++ b/data/lua/wml/find_path.lua
@@ -28,8 +28,7 @@ function wesnoth.wml_actions.find_path(cfg)
 
 	if not cfg.check_visibility then viewing_side = 0 end -- if check_visiblity then shroud is taken in account
 
-	-- only the location with the lowest distance and lowest movement cost
-	-- will match. If there will still be more than 1, only the 1st maching one.
+	-- only the first location with the lowest distance and lowest movement cost will match.
 	local locations = wesnoth.get_locations(filter_location)
 
 	local max_cost = nil
@@ -79,21 +78,21 @@ function wesnoth.wml_actions.find_path(cfg)
 		end
 
 		if cost >= 42424242 then -- it's the high value returned for unwalkable or busy terrains
-			wesnoth.set_variable ( string.format("%s", variable), { hexes = 0 } ) -- set only length, nil all other values
+			wesnoth.set_variable ( tostring(variable), { hexes = 0 } ) -- set only length, nil all other values
 			-- support for $this_unit
 			wesnoth.set_variable ( "this_unit" ) -- clearing this_unit
 			utils.end_var_scope("this_unit", this_unit)
 		return end
 
 		if not allow_multiple_turns and turns > 1 then -- location cannot be reached in one turn
-			wesnoth.set_variable ( string.format("%s", variable), { hexes = 0 } )
+			wesnoth.set_variable ( tostring(variable), { hexes = 0 } )
 			-- support for $this_unit
 			wesnoth.set_variable ( "this_unit" ) -- clearing this_unit
 			utils.end_var_scope("this_unit", this_unit)
 		return end -- skip the cycles below
 
 		wesnoth.set_variable (
-			string.format( "%s", variable ),
+			tostring( variable ),
 			{
 				hexes = current_distance,
 				from_x = unit.x, from_y = unit.y,

--- a/data/lua/wml/harm_unit.lua
+++ b/data/lua/wml/harm_unit.lua
@@ -48,14 +48,15 @@ function wml_actions.harm_unit(cfg)
 						with_bars = true,
 						T.filter { id = harmer.id },
 						T.primary_attack ( primary_attack ),
-						T.secondary_attack ( secondary_attack ), 
+						T.secondary_attack ( secondary_attack ),
 						T.facing { x = unit_to_harm.x, y = unit_to_harm.y },
 					}
 				end
 				wesnoth.scroll_to_tile(unit_to_harm.x, unit_to_harm.y, true)
 			end
 
-			-- the two functions below are taken straight from the C++ engine, utils.cpp and actions.cpp, with a few unuseful parts removed
+			-- the two functions below are taken straight from the C++ engine,
+			-- utils.cpp and actions.cpp, with a few unuseful parts removed
 			-- may be moved in helper.lua in 1.11
 			local function round_damage( base_damage, bonus, divisor )
 				local rounding
@@ -148,7 +149,7 @@ function wml_actions.harm_unit(cfg)
 						T.facing { x = harmer.x, y = harmer.y },
 					}
 				else
-					wml_actions.animate_unit { 
+					wml_actions.animate_unit {
 						flag = "defend",
 						hits = true,
 						with_bars = true,
@@ -166,7 +167,9 @@ function wml_actions.harm_unit(cfg)
 				else return level * 8 end
 			end
 
-			if experience ~= false and harmer and harmer.valid and wesnoth.is_enemy( unit_to_harm.side, harmer.side ) then -- no XP earned for harming friendly units
+			if experience ~= false and harmer and harmer.valid
+				and wesnoth.is_enemy( unit_to_harm.side, harmer.side )
+			then
 				if kill ~= false and unit_to_harm.hitpoints <= 0 then
 					harmer.experience = harmer.experience + calc_xp( unit_to_harm.__cfg.level )
 				else

--- a/data/lua/wml/items.lua
+++ b/data/lua/wml/items.lua
@@ -11,7 +11,16 @@ local function add_overlay(x, y, cfg)
 		items = {}
 		scenario_items[x * 10000 + y] = items
 	end
-	table.insert(items, { x = x, y = y, image = cfg.image, halo = cfg.halo, team_name = cfg.team_name, visible_in_fog = cfg.visible_in_fog, redraw = cfg.redraw, name = cfg.name })
+	table.insert(items,
+		{
+			x = x, y = y,
+			image = cfg.image,
+			halo = cfg.halo,
+			team_name = cfg.team_name,
+			visible_in_fog = cfg.visible_in_fog,
+			redraw = cfg.redraw,
+			name = cfg.name
+		})
 end
 
 local function remove_overlay(x, y, name)
@@ -78,7 +87,7 @@ function wml_actions.item(cfg)
 	local redraw = cfg.redraw
 	if redraw == nil then redraw = true end
 	if redraw then wml_actions.redraw {} end
-	if cfg.write_name then wesnoth.set_variable(write_name, cfg.name) end
+	if cfg.write_name then wesnoth.set_variable(cfg.write_name, cfg.name) end
 	return cfg.name
 end
 

--- a/data/lua/wml/kill.lua
+++ b/data/lua/wml/kill.lua
@@ -31,7 +31,9 @@ function wesnoth.wml_actions.kill(cfg)
 				if wesnoth.current.event_context.name == "die" or wesnoth.current.event_context.name == "last breath" then
 					if recursion >= 10 then
 						can_fire = false;
-						wesnoth.log("error", "tried to fire 'die' or 'last breath' event on unit from the unit's 'die' or 'last breath' event with first_time_only=no!")
+						wesnoth.log("error", "tried to fire 'die' or 'last breath' event "
+							.. "on unit from the unit's 'die' or 'last breath' event "
+							.. "with first_time_only=no!")
 					end
 				end
 			end
@@ -57,7 +59,7 @@ function wesnoth.wml_actions.kill(cfg)
 				wesnoth.log('err', "Primary weapon:\n" .. wml.tostring(primary.__cfg))
 			end
 			if secondary then
-				if primary_unit then
+				if primary then
 					secondary = helper.find_attack(unit, secondary)
 				else
 					secondary = wesnoth.create_weapon(secondary)

--- a/data/lua/wml/message.lua
+++ b/data/lua/wml/message.lua
@@ -281,12 +281,12 @@ function wesnoth.wml_actions.message(cfg)
 
 	-- Only the first text_input tag is considered
 	local text_input
-	for cfg_text in helper.child_range(cfg, "text_input") do
+	for text_input_cfg in helper.child_range(cfg, "text_input") do
 		if text_input ~= nil then
 			log("Too many [text_input] tags, only first one accepted", "warning")
 			break
 		end
-		text_input = cfg_text
+		text_input = text_input_cfg
 	end
 
 	local options, option_events = {}, {}

--- a/data/lua/wml/message.lua
+++ b/data/lua/wml/message.lua
@@ -1,7 +1,6 @@
 
 local helper = wesnoth.require "helper"
 local utils = wesnoth.require "wml-utils"
-local location_set = wesnoth.require "location_set"
 local _ = wesnoth.textdomain "wesnoth"
 
 local function log(msg, level)
@@ -51,7 +50,7 @@ end
 
 local function get_pango_color(color)
 	local pango_color = "#"
-	
+
 	-- if a hex color was passed in
 	-- or if a color string was passed in - contains no non-letter characters
 	-- just use that
@@ -63,113 +62,113 @@ local function get_pango_color(color)
 			pango_color = pango_color .. tonumber(s, 16)
 		end
 	end
-	
+
 	return pango_color
 end
 
 -- add formatting
 local function add_formatting(cfg, text)
 	-- span tag
-	local formatting = "<span"  
-	
+	local formatting = "<span"
+
 	-- if message text, add formatting
 	if text and cfg then
 		-- add font
 		if cfg.font and cfg.font ~= '' then
 			formatting = formatting .. " font='" .. cfg.font .. "'"
 		end
-		
+
 		-- add font_family
 		if cfg.font_family and cfg.font_family ~= '' then
 			formatting = formatting .. " font_family='" .. cfg.font_family .. "'"
 		end
-		
+
 		-- add font_size
 		if cfg.font_size and cfg.font_size ~= '' then
 			formatting = formatting .. " font_size='" .. cfg.font_size .. "'"
 		end
-		
+
 		-- font_style
 		if cfg.font_style and cfg.font_style ~= '' then
 			formatting = formatting .. " font_style='" .. cfg.font_style .. "'"
 		end
-		
+
 		-- font_weight
 		if cfg.font_weight and cfg.font_weight ~= '' then
 			formatting = formatting .. " font_weight='" .. cfg.font_weight .. "'"
 		end
-		
+
 		-- font_variant
 		if cfg.font_variant and cfg.font_variant ~= '' then
 			formatting = formatting .. " font_variant='" .. cfg.font_variant .. "'"
 		end
-		
+
 		-- font_stretch
 		if cfg.font_stretch and cfg.font_stretch ~= '' then
 			formatting = formatting .. " font_stretch='" .. cfg.font_stretch .. "'"
 		end
-		
+
 		-- add color
 		if cfg.color and cfg.color ~= '' then
 			formatting = formatting .. " color='" .. get_pango_color(cfg.color) .. "'"
 		end
-		
+
 		-- bgcolor
 		if cfg.bgcolor and cfg.bgcolor ~= '' then
 			formatting = formatting .. " bgcolor='" .. get_pango_color(cfg.bgcolor) .. "'"
 		end
-		
+
 		-- underline
 		if cfg.underline and cfg.underline ~= '' then
 			formatting = formatting .. " underline='" .. cfg.underline .. "'"
 		end
-		
+
 		-- underline_color
 		if cfg.underline_color and cfg.underline_color ~= '' then
 			formatting = formatting .. " underline_color='" .. get_pango_color(cfg.underline_color) .. "'"
 		end
-		
+
 		-- rise
 		if cfg.rise and cfg.rise ~= '' then
 			formatting = formatting .. " rise='" .. cfg.rise .. "'"
 		end
-		
+
 		-- strikethrough
 		if cfg.strikethrough and tostring(cfg.strikethrough) ~= '' then
 			formatting = formatting .. " strikethrough='" .. tostring(cfg.strikethrough) .. "'"
 		end
-		
+
 		-- strikethrough_color
 		if cfg.strikethrough_color and cfg.strikethrough_color ~= '' then
 			formatting = formatting .. " strikethrough_color='" .. get_pango_color(cfg.strikethrough_color) .. "'"
 		end
-		
+
 		-- fallback
 		if cfg.fallback and tostring(cfg.fallback) ~= '' then
 			formatting = formatting .. " fallback='" .. tostring(cfg.fallback) .. "'"
 		end
-		
+
 		-- letter_spacing
 		if cfg.letter_spacing and cfg.letter_spacing ~= '' then
 			formatting = formatting .. " letter_spacing='" .. cfg.letter_spacing .. "'"
 		end
-		
+
 		-- gravity
 		if cfg.gravity and cfg.gravity ~= '' then
 			formatting = formatting .. " gravity='" .. cfg.gravity .. "'"
 		end
-		
+
 		-- gravity_hint
 		if cfg.gravity_hint and cfg.gravity_hint ~= '' then
 			formatting = formatting .. " gravity_hint='" .. cfg.gravity_hint .. "'"
 		end
-		
+
 		-- wrap in span tags and return if a color was added
 		if formatting ~= "<span" then
 			return formatting .. ">" .. text .. "</span>"
 		end
- 	end
- 	
+	end
+
 	-- or return unmodified message
 	return text
 end
@@ -204,7 +203,7 @@ local function message_user_choice(cfg, speaker, options, text_input, sound, voi
 		second_portrait = cfg.second_image,
 		second_mirror = cfg.second_mirror,
 	}
-	
+
 	if speaker ~= nil then
 		if cfg.male_message ~= nil and speaker.gender == "male" then
 			msg_cfg.message = cfg.male_message
@@ -212,10 +211,10 @@ local function message_user_choice(cfg, speaker, options, text_input, sound, voi
 			msg_cfg.message = cfg.female_message
 		end
 	end
-	
+
 	-- add formatting
 	msg_cfg.message = add_formatting(cfg, msg_cfg.message)
-	
+
 	-- Parse input text, if not available all fields are empty
 	if text_input then
 		local input_max_size = tonumber(text_input.max_length) or 256
@@ -282,12 +281,12 @@ function wesnoth.wml_actions.message(cfg)
 
 	-- Only the first text_input tag is considered
 	local text_input
-	for cfg in helper.child_range(cfg, "text_input") do
+	for cfg_text in helper.child_range(cfg, "text_input") do
 		if text_input ~= nil then
-			log("Too many [text_input] tags, only one accepted", "warning")
+			log("Too many [text_input] tags, only first one accepted", "warning")
 			break
 		end
-		text_input = cfg
+		text_input = cfg_text
 	end
 
 	local options, option_events = {}, {}
@@ -345,7 +344,10 @@ function wesnoth.wml_actions.message(cfg)
 		-- Sanity checks on side number and controller
 		for side in utils.split(sides_for) do
 			side = tonumber(side)
-			if side > 0 and side < #wesnoth.sides and wesnoth.sides[side].controller == "human" and wesnoth.sides[side].is_local then
+			if side > 0 and side < #wesnoth.sides
+				and wesnoth.sides[side].controller == "human"
+				and wesnoth.sides[side].is_local
+			then
 				show_for_side = true
 				break
 			end
@@ -401,7 +403,7 @@ function wesnoth.wml_actions.message(cfg)
 			wesnoth.set_variable(text_input.variable or "input", choice.text)
 		end
 	end
-	
+
 	-- Unhilight the speaker
 	if speaker and not cfg.highlight == false then
 		wesnoth.deselect_hex()

--- a/data/lua/wml/micro_ai.lua
+++ b/data/lua/wml/micro_ai.lua
@@ -1,5 +1,4 @@
 local H = wesnoth.require "helper"
-local W = H.set_wml_action_metatable {}
 local MAIH = wesnoth.require("ai/micro_ais/micro_ai_helper.lua")
 
 wesnoth.micro_ais = {}

--- a/data/lua/wml/objectives.lua
+++ b/data/lua/wml/objectives.lua
@@ -194,7 +194,7 @@ function wml_actions.objectives(cfg)
 		cfg = helper.parsed(cfg)
 	end
 
-	local cfg_sides = wesnoth.get_sides(cfg)
+	local sides_cfg = wesnoth.get_sides(cfg)
 	local silent = cfg.silent
 
 	local objectives = generate_objectives(cfg)
@@ -207,12 +207,12 @@ function wml_actions.objectives(cfg)
 			team.objectives_changed = not silent
 		end
 	end
-	if #cfg_sides == #wesnoth.sides or #cfg_sides == 0 then
+	if #sides_cfg == #wesnoth.sides or #sides_cfg == 0 then
 		scenario_objectives[0] = helper.literal(cfg)
 		remove_ssf_info_from(scenario_objectives[0])
 		set_objectives(wesnoth.sides)
 	else
-		set_objectives(cfg_sides, true)
+		set_objectives(sides_cfg, true)
 	end
 end
 

--- a/data/lua/wml/objectives.lua
+++ b/data/lua/wml/objectives.lua
@@ -84,7 +84,9 @@ local function generate_objectives(cfg)
 					win_objectives = win_objectives .. caption .. "\n"
 				end
 
-				win_objectives = win_objectives .. color_prefix(r, g, b) .. objective_bullet .. description .. turn_counter .. "</span>" .. "\n"
+				win_objectives = win_objectives
+					.. color_prefix(r, g, b) .. objective_bullet
+					.. description .. turn_counter .. "</span>" .. "\n"
 			elseif condition == "lose" then
 				local caption = obj.caption
 				local r = obj.red or 255
@@ -95,7 +97,9 @@ local function generate_objectives(cfg)
 					lose_objectives = lose_objectives .. caption .. "\n"
 				end
 
-				lose_objectives = lose_objectives .. color_prefix(r, g, b) .. objective_bullet .. description .. turn_counter .. "</span>" .. "\n"
+				lose_objectives = lose_objectives
+					.. color_prefix(r, g, b) .. objective_bullet.. description
+					.. turn_counter .. "</span>" .. "\n"
 			else
 				wesnoth.message "Unknown condition, ignoring."
 			end
@@ -112,14 +116,16 @@ local function generate_objectives(cfg)
 
 			if obj.bonus ~= nil then
 				if obj.bonus then
-					gold_carryover = color_prefix(r, g, b) .. gold_carryover_bullet .. "<small>" .. _"Early finish bonus." .. "</small></span>\n"
+					gold_carryover = color_prefix(r, g, b) .. gold_carryover_bullet
+						.. "<small>" .. _"Early finish bonus." .. "</small></span>\n"
 				else
-					gold_carryover = color_prefix(r, g, b) .. gold_carryover_bullet .. "<small>" .. _"No early finish bonus." .. "</small></span>\n"
+					gold_carryover = color_prefix(r, g, b) .. gold_carryover_bullet
+					.. "<small>" .. _"No early finish bonus." .. "</small></span>\n"
 				end
 			end
 
 			if obj.carryover_percentage then
-				local carryover_amount_string = ""
+				local carryover_amount_string
 
 				if obj.carryover_percentage == 0 then
 					carryover_amount_string = _"No gold carried over to the next scenario."
@@ -127,7 +133,9 @@ local function generate_objectives(cfg)
 					carryover_amount_string = string.format(tostring(_ "%d%% of gold carried over to the next scenario."), obj.carryover_percentage)
 				end
 
-				gold_carryover = gold_carryover .. color_prefix(r, g, b) .. gold_carryover_bullet .. "<small>" .. carryover_amount_string .. "</small></span>\n"
+				gold_carryover = gold_carryover
+					.. color_prefix(r, g, b) .. gold_carryover_bullet
+					.. "<small>" .. carryover_amount_string .. "</small></span>\n"
 			end
 		end
 	end
@@ -186,7 +194,7 @@ function wml_actions.objectives(cfg)
 		cfg = helper.parsed(cfg)
 	end
 
-	local sides = wesnoth.get_sides(cfg)
+	local cfg_sides = wesnoth.get_sides(cfg)
 	local silent = cfg.silent
 
 	local objectives = generate_objectives(cfg)
@@ -199,12 +207,12 @@ function wml_actions.objectives(cfg)
 			team.objectives_changed = not silent
 		end
 	end
-	if #sides == #wesnoth.sides or #sides == 0 then
+	if #cfg_sides == #wesnoth.sides or #cfg_sides == 0 then
 		scenario_objectives[0] = helper.literal(cfg)
 		remove_ssf_info_from(scenario_objectives[0])
 		set_objectives(wesnoth.sides)
 	else
-		set_objectives(sides, true)
+		set_objectives(cfg_sides, true)
 	end
 end
 

--- a/data/lua/wml/random_placement.lua
+++ b/data/lua/wml/random_placement.lua
@@ -11,9 +11,9 @@ wesnoth.wml_actions.random_placement = function(cfg)
 	local variable = cfg.variable or helper.wml_error("[random_placement] missing required 'variable' attribute")
 	local allow_less = cfg.allow_less == true
 	local variable_previous = utils.start_var_scope(variable)
-	local math_abs = math.abs	
+	local math_abs = math.abs
 	local locs = wesnoth.get_locations(filter)
-	if type(num_items) == "string" then		
+	if type(num_items) == "string" then
 		num_items = math.floor(load("local size = " .. #locs .. "; return " .. num_items)())
 		print("num_items=" .. num_items .. ", #locs=" .. #locs)
 	end

--- a/data/lua/wml/role.lua
+++ b/data/lua/wml/role.lua
@@ -85,7 +85,7 @@ function wesnoth.wml_actions.role(cfg)
 
 	if search_recall then
 		-- then try to match units on the recall lists
-		i = 1
+		local i = 1
 		repeat
 			if #types > 0 then
 				filter.type = types[i]

--- a/data/lua/wml/set_variable.lua
+++ b/data/lua/wml/set_variable.lua
@@ -63,7 +63,7 @@ function wesnoth.wml_actions.set_variable(cfg)
 		elseif round_val == "floor" then
 			wesnoth.set_variable(name, math.floor(var))
 		else
-			local decimals, discarded = math.modf(tonumber(round_val) or 0)
+			local decimals = math.modf(tonumber(round_val) or 0)
 			local value = var * (10 ^ decimals)
 			value = helper.round(value)
 			value = value * (10 ^ -decimals)
@@ -75,7 +75,7 @@ function wesnoth.wml_actions.set_variable(cfg)
 	-- the value already contained in the variable
 	-- but on the value assigned to the respective key
 	if cfg.ipart then
-		local ivalue, fvalue = math.modf(tonumber(cfg.ipart) or 0)
+		local ivalue = math.modf(tonumber(cfg.ipart) or 0)
 		wesnoth.set_variable(name, ivalue)
 	end
 


### PR DESCRIPTION
Second iteration of the process, now handling data/lua/wml/*.lua

luacheck command used to find bugs:
`luacheck ./*.lua --globals wesnoth wml --codes --ignore 542 213`
Additionally, error code 211 (unused variables) could be ignored,
as using underscore convention `_` is controversial in
wesnoth ( see https://github.com/wesnoth/wesnoth/pull/2380#discussion_r162519341 )

Actual bugs found:
* items.lua, access of global `write_name` instead of local `cfg.write_name`
* kill.lua, typo `primary_unit` -> `primary`
* bad code style: global `i` instead of local `i`
  (would conflict with 3-rd party code if it would use global `i`, too)