### PR TITLE
campaignd: Reject empty passphrases

### DIFF
--- a/changelog
+++ b/changelog
@@ -4,6 +4,10 @@ Version 1.13.11:
      latest update or original upload (issue #1747)
    * Players will now be prompted to update outdated dependencies alongside
      downloading missing ones when installing an add-on.
+ * Add-ons server:
+   * Empty passphrases from malfunctioning clients that do not provide or
+     generate a passphrase otherwise are now rejected instead of treated as
+     valid.
  * Campaigns:
    * The Cutscene_Minimal theme is now used in all dialog only scenarios that
      have linger=no in [end_level].


### PR DESCRIPTION
Fixes issue #2444.

Clients may send an empty passphrase, especially if they do not do as the mainline client and generate a random one to substitute in the .pbl. An empty string is still hashable, but the server is really not supposed
to allow an empty passphrase so we should just reject those. It's also a good warning sign against broken clients -- like wesnoth_addon_manager right now.