### PR TITLE
Fixes event scrolling per issue #2218

### DIFF
--- a/src/controller_base.cpp
+++ b/src/controller_base.cpp
@@ -132,7 +132,11 @@ void controller_base::handle_event(const SDL_Event& event)
 		break;
 
 	case SDL_MOUSEWHEEL:
+#if defined(_WIN32) || defined(__APPLE__)
 		mh_base.mouse_wheel(-event.wheel.x, event.wheel.y, is_browsing());
+#else
+		mh_base.mouse_wheel(event.wheel.x, event.wheel.y, is_browsing());
+#endif
 		break;
 
 	default:


### PR DESCRIPTION
UNIXes (namely, Linux and other non-Windows, non-macOS) were scrolling horizontally the incorrect direction on the game map. This addresses a problem that was introduced in #1754. Windows and macOS keep the new behavior where other platforms keep the original behavior.