### PR TITLE
Add a major_report option in [damage] in some case. for report attack is like ledership tod case

### DIFF
--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -682,9 +682,18 @@ static int attack_info(reports::context & rc, const attack_type &at, config &res
 	unsigned num_attacks = swarm_blows(min_attacks, max_attacks, cur_hp, max_hp);
 
 	color_t dmg_color = font::weapon_color;
-	if ( damage > specials_damage )
+	int damage_color;
+	bool color_option = at.get_special_bool_color("damage");
+	if (color_option){
+damage_color=base_damage;
+	} else
+	{
+	damage_color=specials_damage;
+	}
+
+	if ( damage > damage_color )
 		dmg_color = font::good_dmg_color;
-	else if ( damage < specials_damage )
+	else if ( damage < damage_color )
 		dmg_color = font::bad_dmg_color;
 
 	str << span_color(dmg_color) << "  " << damage << naps << span_color(font::weapon_color)

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -605,6 +605,37 @@ bool attack_type::get_special_bool(const std::string& special, bool simple_check
 	return false;
 }
 
+bool attack_type::get_special_bool_color(const std::string& special, bool simple_check) const
+{
+	{
+		std::vector<const config*> list;
+		if ( get_special_children(list, specials_, special, simple_check) ) {
+			return true;
+		}
+		// If we make it to here, then either list.empty() or !simple_check.
+		// So if the list is not empty, then this is not a simple check and
+		// we need to check each special in the list to see if any are active.
+		for (std::vector<const config*>::iterator i = list.begin(), i_end = list.end(); i != i_end; ++i) {
+			if ( special_active_colored(**i, AFFECT_SELF) ) {
+				return true;
+			}
+		}
+	}
+	// Skip checking the opponent's attack?
+	if ( simple_check || !other_attack_ ) {
+		return false;
+	}
+
+	std::vector<const config*> list;
+	get_special_children(list, other_attack_->specials_, special);
+	for (std::vector<const config*>::iterator i = list.begin(), i_end = list.end(); i != i_end; ++i) {
+		if ( other_attack_->special_active_colored(**i, AFFECT_OTHER) ) {
+			return true;
+		}
+	}
+	return false;
+}
+
 /**
  * Returns the currently active specials as an ability list, given the current
  * context (see set_specials_context).
@@ -1000,6 +1031,17 @@ bool attack_type::special_active(const config& special, AFFECTS whom,
 	}
 
 	return true;
+}
+
+bool attack_type::special_active_colored(const config& special,AFFECTS whom) const
+{
+	//log_scope("special_active");
+
+	// Backstab check
+		if ( special["major_report"].to_bool()&& special_active(special,whom) )
+			return true;
+
+	return false;
 }
 
 

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -69,6 +69,7 @@ public:
 	// In unit_abilities.cpp:
 
 	bool get_special_bool(const std::string& special, bool simple_check=false) const;
+	bool get_special_bool_color(const std::string& special, bool simple_check=false) const;
 	unit_ability_list get_specials(const std::string& special) const;
 	std::vector<std::pair<t_string, t_string> > special_tooltips(boost::dynamic_bitset<>* active_list = nullptr) const;
 	std::string weapon_specials(bool only_active=false, bool is_backstab=false) const;
@@ -102,6 +103,7 @@ private:
 	enum AFFECTS { AFFECT_SELF=1, AFFECT_OTHER=2, AFFECT_EITHER=3 };
 	bool special_active(const config& special, AFFECTS whom,
 	                    bool include_backstab=true) const;
+	bool special_active_colored(const config& special,AFFECTS whom) const;
 
 	// Used via set_specials_context() to control which specials are
 	// considered active.


### PR DESCRIPTION
In some addons, some [damage] simulate the time-of-day, i propose what the color in report can simulate an true tod or leadership influence for an attack only.
![simulate_tod](https://user-images.githubusercontent.com/31768074/36151138-739494f2-10c6-11e8-9849-3cf35f9649cf.png)
![simulate_leadership](https://user-images.githubusercontent.com/31768074/36151143-77a131cc-10c6-11e8-8820-e31b7c6f1ac8.png)
![simulate_without_leader](https://user-images.githubusercontent.com/31768074/36151147-7f4cf97e-10c6-11e8-8eb3-8db51731fbed.png)


