### PR TITLE
Enables travis to cache scons' build/ directory.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ sudo:     required
 services:
     - docker
 
+cache:
+  directories:
+    - build-cache
+
 matrix:
   include:
     - compiler: clang
@@ -52,8 +56,9 @@ install:
           docker build -t wesnoth-repo:16.04 -f docker/Dockerfile-travis .;
       fi
 
-script: 
+script:
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+          ln -s build-cache/ build;
           ./utils/travis/check_utf8.sh;
           ./utils/travis/utf8_bom_dog.sh;
           "$CXX" --version;
@@ -62,7 +67,7 @@ script:
           export DISPLAY=:99.0;
           /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1024x768x24;
           
-          docker run wesnoth-repo:16.04 bash -c './docker_run.sh "$@"' bash "$NLS" "$TOOL" "$CC" "$CXX" "$CXXSTD" "$EXTRA_FLAGS_RELEASE" "$WML_TESTS" "$WML_TEST_TIME" "$PLAY_TEST" "$MP_TEST" "$BOOST_TEST";
+          docker run -v `pwd`/build-cache:/home/wesnoth-travis/build wesnoth-repo:16.04 bash -c './docker_run.sh "$@"' bash "$NLS" "$TOOL" "$CC" "$CXX" "$CXXSTD" "$EXTRA_FLAGS_RELEASE" "$WML_TESTS" "$WML_TEST_TIME" "$PLAY_TEST" "$MP_TEST" "$BOOST_TEST";
       fi
 
 notifications:


### PR DESCRIPTION
Scons makes this simple - all the object files are placed in `build/release/`, and the `build/sconsign.dblite` file keeps track of the md5 sum of each file built. This then means all that's necessary to prevent scons from doing a full rebuild each time is to cache the `build/` directory.

Keep in mind however, that this does not make the actual compiling faster, it just means that most of the time fewer things will need to be compiled. Any change that would trigger a rebuild of most or all of the source files will still take just as long as before.

---

The (c)make builds do not benefit from this partially because they put their compiled object files into a different directory(so they aren't being picked up right now anyways), but also because to my understanding git does not preserve the last modified timestamp when cloning and `make` uses the last modified timestamp to determine when it needs to recompile something.  It wouldn't be impossible to get this same sort of speedup with the (c)make builds - there are custom scripts and things like mtime_cache that would be able to restore the last modified timestamp - but it would also be a fair amount easier to just use scons on travis for all builds instead.

In any case though, as an example, [this](https://travis-ci.org/Pentarctagon/wesnoth/builds/337837617) is the time taken when there is no cache for a push, and then [this](https://travis-ci.org/Pentarctagon/wesnoth/builds/337879609) is the time taken for the next push(triggered from within travis, so it would represent a best case scenario of there being no C++ changes).