### PR TITLE
Make wesnoth.unit_types a real table

### DIFF
--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -4141,9 +4141,6 @@ game_lua_kernel::game_lua_kernel(game_state & gs, play_controller & pc, reports 
 	// Create the getside metatable.
 	cmd_log_ << lua_team::register_metatable(L);
 
-	// Create the gettype metatable.
-	cmd_log_ << lua_unit_type::register_metatable(L);
-
 	//Create the getrace metatable
 	cmd_log_ << lua_race::register_metatable(L);
 

--- a/src/scripting/lua_kernel_base.hpp
+++ b/src/scripting/lua_kernel_base.hpp
@@ -28,6 +28,9 @@ public:
 	lua_kernel_base();
 	virtual ~lua_kernel_base();
 
+	/** The name of a read-only metatable (that can be used as a metatable for any Lua table) in the Lua registry. */
+	static const char* read_only;
+
 	/** Runs a [lua] tag. Doesn't throw lua_error.*/
 	void run_lua_tag(const config& cfg);
 

--- a/src/scripting/lua_unit_type.cpp
+++ b/src/scripting/lua_unit_type.cpp
@@ -38,7 +38,7 @@ static lg::log_domain log_scripting_lua("scripting/lua");
 #define LOG_LUA LOG_STREAM(info, log_scripting_lua)
 
 // Forward declarations
-void push_unit_type(lua_State* L, const unit_type& ut, const std::string& id);
+static void push_unit_type(lua_State* L, const unit_type& ut, const std::string& id);
 
 static void push_string_vec(lua_State* L, const std::vector<std::string>& vec, const std::string& key)
 {

--- a/src/scripting/lua_unit_type.cpp
+++ b/src/scripting/lua_unit_type.cpp
@@ -51,6 +51,20 @@ static void push_string_vec(lua_State* L, const std::vector<std::string>& vec, c
 	lua_setfield(L, -2, key.c_str());
 }
 
+static void push_traits(lua_State* L, const unit_type& ut)
+{
+	lua_newtable(L);
+
+	for(const config& trait : ut.possible_traits()) {
+		const std::string& id = trait["id"];
+		lua_pushlstring(L, id.c_str(), id.length());
+		luaW_pushconfig(L, trait);
+		lua_rawset(L, -3);
+	}
+
+	lua_setfield(L, -2, "traits");
+}
+
 static void push_unit_type(lua_State* L, const unit_type& ut)
 {
 	lua_newtable(L);
@@ -83,8 +97,13 @@ static void push_unit_type(lua_State* L, const unit_type& ut)
 	push_string_vec(L, ut.advances_from(), "advances_from");
 	luaW_pushconfig(L, ut.get_cfg());
 	lua_setfield(L, -2, "__cfg");
+	push_traits(L, ut);
+	push_string_vec(L, ut.get_ability_list(), "abilities");
+	push_unit_attacks_table(L, -1);
+	lua_setfield(L, -2, "attacks");
 
-	// TODO: traits, abilities, attacks and variations
+	// TODO: add unit type variations and genders
+	// TODO: write-protect the tables
 
 	lua_setfield(L, -2, ut.id().c_str());
 }

--- a/src/scripting/lua_unit_type.cpp
+++ b/src/scripting/lua_unit_type.cpp
@@ -23,6 +23,7 @@
 
 #include <chrono>
 #include <cstring>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -35,10 +36,6 @@
 
 static lg::log_domain log_scripting_lua("scripting/lua");
 #define LOG_LUA LOG_STREAM(info, log_scripting_lua)
-
-// Registry key
-static const char UnitType[] = "unit type";
-static const char UnitTypeTable[] = "unit types";
 
 // Forward declarations
 void push_unit_type(lua_State* L, const unit_type& ut, const std::string& id);
@@ -145,172 +142,7 @@ static void push_unit_type(lua_State* L, const unit_type& ut, const std::string&
 	lua_setfield(L, -2, id.c_str());
 }
 
-/**
- * Gets some data on a unit type (__index metamethod).
- * - Arg 1: table containing an "id" field.
- * - Arg 2: string containing the name of the property.
- * - Ret 1: something containing the attribute.
- */
-static int impl_unit_type_get(lua_State *L)
-{
-	const unit_type& ut = luaW_checkunittype(L, 1);
-	char const *m = luaL_checkstring(L, 2);
-
-	// Find the corresponding attribute.
-	return_tstring_attrib("name", ut.type_name());
-	return_string_attrib("id", ut.id());
-	return_string_attrib("alignment", ut.alignment().to_string());
-	return_string_attrib("race", ut.race_id());
-	return_string_attrib("image", ut.image());
-	return_string_attrib("icon", ut.icon());
-	return_int_attrib("max_hitpoints", ut.hitpoints());
-	return_int_attrib("max_moves", ut.movement());
-	return_int_attrib("max_experience", ut.experience_needed());
-	return_int_attrib("cost", ut.cost());
-	return_int_attrib("level", ut.level());
-	return_int_attrib("recall_cost", ut.recall_cost());
-	return_vector_string_attrib("advances_to", ut.advances_to());
-	return_vector_string_attrib("advances_from", ut.advances_from());
-	return_cfgref_attrib("__cfg", ut.get_cfg());
-	if (strcmp(m, "traits") == 0) {
-		lua_newtable(L);
-		for (const config& trait : ut.possible_traits()) {
-			const std::string& id = trait["id"];
-			lua_pushlstring(L, id.c_str(), id.length());
-			luaW_pushconfig(L, trait);
-			lua_rawset(L, -3);
-		}
-		return 1;
-	}
-	if (strcmp(m, "abilities") == 0) {
-		lua_push(L, ut.get_ability_list());
-		return 1;
-	}
-	if (strcmp(m, "attacks") == 0) {
-		push_unit_attacks_table(L, 1);
-		return 1;
-	}
-	// TODO: Should this only exist for base units?
-	if(strcmp(m, "variations") == 0) {
-		*new(L) const unit_type* = &ut;
-		luaL_setmetatable(L, UnitTypeTable);
-		return 1;
-	}
-	return 0;
-}
-
-static int impl_unit_type_equal(lua_State* L)
-{
-	const unit_type& ut1 = luaW_checkunittype(L, 1);
-	if(const unit_type* ut2 = luaW_tounittype(L, 2)) {
-		lua_pushboolean(L, &ut1 == ut2);
-	} else {
-		lua_pushboolean(L, false);
-	}
-	return 1;
-}
-
-static int impl_unit_type_lookup(lua_State* L)
-{
-	std::string id = luaL_checkstring(L, 2);
-	const unit_type* ut;
-	if(const unit_type* base = *static_cast<const unit_type**>(luaL_testudata(L, 1, UnitTypeTable))) {
-		if(id == "male" || id == "female") {
-			ut = &base->get_gender_unit_type(id);
-		} else {
-			ut = &base->get_variation(id);
-		}
-	} else {
-		ut = unit_types.find(id);
-	}
-	if(ut) {
-		luaW_pushunittype(L, *ut);
-		return 1;
-	}
-	return 0;
-}
-
-static int impl_unit_type_new(lua_State* L)
-{
-	// This could someday become a hook to construct new unit types on the fly?
-	// For now though, it's just an error
-	lua_pushstring(L, "unit_types table is read-only");
-	return lua_error(L);
-}
-
-static int impl_unit_type_count(lua_State* L)
-{
-	lua_pushnumber(L, unit_types.types().size());
-	return 1;
-}
-
-static int impl_unit_type_next(lua_State* L)
-{
-	const unit_type* base = *static_cast<const unit_type**>(luaL_checkudata(L, 1, UnitTypeTable));
-	auto unit_map = base ? base->variation_types() : unit_types.types();
-	decltype(unit_map)::const_iterator it = unit_map.end();
-	if(lua_isnoneornil(L, 2)) {
-		if(base) {
-			if(base->has_gender_variation(unit_race::MALE)) {
-				lua_pushstring(L, "male");
-				luaW_pushunittype(L, base->get_gender_unit_type(unit_race::MALE));
-				return 2;
-			} else if(base->has_gender_variation(unit_race::FEMALE)) {
-				lua_pushstring(L, "female");
-				luaW_pushunittype(L, base->get_gender_unit_type(unit_race::FEMALE));
-				return 2;
-			}
-		}
-		it = unit_map.begin();
-	} else {
-		const std::string id = luaL_checkstring(L, 2);
-		if(base) {
-			if(id == "male" && base->has_gender_variation(unit_race::FEMALE)) {
-				lua_pushstring(L, "female");
-				luaW_pushunittype(L, base->get_gender_unit_type(unit_race::FEMALE));
-				return 2;
-			} else if(id == "male" || id == "female") {
-				it = unit_map.begin();
-			}
-		}
-		if(it == unit_map.end()) {
-			it = unit_map.find(id);
-		}
-		if(it == unit_map.end()) {
-			return 0;
-		}
-		++it;
-	}
-	if (it == unit_map.end()) {
-		return 0;
-	}
-	lua_pushlstring(L, it->first.c_str(), it->first.size());
-	luaW_pushunittype(L, it->second);
-	return 2;
-}
-
-static int impl_unit_type_pairs(lua_State* L) {
-	lua_pushcfunction(L, &impl_unit_type_next);
-	lua_pushvalue(L, -2);
-	lua_pushnil(L);
-	return 3;
-}
-
 namespace lua_unit_type {
-	std::string register_metatable(lua_State * L)
-	{
-		luaL_newmetatable(L, UnitType);
-
-		lua_pushcfunction(L, impl_unit_type_get);
-		lua_setfield(L, -2, "__index");
-		lua_pushcfunction(L, impl_unit_type_equal);
-		lua_setfield(L, -2, "__eq");
-		lua_pushstring(L, UnitType);
-		lua_setfield(L, -2, "__metatable");
-
-		return "Adding unit type metatable...\n";
-	}
-
 	void register_table(lua_State* L)
 	{
 		lua_getglobal(L, "wesnoth");
@@ -337,21 +169,29 @@ namespace lua_unit_type {
 	}
 }
 
-void luaW_pushunittype(lua_State *L, const unit_type& ut)
-{
-	*static_cast<const unit_type**>(lua_newuserdata(L, sizeof(unit_type*))) = &ut;
-	luaL_setmetatable(L, UnitType);
-}
-
 const unit_type* luaW_tounittype(lua_State* L, int idx)
 {
-	if(void* p = luaL_testudata(L, idx, UnitType)) {
-		return *static_cast<const unit_type**>(p);
+	lua_getfield(L, idx, "id");
+	if(lua_isstring(L, -1)) {
+		std::string id = luaL_checkstring(L, -1);
+		lua_pop(L, 1);
+		auto ut = unit_types.types().find(id);
+		if(ut != unit_types.types().end()) {
+			return &ut->second;
+		}
+	} else {
+		lua_pop(L, 1);
 	}
+
 	return nullptr;
 }
 
 const unit_type& luaW_checkunittype(lua_State* L, int idx)
 {
-	return **static_cast<const unit_type**>(luaL_checkudata(L, idx, UnitType));;
+	const unit_type* ut = luaW_tounittype(L, idx);
+	if(ut != nullptr) {
+		return *ut;
+	} else {
+		throw std::invalid_argument("Not a unit type");
+	}
 }

--- a/src/scripting/lua_unit_type.cpp
+++ b/src/scripting/lua_unit_type.cpp
@@ -16,6 +16,7 @@
 
 #include "log.hpp"
 #include "scripting/lua_common.hpp"
+#include "scripting/lua_kernel_base.hpp"
 #include "scripting/lua_unit_attacks.hpp"
 #include "scripting/push_check.hpp"
 #include "units/types.hpp"
@@ -51,6 +52,9 @@ static void push_string_vec(lua_State* L, const std::vector<std::string>& vec, c
 		lua_seti(L, -2, i);
 	}
 
+	lua_getfield(L, LUA_REGISTRYINDEX, lua_kernel_base::read_only);
+	lua_setmetatable(L, -2);
+
 	lua_setfield(L, -2, key.c_str());
 }
 
@@ -64,6 +68,9 @@ static void push_traits(lua_State* L, const unit_type& ut)
 		luaW_pushconfig(L, trait);
 		lua_rawset(L, -3);
 	}
+
+	lua_getfield(L, LUA_REGISTRYINDEX, lua_kernel_base::read_only);
+	lua_setmetatable(L, -2);
 
 	lua_setfield(L, -2, "traits");
 }
@@ -87,6 +94,9 @@ static void push_variations_and_genders(lua_State* L, const unit_type& ut)
 			push_unit_type(L, gender_unit_type, gender_string(g));
 		}
 	}
+
+	lua_getfield(L, LUA_REGISTRYINDEX, lua_kernel_base::read_only);
+	lua_setmetatable(L, -2);
 
 	lua_setfield(L, -2, "variations");
 }
@@ -129,7 +139,8 @@ static void push_unit_type(lua_State* L, const unit_type& ut, const std::string&
 	lua_setfield(L, -2, "attacks");
 	push_variations_and_genders(L, ut);
 
-	// TODO: write-protect the tables
+	lua_getfield(L, LUA_REGISTRYINDEX, lua_kernel_base::read_only);
+	lua_setmetatable(L, -2);
 
 	lua_setfield(L, -2, id.c_str());
 }
@@ -317,6 +328,9 @@ namespace lua_unit_type {
 
 		LOG_LUA << "wesnoth.unit_types constructed in " <<
 			std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << " ms\n";
+
+		lua_getfield(L, LUA_REGISTRYINDEX, lua_kernel_base::read_only);
+		lua_setmetatable(L, -2);
 
 		lua_setfield(L, -2, "unit_types");
 		lua_pop(L, 1);

--- a/src/scripting/lua_unit_type.cpp
+++ b/src/scripting/lua_unit_type.cpp
@@ -14,24 +14,80 @@
 
 #include "scripting/lua_unit_type.hpp"
 
+#include "log.hpp"
 #include "scripting/lua_common.hpp"
 #include "scripting/lua_unit_attacks.hpp"
 #include "scripting/push_check.hpp"
 #include "units/types.hpp"
 
-#include <string>
+#include <chrono>
 #include <cstring>
+#include <string>
+#include <vector>
 
 #include "lua/lua.h"
 #include "lua/lauxlib.h"
 
 /**
- * Implementation for a lua reference to a unit_type.
+ * Implementation for a Lua table of unit types.
  */
+
+static lg::log_domain log_scripting_lua("scripting/lua");
+#define LOG_LUA LOG_STREAM(info, log_scripting_lua)
 
 // Registry key
 static const char UnitType[] = "unit type";
 static const char UnitTypeTable[] = "unit types";
+
+static void push_string_vec(lua_State* L, const std::vector<std::string>& vec, const std::string& key)
+{
+	lua_newtable(L);
+
+	for(unsigned int i = 0; i < vec.size(); ++i) {
+		lua_pushlstring(L, vec[i].data(), vec[i].length());
+		lua_seti(L, -2, i);
+	}
+
+	lua_setfield(L, -2, key.c_str());
+}
+
+static void push_unit_type(lua_State* L, const unit_type& ut)
+{
+	lua_newtable(L);
+
+	luaW_pushtstring(L, ut.type_name());
+	lua_setfield(L, -2, "name");
+	lua_pushlstring(L, ut.id().data(), ut.id().length());
+	lua_setfield(L, -2, "id");
+	lua_pushstring(L, ut.alignment().to_cstring());
+	lua_setfield(L, -2, "alignment");
+	lua_pushlstring(L, ut.race_id().data(), ut.race_id().length());
+	lua_setfield(L, -2, "race");
+	lua_pushlstring(L, ut.image().data(), ut.image().length());
+	lua_setfield(L, -2, "image");
+	lua_pushlstring(L, ut.icon().data(), ut.icon().length());
+	lua_setfield(L, -2, "icon");
+	lua_pushinteger(L, ut.hitpoints());
+	lua_setfield(L, -2, "max_hitpoints");
+	lua_pushinteger(L, ut.movement());
+	lua_setfield(L, -2, "max_moves");
+	lua_pushinteger(L, ut.experience_needed());
+	lua_setfield(L, -2, "max_experience");
+	lua_pushinteger(L, ut.cost());
+	lua_setfield(L, -2, "cost");
+	lua_pushinteger(L, ut.level());
+	lua_setfield(L, -2, "level");
+	lua_pushinteger(L, ut.recall_cost());
+	lua_setfield(L, -2, "recall_cost");
+	push_string_vec(L, ut.advances_to(), "advances_to");
+	push_string_vec(L, ut.advances_from(), "advances_from");
+	luaW_pushconfig(L, ut.get_cfg());
+	lua_setfield(L, -2, "__cfg");
+
+	// TODO: traits, abilities, attacks and variations
+
+	lua_setfield(L, -2, ut.id().c_str());
+}
 
 /**
  * Gets some data on a unit type (__index metamethod).
@@ -199,26 +255,26 @@ namespace lua_unit_type {
 		return "Adding unit type metatable...\n";
 	}
 
-	std::string register_table(lua_State* L)
+	void register_table(lua_State* L)
 	{
 		lua_getglobal(L, "wesnoth");
-		*new(L) unit_type* = nullptr;
-		luaL_newmetatable(L, UnitTypeTable);
-		lua_pushcfunction(L, impl_unit_type_lookup);
-		lua_setfield(L, -2, "__index");
-		lua_pushcfunction(L, impl_unit_type_new);
-		lua_setfield(L, -2, "__newindex");
-		lua_pushcfunction(L, impl_unit_type_count);
-		lua_setfield(L, -2, "__len");
-		lua_pushcfunction(L, impl_unit_type_pairs);
-		lua_setfield(L, -2, "__pairs");
-		lua_pushstring(L, UnitTypeTable);
-		lua_setfield(L, -2, "__metatable");
-		lua_setmetatable(L, -2);
+
+		lua_newtable(L);
+
+		std::chrono::high_resolution_clock::time_point start, end;
+		start = std::chrono::high_resolution_clock::now();
+
+		for(const auto& ut : unit_types.types()) {
+			push_unit_type(L, ut.second);
+		}
+
+		end = std::chrono::high_resolution_clock::now();
+
+		LOG_LUA << "wesnoth.unit_types constructed in " <<
+			std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << " ms\n";
+
 		lua_setfield(L, -2, "unit_types");
 		lua_pop(L, 1);
-
-		return "Adding unit_types table...\n";
 	}
 }
 

--- a/src/scripting/lua_unit_type.hpp
+++ b/src/scripting/lua_unit_type.hpp
@@ -24,13 +24,8 @@ class unit_type;
  * unit type and access its stats.
  */
 namespace lua_unit_type {
-	std::string register_metatable(lua_State *);
 	void register_table(lua_State *);
 } //end namespace lua_team
-
-/// Create a lua object containing a reference to a unittype, and a
-/// metatable to access the properties.
-void luaW_pushunittype(lua_State *, const unit_type&);
 
 /// Test if a stack element is a unit type, and return it if so
 const unit_type* luaW_tounittype(lua_State*, int);

--- a/src/scripting/lua_unit_type.hpp
+++ b/src/scripting/lua_unit_type.hpp
@@ -25,7 +25,7 @@ class unit_type;
  */
 namespace lua_unit_type {
 	std::string register_metatable(lua_State *);
-	std::string register_table(lua_State *);
+	void register_table(lua_State *);
 } //end namespace lua_team
 
 /// Create a lua object containing a reference to a unittype, and a


### PR DESCRIPTION
This is a fix for bug #2339. If `wesnoth.unit_types` is a real Lua table, it isn't any slower to iterate than any normal table once it has been generated.

The time to generate the table is quite significant, though, especially with Ageless Era active. My most recent measurement shows 1418 ms with AE activated, i.e. 580 microseconds per unit type. (This is faster than in my older measurements because I upgraded to faster hardware in between.) Therefore the entire table is generated lazily on first access: there is no performance penalty to level loading if UMC doesn't access `wesnoth.unit_types`. And if it does, all subsequent access will be fast.

For reference, @vgaming 's testing on master showed that *iterating* `wesnoth.unit_types` took 38 seconds with AE active, i.e. 14 milliseconds per unit type, or 24 times longer. And it didn't get any faster in subsequent rounds, either.

With only mainline units active, generating the table in this branch takes about 100 ms in total.

This implementation is now theoretically complete, but I haven't tested it yet.