### PR TITLE
Fixes cmake's cache getting corrupted in certain situations.

### DIFF
--- a/cmake_mtime_crc.py
+++ b/cmake_mtime_crc.py
@@ -28,7 +28,7 @@ def getAllFiles(start):
 # Variables
 # #
 today = time()
-yesterday = time() - (24*60*60)
+yesterday = today - (24*60*60)
 mtime_file = "build/cmake_mtime_crc.txt"
 
 # #
@@ -50,7 +50,8 @@ if os.path.isfile(mtime_file):
 
     for line in readfile:
         line_list = line.strip().split(":")
-        crc_dict_prev.update({line_list[0] : int(line_list[1])})
+        if len(line_list) == 2:
+            crc_dict_prev.update({line_list[0] : int(line_list[1])})
     readfile.close()
 
 # compare file CRCs between the set of CRCs from the previous run and the current run


### PR DESCRIPTION
This adds functionality to check if a failed build used cmake, and if it did, clear out everything that was compiled during the failed run so that they will be treated as new and will be guaranteed to be rebuilt on the next run.

It also adds an inverted grep match on make to filter out the thousands of "is newer than" messages that can occasionally appear and clog up the log.

To verify that this did actually fix the issue, I re-ran the commits that originally caused the problem:
[The commit before the failed commit.](https://travis-ci.org/Pentarctagon/wesnoth/builds/341701475)
[The commit that failed.](https://travis-ci.org/Pentarctagon/wesnoth/builds/341706516)
[An unrelated commit that followed.](https://travis-ci.org/Pentarctagon/wesnoth/builds/341711673)
[The fix that caused the corrupted cache to corrupt memory](https://travis-ci.org/Pentarctagon/wesnoth/builds/341718261)(Check the raw log - I hadn't put the inverted grep match in, but the raw log shows that with the fix it fails by the same unit test error as scons did in the original commit) compared to the travis run of the [original commit](https://travis-ci.org/wesnoth/wesnoth/builds/340537853?utm_source=github_status&utm_medium=notification).

------

Alternatively, on failure `make clean` could be used along with deleting `build/cmake_mtime_crc.txt`, so a failure always triggers a full rebuild of everything.