### PR TITLE
Fixed WML parser not properly handling unquoted keys with variables (…

### DIFF
--- a/src/serialization/tokenizer.cpp
+++ b/src/serialization/tokenizer.cpp
@@ -137,7 +137,7 @@ const token &tokenizer::next_token()
 		FALLTHROUGH;
 
 	default:
-		if (is_alnum(current_)) {
+		if (is_alnum(current_) || current_ == '$') {
 			token_.type = token::STRING;
 			do {
 				token_.value += current_;
@@ -146,7 +146,7 @@ const token &tokenizer::next_token()
 					skip_comment();
 					next_char_fast();
 				}
-			} while (is_alnum(current_));
+			} while (is_alnum(current_) || current_ == '$');
 		} else {
 			token_.type = token::MISC;
 			token_.value += current_;


### PR DESCRIPTION
…fixes #1236)

In cases such as `name=turn $var`, the key value would get parsed and serialized as
`turn$var`. The reason for this was that that string was broken down into 3 tokens:
"turn", "$", and "var". parser::parse_variable() handled these tokens, and the issue
was that "$" was considered a "misc" token instead of a string one. In cases where
two string tokens were added consecutively, a space would be added between them
(manually added spacing was not preserved). Since "$" did not count as a string, the
space was not added, which resulted in "turn$var". To fix that, I made the tokenizer
consider "$" a string token, so the spacing is correctly preserved.

For the record, despite what the bug report above says, wrapping the value in quotes
did work in lieu of this fix.