### PR TITLE
Fix 2p - Clearing Gushes team names

### DIFF
--- a/data/multiplayer/scenarios/2p_Clearing_Gushes.cfg
+++ b/data/multiplayer/scenarios/2p_Clearing_Gushes.cfg
@@ -21,8 +21,8 @@
         side=1
         canrecruit=yes
         controller=human
-        team_name=north
-        user_team_name= _ "teamname^North"
+        team_name=south
+        user_team_name= _ "teamname^South"
         gold=100
         fog=yes
     [/side]
@@ -33,8 +33,8 @@
         side=2
         canrecruit=yes
         controller=human
-        team_name=south
-        user_team_name= _ "teamname^South"
+        team_name=north
+        user_team_name= _ "teamname^North"
         gold=100
         fog=yes
         [village]


### PR DESCRIPTION
On this map, side 1 starts at the bottom, while side 2 starts at the top. The naming of the teams assumed the opposite. Another check mark on issue #2453.