### PR TITLE
Hide 'Rails' and 'Fake Shroud' terrains in the unit help pages when impassable

### DIFF
--- a/data/core/terrain.cfg
+++ b/data/core/terrain.cfg
@@ -2752,6 +2752,7 @@ For those who go by land or sea, a bridge is the best of both worlds — for gam
     name= _ "Fake Shroud"
     string=^_s       # wmllint: ignore
     editor_group=special
+    hide_if_impassable=yes
     hide_help=yes
 [/terrain_type]
 
@@ -2989,5 +2990,6 @@ Most units have 50 to 60% defense in villages, whereas cavalry receive only 40%.
     editor_name= _ "Rails"
     string=Rt      # wmllint: ignore
     help_topic_text= _ "<italic>text='Rails'</italic> are used to transport ore, mostly by dwarves."
+    hide_if_impassable=yes
     hidden=yes
 [/terrain_type]

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -636,12 +636,16 @@ std::string unit_topic_generator::operator()() const {
 				continue;
 			}
 			const terrain_type& info = tdata->get_terrain_info(terrain);
+			const int moves = movement_type.movement_cost(terrain);
+			const bool cannot_move = moves > type_.movement();
+			if (cannot_move && info.hide_if_impassable()) {
+				continue;
+			}
 
 			if (info.union_type().size() == 1 && info.union_type()[0] == info.number() && info.is_nonnull()) {
 				std::vector<item> row;
 				const std::string& name = info.name();
 				const std::string& id = info.id();
-				const int moves = movement_type.movement_cost(terrain);
 				const int views = movement_type.vision_cost(terrain);
 				const int jams  = movement_type.jamming_cost(terrain);
 
@@ -677,7 +681,6 @@ std::string unit_topic_generator::operator()() const {
 
 				//movement  -  range: 1 .. 5, movetype::UNREACHABLE=impassable
 				str.str(clear_stringstream);
-				const bool cannot_move = moves > type_.movement();
 				if (cannot_move) {		// cannot move in this terrain
 					color = "red";
 				} else if (moves > 1) {

--- a/src/terrain/terrain.cpp
+++ b/src/terrain/terrain.cpp
@@ -97,7 +97,8 @@ terrain_type::terrain_type(const config& cfg) :
 		combined_(false),
 		editor_default_base_(t_translation::read_terrain_code(cfg["default_base"])),
 		hide_help_(cfg["hide_help"].to_bool(false)),
-		hide_in_editor_(cfg["hidden"].to_bool(false))
+		hide_in_editor_(cfg["hidden"].to_bool(false)),
+		hide_if_impassable_(cfg["hide_if_impassable"].to_bool(false))
 {
 /**
  *  @todo reenable these validations. The problem is that all MP

--- a/src/terrain/terrain.hpp
+++ b/src/terrain/terrain.hpp
@@ -39,6 +39,7 @@ public:
 
 	bool hide_help() const { return hide_help_; }
 	bool hide_in_editor() const { return hide_in_editor_; }
+	bool hide_if_impassable() const { return hide_if_impassable_; }
 
 	//the character representing this terrain
 	t_translation::terrain_code number() const { return number_; }
@@ -135,7 +136,7 @@ private:
 
 	bool overlay_, combined_;
 	t_translation::terrain_code editor_default_base_;
-	bool hide_help_, hide_in_editor_;
+	bool hide_help_, hide_in_editor_, hide_if_impassable_;
 };
 
 void create_terrain_maps(const config::const_child_itors &cfgs,


### PR DESCRIPTION
Fixes #1399. Supersedes #536.