### PR TITLE
Fixes LTO/PGO options not being used when ccache is enabled.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -525,7 +525,7 @@ for env in [test_env, client_env, env]:
         rel_comp_flags = rel_comp_flags + env["arch"]
         
 # PGO and LTO setup
-        if env["CC"] == "gcc":
+        if "gcc" in env["TOOLS"]:
             if env["pgo_data"] == "generate":
                 rel_comp_flags = rel_comp_flags + " -fprofile-generate=pgo_data/"
                 rel_link_flags = "-fprofile-generate=pgo_data/"


### PR DESCRIPTION
When ccache is enabled, env["CC"] becomes - `'CC': '$CCACHE gcc'`