### PR TITLE
Remove checking for a different SDL2 minimum version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,12 +72,7 @@ else()
 	message(WARNING "You are cross-compiling. Skipping IEEE 754 test.")
 endif()
 
-if(DEFINED ENV{TRAVIS})
-	find_package(SDL2 2.0.2 REQUIRED)
-else()
-	find_package(SDL2 2.0.4 REQUIRED)
-endif()
-
+find_package(SDL2 2.0.4 REQUIRED)
 find_package(Crypto 1.0 REQUIRED)
 find_package(Boost 1.50 REQUIRED COMPONENTS iostreams program_options regex system thread random)
 


### PR DESCRIPTION
I removed this from scons a while ago, though it looks like I forgot or didn't notice that cmake does the same.