### PR TITLE
Remove duplicated headers search path

### DIFF
--- a/projectfiles/Xcode/Wesnoth.xcodeproj/project.pbxproj
+++ b/projectfiles/Xcode/Wesnoth.xcodeproj/project.pbxproj
@@ -6320,7 +6320,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/../../src",
-					"$(PROJECT_DIR)/Headers",
 					"$(PROJECT_DIR)/Headers/cairo",
 					"$(PROJECT_DIR)/Headers/glib-2.0",
 					"$(PROJECT_DIR)/lib/SDL2.framework/Headers",
@@ -6372,7 +6371,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/../../src",
-					"$(PROJECT_DIR)/Headers",
 					"$(PROJECT_DIR)/Headers/cairo",
 					"$(PROJECT_DIR)/Headers/glib-2.0",
 					"$(PROJECT_DIR)/lib/SDL2.framework/Headers",


### PR DESCRIPTION
`$(PROJECT_DIR)/Headers` is included in `System Header Search Path` so this is just redundant duplicate.