### PR TITLE
Made display class no longer inherit from filter_context

### DIFF
--- a/src/actions/create.cpp
+++ b/src/actions/create.cpp
@@ -132,7 +132,7 @@ namespace { // Helpers for get_recalls()
 		const team& leader_team = resources::gameboard->get_team(leader->side());
 		const std::string& save_id = leader_team.save_id();
 
-		const unit_filter ufilt(vconfig(leader->recall_filter()), resources::filter_con);
+		const unit_filter ufilt(vconfig(leader->recall_filter()));
 
 		for (const unit_const_ptr & recall_unit_ptr : leader_team.recall_list())
 		{
@@ -248,7 +248,7 @@ namespace { // Helpers for check_recall_location()
 		scoped_recall_unit this_unit("this_unit", recall_team.save_id(),
 						recall_team.recall_list().find_index(recall_unit.id()));
 
-		const unit_filter ufilt(vconfig(recaller.recall_filter()), resources::filter_con);
+		const unit_filter ufilt(vconfig(recaller.recall_filter()));
 		if ( !ufilt(recall_unit, map_location::null_location()) )
 			return RECRUIT_NO_ABLE_LEADER;
 

--- a/src/ai/composite/goal.cpp
+++ b/src/ai/composite/goal.cpp
@@ -145,7 +145,7 @@ void target_unit_goal::add_targets(std::back_insert_iterator< std::vector< targe
 	if (!criteria) return;
 
 	//find the enemy leaders and explicit targets
-	const unit_filter ufilt(vconfig(criteria), resources::filter_con);
+	const unit_filter ufilt{ vconfig(criteria) };
 	for (const unit &u : resources::gameboard->units()) {
 		if (ufilt( u )) {
 			LOG_AI_GOAL << "found explicit target unit at ... " << u.get_location() << " with value: " << value() << "\n";
@@ -261,7 +261,7 @@ void protect_goal::add_targets(std::back_insert_iterator< std::vector< target > 
 
 	std::set<map_location> items;
 	if (protect_unit_) {
-		const unit_filter ufilt(vconfig(criteria), resources::filter_con);
+		const unit_filter ufilt{ vconfig(criteria) };
 		for (const unit &u : units)
 		{
 			//TODO: we will protect hidden units, by not testing for invisibility to current side

--- a/src/ai/default/aspect_attacks.cpp
+++ b/src/ai/default/aspect_attacks.cpp
@@ -55,12 +55,12 @@ aspect_attacks::aspect_attacks(readonly_context &context, const config &cfg, con
 	if (const config &filter_own = cfg.child("filter_own")) {
 		vconfig vcfg(filter_own);
 		vcfg.make_safe();
-		filter_own_.reset(new unit_filter(vcfg, resources::filter_con));
+		filter_own_.reset(new unit_filter(vcfg));
 	}
 	if (const config &filter_enemy = cfg.child("filter_enemy")) {
 		vconfig vcfg(filter_enemy);
 		vcfg.make_safe();
-		filter_enemy_.reset(new unit_filter(vcfg, resources::filter_con));
+		filter_enemy_.reset(new unit_filter(vcfg));
 	}
 }
 

--- a/src/ai/default/recruitment.cpp
+++ b/src/ai/default/recruitment.cpp
@@ -265,7 +265,7 @@ void recruitment::execute() {
 		// we'll check if we can do a recall instead of a recruitment.
 		for (const unit_const_ptr & recall : current_team().recall_list()) {
 			// Check if this leader is allowed to recall this unit.
-			const unit_filter ufilt( vconfig(leader->recall_filter()), resources::filter_con);
+			const unit_filter ufilt( vconfig(leader->recall_filter()));
 			if (!ufilt(*recall, map_location::null_location())) {
 				continue;
 			}
@@ -490,7 +490,7 @@ const std::string* recruitment::get_appropriate_recall(const std::string& type,
 			continue;
 		}
 		// Check if this leader is allowed to recall this unit.
-		const unit_filter ufilt(vconfig(leader_data.leader->recall_filter()), resources::filter_con);
+		const unit_filter ufilt(vconfig(leader_data.leader->recall_filter()));
 		if (!ufilt(*recall_unit, map_location::null_location())) {
 			LOG_AI_RECRUITMENT << "Refused recall because of filter: " << recall_unit->id() << "\n";
 			continue;

--- a/src/ai/lua/lua_object.cpp
+++ b/src/ai/lua/lua_object.cpp
@@ -49,7 +49,7 @@ namespace ai {
 		if(lua_istable(L, -1)) {
 			vconfig vcfg(config(), true);
 			if(luaW_tovconfig(L, -1, vcfg)) {
-				att->filter_own_.reset(new unit_filter(vcfg, resources::filter_con));
+				att->filter_own_.reset(new unit_filter(vcfg));
 			}
 		} else if(lua_isfunction(L, -1)) {
 			att->lua = L;
@@ -60,7 +60,7 @@ namespace ai {
 		if(lua_istable(L, -1)) {
 			vconfig vcfg(config(), true);
 			if(luaW_tovconfig(L, -1, vcfg)) {
-				att->filter_enemy_.reset(new unit_filter(vcfg, resources::filter_con));
+				att->filter_enemy_.reset(new unit_filter(vcfg));
 			}
 		} else if(lua_isfunction(L, -1)) {
 			att->lua = L;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -440,16 +440,6 @@ const time_of_day & display::get_time_of_day(const map_location& /*loc*/) const
 	return tod;
 }
 
-/**
- * Display objects don't hold a tod maanger, instead game_display objects do. If the base version of this method is called,
- * try to get it from resources and use an assert to check for failure.
- */
-const tod_manager & display::get_tod_man() const
-{
-	assert(resources::tod_manager);
-	return *resources::tod_manager;
-}
-
 void display::update_tod(const time_of_day* tod_override)
 {
 	const time_of_day* tod = tod_override;

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -50,7 +50,6 @@ namespace wb {
 
 #include "animated.hpp"
 #include "display_context.hpp"
-#include "filter_context.hpp"
 #include "font/sdl_ttf.hpp"
 #include "font/standard_colors.hpp"
 #include "image.hpp" //only needed for enums (!)
@@ -75,7 +74,7 @@ namespace wb {
 
 class gamemap;
 
-class display : public filter_context, public video2::draw_layering
+class display : public video2::draw_layering
 {
 public:
 	display(const display_context * dc, std::weak_ptr<wb::manager> wb,
@@ -163,11 +162,12 @@ public:
 	 */
 	void reload_map();
 
-	void change_display_context(const display_context * dc);
-	const display_context & get_disp_context() const { return *dc_; }
-	virtual const tod_manager & get_tod_man() const; //!< This is implemented properly in game_display. The display:: impl could be pure virtual here but we decide not to.
-	virtual const game_data * get_game_data() const { return nullptr; }
-	virtual game_lua_kernel * get_lua_kernel() const { return nullptr; } //!< TODO: display should not work as a filter context, this was only done for expedience so that the unit animation code can have a convenient and correct filter context readily available. a more correct solution is most likely to pass it a filter context from unit_animator when it needs to be matched. (it's not possible to store filter contexts with animations, because animations are cached across scenarios.) Note that after these lines which return nullptr, unit filters used in animations will not be able to make use of wml variables or lua scripting (but the latter was a bad idea anyways because it would be slow to constantly recompile the script.)
+	void change_display_context(const display_context* dc);
+
+	const display_context& get_disp_context() const
+	{
+		return *dc_;
+	}
 
 	void reset_halo_manager();
 	void reset_halo_manager(halo::manager & hm);

--- a/src/editor/editor_display.cpp
+++ b/src/editor/editor_display.cpp
@@ -121,14 +121,9 @@ void editor_display::draw_sidebar()
 	}
 }
 
-const tod_manager& editor_display::get_tod_man() const
-{
-	return *controller_.get_current_map_context().get_time_manager();
-}
-
 const time_of_day& editor_display::get_time_of_day(const map_location& /*loc*/) const
 {
-	return get_tod_man().get_time_of_day();
+	return controller_.get_current_map_context().get_time_manager()->get_time_of_day();
 }
 
 } //end namespace editor

--- a/src/editor/editor_display.hpp
+++ b/src/editor/editor_display.hpp
@@ -34,9 +34,6 @@ public:
 	void rebuild_terrain(const map_location &loc);
 
 	/** Inherited from display. */
-	virtual const tod_manager& get_tod_man() const override;
-
-	/** Inherited from display. */
 	virtual const time_of_day& get_time_of_day(const map_location& loc = map_location::null_location()) const override;
 
 	editor_controller& get_controller()

--- a/src/editor/map/context_manager.cpp
+++ b/src/editor/map/context_manager.cpp
@@ -74,6 +74,8 @@ context_manager::context_manager(editor_display& gui, const config& game_config)
 	, map_contexts_()
 	, clipboard_()
 {
+	resources::filter_con = this;
+
 	if(default_dir_.empty()) {
 		default_dir_ = filesystem::get_dir(filesystem::get_user_data_dir() + "/editor");
 	}
@@ -86,6 +88,8 @@ context_manager::~context_manager()
 {
 	// Restore default window title
 	CVideo::get_singleton().set_window_title(game_config::get_default_title_string());
+
+	resources::filter_con = nullptr;
 }
 
 void context_manager::refresh_on_context_change()
@@ -94,7 +98,6 @@ void context_manager::refresh_on_context_change()
 
 	// TODO register the tod_manager with the gui?
 	resources::tod_manager = get_map_context().get_time_manager();
-	resources::filter_con = &gui();
 
 	gui().replace_overlay_map(&get_map_context().get_overlays());
 

--- a/src/editor/map/context_manager.hpp
+++ b/src/editor/map/context_manager.hpp
@@ -15,15 +15,16 @@
 #pragma once
 
 #include "editor/map/map_context.hpp"
-#include "preferences/editor.hpp"
 #include "editor/map/map_fragment.hpp"
+#include "filter_context.hpp"
+#include "preferences/editor.hpp"
 
 class map_generator;
 
 namespace editor
 {
 
-class context_manager
+class context_manager : public filter_context
 {
 public:
 	using context_ptr = std::unique_ptr<map_context>;
@@ -164,6 +165,30 @@ public:
 	void set_default_dir(const std::string& str)
 	{
 		default_dir_ = str;
+	}
+
+	/** Inherited from @ref filter_context. */
+	virtual const display_context& get_disp_context() const override
+	{
+		return get_map_context();
+	}
+
+	/** Inherited from @ref filter_context. */
+	virtual const tod_manager& get_tod_man() const override
+	{
+		return *get_map_context().get_time_manager();
+	}
+
+	/** Inherited from @ref filter_context. */
+	virtual const game_data* get_game_data() const override
+	{
+		return nullptr; // No game_data in the editor.
+	}
+
+	/** Inherited from @ref filter_context. */
+	virtual game_lua_kernel* get_lua_kernel() const override
+	{
+		return nullptr; // No Lua kernel in the editor.
 	}
 
 private:

--- a/src/editor/map/map_context.hpp
+++ b/src/editor/map/map_context.hpp
@@ -177,6 +177,10 @@ public:
 		++actions_since_save_;
 	}
 
+	const tod_manager* get_time_manager() const {
+		return tod_manager_.get();
+	}
+
 	tod_manager* get_time_manager() {
 		return tod_manager_.get();
 	}

--- a/src/game_display.cpp
+++ b/src/game_display.cpp
@@ -64,7 +64,6 @@ std::vector<surface> footsteps_images(const map_location& loc, const pathfind::m
 
 game_display::game_display(game_board& board, std::weak_ptr<wb::manager> wb,
 		reports & reports_object,
-		const tod_manager& tod,
 		const config& theme_cfg,
 		const config& level,
 		bool) :
@@ -73,7 +72,6 @@ game_display::game_display(game_board& board, std::weak_ptr<wb::manager> wb,
 		attack_indicator_src_(),
 		attack_indicator_dst_(),
 		route_(),
-		tod_manager_(&tod),
 		displayedUnitHex_(),
 		sidebarScaling_(1.0),
 		first_turn_(true),
@@ -96,10 +94,10 @@ game_display::~game_display()
 
 void game_display::new_turn()
 {
-	const time_of_day& tod = tod_manager_->get_time_of_day();
+	const time_of_day& tod = resources::tod_manager->get_time_of_day();
 
 	if( !first_turn_) {
-		const time_of_day& old_tod = tod_manager_->get_previous_time_of_day();
+		const time_of_day& old_tod = resources::tod_manager->get_previous_time_of_day();
 
 		if(old_tod.image_mask != tod.image_mask) {
 			surface old_mask(image::get_image(old_tod.image_mask,image::SCALED_TO_HEX));
@@ -359,12 +357,12 @@ void game_display::draw_hex(const map_location& loc)
 
 const time_of_day& game_display::get_time_of_day(const map_location& loc) const
 {
-	return tod_manager_->get_time_of_day(loc);
+	return resources::tod_manager->get_time_of_day(loc);
 }
 
 bool game_display::has_time_area() const
 {
-	return tod_manager_->has_time_area();
+	return resources::tod_manager->has_time_area();
 }
 
 void game_display::draw_sidebar()

--- a/src/game_display.hpp
+++ b/src/game_display.hpp
@@ -17,7 +17,6 @@
 #pragma once
 
 class config;
-class tod_manager;
 class team;
 class game_board;
 
@@ -38,7 +37,6 @@ public:
 	game_display(game_board& board,
 			std::weak_ptr<wb::manager> wb,
 			reports & reports_object,
-			const tod_manager& tod_manager,
 			const config& theme_cfg,
 			const config& level,
 			bool dummy=false);
@@ -123,11 +121,9 @@ public:
 	/** Same as invalidate_unit() if moving the displayed unit. */
 	void invalidate_unit_after_move(const map_location& src, const map_location& dst);
 
-	const time_of_day& get_time_of_day(const map_location& loc) const;
+	virtual const time_of_day& get_time_of_day(const map_location& loc) const override;
 
 	bool has_time_area() const;
-
-	const tod_manager & get_tod_man() const { return *tod_manager_; } /**< Allows this class to properly implement filter context, used for animations */
 
 protected:
 	/**
@@ -146,11 +142,7 @@ protected:
 
 	void draw_hex(const map_location& loc);
 
-
 public:
-
-
-
 	/** Set the attack direction indicator. */
 	void set_attack_indicator(const map_location& src, const map_location& dst);
 	void clear_attack_indicator();
@@ -174,9 +166,7 @@ public:
 	 */
 	void set_playing_team(size_t team);
 
-
 	const map_location &displayed_unit_hex() const { return displayedUnitHex_; }
-
 
 	/**
 	 * annotate hex with number, useful for debugging or UI prototype
@@ -196,7 +186,6 @@ public:
 	void begin_game();
 
 	virtual bool in_game() const { return in_game_; }
-
 
 	/**
 	 * Sets the linger mode for the display.
@@ -218,10 +207,7 @@ public:
 
 	/// Rebuilds the screen if needs_rebuild(true) was previously called, and resets the flag.
 	bool maybe_rebuild();
-	void reset_tod_manager(const tod_manager& tod_manager)
-	{
-		tod_manager_ = &tod_manager;
-	}
+
 private:
 	game_display(const game_display&);
 	void operator=(const game_display&);
@@ -234,11 +220,7 @@ private:
 	map_location attack_indicator_src_;
 	map_location attack_indicator_dst_;
 
-
-
 	pathfind::marked_route route_;
-
-	const tod_manager* tod_manager_;
 
 	void invalidate_route();
 

--- a/src/game_events/action_wml.cpp
+++ b/src/game_events/action_wml.cpp
@@ -483,8 +483,8 @@ WML_HANDLER_FUNCTION(recall,, cfg)
 		recall_list_manager & avail = resources::gameboard->teams()[index].recall_list();
 		std::vector<unit_map::unit_iterator> leaders = resources::gameboard->units().find_leaders(index + 1);
 
-		const unit_filter ufilt(unit_filter_cfg, resources::filter_con);
-		const unit_filter lfilt(leader_filter, resources::filter_con); // Note that if leader_filter is null, this correctly gives a null filter that matches all units.
+		const unit_filter ufilt(unit_filter_cfg);
+		const unit_filter lfilt(leader_filter); // Note that if leader_filter is null, this correctly gives a null filter that matches all units.
 		for(std::vector<unit_ptr>::iterator u = avail.begin(); u != avail.end(); ++u) {
 			DBG_NG << "checking unit against filter...\n";
 			scoped_recall_unit auto_store("this_unit", player_id, u - avail.begin());
@@ -500,7 +500,7 @@ WML_HANDLER_FUNCTION(recall,, cfg)
 					DBG_NG << "...considering " + leader->id() + " as the recalling leader...\n";
 					map_location loc = cfg_loc;
 					if ( lfilt(*leader)  &&
-					     unit_filter(vconfig(leader->recall_filter()), resources::filter_con).matches( *(*u),map_location() ) ) {
+					     unit_filter(vconfig(leader->recall_filter())).matches( *(*u),map_location() ) ) {
 						DBG_NG << "...matched the leader filter and is able to recall the unit.\n";
 						if(!resources::gameboard->map().on_board(loc))
 							loc = leader->get_location();

--- a/src/game_events/conditional_wml.cpp
+++ b/src/game_events/conditional_wml.cpp
@@ -52,7 +52,7 @@ namespace builtin_conditions {
 		std::vector<std::pair<int,int> > counts = cfg.has_attribute("count")
 			? utils::parse_ranges(cfg["count"]) : default_counts;
 		int match_count = 0;
-		const unit_filter ufilt(cfg, resources::filter_con);
+		const unit_filter ufilt(cfg);
 		for(const unit &i : resources::gameboard->units()) {
 			if(i.hitpoints() > 0 && ufilt(i)) {
 				++match_count;

--- a/src/game_events/entity_location.cpp
+++ b/src/game_events/entity_location.cpp
@@ -100,7 +100,7 @@ bool entity_location::matches_unit_filter(const unit_map::const_iterator & un_it
 
 	// Filter the unit at the filter location (should be the unit's
 	// location if no special filter location was specified).
-	return unit_filter(filter, resources::filter_con).matches(*un_it, filter_loc_)  &&
+	return unit_filter(filter).matches(*un_it, filter_loc_)  &&
 	       matches_unit(un_it);
 }
 

--- a/src/game_state.hpp
+++ b/src/game_state.hpp
@@ -83,10 +83,29 @@ public:
 
 	void write(config& cfg) const;
 
-	virtual const display_context & get_disp_context() const { return board_; }
-	virtual const tod_manager & get_tod_man() const { return tod_manager_; }
-	virtual const game_data * get_game_data() const { return &gamedata_; }
-	virtual game_lua_kernel * get_lua_kernel() const { return lua_kernel_.get(); }
+	/** Inherited from @ref filter_context. */
+	virtual const display_context& get_disp_context() const override
+	{
+		return board_; 
+	}
+
+	/** Inherited from @ref filter_context. */
+	virtual const tod_manager& get_tod_man() const override 
+	{ 
+		return tod_manager_;
+	}
+
+	/** Inherited from @ref filter_context. */
+	virtual const game_data* get_game_data() const override 
+	{
+		return &gamedata_;
+	}
+
+	/** Inherited from @ref filter_context. */
+	virtual game_lua_kernel* get_lua_kernel() const override 
+	{
+		return lua_kernel_.get();
+	}
 
 	/// Checks to see if a leader at @a leader_loc could recruit somewhere.
 	bool can_recruit_from(const map_location& leader_loc, int side) const;

--- a/src/pathfind/teleport.cpp
+++ b/src/pathfind/teleport.cpp
@@ -92,10 +92,10 @@ public:
 		, lk_(fc.get_lua_kernel())
 	{}
 
-	const display_context & get_disp_context() const { return dc_; }
-	const tod_manager & get_tod_man() const { return *tod_; }
-	const game_data * get_game_data() const { return gd_; }
-	game_lua_kernel * get_lua_kernel() const { return lk_; }
+	const display_context & get_disp_context() const override { return dc_; }
+	const tod_manager & get_tod_man() const override { return *tod_; }
+	const game_data * get_game_data() const override { return gd_; }
+	game_lua_kernel * get_lua_kernel() const override { return lk_; }
 
 private:
 	const ignore_units_display_context dc_;
@@ -119,7 +119,7 @@ void teleport_group::get_teleport_pair(
 	vconfig filter(cfg_.child_or_empty("filter"), true);
 	vconfig source(cfg_.child_or_empty("source"), true);
 	vconfig target(cfg_.child_or_empty("target"), true);
-	const unit_filter ufilt(filter, resources::filter_con); //Note: Don't use the ignore units filter context here, only for the terrain filters. (That's how it worked before the filter contexts were introduced)
+	const unit_filter ufilt(filter); //Note: Don't use the ignore units filter context here, only for the terrain filters. (That's how it worked before the filter contexts were introduced)
 	if (ufilt.matches(u)) {
 		terrain_filter source_filter(source, fc);
 		source_filter.get_locations(reversed_ ? loc_pair.second : loc_pair.first, u);

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -234,7 +234,7 @@ void play_controller::init(const config& level)
 
 		LOG_NG << "building terrain rules... " << (SDL_GetTicks() - ticks()) << std::endl;
 		gui2::dialogs::loading_screen::progress(loading_stage::build_terrain);
-		gui_.reset(new game_display(gamestate().board_, whiteboard_manager_, *gamestate().reports_, gamestate().tod_manager_, theme_cfg, level));
+		gui_.reset(new game_display(gamestate().board_, whiteboard_manager_, *gamestate().reports_, theme_cfg, level));
 		map_start_ = map_location(level.child_or_empty("display").child_or_empty("location"));
 		if (!gui_->video().faked()) {
 			if (saved_game_.mp_settings().mp_countdown)
@@ -318,7 +318,6 @@ void play_controller::reset_gamestate(const config& level, int replay_pos)
 	gamestate().set_game_display(gui_.get());
 	resources::tunnels = gamestate().pathfind_manager_.get();
 
-	gui_->reset_tod_manager(gamestate().tod_manager_);
 	gui_->reset_reports(*gamestate().reports_);
 	gui_->change_display_context(&gamestate().board_);
 	saved_game_.get_replay().set_pos(replay_pos);

--- a/src/side_filter.cpp
+++ b/src/side_filter.cpp
@@ -124,7 +124,7 @@ bool side_filter::match_internal(const team &t) const
 	if(cfg_.has_child("has_unit")) {
 		const vconfig & ufilt_cfg = cfg_.child("has_unit");
 		if (!ufilter_) {
-			ufilter_.reset(new unit_filter(ufilt_cfg.make_safe(), fc_));
+			ufilter_.reset(new unit_filter(ufilt_cfg.make_safe()));
 			ufilter_->set_use_flat_tod(flat_);
 		}
 		bool found = false;

--- a/src/terrain/filter.cpp
+++ b/src/terrain/filter.cpp
@@ -166,7 +166,7 @@ bool terrain_filter::match_internal(const map_location& loc, const unit* ref_uni
 		if (!u.valid())
 			return false;
 		if (!cache_.ufilter_) {
-			cache_.ufilter_.reset(new unit_filter(cfg_.child("filter").make_safe(), fc_));
+			cache_.ufilter_.reset(new unit_filter(cfg_.child("filter").make_safe()));
 			cache_.ufilter_->set_use_flat_tod(flat_);
 		}
 		if (!cache_.ufilter_->matches(*u, loc))

--- a/src/tests/utils/fake_display.cpp
+++ b/src/tests/utils/fake_display.cpp
@@ -19,7 +19,6 @@
 #include "game_board.hpp"
 #include "game_display.hpp"
 #include "terrain/type_data.hpp"
-#include "tod_manager.hpp"
 #include "reports.hpp"
 
 namespace wb {
@@ -35,7 +34,6 @@ namespace test_utils {
 		config dummy_cfg_;
 		config dummy_cfg2_;
 		game_board dummy_board_;
-		tod_manager dummy_tod_;
 		reports dummy_reports;
 		const events::event_context main_event_context_;
 
@@ -66,10 +64,8 @@ namespace test_utils {
 		dummy_cfg_(),
 		dummy_cfg2_(),
 		dummy_board_(std::make_shared<terrain_type_data>(dummy_cfg_), dummy_cfg2_),
-		dummy_tod_(dummy_cfg_),
 		main_event_context_(),
-		disp_(dummy_board_, std::shared_ptr<wb::manager> (), dummy_reports, dummy_tod_,
-				dummy_cfg_, dummy_cfg_)
+		disp_(dummy_board_, std::shared_ptr<wb::manager> (), dummy_reports, dummy_cfg_, dummy_cfg_)
 	{
 	}
 

--- a/src/tooltips.cpp
+++ b/src/tooltips.cpp
@@ -20,7 +20,6 @@
 #include "game_display.hpp"
 #include "help/help.hpp"
 #include "font/marked-up_text.hpp"
-#include "resources.hpp"
 #include "video.hpp"
 
 #include <SDL_rect.h> // Travis doesn't like this, although it works on my machine -> '#include <SDL_sound.h>

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -307,7 +307,7 @@ bool unit::ability_active(const std::string& ability,const config& cfg,const map
 	bool illuminates = ability == "illuminates";
 
 	if (const config &afilter = cfg.child("filter"))
-		if ( !unit_filter(vconfig(afilter), resources::filter_con).set_use_flat_tod(illuminates).matches(*this, loc) )
+		if ( !unit_filter(vconfig(afilter)).set_use_flat_tod(illuminates).matches(*this, loc) )
 			return false;
 
 	map_location adjacent[6];
@@ -319,7 +319,7 @@ bool unit::ability_active(const std::string& ability,const config& cfg,const map
 	for (const config &i : cfg.child_range("filter_adjacent"))
 	{
 		size_t count = 0;
-		unit_filter ufilt(vconfig(i), resources::filter_con);
+		unit_filter ufilt{ vconfig(i) };
 		ufilt.set_use_flat_tod(illuminates);
 		std::vector<map_location::DIRECTION> dirs = map_location::parse_directions(i["adjacent"]);
 		for (const map_location::DIRECTION index : dirs)
@@ -391,7 +391,7 @@ bool unit::ability_affects_adjacent(const std::string& ability, const config& cf
 		}
 		const config &filter = i.child("filter");
 		if (!filter || //filter tag given
-			unit_filter(vconfig(filter), resources::filter_con).set_use_flat_tod(illuminates).matches(*this, loc, from) ) {
+			unit_filter(vconfig(filter)).set_use_flat_tod(illuminates).matches(*this, loc, from) ) {
 			return true;
 		}
 	}
@@ -403,7 +403,7 @@ bool unit::ability_affects_self(const std::string& ability,const config& cfg,con
 	const config &filter = cfg.child("filter_self");
 	bool affect_self = cfg["affect_self"].to_bool(true);
 	if (!filter || !affect_self) return affect_self;
-	return unit_filter(vconfig(filter), resources::filter_con).set_use_flat_tod(ability == "illuminates").matches(*this, loc);
+	return unit_filter(vconfig(filter)).set_use_flat_tod(ability == "illuminates").matches(*this, loc);
 }
 
 bool unit::has_ability_type(const std::string& ability) const
@@ -853,7 +853,7 @@ namespace { // Helpers for attack_type::special_active()
 			return false;
 		}
 
-		unit_filter ufilt(vconfig(filter_child), resources::filter_con);
+		unit_filter ufilt{vconfig(filter_child)};
 
 		// If the other unit doesn't exist, try matching without it
 		if (!u2.valid()) {
@@ -952,7 +952,7 @@ bool attack_type::special_active(const config& special, AFFECTS whom,
 	{
 		size_t count = 0;
 		std::vector<map_location::DIRECTION> dirs = map_location::parse_directions(i["adjacent"]);
-		unit_filter filter(vconfig(i), resources::filter_con);
+		unit_filter filter{ vconfig(i) };
 		for (const map_location::DIRECTION index : dirs)
 		{
 			if (index == map_location::NDIRECTIONS)

--- a/src/units/animation.cpp
+++ b/src/units/animation.cpp
@@ -414,7 +414,7 @@ int unit_animation::matches(const display& disp, const map_location& loc, const 
 		}
 
 		for(const auto& filter : unit_filter_) {
-			unit_filter f(vconfig(filter), &disp);
+			unit_filter f{ vconfig(filter) };
 			if(!f(*my_unit, loc)) return MATCH_FAIL;
 			++result;
 		}
@@ -426,7 +426,7 @@ int unit_animation::matches(const display& disp, const map_location& loc, const 
 			}
 
 			for(const config& c : secondary_unit_filter_) {
-				unit_filter f(vconfig(c), &disp);
+				unit_filter f{ vconfig(c) };
 				if(!f(*unit, second_loc)) return MATCH_FAIL;
 				result++;
 			}

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -44,6 +44,15 @@ static lg::log_domain log_config("config");
 
 using namespace unit_filter_impl;
 
+unit_filter::unit_filter(vconfig cfg)
+	: cfg_(cfg)
+	, fc_(resources::filter_con)
+	, use_flat_tod_(false)
+	, impl_(cfg_)
+	, max_matches_(-1)
+{
+}
+
 bool unit_filter::matches(const unit& u) const {
 	return impl_.matches(unit_filter_impl::unit_filter_args{u, u.get_location(), nullptr, fc_, use_flat_tod_});
 }

--- a/src/units/filter.hpp
+++ b/src/units/filter.hpp
@@ -29,8 +29,8 @@
 #include "utils/make_enum.hpp"
 
 #include "display_context.hpp"
-#include "units/map.hpp"
 #include "filter_context.hpp"
+#include "units/map.hpp"
 #include "variable.hpp"
 
 #include <memory>
@@ -96,14 +96,7 @@ namespace unit_filter_impl
 class unit_filter
 {
 public:
-	unit_filter(vconfig cfg, const filter_context * fc)
-		: cfg_(cfg)
-		, fc_(fc)
-		, use_flat_tod_(false)
-		, impl_(cfg_)
-		, max_matches_(-1)
-	{
-	}
+	explicit unit_filter(vconfig cfg);
 
 	unit_filter(const unit_filter&) = default;
 	unit_filter& operator=(const unit_filter&) = default;

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -2167,7 +2167,7 @@ void unit::add_modification(const std::string& mod_type, const config& mod, bool
 		// Apply SUF.
 		if(const config& afilter = effect.child("filter")) {
 			// @FIXME: during gamestate construction resources::filter_con is not available
-			if(resources::filter_con && !unit_filter(vconfig(afilter), resources::filter_con).matches(*this, loc_)) {
+			if(resources::filter_con && !unit_filter(vconfig(afilter)).matches(*this, loc_)) {
 				continue;
 			}
 		}


### PR DESCRIPTION
The only function that display meaningfully implemented was get_disp_context. It did implement
get_tod_man, but only meaningfully in its two derived classes (it returned the result of
resources::tod_manager in display). Additionally, the long-ass comment in the header stated the
display class should *not* inherit from filter_context.

Upon further investigation, I found that there were only two places where the display class was
passed to unit_filter. All others passed resources::filter_con. The editor_display class was also
assigned to resources::filter_con in editor::context_manager. So, I removed the second filter_context
argument from unit_filter and initialized it from resources::filter_con in all cases.

unit_filter only used the filter_context to get its display_context and the unit_map within anyway.
When using display::get_disp_context in-game, that would return a game_board object. Using
resources::filter_con in the same context would return the game_state object that owned the
aforementioned game_board, and calling get_disp_context on that game_state would return the board
as well. So we end up in the same place.

To be complete, I also made editor::context_manager inherit from filter_context. It makes much more
sense, since it can nicely implement 2/4 of the fc functions. It also ensures resources::filter_con
is valid in the editor, in case it's needed. I'm not 100% sure it is, but since it was assigned
before (to editor_display), it's very likely.

Another side effect of the above is that get_tod_man is now implemented in a more apropos class
in the editor. Essentially, editor_display (where it was implemented before by reaching into the
context_manager) holds an editor_controller which holds a context_manager (where it's now implemented).
It wasn't even really needed in editor_display and was only called once.

Similarly, get_tod_man has been removed from game_display. Again, it was only present to "properly"
implement the function in display, which only existed because display inherited from filter_context.
And get_tod_man wasn't even needed in display, game_display, or editor_display (save for the one
aforementioned call)!!! AND in game_display, it simply dereferenced a pointer to the *actual* ToD
manager in the game_state class, WHICH IN AND OF ITSELF INHERITS FROM FILTER_CONTEXT!!!

I have removed the tod_manager pointer in game_display and replaced its use with resources::tod_manager,
which in the context of the game (where game_display) would be use, point to the same thing the class
pointer did. I suppose I could have left it, since I'm trying to remove/improve the use of the
resources pointers, but I felt it better to decouple the two classes (game_display and game_state)
slightly, especially since its main purpose for existing (overriding display::get_tod_man) no longer
exists.

Finally, some of the instances where a unit_filter object is created had to be changed to use brace
initialization or else the build failed. @celticminstrel tells me this is because of some "most vexing
parse" issue, whatever that means.

Some formatting and virtual/override specifiers were also applied/added.

*huffs*