### PR TITLE
Networked MP replay: move to end before returning to play mode (#2508)

### DIFF
--- a/src/hotkey/hotkey_handler_sp.cpp
+++ b/src/hotkey/hotkey_handler_sp.cpp
@@ -325,6 +325,8 @@ void playsingle_controller::hotkey_handler::replay_exit()
 {
 	if(!playsingle_controller_.is_networked_mp()) {
 		resources::recorder->delete_upcoming_commands();
+	} else {
+		resources::recorder->set_to_end();
 	}
 	playsingle_controller_.set_player_type_changed();
 }


### PR DESCRIPTION
This appears to fix an assertion failure I got while trying to reproduce #2508.

I'm not very familiar with MP code, and therefore I'd appreciate a code review before merging.