### PR TITLE
Don't assume unit is on the map when testing ability active

### DIFF
--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -927,11 +927,24 @@ void attack::fire_event(const std::string& n)
 	config& a_weapon_cfg = ev_data.add_child("first");
 	config& d_weapon_cfg = ev_data.add_child("second");
 
+	// Need these to ensure weapon filters work correctly
+	boost::optional<attack_type::specials_context_t> a_ctx, d_ctx;
+
 	if(a_stats_->weapon != nullptr && a_.valid()) {
+		if(d_stats_->weapon != nullptr && d_.valid()) {
+			a_ctx.emplace(a_stats_->weapon->specials_context(a_.get_unit(), d_.get_unit(), a_.loc_, d_.loc_, true, d_stats_->weapon));
+		} else {
+			a_ctx.emplace(a_stats_->weapon->specials_context(a_.get_unit(), a_.loc_, true));
+		}
 		a_stats_->weapon->write(a_weapon_cfg);
 	}
 
 	if(d_stats_->weapon != nullptr && d_.valid()) {
+		if(a_stats_->weapon != nullptr && a_.valid()) {
+			d_ctx.emplace(d_stats_->weapon->specials_context(d_.get_unit(), a_.get_unit(), d_.loc_, a_.loc_, false, a_stats_->weapon));
+		} else {
+			d_ctx.emplace(d_stats_->weapon->specials_context(d_.get_unit(), d_.loc_, false));
+		}
 		d_stats_->weapon->write(d_weapon_cfg);
 	}
 

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -122,10 +122,11 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 	}
 
 	// Get the weapon characteristics as appropriate.
-	weapon->set_specials_context(u, opp, u_loc, opp_loc, attacking, opp_weapon);
+	auto ctx = weapon->specials_context(u, opp, u_loc, opp_loc, attacking, opp_weapon);
+	boost::optional<decltype(ctx)> opp_ctx;
 
 	if(opp_weapon) {
-		opp_weapon->set_specials_context(u, opp, opp_loc, u_loc, !attacking, weapon);
+		opp_ctx.emplace(opp_weapon->specials_context(u, opp, opp_loc, u_loc, !attacking, weapon));
 	}
 
 	slows = weapon->get_special_bool("slow");
@@ -278,10 +279,11 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 	}
 
 	// Get the weapon characteristics as appropriate.
-	weapon->set_specials_context(u_type, map_location::null_location(), attacking);
+	auto ctx = weapon->specials_context(*u_type, map_location::null_location(), attacking);
+	boost::optional<decltype(ctx)> opp_ctx;
 
 	if(opp_weapon) {
-		opp_weapon->set_specials_context(u_type, map_location::null_location(), !attacking);
+		opp_ctx.emplace(opp_weapon->specials_context(*u_type, map_location::null_location(), !attacking));
 	}
 
 	slows = weapon->get_special_bool("slow");

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -122,10 +122,10 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 	}
 
 	// Get the weapon characteristics as appropriate.
-	weapon->set_specials_context(u_loc, opp_loc, attacking, opp_weapon);
+	weapon->set_specials_context(u, opp, u_loc, opp_loc, attacking, opp_weapon);
 
 	if(opp_weapon) {
-		opp_weapon->set_specials_context(opp_loc, u_loc, !attacking, weapon);
+		opp_weapon->set_specials_context(u, opp, opp_loc, u_loc, !attacking, weapon);
 	}
 
 	slows = weapon->get_special_bool("slow");
@@ -278,10 +278,10 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 	}
 
 	// Get the weapon characteristics as appropriate.
-	weapon->set_specials_context(map_location::null_location(), attacking);
+	weapon->set_specials_context(u_type, map_location::null_location(), attacking);
 
 	if(opp_weapon) {
-		opp_weapon->set_specials_context(map_location::null_location(), !attacking);
+		opp_weapon->set_specials_context(u_type, map_location::null_location(), !attacking);
 	}
 
 	slows = weapon->get_special_bool("slow");

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -126,7 +126,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 	boost::optional<decltype(ctx)> opp_ctx;
 
 	if(opp_weapon) {
-		opp_ctx.emplace(opp_weapon->specials_context(u, opp, opp_loc, u_loc, !attacking, weapon));
+		opp_ctx.emplace(opp_weapon->specials_context(opp, u, opp_loc, u_loc, !attacking, weapon));
 	}
 
 	slows = weapon->get_special_bool("slow");
@@ -283,7 +283,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 	boost::optional<decltype(ctx)> opp_ctx;
 
 	if(opp_weapon) {
-		opp_ctx.emplace(opp_weapon->specials_context(*u_type, map_location::null_location(), !attacking));
+		opp_ctx.emplace(opp_weapon->specials_context(*opp_type, map_location::null_location(), !attacking));
 	}
 
 	slows = weapon->get_special_bool("slow");

--- a/src/gui/dialogs/attack_predictions.cpp
+++ b/src/gui/dialogs/attack_predictions.cpp
@@ -127,7 +127,7 @@ void attack_predictions::set_data(window& window, const combatant_data& attacker
 
 	// Set specials context (for safety, it should not have changed normally).
 	const_attack_ptr weapon = attacker.stats_.weapon;
-	weapon->set_specials_context(attacker.unit_, defender.unit_, attacker.unit_.get_location(), defender.unit_.get_location(), attacker.stats_.is_attacker, defender.stats_.weapon);
+	auto ctx = weapon->specials_context(attacker.unit_, defender.unit_, attacker.unit_.get_location(), defender.unit_.get_location(), attacker.stats_.is_attacker, defender.stats_.weapon);
 
 	// Get damage modifiers.
 	unit_ability_list dmg_specials = weapon->get_specials("damage");

--- a/src/gui/dialogs/attack_predictions.cpp
+++ b/src/gui/dialogs/attack_predictions.cpp
@@ -127,7 +127,7 @@ void attack_predictions::set_data(window& window, const combatant_data& attacker
 
 	// Set specials context (for safety, it should not have changed normally).
 	const_attack_ptr weapon = attacker.stats_.weapon;
-	weapon->set_specials_context(attacker.unit_.get_location(), defender.unit_.get_location(), attacker.stats_.is_attacker, defender.stats_.weapon);
+	weapon->set_specials_context(attacker.unit_, defender.unit_, attacker.unit_.get_location(), defender.unit_.get_location(), attacker.stats_.is_attacker, defender.stats_.weapon);
 
 	// Get damage modifiers.
 	unit_ability_list dmg_specials = weapon->get_specials("damage");

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -658,7 +658,7 @@ static int attack_info(reports::context & rc, const attack_type &at, config &res
 {
 	std::ostringstream str, tooltip;
 
-	at.set_specials_context(displayed_unit_hex, u.side() == rc.screen().playing_side());
+	at.set_specials_context(u, displayed_unit_hex, u.side() == rc.screen().playing_side());
 	int base_damage = at.damage();
 	int specials_damage = at.modified_damage(false);
 	int damage_multiplier = 100;

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -657,8 +657,10 @@ static inline const color_t attack_info_percent_color(int resistance)
 static int attack_info(reports::context & rc, const attack_type &at, config &res, const unit &u, const map_location &displayed_unit_hex)
 {
 	std::ostringstream str, tooltip;
+	int damage = 0;
 
-	at.set_specials_context(u, displayed_unit_hex, u.side() == rc.screen().playing_side());
+	{
+	auto ctx = at.specials_context(u, displayed_unit_hex, u.side() == rc.screen().playing_side());
 	int base_damage = at.damage();
 	int specials_damage = at.modified_damage(false);
 	int damage_multiplier = 100;
@@ -671,7 +673,7 @@ static int attack_info(reports::context & rc, const attack_type &at, config &res
 	bool slowed = u.get_state(unit::STATE_SLOWED);
 	int damage_divisor = slowed ? 20000 : 10000;
 	// Assume no specific resistance (i.e. multiply by 100).
-	int damage = round_damage(specials_damage, damage_multiplier * 100, damage_divisor);
+	damage = round_damage(specials_damage, damage_multiplier * 100, damage_divisor);
 
 	// Hit points are used to calculate swarm, so they need to be bounded.
 	unsigned max_hp = u.max_hitpoints();
@@ -810,8 +812,10 @@ static int attack_info(reports::context & rc, const attack_type &at, config &res
 			}
 		add_text(res, flush(str), flush(tooltip));
 	}
+	}
 
-	at.set_specials_context_for_listing();
+	{
+	auto ctx = at.specials_context_for_listing();
 	boost::dynamic_bitset<> active;
 	const std::vector<std::pair<t_string, t_string>> &specials = at.special_tooltips(&active);
 	const size_t specials_size = specials.size();
@@ -831,6 +835,7 @@ static int attack_info(reports::context & rc, const attack_type &at, config &res
 		tooltip << '\n' << description;
 
 		add_text(res, flush(str), flush(tooltip), help_page);
+	}
 	}
 	return damage;
 }

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -767,6 +767,7 @@ attack_type::specials_context_t::specials_context_t(const attack_type& weapon)
 
 attack_type::specials_context_t::~specials_context_t()
 {
+	if(was_moved) return;
 	parent.self_ = nullptr;
 	parent.other_ = nullptr;
 	parent.self_loc_ = map_location::null_location();
@@ -774,6 +775,12 @@ attack_type::specials_context_t::~specials_context_t()
 	parent.is_attacker_ = false;
 	parent.other_attack_ = nullptr;
 	parent.is_for_listing_ = false;
+}
+
+attack_type::specials_context_t::specials_context_t(attack_type::specials_context_t&& other)
+	: parent(other.parent)
+{
+	other.was_moved = true;
 }
 
 /**

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -702,20 +702,22 @@ std::string attack_type::weapon_specials(bool only_active, bool is_backstab) con
  * @param[in]  attacking     Whether or not the unit with this weapon is the attacker.
  * @param[in]  other_attack  The attack used by the other unit.
  */
-void attack_type::set_specials_context(const unit& self,
+attack_type::specials_context_t::specials_context_t(const attack_type& weapon,
+                                       const_attack_ptr other_attack,
+									   const unit& self,
                                        const unit& other,
                                        const map_location& unit_loc,
                                        const map_location& other_loc,
-                                       bool attacking,
-                                       const_attack_ptr other_attack) const
+                                       bool attacking)
+	: parent(weapon)
 {
-	self_ = &self;
-	other_ = &other;
-	self_loc_ = unit_loc;
-	other_loc_ = other_loc;
-	is_attacker_ = attacking;
-	other_attack_ = other_attack;
-	is_for_listing_ = false;
+	weapon.self_ = &self;
+	weapon.other_ = &other;
+	weapon.self_loc_ = unit_loc;
+	weapon.other_loc_ = other_loc;
+	weapon.is_attacker_ = attacking;
+	weapon.other_attack_ = other_attack;
+	weapon.is_for_listing_ = false;
 }
 
 /**
@@ -725,15 +727,16 @@ void attack_type::set_specials_context(const unit& self,
  * @param[in]  loc           The location of the unit with this weapon.
  * @param[in]  attacking     Whether or not the unit with this weapon is the attacker.
  */
-void attack_type::set_specials_context(const unit& self, const map_location& loc, bool attacking) const
+attack_type::specials_context_t::specials_context_t(const attack_type& weapon, const unit& self, const map_location& loc, bool attacking)
+	: parent(weapon)
 {
-	self_ = &self;
-	other_ = nullptr;
-	self_loc_ = loc;
-	other_loc_ = map_location::null_location();
-	is_attacker_ = attacking;
-	other_attack_ = nullptr;
-	is_for_listing_ = false;
+	weapon.self_ = &self;
+	weapon.other_ = nullptr;
+	weapon.self_loc_ = loc;
+	weapon.other_loc_ = map_location::null_location();
+	weapon.is_attacker_ = attacking;
+	weapon.other_attack_ = nullptr;
+	weapon.is_for_listing_ = false;
 }
 
 /**
@@ -743,23 +746,35 @@ void attack_type::set_specials_context(const unit& self, const map_location& loc
  * @param[in]  loc           The location of the unit with this weapon.
  * @param[in]  attacking     Whether or not the unit with this weapon is the attacker.
  */
-void attack_type::set_specials_context(const unit_type* self_type, const map_location& loc, bool attacking) const
+attack_type::specials_context_t::specials_context_t(const attack_type& weapon, const unit_type& self_type, const map_location& loc, bool attacking)
+	: parent(weapon)
 {
 	UNUSED(self_type);
-	self_ = nullptr;
-	other_ = nullptr;
-	self_loc_ = loc;
-	other_loc_ = map_location::null_location();
-	is_attacker_ = attacking;
-	other_attack_ = nullptr;
-	is_for_listing_ = false;
+	weapon.self_ = nullptr;
+	weapon.other_ = nullptr;
+	weapon.self_loc_ = loc;
+	weapon.other_loc_ = map_location::null_location();
+	weapon.is_attacker_ = attacking;
+	weapon.other_attack_ = nullptr;
+	weapon.is_for_listing_ = false;
 }
 
-void attack_type::set_specials_context_for_listing() const
+attack_type::specials_context_t::specials_context_t(const attack_type& weapon)
+	: parent(weapon)
 {
-	is_for_listing_ = true;
+	weapon.is_for_listing_ = true;
 }
 
+attack_type::specials_context_t::~specials_context_t()
+{
+	parent.self_ = nullptr;
+	parent.other_ = nullptr;
+	parent.self_loc_ = map_location::null_location();
+	parent.other_loc_ = map_location::null_location();
+	parent.is_attacker_ = false;
+	parent.other_attack_ = nullptr;
+	parent.is_for_listing_ = false;
+}
 
 /**
  * Calculates the number of attacks this weapon has, considering specials.

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -102,10 +102,19 @@ private:
 
 	// Used via specials_context() to control which specials are
 	// considered active.
-	struct specials_context_t {
+	friend class specials_context_t;
+	mutable map_location self_loc_, other_loc_;
+	mutable const unit* self_;
+	mutable const unit* other_;
+	mutable bool is_attacker_;
+	mutable const_attack_ptr other_attack_;
+	mutable bool is_for_listing_ = false;
+public:
+	class specials_context_t {
+		friend class attack_type;
 		const attack_type& parent;
 		/// Initialize weapon specials context for listing
-		specials_context_t(const attack_type& weapon);
+		explicit specials_context_t(const attack_type& weapon);
 		/// Initialize weapon specials context for a unit type
 		specials_context_t(const attack_type& weapon, const unit_type& self_type, const map_location& loc, bool attacking = true);
 		/// Initialize weapon specials context for a single unit
@@ -115,16 +124,13 @@ private:
 			bool attacking);
 		/// Initialize weapon specials context for a pair of units
 		specials_context_t(const attack_type& weapon, const unit& self, const map_location& loc, bool attacking);
+		specials_context_t(const specials_context_t&) = delete;
+		bool was_moved = false;
+	public:
+		// Destructor at least needs to be public for all this to work.
 		~specials_context_t();
+		specials_context_t(specials_context_t&&);
 	};
-	friend struct specials_context_t;
-	mutable map_location self_loc_, other_loc_;
-	mutable const unit* self_;
-	mutable const unit* other_;
-	mutable bool is_attacker_;
-	mutable const_attack_ptr other_attack_;
-	mutable bool is_for_listing_ = false;
-public:
 	// Set up a specials context.
 	// Usage: auto ctx = weapon.specials_context(...);
 	specials_context_t specials_context(const unit& self, const unit& other,

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -28,6 +28,7 @@
 #include "units/ptr.hpp" // for attack_ptr
 
 class unit_ability_list;
+class unit_type;
 
 //the 'attack type' is the type of attack, how many times it strikes,
 //and how much damage it does.
@@ -72,9 +73,11 @@ public:
 	unit_ability_list get_specials(const std::string& special) const;
 	std::vector<std::pair<t_string, t_string>> special_tooltips(boost::dynamic_bitset<>* active_list = nullptr) const;
 	std::string weapon_specials(bool only_active=false, bool is_backstab=false) const;
-	void set_specials_context(const map_location& unit_loc, const map_location& other_loc,
+	void set_specials_context(const unit& self, const unit& other,
+	                          const map_location& unit_loc, const map_location& other_loc,
 	                          bool attacking, const_attack_ptr other_attack) const;
-	void set_specials_context(const map_location& loc, bool attacking = true) const;
+	void set_specials_context(const unit& self, const map_location& loc, bool attacking = true) const;
+	void set_specials_context(const unit_type* self_type, const map_location& loc, bool attacking = true) const;
 	void set_specials_context_for_listing() const;
 
 	/// Calculates the number of attacks this weapon has, considering specials.
@@ -106,6 +109,8 @@ private:
 	// Used via set_specials_context() to control which specials are
 	// considered active.
 	mutable map_location self_loc_, other_loc_;
+	mutable const unit* self_;
+	mutable const unit* other_;
 	mutable bool is_attacker_;
 	mutable const_attack_ptr other_attack_;
 	mutable bool is_for_listing_ = false;


### PR DESCRIPTION
This refactors ability tests to use a passed-in unit instead of
searching for the unit on the map based on its location.

While it does fix #2247, I am not confident that this won't also
have some undesirable side-effects.