### PR TITLE
Fix deprecation spam

### DIFF
--- a/data/advanced_preferences.cfg
+++ b/data/advanced_preferences.cfg
@@ -186,6 +186,15 @@
 
 #ifdef __UNUSED__
 [advanced_preference]
+    field=show_deprecation
+    # TODO: Add translation marks and enable this after 1.14
+    name="Show deprecation messages in-game"
+    description="Show warnings about deprecated API in the in-game chat area. These messages will still be shown in the log, even if this is disabled. In addition, the deprecation log-domain controls how many messages are printed."
+    type=boolean
+    default=no
+[/advanced_preference]
+
+[advanced_preference]
     field=joystick_support_enabled
     name= _ "Joystick support"
     type=boolean

--- a/data/ai/lua/patrol.lua
+++ b/data/ai/lua/patrol.lua
@@ -1,7 +1,7 @@
 
 local _ = wesnoth.textdomain "wesnoth-ai"
 
-wesnoth.deprecation_message('data/ai/lua/patrol.lua', 1, nil, _"Use the Patrols Micro AI instead of patrol.lua.")
+wesnoth.deprecated_message('data/ai/lua/patrol.lua', 1, nil, _"Use the Patrols Micro AI instead of patrol.lua.")
 
 function patrol_gen(n, wp)
     -- n is the name of the unit, like Kiressh

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -893,11 +893,7 @@ function wml_actions.deprecated_message(cfg)
 		local _ = wesnoth.textdomain "wesnoth"
 		helper.wml_error(_"Invalid deprecation level (should be 1-4)")
 	end
-	wesnoth.deprecated_message(cfg.what, cfg.level, cfg.version, cfg.message or '')
-	if not wesnoth.game_config.debug then return end
-	if cfg.level > 1 then
-		wesnoth.log('wml', cfg.message)
-	end
+	wesnoth.deprecation_message(cfg.what, cfg.level, cfg.version, cfg.message or '')
 end
 
 function wml_actions.wml_message(cfg)

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -893,7 +893,7 @@ function wml_actions.deprecated_message(cfg)
 		local _ = wesnoth.textdomain "wesnoth"
 		helper.wml_error(_"Invalid deprecation level (should be 1-4)")
 	end
-	wesnoth.deprecation_message(cfg.what, cfg.level, cfg.version, cfg.message or '')
+	wesnoth.deprecated_message(cfg.what, cfg.level, cfg.version, cfg.message or '')
 	if not wesnoth.game_config.debug then return end
 	if cfg.level > 1 then
 		wesnoth.log('wml', cfg.message)

--- a/data/lua/wml/message.lua
+++ b/data/lua/wml/message.lua
@@ -296,10 +296,7 @@ function wesnoth.wml_actions.message(cfg)
 		if wesnoth.eval_conditional(condition) then
 			if option.message and not option.image and not option.label then
 				local message = tostring(option.message)
-				if message:find("&") or message:find("=") or message:find("*") == 1 then
-					-- Perhaps someday this should be promoted from "debug" to "warning", but for now, we're keeping it quiet.
-					log('[option]message="&image=col1=col2" is deprecated, use new DescriptionWML instead (default, image, label, description)', "debug")
-				end
+				wesnoth.deprecated_message("[option]message=", 2, "1.15.0", "Use label= instead.");
 				-- Legacy format
 				table.insert(options, option.message)
 			else
@@ -311,6 +308,7 @@ function wesnoth.wml_actions.message(cfg)
 					value = option.value
 				}
 				if option.message then
+					wesnoth.deprecated_message("[option]message=", 2, "1.15.0", "Use label= instead.");
 					if not option.label then
 						-- Support either message or description
 						opt.label = option.message

--- a/projectfiles/VC12/wesnoth.vcxproj
+++ b/projectfiles/VC12/wesnoth.vcxproj
@@ -744,6 +744,7 @@
     <ClCompile Include="..\..\src\controller_base.cpp" />
     <ClCompile Include="..\..\src\countdown_clock.cpp" />
     <ClCompile Include="..\..\src\cursor.cpp" />
+    <ClCompile Include="..\..\src\deprecation.cpp" />
     <ClCompile Include="..\..\src\desktop\clipboard.cpp">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)Desktop\</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='ReleaseDEBUG|Win32'">$(IntDir)Desktop\</ObjectFileName>
@@ -3581,6 +3582,7 @@
     <ClInclude Include="..\..\src\controller_base.hpp" />
     <ClInclude Include="..\..\src\countdown_clock.hpp" />
     <ClInclude Include="..\..\src\cursor.hpp" />
+    <ClInclude Include="..\..\src\deprecation.hpp" />
     <ClInclude Include="..\..\src\desktop\clipboard.hpp" />
     <ClInclude Include="..\..\src\desktop\notifications.hpp" />
     <ClInclude Include="..\..\src\desktop\open.hpp" />

--- a/projectfiles/VC12/wesnoth.vcxproj.filters
+++ b/projectfiles/VC12/wesnoth.vcxproj.filters
@@ -1558,6 +1558,7 @@
     <ClCompile Include="..\..\src\gui\dialogs\surrender_quit.cpp">
       <Filter>Gui\Dialogs</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\deprecation.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\addon\client.hpp">
@@ -3025,6 +3026,7 @@
     <ClInclude Include="..\..\src\gui\dialogs\surrender_quit.hpp">
       <Filter>Gui\Dialogs</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\deprecation.hpp" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\..\src\tests\test_sdl_utils.hpp">

--- a/projectfiles/VC12/wesnothlib.vcxproj
+++ b/projectfiles/VC12/wesnothlib.vcxproj
@@ -138,7 +138,6 @@
     <ClCompile Include="..\..\src\color_range.cpp" />
     <ClCompile Include="..\..\src\config.cpp" />
     <ClCompile Include="..\..\src\config_attribute_value.cpp" />
-    <ClCompile Include="..\..\src\deprecation.cpp" />
     <ClCompile Include="..\..\src\filesystem_boost.cpp" />
     <ClCompile Include="..\..\src\filesystem_common.cpp" />
     <ClCompile Include="..\..\src\font\constants.cpp" />

--- a/projectfiles/VC12/wesnothlib.vcxproj.filters
+++ b/projectfiles/VC12/wesnothlib.vcxproj.filters
@@ -71,7 +71,6 @@
     <ClCompile Include="..\..\src\formula\string_utils.cpp">
       <Filter>Formula</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\deprecation.cpp" />
     <ClCompile Include="..\..\src\bcrypt\bcrypt.c">
       <Filter>Bcrypt</Filter>
     </ClCompile>

--- a/src/actions/unit_creator.cpp
+++ b/src/actions/unit_creator.cpp
@@ -130,7 +130,7 @@ map_location unit_creator::find_location(const config &cfg, const unit* pass_che
 				loc = start_pos_;
 			}
 			if(place == "leader_passable") {
-				deprecated_message("placement=leader_passable", 2, {1, 15, 0}, "Please use placement=leader and passable=yes instead");
+				deprecated_message("placement=leader_passable", DEP_LEVEL::PREEMPTIVE, {1, 15, 0}, "Please use placement=leader and passable=yes instead");
 				pass = true;
 			}
 		}
@@ -144,10 +144,10 @@ map_location unit_creator::find_location(const config &cfg, const unit* pass_che
 				loc = map_location(cfg, resources::gamedata);
 			}
 			if(place == "map_passable") {
-				deprecated_message("placement=map_passable", 2, {1, 15, 0}, "Please use placement=map and passable=yes instead");
+				deprecated_message("placement=map_passable", DEP_LEVEL::PREEMPTIVE, {1, 15, 0}, "Please use placement=map and passable=yes instead");
 				pass = true;
 			} else if(place == "map_overwrite") {
-				deprecated_message("placement=map_overwrite", 2, {1, 15, 0}, "Please use placement=map and overwrite=yes instead");
+				deprecated_message("placement=map_overwrite", DEP_LEVEL::PREEMPTIVE, {1, 15, 0}, "Please use placement=map and overwrite=yes instead");
 				vacant = false;
 			}
 		}

--- a/src/actions/unit_creator.cpp
+++ b/src/actions/unit_creator.cpp
@@ -37,6 +37,7 @@
 #include "units/unit.hpp" // for unit
 #include "units/udisplay.hpp" // for unit_display
 #include "variable.hpp" // for vconfig
+#include "deprecation.hpp"
 
 static lg::log_domain log_engine("engine");
 #define DBG_NG LOG_STREAM(debug, log_engine)
@@ -129,7 +130,7 @@ map_location unit_creator::find_location(const config &cfg, const unit* pass_che
 				loc = start_pos_;
 			}
 			if(place == "leader_passable") {
-				WARN_NG << "placement=leader_passable is deprecated; please use placement=leader and passable=yes instead\n";
+				deprecated_message("placement=leader_passable", 2, {1, 15, 0}, "Please use placement=leader and passable=yes instead");
 				pass = true;
 			}
 		}
@@ -143,10 +144,10 @@ map_location unit_creator::find_location(const config &cfg, const unit* pass_che
 				loc = map_location(cfg, resources::gamedata);
 			}
 			if(place == "map_passable") {
-				WARN_NG << "placement=map_passable is deprecated; please use placement=map and passable=yes instead\n";
+				deprecated_message("placement=map_passable", 2, {1, 15, 0}, "Please use placement=map and passable=yes instead");
 				pass = true;
 			} else if(place == "map_overwrite") {
-				WARN_NG << "placement=map_overwrite is deprecated; please use placement=map and overwrite=yes instead\n";
+				deprecated_message("placement=map_overwrite", 2, {1, 15, 0}, "Please use placement=map and overwrite=yes instead");
 				vacant = false;
 			}
 		}

--- a/src/ai/lua/core.cpp
+++ b/src/ai/lua/core.cpp
@@ -42,6 +42,7 @@
 #include "ai/lua/engine_lua.hpp"
 #include "ai/composite/contexts.hpp"
 #include "ai/default/aspect_attacks.hpp"
+#include "deprecation.hpp"
 
 #include "lua/lualib.h"
 #include "lua/lauxlib.h"
@@ -385,7 +386,11 @@ static int cfun_ai_get_targets(lua_State *L)
 	return 1;
 }
 
-#define DEPRECATED_ASPECT_MESSAGE(name) WRN_LUA << "ai.get_" name "() is deprecated, use ai.aspects." name " instead\n"
+// Note: If adding new uses of this macro, it will be necessary to either remove the old ones
+// (and the things so deprecated) OR add a version parameter to the macro.
+// Also note that the name MUST be a string literal.
+#define DEPRECATED_ASPECT_MESSAGE(name) \
+	deprecated_message("ai.get_" name, 2, {1, 15, 0}, "Use ai.aspects." name " instead")
 
 // Aspect section
 static int cfun_ai_get_aggression(lua_State *L)
@@ -406,7 +411,8 @@ static int cfun_ai_get_attack_depth(lua_State *L)
 
 static int cfun_ai_get_attacks(lua_State *L)
 {
-	// Unlike the other aspect fetchers, this one is not deprecated, because ai.aspects.attacks returns the viable units but this returns a full attack analysis
+	// Unlike the other aspect fetchers, this one is not deprecated!
+	// This is because ai.aspects.attacks returns the viable units but this returns a full attack analysis
 	const ai::attacks_vector& attacks = get_readonly_context(L).get_attacks();
 	lua_createtable(L, attacks.size(), 0);
 	int table_index = lua_gettop(L);

--- a/src/ai/lua/core.cpp
+++ b/src/ai/lua/core.cpp
@@ -390,7 +390,7 @@ static int cfun_ai_get_targets(lua_State *L)
 // (and the things so deprecated) OR add a version parameter to the macro.
 // Also note that the name MUST be a string literal.
 #define DEPRECATED_ASPECT_MESSAGE(name) \
-	deprecated_message("ai.get_" name, 2, {1, 15, 0}, "Use ai.aspects." name " instead")
+	deprecated_message("ai.get_" name, DEP_LEVEL::PREEMPTIVE, {1, 15, 0}, "Use ai.aspects." name " instead")
 
 // Aspect section
 static int cfun_ai_get_aggression(lua_State *L)

--- a/src/campaign_server/campaign_server.cpp
+++ b/src/campaign_server/campaign_server.cpp
@@ -930,6 +930,3 @@ int main()
 
 	return 0;
 }
-
-void deprecated_message(const std::string&, int, const version_info&, const std::string&);
-void deprecated_message(const std::string&, int, const version_info&, const std::string&) {}

--- a/src/commandline_options.cpp
+++ b/src/commandline_options.cpp
@@ -227,6 +227,7 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 		("log-warning", po::value<std::string>(), "sets the severity level of the specified log domain(s) to 'warning'. Similar to --log-error.")
 		("log-info", po::value<std::string>(), "sets the severity level of the specified log domain(s) to 'info'. Similar to --log-error.")
 		("log-debug", po::value<std::string>(), "sets the severity level of the specified log domain(s) to 'debug'. Similar to --log-error.")
+		("log-none", po::value<std::string>(), "sets the severity level of the specified log domain(s) to 'none'. Similar to --log-error.")
 		("log-precise", "shows the timestamps in the logfile with more precision.")
 		;
 
@@ -362,6 +363,8 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 		 parse_log_domains_(vm["log-info"].as<std::string>(),lg::info().get_severity());
 	if (vm.count("log-debug"))
 		 parse_log_domains_(vm["log-debug"].as<std::string>(),lg::debug().get_severity());
+	if (vm.count("log-none"))
+		 parse_log_domains_(vm["log-none"].as<std::string>(),-1);
 	if (vm.count("logdomains"))
 		logdomains = vm["logdomains"].as<std::string>();
 	if (vm.count("log-precise"))

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -725,7 +725,7 @@ const config::attribute_value& config::get_old_attribute(
 		if(!in_tag.empty()) {
 			const std::string what = "[" + in_tag + "]" + old_key + "=";
 			const std::string msg = "Use " + key + "= instead.";
-			deprecated_message(what, 1, "", msg);
+			deprecated_message(what, DEP_LEVEL::INDEFINITE, "", msg);
 			lg::wml_error() << msg;
 		}
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -24,6 +24,8 @@
 #include "log.hpp"
 #include "utils/const_clone.hpp"
 #include "utils/functional.hpp"
+#include "deprecation.hpp"
+#include "version.hpp"
 
 #include <algorithm>
 #include <cstdlib>
@@ -709,7 +711,7 @@ config::attribute_value& config::operator[](config_key_type key)
 }
 
 const config::attribute_value& config::get_old_attribute(
-		config_key_type key, const std::string& old_key, const std::string& msg) const
+		config_key_type key, const std::string& old_key, const std::string& in_tag) const
 {
 	check_valid();
 
@@ -720,7 +722,10 @@ const config::attribute_value& config::get_old_attribute(
 
 	i = values_.find(old_key);
 	if(i != values_.end()) {
-		if(!msg.empty()) {
+		if(!in_tag.empty()) {
+			const std::string what = "[" + in_tag + "]" + old_key + "=";
+			const std::string msg = "Use " + key + "= instead.";
+			deprecated_message(what, 1, "", msg);
 			lg::wml_error() << msg;
 		}
 

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -455,7 +455,7 @@ public:
 	 * Get the value of key and if missing try old_key
 	 * and log msg as a WML error (if not empty)
 	*/
-	const attribute_value &get_old_attribute(config_key_type key, const std::string &old_key, const std::string& msg = "") const;
+	const attribute_value &get_old_attribute(config_key_type key, const std::string &old_key, const std::string& in_tag = "") const;
 	/**
 	 * Returns a reference to the first child with the given @a key.
 	 * Creates the child if it does not yet exist.

--- a/src/deprecation.cpp
+++ b/src/deprecation.cpp
@@ -19,6 +19,7 @@
 #include "tstring.hpp"
 #include "game_config.hpp"
 #include "version.hpp"
+#include "preferences/general.hpp"
 
 // Set the default severity with the second parameter.
 // -1 means the default is to never log on this domain.
@@ -61,11 +62,12 @@ std::string deprecated_message(const std::string& elem_name, int level, const ve
 		message += "\n  ";
 		message += detail;
 	}
-	// TODO: Decide when to dump to wml_error()
 	if(log_ptr && !log_ptr->dont_log(log_deprecate)) {
 		const lg::logger& out_log = *log_ptr;
 		out_log(log_deprecate) << message << '\n';
-		//lg::wml_error() << message << '\n';
+		if(preferences::get("show_deprecation", false)) {
+			lg::wml_error() << message << '\n';
+		}
 	}
 	return message;
 }

--- a/src/deprecation.hpp
+++ b/src/deprecation.hpp
@@ -11,10 +11,14 @@
    See the COPYING file for more details.
 */
 
+#pragma once
+
 #include <string>
+
+enum class DEP_LEVEL {INDEFINITE = 1, PREEMPTIVE, FOR_REMOVAL, REMOVED};
 
 // Note: When using version (for level 2 or 3 deprecation), specify the first version
 // in which the feature could be removed... NOT the version at which it was deprecated.
 // For level 1 or 4 deprecation, it's fine to just pass an empty string, as the parameter will not be used.
 // It returns the final translated deprecation message, in case you want to output it elsewhere as well.
-std::string deprecated_message(const std::string& elem_name, int level, const class version_info& version, const std::string& detail = "");
+std::string deprecated_message(const std::string& elem_name, DEP_LEVEL level, const class version_info& version, const std::string& detail = "");

--- a/src/deprecation.hpp
+++ b/src/deprecation.hpp
@@ -16,4 +16,5 @@
 // Note: When using version (for level 2 or 3 deprecation), specify the first version
 // in which the feature could be removed... NOT the version at which it was deprecated.
 // For level 1 or 4 deprecation, it's fine to just pass an empty string, as the parameter will not be used.
-void deprecated_message(const std::string& elem_name, int level, const class version_info& version, const std::string& detail = "");
+// It returns the final translated deprecation message, in case you want to output it elsewhere as well.
+std::string deprecated_message(const std::string& elem_name, int level, const class version_info& version, const std::string& detail = "");

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -19,6 +19,7 @@
 #include "gettext.hpp"
 #include "log.hpp"
 #include "utils/general.hpp"
+#include "utils/math.hpp"
 #include "version.hpp"
 #include "wesconfig.h"
 #include "serialization/string_utils.hpp"
@@ -41,6 +42,13 @@ const std::string version = VERSION;
 const version_info wesnoth_version(VERSION);
 const version_info min_savegame_version(MIN_SAVEGAME_VERSION);
 const version_info test_version("test");
+// Not sure if there's any actual good use for this, which is why I haven't added it to the header...
+// In particular, it shouldn't be used for deprecation messages, because that would defeat the point.
+const version_info next_dev_version(
+	wesnoth_version.major_version(),
+	wesnoth_version.minor_version() + is_even(wesnoth_version.minor_version()) ? 1 : 0,
+	is_odd(wesnoth_version.minor_version()) ? wesnoth_version.revision_level() + 1 : 0
+);
 
 #ifdef REVISION
 const std::string revision = VERSION " (" REVISION ")";

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -113,7 +113,7 @@ std::vector<server_info> server_list;
 // Gamestate flags
 //
 bool
-	debug                = false,
+	debug_impl           = false,
 	debug_lua            = false,
 	editor               = false,
 	ignore_replay_errors = false,
@@ -122,6 +122,25 @@ bool
 	no_delay             = false,
 	disable_autosave     = false,
 	no_addons            = false;
+
+const bool& debug = debug_impl;
+
+void set_debug(bool new_debug) {
+	if(debug_impl && !new_debug) {
+		// Turning debug mode off; decrease deprecation severity
+		int severity;
+		if(lg::get_log_domain_severity("deprecation", severity)) {
+			lg::set_log_domain_severity("deprecation", severity - 2);
+		}
+	} else if(!debug_impl && new_debug) {
+		// Turning debug mode on; increase deprecation severity
+		int severity;
+		if(lg::get_log_domain_severity("deprecation", severity)) {
+			lg::set_log_domain_severity("deprecation", severity + 2);
+		}
+	}
+	debug_impl = new_debug;
+}
 
 //
 // Orb display flahs

--- a/src/game_config.hpp
+++ b/src/game_config.hpp
@@ -55,8 +55,11 @@ namespace game_config
 	/** Default percentage gold carried over to the next scenario. */
 	extern const int gold_carryover_percentage;
 
-	extern bool debug, debug_lua, editor, ignore_replay_errors, mp_debug,
+	extern bool debug_lua, editor, ignore_replay_errors, mp_debug,
 		exit_at_end, no_delay, disable_autosave, no_addons;
+
+	extern const bool& debug;
+	void set_debug(bool new_debug);
 
 	extern int cache_compression_level;
 

--- a/src/game_events/menu_item.cpp
+++ b/src/game_events/menu_item.cpp
@@ -82,7 +82,7 @@ wml_menu_item::wml_menu_item(const std::string& id, const config& cfg)
 	, is_synced_(cfg["synced"].to_bool(true))
 {
 	if(cfg.has_attribute("needs_select")) {
-		deprecated_message("needs_select", 1, {1, 15, 0});
+		deprecated_message("needs_select", DEP_LEVEL::INDEFINITE, {1, 15, 0});
 	}
 	gui2::legacy_menu_item parsed(cfg["description"].str(), "Multiple columns in [set_menu_item] are no longer supported; the image is specified by image=.");
 	if(parsed.contained_markup()) {
@@ -287,7 +287,7 @@ void wml_menu_item::update(const vconfig& vcfg)
 	}
 
 	if(vcfg.has_attribute("needs_select")) {
-		deprecated_message("needs_select", 1, {1, 15, 0});
+		deprecated_message("needs_select", DEP_LEVEL::INDEFINITE, {1, 15, 0});
 		needs_select_ = vcfg["needs_select"].to_bool();
 	}
 

--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -168,7 +168,7 @@ game_launcher::game_launcher(const commandline_options& cmdline_opts, const char
 	if (cmdline_opts_.clock)
 		gui2::dialogs::show_debug_clock_button = true;
 	if (cmdline_opts_.debug) {
-		game_config::debug = true;
+		game_config::set_debug(true);
 		game_config::mp_debug = true;
 	}
 #ifdef DEBUG_WINDOW_LAYOUT_GRAPHS

--- a/src/generators/cave_map_generator.cpp
+++ b/src/generators/cave_map_generator.cpp
@@ -95,8 +95,10 @@ cave_map_generator::cave_map_generator_job::cave_map_generator_job(const cave_ma
 {
 	res_.add_child("event", config {
 		"name", "start",
-		"message", config {
-			"message", "scenario_generation=cave is deprecated and will be removed soon.",
+		"deprecated_message", config {
+			"what", "scenario_generation=cave",
+			"level", 1,
+			"message", "Use the Lua cave generator instead, with scenario_generation=lua and create_scenario= (see wiki for details).",
 		},
 	});
 	uint32_t seed = randomseed.get_ptr() ? *randomseed.get_ptr() : seed_rng::next_seed();

--- a/src/generators/default_map_generator_job.cpp
+++ b/src/generators/default_map_generator_job.cpp
@@ -720,7 +720,7 @@ std::string default_map_generator_job::default_generate_map(generator_data data,
 	if(misc_labels != nullptr) {
 		name_generator_factory base_generator_factory{ naming, {"male", "base", "bridge", "road", "river", "forest", "lake", "mountain", "swamp"} };
 
-		naming.get_old_attribute("base_names", "male_names", "[naming]male_names= is deprecated, use base_names= instead");
+		naming.get_old_attribute("base_names", "male_names", "naming");
 		//Due to the attribute detection feature of the factory we also support male_name_generator= but keep it undocumented.
 
 		base_name_generator = base_generator_factory.get_name_generator( (naming.has_attribute("base_names") || naming.has_attribute("base_name_generator")) ? "base" : "male" );
@@ -1282,7 +1282,7 @@ std::string default_map_generator_job::default_generate_map(generator_data data,
 				name_generator_factory village_name_generator_factory{ village_naming,
 					{"base", "male", "village", "lake", "river", "bridge", "grassland", "forest", "hill", "mountain", "mountain_anon", "road", "swamp"} };
 
-				village_naming.get_old_attribute("base_names", "male_names", "[village_naming]male_names= is deprecated, use base_names= instead");
+				village_naming.get_old_attribute("base_names", "male_names", "village_naming");
 				//Due to the attribute detection feature of the factory we also support male_name_generator= but keep it undocumented.
 
 				base_name_generator = village_name_generator_factory.get_name_generator(

--- a/src/gui/auxiliary/old_markup.cpp
+++ b/src/gui/auxiliary/old_markup.cpp
@@ -68,7 +68,7 @@ legacy_menu_item::legacy_menu_item(const std::string& str, const std::string dep
 	}
 
 	if(contained_markup_) {
-		deprecated_message("Legacy DescriptionWML markup (&img=col1=col2)", 3, {1, 15, 0}, deprecation_msg);
+		deprecated_message("Legacy DescriptionWML markup (&img=col1=col2)", DEP_LEVEL::FOR_REMOVAL, {1, 15, 0}, deprecation_msg);
 	}
 }
 }

--- a/src/gui/auxiliary/old_markup.cpp
+++ b/src/gui/auxiliary/old_markup.cpp
@@ -13,12 +13,14 @@
 */
 
 #include "gui/auxiliary/old_markup.hpp"
+#include "deprecation.hpp"
+#include "version.hpp"
 
 namespace gui2
 {
 
-legacy_menu_item::legacy_menu_item(const std::string& str)
-	: icon_(), label_(str), desc_(), default_(false)
+legacy_menu_item::legacy_menu_item(const std::string& str, const std::string deprecation_msg)
+	: icon_(), label_(str), desc_(), default_(false), contained_markup_(false)
 {
 	if(label_.empty()) {
 		return;
@@ -28,14 +30,17 @@ legacy_menu_item::legacy_menu_item(const std::string& str)
 	if(label_[0] == '*') {
 		default_ = true;
 		label_.erase(0, 1);
+		contained_markup_ = true;
 	}
 
 	// Handle the special case with an image.
+	// 99.9% of uses put the image in the first column, so we ignore the slim possibility of it going in a different column
 	std::string::size_type pos = label_.find('=');
 	if(pos != std::string::npos && (label_[0] == '&' || pos == 0)) {
 		if(pos)
 			icon_ = label_.substr(1, pos - 1);
 		label_.erase(0, pos + 1);
+		contained_markup_ = true;
 	}
 
 	// Search for an '=' symbol that is not inside markup.
@@ -59,6 +64,11 @@ legacy_menu_item::legacy_menu_item(const std::string& str)
 	if(pos != std::string::npos) {
 		desc_ = label_.substr(pos + 1);
 		label_.erase(pos);
+		contained_markup_ = true;
+	}
+
+	if(contained_markup_) {
+		deprecated_message("Legacy DescriptionWML markup (&img=col1=col2)", 3, {1, 15, 0}, deprecation_msg);
 	}
 }
 }

--- a/src/gui/auxiliary/old_markup.hpp
+++ b/src/gui/auxiliary/old_markup.hpp
@@ -39,7 +39,7 @@ class legacy_menu_item
 	 * with special meanings for certain characters.
 	 */
 public:
-	explicit legacy_menu_item(const std::string& str = std::string());
+	explicit legacy_menu_item(const std::string& str = "", const std::string deprecation_msg = "");
 
 	const std::string& icon() const
 	{
@@ -59,6 +59,11 @@ public:
 	bool is_default() const
 	{
 		return default_;
+	}
+
+	bool contained_markup() const
+	{
+		return contained_markup_;
 	}
 
 	legacy_menu_item& operator=(const legacy_menu_item& rhs)
@@ -88,5 +93,10 @@ private:
 	 * It's unspecified what happens if multiple items in a menu are selected.
 	 */
 	bool default_;
+
+	/**
+	 * Was any old markup actually parsed?
+	 */
+	bool contained_markup_;
 };
 }

--- a/src/gui/dialogs/campaign_difficulty.cpp
+++ b/src/gui/dialogs/campaign_difficulty.cpp
@@ -82,9 +82,9 @@ config generate_difficulty_config(const config& source)
 
 	// Convert legacy format to new-style config if latter not present
 	if(result.empty() && source.has_attribute("difficulties")) {
-		deprecated_message("[campaign]difficulties", 3, {1, 15, 0}, "Use [difficulty] instead.");
+		deprecated_message("[campaign]difficulties", DEP_LEVEL::FOR_REMOVAL, {1, 15, 0}, "Use [difficulty] instead.");
 		if(source.has_attribute("difficulty_descriptions")) {
-			deprecated_message("[campaign]difficulty_descriptions", 3, {1, 15, 0}, "Use [difficulty] instead.");
+			deprecated_message("[campaign]difficulty_descriptions", DEP_LEVEL::FOR_REMOVAL, {1, 15, 0}, "Use [difficulty] instead.");
 		}
 
 		std::vector<std::string> difficulty_list = utils::split(source["difficulties"]);

--- a/src/gui/dialogs/campaign_difficulty.cpp
+++ b/src/gui/dialogs/campaign_difficulty.cpp
@@ -29,6 +29,7 @@
 #include "gui/widgets/window.hpp"
 #include "log.hpp"
 #include "serialization/string_utils.hpp"
+#include "deprecation.hpp"
 
 static lg::log_domain log_wml("wml");
 #define WRN_WML LOG_STREAM(warn, log_wml)
@@ -80,8 +81,11 @@ config generate_difficulty_config(const config& source)
 	result.append_children(source, "difficulty");
 
 	// Convert legacy format to new-style config if latter not present
-	if(result.empty()) {
-		WRN_WML << "[campaign] difficulties,difficulty_descriptions= is deprecated. Use [difficulty] instead" << std::endl;
+	if(result.empty() && source.has_attribute("difficulties")) {
+		deprecated_message("[campaign]difficulties", 3, {1, 15, 0}, "Use [difficulty] instead.");
+		if(source.has_attribute("difficulty_descriptions")) {
+			deprecated_message("[campaign]difficulty_descriptions", 3, {1, 15, 0}, "Use [difficulty] instead.");
+		}
 
 		std::vector<std::string> difficulty_list = utils::split(source["difficulties"]);
 		std::vector<std::string> difficulty_opts = utils::split(source["difficulty_descriptions"], ';');
@@ -92,7 +96,7 @@ config generate_difficulty_config(const config& source)
 
 		for(std::size_t i = 0; i < difficulty_opts.size(); ++i) {
 			config temp;
-			gui2::legacy_menu_item parsed(difficulty_opts[i]);
+			gui2::legacy_menu_item parsed(difficulty_opts[i], "Use [difficulty] instead.");
 
 			temp["define"] = difficulty_list[i];
 			temp["image"] = parsed.icon();

--- a/src/gui/dialogs/log_settings.cpp
+++ b/src/gui/dialogs/log_settings.cpp
@@ -77,8 +77,8 @@ void log_settings::pre_show(window& window)
 				group.add_member(button, this_id);
 			}
 		}
-		int current_sev;
-		if (lg::get_log_domain_severity(this_domain, current_sev)){
+		int current_sev, max_sev = widget_id_.size() - 1;
+		if (lg::get_log_domain_severity(this_domain, current_sev) && current_sev >= 0 && current_sev <= max_sev){
 			group.set_member_states(widget_id_[current_sev]);
 		}
 	}

--- a/src/gui/dialogs/multiplayer/faction_select.cpp
+++ b/src/gui/dialogs/multiplayer/faction_select.cpp
@@ -36,9 +36,6 @@
 
 #include "utils/functional.hpp"
 
-static lg::log_domain log_wml("wml");
-#define WRN_WML LOG_STREAM(warn, log_wml)
-
 namespace gui2
 {
 namespace dialogs
@@ -96,25 +93,24 @@ void faction_select::pre_show(window& window)
 		string_map item;
 
 		const std::string name = side["name"].str();
+		// flag_rgb here is unrelated to any handling in the unit class
+		const std::string flag_rgb = !side["flag_rgb"].empty() ? side["flag_rgb"].str() : "magenta";
 
-		// Handle legacy DescriptionWML format. The first character is '&'.
-		if(name[0] == '&') {
-			// TODO: @celticminstrel how should this use the new deprecated_message stuff?
-			WRN_WML
-				<< "Legacy DescriptionWML formatting for [multiplayer_side] name= is deprectaed. "
-				<< "Use separate name= and image= keys\n";
+		// Handle legacy DescriptionWML format.
+		if(name.find_first_of("=") != std::string::npos) {
+			gui2::legacy_menu_item parsed(name, "Use separate name= and image= keys. Multiple text columns are no longer supported.");
 
-			gui2::legacy_menu_item parsed(name);
-
-			item["label"] = parsed.icon();
-			data.emplace("faction_image", item);
+			if(!side.has_attribute("image")) {
+				item["label"] = (formatter() << parsed.icon() << "~RC(" << flag_rgb << ">" << tc_color_ << ")").str();
+				data.emplace("faction_image", item);
+			}
 
 			item["label"] = parsed.label();
+			if(!parsed.description().empty()) {
+				item["label"] += " " + parsed.description();
+			}
 			data.emplace("faction_name", item);
 		} else {
-			// flag_rgb here is unrelated to any handling in the unit class
-			const std::string flag_rgb = !side["flag_rgb"].empty() ? side["flag_rgb"].str() : "magenta";
-
 			item["label"] = (formatter() << side["image"] << "~RC(" << flag_rgb << ">" << tc_color_ << ")").str();
 			data.emplace("faction_image", item);
 

--- a/src/gui/dialogs/multiplayer/mp_options_helper.cpp
+++ b/src/gui/dialogs/multiplayer/mp_options_helper.cpp
@@ -25,6 +25,7 @@
 #include "gui/widgets/tree_view.hpp"
 #include "gui/widgets/tree_view_node.hpp"
 #include "gui/widgets/window.hpp"
+#include "deprecation.hpp"
 
 namespace gui2
 {
@@ -259,7 +260,7 @@ void mp_options_helper::display_custom_options(const std::string& type, int node
 
 			} else if(opt.key == "choice" || opt.key == "combo") {
 				if(opt.key == "combo") {
-					lg::wml_error() << "[options][combo] is deprecated; use [choice] instead\n";
+					deprecated_message("combo", 3, {1, 15, 0}, "Use [choice] instead.");
 				}
 
 				if(!option_cfg.has_child("item")) {

--- a/src/gui/dialogs/multiplayer/mp_options_helper.cpp
+++ b/src/gui/dialogs/multiplayer/mp_options_helper.cpp
@@ -260,7 +260,7 @@ void mp_options_helper::display_custom_options(const std::string& type, int node
 
 			} else if(opt.key == "choice" || opt.key == "combo") {
 				if(opt.key == "combo") {
-					deprecated_message("combo", 3, {1, 15, 0}, "Use [choice] instead.");
+					deprecated_message("combo", DEP_LEVEL::FOR_REMOVAL, {1, 15, 0}, "Use [choice] instead.");
 				}
 
 				if(!option_cfg.has_child("item")) {

--- a/src/help/help_impl.cpp
+++ b/src/help/help_impl.cpp
@@ -70,7 +70,7 @@ help::section hidden_sections;
 
 int last_num_encountered_units = -1;
 int last_num_encountered_terrains = -1;
-bool last_debug_state = game_config::debug;
+boost::tribool last_debug_state = boost::indeterminate;
 
 config dummy_cfg;
 std::vector<std::string> empty_string_vector;

--- a/src/help/help_impl.hpp
+++ b/src/help/help_impl.hpp
@@ -42,6 +42,7 @@
 #include <utility>                      // for pair, make_pair
 #include <vector>                       // for vector, etc
 #include <SDL.h>                  // for SDL_Surface
+#include <boost/logic/tribool.hpp>
 
 class config;
 class unit_type;
@@ -320,7 +321,7 @@ extern help::section hidden_sections;
 
 extern int last_num_encountered_units;
 extern int last_num_encountered_terrains;
-extern bool last_debug_state;
+extern boost::tribool last_debug_state;
 
 extern std::vector<std::string> empty_string_vector;
 extern const int max_section_level;

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -107,12 +107,13 @@ log_domain& general()
 	return dom;
 }
 
-log_domain::log_domain(char const *name)
+log_domain::log_domain(char const *name, int severity)
 	: domain_(nullptr)
 {
 	// Indirection to prevent initialization depending on link order.
 	if (!domains) domains = new domain_map;
-	domain_ = &*domains->insert(logd(name, 1)).first;
+	domain_ = &*domains->insert(logd(name, severity)).first;
+	domain_->second = severity;
 }
 
 bool set_log_domain_severity(const std::string& name, int severity)

--- a/src/log.hpp
+++ b/src/log.hpp
@@ -99,7 +99,7 @@ typedef std::pair<const std::string, int> logd;
 class log_domain {
 	logd *domain_;
 public:
-	log_domain(char const *name);
+	log_domain(char const *name, int severity = 1);
 	friend class logger;
 };
 

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -1713,7 +1713,7 @@ void console_handler::do_debug()
 {
 	if(!menu_handler_.pc_.is_networked_mp() || game_config::mp_debug) {
 		print(get_cmd(), _("Debug mode activated!"));
-		game_config::debug = true;
+		game_config::set_debug(true);
 	} else {
 		command_failed(_("Debug mode not available in network games"));
 	}
@@ -1723,7 +1723,7 @@ void console_handler::do_nodebug()
 {
 	if(game_config::debug) {
 		print(get_cmd(), _("Debug mode deactivated!"));
-		game_config::debug = false;
+		game_config::set_debug(false);
 	}
 }
 

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -850,7 +850,7 @@ int game_lua_kernel::intf_set_end_campaign_text(lua_State *L)
 
 int game_lua_kernel::intf_set_next_scenario(lua_State *L)
 {
-	deprecated_message("wesnoth.set_next_scenario", 1, "");
+	deprecated_message("wesnoth.set_next_scenario", DEP_LEVEL::INDEFINITE, "");
 	gamedata().set_next_scenario(luaL_checkstring(L, 1));
 	return 0;
 }
@@ -2091,7 +2091,7 @@ int game_lua_kernel::intf_put_unit(lua_State *L)
 			if (!map().on_board(loc))
 				return luaL_argerror(L, 1, "invalid location");
 		} else if (unit_arg != 1) {
-			deprecated_message("wesnoth.put_unit(x, y, unit)", 3, {1, 15, 0}, "Use wesnoth.put_unit(unit, x, y) or unit:to_map(x, y) instead.");
+			deprecated_message("wesnoth.put_unit(x, y, unit)", DEP_LEVEL::FOR_REMOVAL, {1, 15, 0}, "Use wesnoth.put_unit(unit, x, y) or unit:to_map(x, y) instead.");
 		}
 		put_unit_helper(loc);
 		u.put_map(loc);
@@ -2105,14 +2105,14 @@ int game_lua_kernel::intf_put_unit(lua_State *L)
 			if (!map().on_board(loc))
 				return luaL_argerror(L, 2, "invalid location");
 		} else if (unit_arg != 1) {
-			deprecated_message("wesnoth.put_unit(x, y, unit)", 3, {1, 15, 0}, "Use wesnoth.put_unit(unit, x, y) or unit:to_map(x, y) instead.");
+			deprecated_message("wesnoth.put_unit(x, y, unit)", DEP_LEVEL::FOR_REMOVAL, {1, 15, 0}, "Use wesnoth.put_unit(unit, x, y) or unit:to_map(x, y) instead.");
 		}
 		unit_ptr u(new unit(cfg, true, vcfg));
 		put_unit_helper(loc);
 		u->set_location(loc);
 		units().insert(u);
 	} else {
-		deprecated_message("wesnoth.put_unit(x, y)", 3, {1, 15, 0}, "Use wesnoth.erase_unit(x, y) or unit:erase() instead.");
+		deprecated_message("wesnoth.put_unit(x, y)", DEP_LEVEL::FOR_REMOVAL, {1, 15, 0}, "Use wesnoth.erase_unit(x, y) or unit:erase() instead.");
 		put_unit_helper(loc);
 		return 0; // Don't fire event when unit is only erase
 	}
@@ -2556,7 +2556,7 @@ int game_lua_kernel::intf_simulate_combat(lua_State *L)
  */
 static int intf_set_music(lua_State *L)
 {
-	deprecated_message("wesnoth.set_music", 1, "", "Use the wesnoth.playlist table instead!");
+	deprecated_message("wesnoth.set_music", DEP_LEVEL::INDEFINITE, "", "Use the wesnoth.playlist table instead!");
 	if (lua_isnoneornil(L, 1)) {
 		sound::commit_music_changes();
 		return 0;
@@ -2629,7 +2629,7 @@ int game_lua_kernel::intf_scroll_to_tile(lua_State *L)
 int game_lua_kernel::intf_select_hex(lua_State *L)
 {
 	events::command_disabler command_disabler;
-	deprecated_message("wesnoth.select_hex", 2, {1, 15, 0}, "Use wesnoth.select_unit and/or wesnoth.highlight_hex instead.");
+	deprecated_message("wesnoth.select_hex", DEP_LEVEL::PREEMPTIVE, {1, 15, 0}, "Use wesnoth.select_unit and/or wesnoth.highlight_hex instead.");
 
 	// Need this because check_location may change the stack
 	// By doing this now, we ensure that it won't do so when
@@ -3124,7 +3124,7 @@ static int intf_add_modification(lua_State *L)
 	std::string sm = m;
 	if (sm == "advance") { // Maintain backwards compatibility
 		sm = "advancement";
-		deprecated_message("\"advance\" modification type", 2, {1, 15, 0}, "Use \"advancement\" instead.");
+		deprecated_message("\"advance\" modification type", DEP_LEVEL::PREEMPTIVE, {1, 15, 0}, "Use \"advancement\" instead.");
 	}
 	if (sm != "advancement" && sm != "object" && sm != "trait") {
 		return luaL_argerror(L, 2, "unknown modification type");
@@ -3380,7 +3380,7 @@ static int intf_modify_ai_old(lua_State *L)
 	config cfg;
 	luaW_toconfig(L, 1, cfg);
 	int side = cfg["side"];
-	deprecated_message("wesnoth.modify_ai", 2, {1, 15, 0}, "Use wesnoth.add_ai_component, wesnoth.delete_ai_component, or wesnoth.change_ai_component.");
+	deprecated_message("wesnoth.modify_ai", DEP_LEVEL::PREEMPTIVE, {1, 15, 0}, "Use wesnoth.add_ai_component, wesnoth.delete_ai_component, or wesnoth.change_ai_component.");
 	ai::manager::get_singleton().modify_active_ai_for_side(side, cfg);
 	return 0;
 }

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -107,6 +107,7 @@
 #include "variable_info.hpp"
 #include "whiteboard/manager.hpp"       // for whiteboard
 #include "wml_exception.hpp"
+#include "deprecation.hpp"
 
 #include "utils/functional.hpp"               // for bind_t, bind
 #include <boost/range/algorithm/copy.hpp>    // boost::copy
@@ -849,7 +850,7 @@ int game_lua_kernel::intf_set_end_campaign_text(lua_State *L)
 
 int game_lua_kernel::intf_set_next_scenario(lua_State *L)
 {
-	WRN_LUA << "wesnoth.set_next_scenario() is deprecated" << std::endl;
+	deprecated_message("wesnoth.set_next_scenario", 1, "");
 	gamedata().set_next_scenario(luaL_checkstring(L, 1));
 	return 0;
 }
@@ -2090,7 +2091,7 @@ int game_lua_kernel::intf_put_unit(lua_State *L)
 			if (!map().on_board(loc))
 				return luaL_argerror(L, 1, "invalid location");
 		} else if (unit_arg != 1) {
-			WRN_LUA << "wesnoth.put_unit(x, y, unit) is deprecated. Use wesnoth.put_unit(unit, x, y) instead\n";
+			deprecated_message("wesnoth.put_unit(x, y, unit)", 3, {1, 15, 0}, "Use wesnoth.put_unit(unit, x, y) or unit:to_map(x, y) instead.");
 		}
 		put_unit_helper(loc);
 		u.put_map(loc);
@@ -2104,14 +2105,14 @@ int game_lua_kernel::intf_put_unit(lua_State *L)
 			if (!map().on_board(loc))
 				return luaL_argerror(L, 2, "invalid location");
 		} else if (unit_arg != 1) {
-			WRN_LUA << "wesnoth.put_unit(x, y, unit) is deprecated. Use wesnoth.put_unit(unit, x, y) instead\n";
+			deprecated_message("wesnoth.put_unit(x, y, unit)", 3, {1, 15, 0}, "Use wesnoth.put_unit(unit, x, y) or unit:to_map(x, y) instead.");
 		}
 		unit_ptr u(new unit(cfg, true, vcfg));
 		put_unit_helper(loc);
 		u->set_location(loc);
 		units().insert(u);
 	} else {
-		WRN_LUA << "wesnoth.put_unit(x, y) is deprecated. Use wesnoth.erase_unit(x, y) instead\n";
+		deprecated_message("wesnoth.put_unit(x, y)", 3, {1, 15, 0}, "Use wesnoth.erase_unit(x, y) or unit:erase() instead.");
 		put_unit_helper(loc);
 		return 0; // Don't fire event when unit is only erase
 	}
@@ -2153,15 +2154,8 @@ int game_lua_kernel::intf_erase_unit(lua_State *L)
 		if (!map().on_board(loc)) {
 			return luaL_argerror(L, 1, "invalid location");
 		}
-	} else if (!lua_isnoneornil(L, 1)) {
-		config cfg = luaW_checkconfig(L, 1);
-		loc.set_wml_x(cfg["x"]);
-		loc.set_wml_y(cfg["y"]);
-		if (!map().on_board(loc)) {
-			return luaL_argerror(L, 1, "invalid location");
-		}
 	} else {
-		return luaL_argerror(L, 1, "expected unit or integer");
+		return luaL_argerror(L, 1, "expected unit or location");
 	}
 
 	units().erase(loc);
@@ -2562,7 +2556,7 @@ int game_lua_kernel::intf_simulate_combat(lua_State *L)
  */
 static int intf_set_music(lua_State *L)
 {
-	lg::wml_error() << "set_music is deprecated; please use the wesnoth.playlist table instead!\n";
+	deprecated_message("wesnoth.set_music", 1, "", "Use the wesnoth.playlist table instead!");
 	if (lua_isnoneornil(L, 1)) {
 		sound::commit_music_changes();
 		return 0;
@@ -2635,7 +2629,7 @@ int game_lua_kernel::intf_scroll_to_tile(lua_State *L)
 int game_lua_kernel::intf_select_hex(lua_State *L)
 {
 	events::command_disabler command_disabler;
-	ERR_LUA << "wesnoth.select_hex is deprecated, use wesnoth.select_unit and/or wesnoth.highlight_hex" << std::endl;
+	deprecated_message("wesnoth.select_hex", 2, {1, 15, 0}, "Use wesnoth.select_unit and/or wesnoth.highlight_hex instead.");
 
 	// Need this because check_location may change the stack
 	// By doing this now, we ensure that it won't do so when
@@ -3130,7 +3124,7 @@ static int intf_add_modification(lua_State *L)
 	std::string sm = m;
 	if (sm == "advance") { // Maintain backwards compatibility
 		sm = "advancement";
-		lg::wml_error() << "(Lua) Modifications of type \"advance\" are deprecated, use \"advancement\" instead\n";
+		deprecated_message("\"advance\" modification type", 2, {1, 15, 0}, "Use \"advancement\" instead.");
 	}
 	if (sm != "advancement" && sm != "object" && sm != "trait") {
 		return luaL_argerror(L, 2, "unknown modification type");
@@ -3386,7 +3380,7 @@ static int intf_modify_ai_old(lua_State *L)
 	config cfg;
 	luaW_toconfig(L, 1, cfg);
 	int side = cfg["side"];
-	WRN_LUA << "wesnoth.modify_ai is deprecated\n";
+	deprecated_message("wesnoth.modify_ai", 2, {1, 15, 0}, "Use wesnoth.add_ai_component, wesnoth.delete_ai_component, or wesnoth.change_ai_component.");
 	ai::manager::get_singleton().modify_active_ai_for_side(side, cfg);
 	return 0;
 }

--- a/src/scripting/lua_common.cpp
+++ b/src/scripting/lua_common.cpp
@@ -595,7 +595,7 @@ t_string luaW_checktstring(lua_State *L, int index)
 	return result;
 }
 
-bool luaW_isstring(lua_State* L, int index)
+bool luaW_iststring(lua_State* L, int index)
 {
 	if(lua_isstring(L, index)) {
 		return true;

--- a/src/scripting/lua_common.hpp
+++ b/src/scripting/lua_common.hpp
@@ -82,7 +82,7 @@ t_string luaW_checktstring(lua_State *L, int index);
  * Test if a scalar is either a plain or translatable string.
  * Also returns true if it's a number since that's convertible to string.
  */
-bool luaW_isstring(lua_State* L, int index);
+bool luaW_iststring(lua_State* L, int index);
 
 /**
  * Converts a config object to a Lua table.

--- a/src/scripting/lua_gui2.cpp
+++ b/src/scripting/lua_gui2.cpp
@@ -296,20 +296,11 @@ int show_message_dialog(lua_State* L)
 				// when the deprecated syntax is removed, as a simpler method
 				// of specifying options when only a single string is needed.
 				const std::string& opt_str = short_opt;
-				gui2::legacy_menu_item item(opt_str);
+				gui2::legacy_menu_item item(opt_str, "Use image=, label=, description=, default= instead.");
 				opt["image"] = item.icon();
 				opt["label"] = item.label();
 				opt["description"] = item.description();
 				opt["default"] = item.is_default();
-				if(!opt["image"].blank() || !opt["description"].blank() || !opt["default"].blank()) {
-					// The exact error message depends on whether & or = was actually present
-					if(opt_str.find_first_of('=') == std::string::npos) {
-						// They just used a simple message, so the other error would be misleading
-						ERR_LUA << "[option]message= is deprecated, use label= instead.\n";
-					} else {
-						ERR_LUA << "The &image=col1=col2 syntax is deprecated, use new DescriptionWML instead.\n";
-					}
-				}
 			} else if(!luaW_toconfig(L, -1, opt)) {
 				std::ostringstream error;
 				error << "expected array of config and/or translatable strings, but index ";

--- a/src/scripting/lua_kernel_base.cpp
+++ b/src/scripting/lua_kernel_base.cpp
@@ -284,12 +284,13 @@ static int intf_log(lua_State *L) {
  */
 static int intf_deprecated_message(lua_State* L) {
 	const std::string elem = luaL_checkstring(L, 1);
-	const int level = luaL_checkinteger(L, 2);
+	// This could produce an invalid deprecation level, but that possibility is handled in deprecated_message()
+	const DEP_LEVEL level = DEP_LEVEL(luaL_checkinteger(L, 2));
 	const std::string ver_str = lua_isnoneornil(L, 3) ? "" : luaL_checkstring(L, 3);
 	const std::string detail = luaW_checktstring(L, 4);
 	const version_info ver = ver_str.empty() ? game_config::version : ver_str;
 	const std::string msg = deprecated_message(elem, level, ver, detail);
-	if(level < 1 || level >= 4) {
+	if(level < DEP_LEVEL::INDEFINITE || level >= DEP_LEVEL::REMOVED) {
 		// Invalid deprecation level or level 4 deprecation should raise an interpreter error
 		lua_push(L, msg);
 		return lua_error(L);

--- a/src/serialization/preprocessor.hpp
+++ b/src/serialization/preprocessor.hpp
@@ -21,9 +21,11 @@
 #include <iosfwd>
 #include <map>
 #include <vector>
+#include <boost/optional.hpp>
 
 #include "exceptions.hpp"
 #include "version.hpp"
+#include "deprecation.hpp"
 
 class config_writer;
 class config;
@@ -59,7 +61,7 @@ struct preproc_define
 			int line,
 			const std::string& loc,
 			const std::string& dep_msg,
-			int dep_lvl, const version_info& dep_ver)
+			DEP_LEVEL dep_lvl, const version_info& dep_ver)
 		: value(val)
 		, arguments(args)
 		, optional_arguments(optargs)
@@ -86,12 +88,12 @@ struct preproc_define
 
 	std::string deprecation_message;
 
-	int deprecation_level = -1;
+	boost::optional<DEP_LEVEL> deprecation_level;
 
 	version_info deprecation_version;
 
 	bool is_deprecated() const {
-		return deprecation_level > 0;
+		return deprecation_level != boost::none;
 	}
 
 	void write(config_writer&, const std::string&) const;

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -2832,6 +2832,3 @@ int main(int argc, char** argv) {
 
 	return 0;
 }
-
-void deprecated_message(const std::string&, int, const version_info&, const std::string&);
-void deprecated_message(const std::string&, int, const version_info&, const std::string&) {}

--- a/src/server/server_base.cpp
+++ b/src/server/server_base.cpp
@@ -207,3 +207,10 @@ void async_send_message(socket_ptr socket, const std::string& msg)
 
 	async_send_doc(socket, doc);
 }
+
+// This is just here to get it to build without the deprecation_message function
+#include "version.hpp"
+#include "deprecation.hpp"
+
+std::string deprecated_message(const std::string&, DEP_LEVEL, const version_info&, const std::string&);
+std::string deprecated_message(const std::string&, DEP_LEVEL, const version_info&, const std::string&) {return "";}

--- a/src/storyscreen/parser.cpp
+++ b/src/storyscreen/parser.cpp
@@ -20,6 +20,8 @@
 #include "log.hpp"
 #include "resources.hpp"
 #include "variable.hpp"
+#include "deprecation.hpp"
+#include "version.hpp"
 
 namespace storyscreen
 {
@@ -103,7 +105,7 @@ void story_parser::resolve_wml(const vconfig& cfg)
 		// [deprecated_message]
 		else if(key == "deprecated_message") {
 			// Won't appear until the scenario start event finishes.
-			lg::wml_error() << node["message"] << '\n';
+			deprecated_message(node["what"], node["level"], node["version"].str(), node["message"]);
 		}
 		// [wml_message]
 		else if(key == "wml_message") {

--- a/src/storyscreen/parser.cpp
+++ b/src/storyscreen/parser.cpp
@@ -105,7 +105,8 @@ void story_parser::resolve_wml(const vconfig& cfg)
 		// [deprecated_message]
 		else if(key == "deprecated_message") {
 			// Won't appear until the scenario start event finishes.
-			deprecated_message(node["what"], node["level"], node["version"].str(), node["message"]);
+			DEP_LEVEL level = DEP_LEVEL(node["level"].to_int(2));
+			deprecated_message(node["what"], level, node["version"].str(), node["message"]);
 		}
 		// [wml_message]
 		else if(key == "wml_message") {

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1055,7 +1055,7 @@ effect::effect(const unit_ability_list& list, int def, bool backstab) :
 		const std::string& effect_id = cfg[cfg["id"].empty() ? "name" : "id"];
 
 		if (!cfg["backstab"].blank()) {
-			deprecated_message("backstab= in weapon specials", 2, {1, 15, 0}, "Use [filter_adjacent] instead.");
+			deprecated_message("backstab= in weapon specials", DEP_LEVEL::PREEMPTIVE, {1, 15, 0}, "Use [filter_adjacent] instead.");
 		}
 
 		if (!backstab && cfg["backstab"].to_bool())

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -34,6 +34,7 @@
 #include "formula/formula.hpp"
 #include "formula/function_gamestate.hpp"
 #include "serialization/string_view.hpp"
+#include "deprecation.hpp"
 
 #include <boost/dynamic_bitset.hpp>
 #include <boost/algorithm/string/predicate.hpp>
@@ -1054,7 +1055,7 @@ effect::effect(const unit_ability_list& list, int def, bool backstab) :
 		const std::string& effect_id = cfg[cfg["id"].empty() ? "name" : "id"];
 
 		if (!cfg["backstab"].blank()) {
-			lg::wml_error() << "The backstab= key in weapon specials is deprecated; use [filter_adjacent] instead\n";
+			deprecated_message("backstab= in weapon specials", 2, {1, 15, 0}, "Use [filter_adjacent] instead.");
 		}
 
 		if (!backstab && cfg["backstab"].to_bool())

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -2344,7 +2344,7 @@ void unit::apply_modifications()
 
 	for(const auto& mod : ModificationTypes) {
 		if(mod == "advance" && modifications_.has_child(mod)) {
-			deprecated_message("[advance]", 2, {1, 15, 0}, "Use [advancement] instead.");
+			deprecated_message("[advance]", DEP_LEVEL::PREEMPTIVE, {1, 15, 0}, "Use [advancement] instead.");
 		}
 
 		for(const config& m : modifications_.child_range(mod)) {

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -20,6 +20,7 @@
 #include "units/unit.hpp"
 
 #include "color.hpp"
+#include "deprecation.hpp"
 #include "display_context.hpp"
 #include "formatter.hpp"
 #include "formula/string_utils.hpp" // for vgettext
@@ -48,6 +49,7 @@
 #include "units/id.hpp"
 #include "units/map.hpp"	   // for unit_map, etc
 #include "variable.hpp"		   // for vconfig, etc
+#include "version.hpp"
 
 #include "utils/functional.hpp"
 #include <boost/dynamic_bitset.hpp>
@@ -2342,7 +2344,7 @@ void unit::apply_modifications()
 
 	for(const auto& mod : ModificationTypes) {
 		if(mod == "advance" && modifications_.has_child(mod)) {
-			lg::wml_error() << "[modifications][advance] is deprecated, use [advancement] instead" << std::endl;
+			deprecated_message("[advance]", 2, {1, 15, 0}, "Use [advancement] instead.");
 		}
 
 		for(const config& m : modifications_.child_range(mod)) {

--- a/src/version.hpp
+++ b/src/version.hpp
@@ -45,6 +45,7 @@ class version_info
 public:
 	version_info();                    /**< Default constructor. */
 	version_info(const std::string&);  /**< String constructor. */
+	version_info(const char* str) : version_info(std::string(str)) {}
 
 	/** Simple list constructor. */
 	version_info(unsigned int major, unsigned int minor, unsigned int revision_level,

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -866,19 +866,19 @@ static int do_gameloop(const std::vector<std::string>& args)
 			LOG_GENERAL << "quitting game...\n";
 			return 0;
 		case gui2::dialogs::title_screen::MP_CONNECT:
-			game_config::debug = game_config::mp_debug;
+			game_config::set_debug(game_config::mp_debug);
 			if(!game->play_multiplayer(game_launcher::MP_CONNECT)) {
 				continue;
 			}
 			break;
 		case gui2::dialogs::title_screen::MP_HOST:
-			game_config::debug = game_config::mp_debug;
+			game_config::set_debug(game_config::mp_debug);
 			if(!game->play_multiplayer(game_launcher::MP_HOST)) {
 				continue;
 			}
 			break;
 		case gui2::dialogs::title_screen::MP_LOCAL:
-			game_config::debug = game_config::mp_debug;
+			game_config::set_debug(game_config::mp_debug);
 			if(!game->play_multiplayer(game_launcher::MP_LOCAL)) {
 				continue;
 			}

--- a/src/wml_exception.hpp
+++ b/src/wml_exception.hpp
@@ -141,12 +141,15 @@ std::string missing_mandatory_wml_key(
 		, const std::string& key
 		, const std::string& primary_key = ""
 		, const std::string& primary_value = "");
+
+// TODO: In 1.15 we could rework these two to provide standard detail messages
+// for the deprecated_message() function.
+
 /**
  * Returns a standard warning message for using a deprecated wml key.
  *
  * @param key                     The deprecated key.
- * @param removal_version         The version in which the key will be
- *                                removed key.
+ * @param removal_version         The version in which the key will be removed.
  *
  * @returns                       The warning message.
  */
@@ -159,8 +162,7 @@ std::string deprecate_wml_key_warning(
  *
  * @param deprecated_key          The deprecated key.
  * @param key                     The new key to be used.
- * @param removal_version         The version in which the key will be
- *                                removed key.
+ * @param removal_version         The version in which the key will be removed.
  *
  * @returns                       The warning message.
  */


### PR DESCRIPTION
This fixes the deprecation spam in the log/console by piping it into a brand-new logdomain which by default doesn't output anything at all, effectively adding a new log level below "error".

~The fourth commit is unrelated and would ideally be either discarded or cherry-picked separately, though if the PR is rebased against master it wouldn't really matter.~ It has already been cherry-picked, thanks!