### PR TITLE
Fix missing explicit keyword [WIP]

### DIFF
--- a/src/actions/advancement.hpp
+++ b/src/actions/advancement.hpp
@@ -39,7 +39,7 @@ class  config;
 */
 struct advance_unit_params
 {
-	advance_unit_params(const map_location& loc) : loc_(loc), ai_advancements_(nullptr), force_dialog_(false), fire_events_(true), animate_(true) {}
+	explicit advance_unit_params(const map_location& loc) : loc_(loc), ai_advancements_(nullptr), force_dialog_(false), fire_events_(true), animate_(true) {}
 	advance_unit_params& ai_advancements(const ai::unit_advancements_aspect& value) {ai_advancements_ = &value; return *this;}
 	advance_unit_params& force_dialog(bool value) {force_dialog_ = value; return *this;}
 	advance_unit_params& fire_events(bool value) {fire_events_ = value; return *this;}

--- a/src/actions/move.hpp
+++ b/src/actions/move.hpp
@@ -64,7 +64,7 @@ public:
 
 
 	/** constructor */
-	move_unit_spectator(const unit_map &units);
+	explicit move_unit_spectator(const unit_map &units);
 
 
 	/** destructor */

--- a/src/actions/shroud_clearing_action.hpp
+++ b/src/actions/shroud_clearing_action.hpp
@@ -23,7 +23,7 @@ namespace actions
 struct shroud_clearing_action
 {
 
-	shroud_clearing_action(const config& cfg)
+	explicit shroud_clearing_action(const config& cfg)
 		: route()
 		, view_info(cfg.child_or_empty("unit"))
 		, original_village_owner(cfg["village_owner"].to_int())

--- a/src/actions/undo_action.hpp
+++ b/src/actions/undo_action.hpp
@@ -63,7 +63,7 @@ namespace actions {
 		/// It is assumed that undo actions are constructed after the action is performed
 		/// so that the unit id diff does not change after this constructor.
 		undo_action();
-		undo_action(const config& cfg);
+		explicit undo_action(const config& cfg);
 		// Virtual destructor to support derived classes.
 		virtual ~undo_action() {}
 

--- a/src/actions/vision.hpp
+++ b/src/actions/vision.hpp
@@ -44,8 +44,8 @@ struct clearer_info {
 	bool slowed;
 	movetype::terrain_costs costs;
 
-	clearer_info(const unit & viewer);
-	clearer_info(const config & cfg);
+	explicit clearer_info(const unit & viewer);
+	explicit clearer_info(const config & cfg);
 
 	void write(config & cfg) const;
 };

--- a/src/addon/client.cpp
+++ b/src/addon/client.cpp
@@ -286,7 +286,7 @@ bool addons_client::install_addon(config& archive_cfg, const addon_info& info)
 		"#\n";
 
 	info.write_minimal(wml.add_child("info"));
-	write(info_contents, wml);
+	write(info_contents, configr_of(wml));
 
 	config file;
 	file["name"] = "_info.cfg";

--- a/src/addon/manager.cpp
+++ b/src/addon/manager.cpp
@@ -93,7 +93,7 @@ config get_addon_pbl_info(const std::string& addon_name)
 void set_addon_pbl_info(const std::string& addon_name, const config& cfg)
 {
 	filesystem::scoped_ostream stream = filesystem::ostream_file(get_pbl_file_path(addon_name));
-	write(*stream, cfg);
+	write(*stream, configr_of(cfg));
 }
 
 bool have_addon_install_info(const std::string& addon_name)

--- a/src/ai/actions.hpp
+++ b/src/ai/actions.hpp
@@ -66,7 +66,7 @@ public:
 	/* describe the action */
 	virtual std::string do_describe() const =0;
 protected:
-	action_result( side_number side );
+	explicit action_result( side_number side );
 
 	/* do check before execution or just check. setting status_ via set_error to != cancels the execution.*/
 	virtual void do_check_before() = 0;

--- a/src/ai/composite/aspect.hpp
+++ b/src/ai/composite/aspect.hpp
@@ -187,7 +187,7 @@ protected:
 
 class known_aspect {
 public:
-	known_aspect(const std::string &name);
+	explicit known_aspect(const std::string &name);
 
 
 	virtual ~known_aspect();
@@ -480,7 +480,7 @@ public:
 
 	virtual aspect_ptr get_new_instance( readonly_context &context, const config &cfg, const std::string &id) = 0;
 
-	aspect_factory( const std::string &name )
+	explicit aspect_factory( const std::string &name )
 	{
 		if (is_duplicate(name)) {
 			return;
@@ -496,7 +496,7 @@ public:
 template<class ASPECT>
 class register_aspect_factory : public aspect_factory {
 public:
-	register_aspect_factory( const std::string &name )
+	explicit register_aspect_factory( const std::string &name )
 		: aspect_factory( name )
 	{
 	}
@@ -526,7 +526,7 @@ public:
 
 	virtual aspect_ptr get_new_instance( readonly_context &context, const config &cfg, const std::string &id, std::shared_ptr<lua_ai_context>& l_ctx) = 0;
 
-	lua_aspect_factory( const std::string &name )
+	explicit lua_aspect_factory( const std::string &name )
 	{
 		factory_ptr ptr_to_this(this);
 		get_list().emplace(name,ptr_to_this);
@@ -538,7 +538,7 @@ public:
 template<class ASPECT>
 class register_lua_aspect_factory : public lua_aspect_factory {
 public:
-	register_lua_aspect_factory( const std::string &name )
+	explicit register_lua_aspect_factory( const std::string &name )
 		: lua_aspect_factory( name )
 	{
 	}

--- a/src/ai/composite/engine.hpp
+++ b/src/ai/composite/engine.hpp
@@ -132,7 +132,7 @@ public:
 	virtual engine_ptr get_new_instance( readonly_context &ai, const config &cfg ) = 0;
 	virtual engine_ptr get_new_instance( readonly_context &ai, const std::string& name ) = 0;
 
-	engine_factory( const std::string &name )
+	explicit engine_factory( const std::string &name )
 	{
 		if (is_duplicate(name)) {
 			return;
@@ -148,7 +148,7 @@ public:
 template<class ENGINE>
 class register_engine_factory : public engine_factory {
 public:
-	register_engine_factory( const std::string &name )
+	explicit register_engine_factory( const std::string &name )
 		: engine_factory( name )
 	{
 	}

--- a/src/ai/composite/goal.hpp
+++ b/src/ai/composite/goal.hpp
@@ -184,7 +184,7 @@ public:
 
 	virtual goal_ptr get_new_instance( readonly_context &context, const config &cfg ) = 0;
 
-	goal_factory( const std::string &name )
+	explicit goal_factory( const std::string &name )
 	{
 		if (is_duplicate(name)) {
 			return;
@@ -200,7 +200,7 @@ public:
 template<class GOAL>
 class register_goal_factory : public goal_factory {
 public:
-	register_goal_factory( const std::string &name )
+	explicit register_goal_factory( const std::string &name )
 		: goal_factory( name )
 	{
 	}

--- a/src/ai/composite/property_handler.hpp
+++ b/src/ai/composite/property_handler.hpp
@@ -30,7 +30,7 @@ namespace ai{
 template<typename T>
 class path_element_matches{
 public:
-	path_element_matches(const path_element &element)
+	explicit path_element_matches(const path_element &element)
 		: count_(0), element_(element)
 	{
 	}

--- a/src/ai/composite/rca.hpp
+++ b/src/ai/composite/rca.hpp
@@ -159,7 +159,7 @@ public:
 
 	virtual candidate_action_ptr get_new_instance( rca_context &context, const config &cfg ) = 0;
 
-	candidate_action_factory( const std::string &name )
+	explicit candidate_action_factory( const std::string &name )
 	{
 		if (is_duplicate(name)) {
 			return;
@@ -175,7 +175,7 @@ public:
 template<class CANDIDATE_ACTION>
 class register_candidate_action_factory : public candidate_action_factory {
 public:
-	register_candidate_action_factory( const std::string &name )
+	explicit register_candidate_action_factory( const std::string &name )
 		: candidate_action_factory( name )
 	{
 	}

--- a/src/ai/composite/stage.hpp
+++ b/src/ai/composite/stage.hpp
@@ -108,7 +108,7 @@ public:
 
 	virtual stage_ptr get_new_instance( ai_context &context, const config &cfg ) = 0;
 
-	stage_factory( const std::string &name )
+	explicit stage_factory( const std::string &name )
 	{
 		if (is_duplicate(name)) {
 			return;
@@ -124,7 +124,7 @@ public:
 template<class STAGE>
 class register_stage_factory : public stage_factory {
 public:
-	register_stage_factory( const std::string &name )
+	explicit register_stage_factory( const std::string &name )
 		: stage_factory( name )
 	{
 	}

--- a/src/ai/contexts.hpp
+++ b/src/ai/contexts.hpp
@@ -55,7 +55,7 @@ typedef ai_context* ai_context_ptr;
 // recursion counter
 class recursion_counter {
 public:
-	recursion_counter(int counter)
+	explicit recursion_counter(int counter)
 		: counter_(++counter)
 	{
 		if (counter > MAX_COUNTER_VALUE ) {

--- a/src/ai/default/ca_move_to_targets.cpp
+++ b/src/ai/default/ca_move_to_targets.cpp
@@ -88,7 +88,7 @@ private:
 
 class remove_wrong_targets {
 public:
-	remove_wrong_targets(const readonly_context &context)
+	explicit remove_wrong_targets(const readonly_context &context)
 		:avoid_(context.get_avoid()), map_(resources::gameboard->map())
 	{
 	}

--- a/src/ai/formula/callable_objects.hpp
+++ b/src/ai/formula/callable_objects.hpp
@@ -211,7 +211,7 @@ class position_callable : public formula_callable {
 
 	void get_inputs(formula_input_vector& inputs) const override;
 public:
-	position_callable(/*unit_map* units,*/ int chance) :
+	explicit position_callable(/*unit_map* units,*/ int chance) :
 		//units_(),
 		chance_(chance)
 	{

--- a/src/ai/formula/function_table.cpp
+++ b/src/ai/formula/function_table.cpp
@@ -55,7 +55,7 @@ namespace {
  */
 class unit_adapter {
 	public:
-		unit_adapter(const variant& arg) : unit_type_(), unit_() {
+		explicit unit_adapter(const variant& arg) : unit_type_(), unit_() {
 			auto unit = arg.try_convert<unit_callable>();
 
 			if (unit) {
@@ -173,7 +173,7 @@ namespace {
 
 	struct comp {
 		const std::vector<node>& nodes;
-		comp(const std::vector<node>& n) : nodes(n) { }
+		explicit comp(const std::vector<node>& n) : nodes(n) { }
 		bool operator()(int l, int r) const {
 			return nodes[r] < nodes[l];
 		}

--- a/src/ai/lua/aspect_advancements.hpp
+++ b/src/ai/lua/aspect_advancements.hpp
@@ -29,7 +29,7 @@ class unit_advancements_aspect
 public:
 	unit_advancements_aspect();
 	unit_advancements_aspect(lua_State* L, int n);
-	unit_advancements_aspect(const std::string& val);
+	explicit unit_advancements_aspect(const std::string& val);
 	const std::vector<std::string> get_advancements(const unit_map::const_iterator& unit) const;
 	virtual ~unit_advancements_aspect();
 	const std::string get_value() const;

--- a/src/animated.hpp
+++ b/src/animated.hpp
@@ -40,7 +40,7 @@ template<typename T, typename T_void_value = void_value<T>>
 class animated
 {
 public:
-	animated(int start_time = 0);
+	explicit animated(int start_time = 0);
 	virtual ~animated() {}
 
 	typedef std::pair<int, T> frame_description;

--- a/src/arrow.hpp
+++ b/src/arrow.hpp
@@ -33,7 +33,7 @@ public:
 	arrow(const arrow&) = delete;
 	arrow& operator=(const arrow&) = delete;
 
-	arrow(bool hidden = false);
+	explicit arrow(bool hidden = false);
 	virtual ~arrow();
 
 	///Sets the arrow's visibility

--- a/src/build_info.hpp
+++ b/src/build_info.hpp
@@ -43,7 +43,7 @@ struct optional_feature
 	std::string name;
 	bool enabled;
 
-	optional_feature(const char* n) : name(n), enabled(false) {}
+	explicit optional_feature(const char* n) : name(n), enabled(false) {}
 };
 
 /**

--- a/src/campaign_server/campaign_server.cpp
+++ b/src/campaign_server/campaign_server.cpp
@@ -270,7 +270,7 @@ void server::handle_read_from_fifo(const boost::system::error_code& error, std::
 	std::string cmd;
 	std::getline(is, cmd);
 
-	const control_line ctl = cmd;
+	const control_line ctl { cmd };
 
 	if(ctl == "shut_down") {
 		LOG_CS << "Shut down requested by admin, shutting down...\n";

--- a/src/campaign_server/campaign_server.cpp
+++ b/src/campaign_server/campaign_server.cpp
@@ -410,7 +410,7 @@ void server::write_config()
 {
 	DBG_CS << "writing configuration and add-ons list to disk...\n";
 	filesystem::atomic_commit out(cfg_file_);
-	write(*out.ostream(), cfg_);
+	write(*out.ostream(), configr_of(cfg_));
 	out.commit();
 	DBG_CS << "... done\n";
 }
@@ -594,7 +594,7 @@ void server::handle_request_campaign_list(const server::request& req)
 	response.add_child("campaigns", std::move(campaign_list));
 
 	std::ostringstream ostr;
-	write(ostr, response);
+	write(ostr, configr_of(response));
 	std::string wml = ostr.str();
 	simple_wml::document doc(wml.c_str(), simple_wml::INIT_STATIC);
 	doc.compress();

--- a/src/campaign_server/control.hpp
+++ b/src/campaign_server/control.hpp
@@ -35,7 +35,7 @@ public:
 	/**
 	 * Parses a control line string.
 	 */
-	control_line(const std::string& str) : args_(utils::split(str, ' '))
+	explicit control_line(const std::string& str) : args_(utils::split(str, ' '))
 	{
 		if(args_.empty()) {
 			args_.emplace_back();

--- a/src/campaign_server/fs_commit.hpp
+++ b/src/campaign_server/fs_commit.hpp
@@ -56,7 +56,7 @@ public:
 	 *
 	 * @throws filesystem::io_exception if the operation fails in some way.
 	 */
-	atomic_commit(const std::string& filename);
+	explicit atomic_commit(const std::string& filename);
 
 	atomic_commit(const atomic_commit&) = delete;
 	atomic_commit& operator=(const atomic_commit&) = delete;

--- a/src/carryover.cpp
+++ b/src/carryover.cpp
@@ -163,7 +163,7 @@ void carryover_info::remove_side(const std::string& id) {
 
 struct save_id_equals
 {
-	save_id_equals(const std::string& val) : value (val) {}
+	explicit save_id_equals(const std::string& val) : value (val) {}
 	bool operator () (carryover& v2) const
 	{
 		return value == v2.get_save_id();

--- a/src/color_range.hpp
+++ b/src/color_range.hpp
@@ -68,7 +68,7 @@ public:
 	* Constructor, which expects four reference RGB colors.
 	* @param v STL vector with the four reference colors in order.
 	*/
-	color_range(const std::vector<color_t>& v)
+	explicit color_range(const std::vector<color_t>& v)
 		: mid_(v.size()     ? v[0] : color_t(128, 128, 128))
 		, max_(v.size() > 1 ? v[1] : color_t(255, 255, 255))
 		, min_(v.size() > 2 ? v[2] : color_t(0  , 0  , 0  ))

--- a/src/commandline_options.hpp
+++ b/src/commandline_options.hpp
@@ -24,7 +24,7 @@
 class bad_commandline_resolution : public boost::program_options::error
 {
 public:
-    bad_commandline_resolution(const std::string& resolution);
+    explicit bad_commandline_resolution(const std::string& resolution);
 };
 
 class bad_commandline_tuple : public boost::program_options::error
@@ -42,7 +42,7 @@ class commandline_options
 friend std::ostream& operator<<(std::ostream &os, const commandline_options& cmdline_opts);
 
 public:
-	commandline_options(const std::vector<std::string>& args);
+	explicit commandline_options(const std::vector<std::string>& args);
 
 	config to_config() const; /* Used by lua scrips. Not all of the options need to be exposed here, just those exposed to lua */
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -726,7 +726,7 @@ const config::attribute_value& config::get_old_attribute(
 		if(!in_tag.empty()) {
 			const std::string what = formatter() << "[" << in_tag << "]" << old_key << "=";
 			const std::string msg  = formatter() << "Use " << key << "= instead.";
-			deprecated_message(what, DEP_LEVEL::INDEFINITE, "", msg);
+			deprecated_message(what, DEP_LEVEL::INDEFINITE, version_info(), msg);
 			lg::wml_error() << msg;
 		}
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -545,7 +545,7 @@ namespace
 {
 struct remove_ordered
 {
-	remove_ordered(const config::child_map::iterator& iter)
+	explicit remove_ordered(const config::child_map::iterator& iter)
 		: iter_(iter)
 	{
 	}

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -612,7 +612,7 @@ public:
 		struct arrow_helper
 		{
 			const any_child data;
-			arrow_helper(const const_all_children_iterator &i): data(*i) {}
+			explicit arrow_helper(const const_all_children_iterator &i): data(*i) {}
 			const any_child *operator->() const { return &data; }
 		};
 
@@ -632,7 +632,7 @@ public:
 		this_type operator--(int) { return this_type(i_--); }
 
 		reference operator*() const;
-		pointer operator->() const { return *this; }
+		pointer operator->() const { return arrow_helper(*this); }
 
 		bool operator==(const const_all_children_iterator &i) const { return i_ == i.i_; }
 		bool operator!=(const const_all_children_iterator &i) const { return i_ != i.i_; }

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -560,7 +560,7 @@ public:
 		struct arrow_helper
 		{
 			any_child data;
-			arrow_helper(const all_children_iterator &i): data(*i) {}
+			explicit arrow_helper(const all_children_iterator &i): data(*i) {}
 			const any_child *operator->() const { return &data; }
 		};
 
@@ -579,7 +579,7 @@ public:
 		this_type operator--(int) { return this_type(i_--); }
 
 		reference operator*() const;
-		pointer operator->() const { return *this; }
+		pointer operator->() const { return arrow_helper(*this); }
 
 		bool operator==(const all_children_iterator &i) const { return i_ == i.i_; }
 		bool operator!=(const all_children_iterator &i) const { return i_ != i.i_; }

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -293,7 +293,7 @@ public:
 		typedef const attribute &reference;
 		typedef attribute_map::const_iterator Itor;
 		explicit const_attribute_iterator(const Itor &i): i_(i) {}
-		const_attribute_iterator(attribute_iterator& i): i_(i.i_) {}
+		explicit const_attribute_iterator(attribute_iterator& i): i_(i.i_) {}
 
 		const_attribute_iterator &operator++() { ++i_; return *this; }
 		const_attribute_iterator operator++(int) { return const_attribute_iterator(i_++); }
@@ -533,7 +533,7 @@ public:
 	std::string hash() const;
 
 	struct error : public game::error, public boost::exception {
-		error(const std::string& message) : game::error(message) {}
+		explicit error(const std::string& message) : game::error(message) {}
 	};
 
 	struct child_pos
@@ -624,7 +624,7 @@ public:
 		typedef std::vector<child_pos>::const_iterator Itor;
 		typedef const_all_children_iterator this_type;
 		explicit const_all_children_iterator(const Itor &i): i_(i) {}
-		const_all_children_iterator(all_children_iterator& i): i_(i.i_) {}
+		explicit const_all_children_iterator(all_children_iterator& i): i_(i.i_) {}
 
 		const_all_children_iterator &operator++() { ++i_; return *this; }
 		const_all_children_iterator operator++(int) { return const_all_children_iterator(i_++); }

--- a/src/config_attribute_value.cpp
+++ b/src/config_attribute_value.cpp
@@ -261,7 +261,7 @@ class attribute_numeric_visitor : public boost::static_visitor<T>
 {
 public:
 	// Constructor stores the default value.
-	attribute_numeric_visitor(T def) : def_(def) {}
+	explicit attribute_numeric_visitor(T def) : def_(def) {}
 
 	T operator()(const boost::blank&) const { return def_; }
 	T operator()(bool)                 const { return def_; }
@@ -312,7 +312,7 @@ class config_attribute_value::string_visitor : public boost::static_visitor<std:
 	const std::string default_;
 
 public:
-	string_visitor(const std::string& fallback) : default_(fallback) {}
+	explicit string_visitor(const std::string& fallback) : default_(fallback) {}
 
 	std::string operator()(const boost::blank &) const { return default_; }
 	std::string operator()(const yes_no & b)     const { return b.str(); }

--- a/src/configr_assign.hpp
+++ b/src/configr_assign.hpp
@@ -26,7 +26,7 @@ struct configr_of
 		this->operator()(attrname, value);
 	}
 
-	configr_of(const config& cfg) : subtags_(), data_()
+	explicit configr_of(const config& cfg) : subtags_(), data_()
 	{
 		this->operator()(cfg);
 	}

--- a/src/controller_base.hpp
+++ b/src/controller_base.hpp
@@ -63,7 +63,7 @@ class manager;
 class controller_base : public video2::draw_layering
 {
 public:
-	controller_base(const config& game_config);
+	explicit controller_base(const config& game_config);
 	virtual ~controller_base();
 
 	void play_slice(bool is_delay_enabled = true);
@@ -196,7 +196,7 @@ private:
 	class keyup_listener : public events::sdl_handler
 	{
 	public:
-		keyup_listener(controller_base& controller)
+		explicit keyup_listener(controller_base& controller)
 			: events::sdl_handler(false)
 			, controller_(controller)
 		{

--- a/src/countdown_clock.hpp
+++ b/src/countdown_clock.hpp
@@ -19,7 +19,7 @@ class team;
 class countdown_clock : public events::pump_monitor
 {
 public:
-	countdown_clock(team& team);
+	explicit countdown_clock(team& team);
 	~countdown_clock();
 	/// @returns ticks passed since last update
 	/// @param new_timestamp latest result of SDL_GetTicks()

--- a/src/cursor.hpp
+++ b/src/cursor.hpp
@@ -41,7 +41,7 @@ void set_focus(bool focus);
 
 struct setter
 {
-	setter(CURSOR_TYPE type);
+	explicit setter(CURSOR_TYPE type);
 	~setter();
 
 private:

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -827,7 +827,7 @@ bool display::screenshot(const std::string& filename, bool map_screenshot)
 #endif
 
 		//NOTE: need to be sure that we free this huge surface (is it enough?)
-		map_screenshot_surf_ = nullptr;
+		map_screenshot_surf_ = surface();
 
 		// restore normal rendering
 		map_screenshot_= false;

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -439,7 +439,7 @@ public:
 		{ mouseover_hex_overlay_ = image; }
 
 	void clear_mouseover_hex_overlay()
-		{ mouseover_hex_overlay_ = nullptr; }
+		{ mouseover_hex_overlay_ = surface(); }
 
 	/** Toggle to continuously redraw the screen. */
 	static void toggle_benchmark();
@@ -608,7 +608,7 @@ public:
 	 * Schedule the minimap for recalculation.
 	 * Useful if any terrain in the map has changed.
 	 */
-	void recalculate_minimap() {minimap_ = nullptr; redrawMinimap_ = true; }
+	void recalculate_minimap() {minimap_ = surface(); redrawMinimap_ = true; }
 
 	/**
 	 * Schedule the minimap to be redrawn.

--- a/src/display_chat_manager.hpp
+++ b/src/display_chat_manager.hpp
@@ -26,7 +26,7 @@ class display;
 
 class display_chat_manager {
 public:
-	display_chat_manager(display & disp) : my_disp_(disp) {}
+	explicit display_chat_manager(display & disp) : my_disp_(disp) {}
 
 	void add_observer(const std::string& name) { observers_.insert(name); }
 	void remove_observer(const std::string& name) { observers_.erase(name); }

--- a/src/editor/action/action.hpp
+++ b/src/editor/action/action.hpp
@@ -37,7 +37,7 @@ namespace editor
 class editor_action_whole_map : public editor_action
 {
 public:
-	editor_action_whole_map(const editor_map& m)
+	explicit editor_action_whole_map(const editor_map& m)
 		: m_(m)
 	{
 	}
@@ -189,7 +189,7 @@ protected:
 class editor_action_location : public editor_action
 {
 public:
-	editor_action_location(map_location loc)
+	explicit editor_action_location(map_location loc)
 		: loc_(loc)
 	{
 	}
@@ -232,7 +232,7 @@ protected:
 class editor_action_area : public editor_action_extendable
 {
 public:
-	editor_action_area(const std::set<map_location>& area)
+	explicit editor_action_area(const std::set<map_location>& area)
 		: area_(area)
 	{
 	}
@@ -400,7 +400,7 @@ protected:
 class editor_action_apply_mask : public editor_action
 {
 public:
-	editor_action_apply_mask(const gamemap& mask)
+	explicit editor_action_apply_mask(const gamemap& mask)
 		: mask_(mask)
 	{
 	}
@@ -420,7 +420,7 @@ private:
 class editor_action_create_mask : public editor_action
 {
 public:
-	editor_action_create_mask(const editor_map& target)
+	explicit editor_action_create_mask(const editor_map& target)
 		: target_(target)
 	{
 	}
@@ -441,7 +441,7 @@ private:
 class editor_action_shuffle_area : public editor_action_area
 {
 public:
-	editor_action_shuffle_area(const std::set<map_location>& area)
+	explicit editor_action_shuffle_area(const std::set<map_location>& area)
 		: editor_action_area(area)
 	{
 	}

--- a/src/editor/action/action_base.hpp
+++ b/src/editor/action/action_base.hpp
@@ -112,7 +112,7 @@ private:
 // TODO: add messages etc
 struct editor_action_exception : public editor_exception
 {
-	editor_action_exception(const std::string& msg)
+	explicit editor_action_exception(const std::string& msg)
 		: editor_exception(msg)
 	{
 	}

--- a/src/editor/action/action_item.hpp
+++ b/src/editor/action/action_item.hpp
@@ -65,7 +65,7 @@ protected:
 class editor_action_item_delete : public editor_action_location
 {
 public:
-	editor_action_item_delete(map_location loc)
+	explicit editor_action_item_delete(map_location loc)
 		: editor_action_location(loc)
 	{
 	}

--- a/src/editor/action/action_label.hpp
+++ b/src/editor/action/action_label.hpp
@@ -81,7 +81,7 @@ protected:
 class editor_action_label_delete : public editor_action_location
 {
 public:
-	editor_action_label_delete(map_location loc)
+	explicit editor_action_label_delete(map_location loc)
 		: editor_action_location(loc)
 	{
 	}

--- a/src/editor/action/action_select.hpp
+++ b/src/editor/action/action_select.hpp
@@ -35,7 +35,7 @@ namespace editor
 class editor_action_select : public editor_action_area
 {
 public:
-	editor_action_select(const std::set<map_location>& area)
+	explicit editor_action_select(const std::set<map_location>& area)
 		: editor_action_area(area)
 	{
 	}
@@ -59,7 +59,7 @@ public:
 class editor_action_deselect : public editor_action_area
 {
 public:
-	editor_action_deselect(const std::set<map_location>& area)
+	explicit editor_action_deselect(const std::set<map_location>& area)
 		: editor_action_area(area)
 	{
 	}

--- a/src/editor/action/action_unit.hpp
+++ b/src/editor/action/action_unit.hpp
@@ -63,7 +63,7 @@ protected:
 class editor_action_unit_delete : public editor_action_location
 {
 public:
-	editor_action_unit_delete(map_location loc)
+	explicit editor_action_unit_delete(map_location loc)
 		: editor_action_location(loc)
 	{
 	}

--- a/src/editor/action/action_village.hpp
+++ b/src/editor/action/action_village.hpp
@@ -61,7 +61,7 @@ private:
 class editor_action_village_delete : public editor_action_location
 {
 public:
-	editor_action_village_delete(map_location loc)
+	explicit editor_action_village_delete(map_location loc)
 		: editor_action_location(loc)
 	{
 	}

--- a/src/editor/action/mouse/mouse_action.cpp
+++ b/src/editor/action/mouse/mouse_action.cpp
@@ -119,7 +119,7 @@ editor_action* mouse_action::key_event(
 
 void mouse_action::set_mouse_overlay(editor_display& disp)
 {
-	disp.set_mouseover_hex_overlay(nullptr);
+	disp.set_mouseover_hex_overlay(surface());
 }
 
 bool mouse_action::has_alt_modifier() const
@@ -149,7 +149,7 @@ void mouse_action::set_terrain_mouse_overlay(editor_display& disp, const t_trans
 
 	if (image_fg == nullptr || image_bg == nullptr) {
 		ERR_ED << "Missing terrain icon" << std::endl;
-		disp.set_mouseover_hex_overlay(nullptr);
+		disp.set_mouseover_hex_overlay(surface());
 		return;
 	}
 

--- a/src/editor/action/mouse/mouse_action_unit.cpp
+++ b/src/editor/action/mouse/mouse_action_unit.cpp
@@ -51,7 +51,7 @@ void mouse_action_unit::move(editor_display& disp, const map_location& hex)
 		const unit_map::const_unit_iterator unit_it = units.find(hex);
 		if (unit_it != units.end()) {
 
-			disp.set_mouseover_hex_overlay(nullptr);
+			disp.set_mouseover_hex_overlay(surface());
 
 			SDL_Rect rect;
 			rect.x = disp.get_location_x(hex);

--- a/src/editor/editor_common.hpp
+++ b/src/editor/editor_common.hpp
@@ -39,7 +39,7 @@ namespace editor {
 
 struct editor_exception : public game::error
 {
-	editor_exception(const std::string& msg)
+	explicit editor_exception(const std::string& msg)
 	: game::error(msg)
 	{
 	}
@@ -47,7 +47,7 @@ struct editor_exception : public game::error
 
 struct editor_logic_exception : public editor_exception
 {
-	editor_logic_exception(const std::string& msg)
+	explicit editor_logic_exception(const std::string& msg)
 	: editor_exception(msg)
 	{
 	}

--- a/src/editor/map/editor_map.hpp
+++ b/src/editor/map/editor_map.hpp
@@ -50,7 +50,7 @@ struct editor_map_load_exception : public editor_exception
 
 struct editor_map_save_exception : public editor_exception
 {
-	editor_map_save_exception(const std::string& msg)
+	explicit editor_map_save_exception(const std::string& msg)
 	: editor_exception(msg)
 	{
 	}

--- a/src/editor/map/map_context.hpp
+++ b/src/editor/map/map_context.hpp
@@ -28,7 +28,7 @@
 namespace editor {
 
 struct editor_team_info {
-	editor_team_info(const team& t);
+	explicit editor_team_info(const team& t);
 
 	int side;
 	std::string id;

--- a/src/editor/palette/common_palette.hpp
+++ b/src/editor/palette/common_palette.hpp
@@ -28,7 +28,7 @@ namespace editor {
  */
 struct item_group
 {
-	item_group(const config& cfg)
+	explicit item_group(const config& cfg)
 		: id(cfg["id"])
 		, name(cfg["name"].t_str())
 		, icon(cfg["icon"])
@@ -46,7 +46,7 @@ class common_palette  : public gui::widget {
 
 public:
 
-	common_palette(CVideo& video) : gui::widget(video, true) {}
+	explicit common_palette(CVideo& video) : gui::widget(video, true) {}
 
 	virtual ~common_palette() {}
 
@@ -91,7 +91,7 @@ public:
 class tristate_palette : public common_palette
 {
 public:
-	tristate_palette(CVideo& video)
+	explicit tristate_palette(CVideo& video)
 		: common_palette(video)
 	{
 	}

--- a/src/editor/palette/empty_palette.hpp
+++ b/src/editor/palette/empty_palette.hpp
@@ -27,7 +27,7 @@ class empty_palette : public common_palette {
 
 public:
 
-	empty_palette(display& gui) :
+	explicit empty_palette(display& gui) :
 		common_palette(gui.video()),
 		gui_(gui) {}
 

--- a/src/events.hpp
+++ b/src/events.hpp
@@ -96,7 +96,7 @@ public:
 	virtual bool has_joined() { return has_joined_;}
 	virtual bool has_joined_global() { return has_joined_global_;}
 protected:
-	sdl_handler(const bool auto_join=true);
+	explicit sdl_handler(const bool auto_join=true);
 	virtual ~sdl_handler();
 	virtual std::vector<sdl_handler*> handler_members()
 	{

--- a/src/exceptions.hpp
+++ b/src/exceptions.hpp
@@ -31,7 +31,7 @@ struct error : std::exception
 	std::string message;
 
 	error() : message() {}
-	error(const std::string &msg) : message(msg) {}
+	explicit error(const std::string &msg) : message(msg) {}
 	~error() NOEXCEPT {}
 
 	const char *what() const NOEXCEPT

--- a/src/fake_unit_manager.hpp
+++ b/src/fake_unit_manager.hpp
@@ -24,7 +24,7 @@ class fake_unit_ptr;
 class fake_unit_manager {
 public:
 	///Construct a fake unit manager from a display which owns it.
-	fake_unit_manager(display & disp) : fake_units_(), my_display_(disp) {}
+	explicit fake_unit_manager(display & disp) : fake_units_(), my_display_(disp) {}
 
 	//Anticipate making place_temporary_unit and remove_temporary_unit private to force exception safety
 	friend class fake_unit_ptr;

--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -45,7 +45,7 @@ rwops_ptr make_write_RWops(const std::string &path);
 /** An exception object used when an IO error occurs */
 struct io_exception : public game::error {
 	io_exception() : game::error("") {}
-	io_exception(const std::string& msg) : game::error(msg) {}
+	explicit io_exception(const std::string& msg) : game::error(msg) {}
 };
 
 struct file_tree_checksum;
@@ -284,7 +284,7 @@ char path_separator();
 struct binary_paths_manager
 {
 	binary_paths_manager();
-	binary_paths_manager(const config& cfg);
+	explicit binary_paths_manager(const config& cfg);
 	~binary_paths_manager();
 
 	void set_paths(const config& cfg);

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -40,7 +40,7 @@ std::stack<std::set<int>> label_contexts;
 
 namespace font
 {
-floating_label::floating_label(const std::string& text, const surface& surf)
+	floating_label::floating_label(const std::string& text, const surface& surf)
 #if 0
 	: img_(),
 #else
@@ -66,6 +66,10 @@ floating_label::floating_label(const std::string& text, const surface& surf)
 	, border_(0)
 	, scroll_(ANCHOR_LABEL_SCREEN)
 	, use_markup_(true)
+{
+}
+floating_label::floating_label(const std::string& text)
+	: floating_label(text, surface())
 {
 }
 
@@ -107,7 +111,7 @@ surface floating_label::create_surface()
 
 		if(foreground == nullptr) {
 			ERR_FT << "could not create floating label's text" << std::endl;
-			return nullptr;
+			return surface();
 		}
 
 		// combine foreground text with its background

--- a/src/floating_label.hpp
+++ b/src/floating_label.hpp
@@ -35,7 +35,8 @@ enum LABEL_SCROLL_MODE { ANCHOR_LABEL_SCREEN, ANCHOR_LABEL_MAP };
 class floating_label
 {
 public:
-	floating_label(const std::string& text, const surface& surface = nullptr);
+	explicit floating_label(const std::string& text);
+	floating_label(const std::string& text, const surface& surface);
 
 	void set_font_size(int font_size) {font_size_ = font_size;}
 

--- a/src/font/error.hpp
+++ b/src/font/error.hpp
@@ -20,7 +20,7 @@
 namespace font {
 
 struct error : public game::error {
-	error(const std::string& str = "Font initialization failed") : game::error(str) {}
+	explicit error(const std::string& str = "Font initialization failed") : game::error(str) {}
 };
 
 } // end namespace font

--- a/src/font/font_id.hpp
+++ b/src/font/font_id.hpp
@@ -57,7 +57,7 @@ struct font_id
  */
 struct text_chunk
 {
-	text_chunk(subset_id subset)
+	explicit text_chunk(subset_id subset)
 		: subset(subset)
 		, text()
 	{

--- a/src/formula/debugger.cpp
+++ b/src/formula/debugger.cpp
@@ -260,7 +260,7 @@ const std::string& base_breakpoint::name() const
 
 class end_breakpoint : public base_breakpoint {
 public:
-	end_breakpoint(formula_debugger &fdb)
+	explicit end_breakpoint(formula_debugger &fdb)
 		: base_breakpoint(fdb,"End", true)
 	{
 	}
@@ -282,7 +282,7 @@ public:
 
 class step_in_breakpoint : public base_breakpoint {
 public:
-	step_in_breakpoint(formula_debugger &fdb)
+	explicit step_in_breakpoint(formula_debugger &fdb)
 		: base_breakpoint(fdb,"Step",true)
 	{
 	}
@@ -305,7 +305,7 @@ public:
 
 class step_out_breakpoint : public base_breakpoint {
 public:
-	step_out_breakpoint(formula_debugger &fdb)
+	explicit step_out_breakpoint(formula_debugger &fdb)
 		: base_breakpoint(fdb,"Step out",true), level_(fdb.get_call_stack().size()-1)
 	{
 	}
@@ -333,7 +333,7 @@ private:
 
 class next_breakpoint : public base_breakpoint {
 public:
-	next_breakpoint(formula_debugger &fdb)
+	explicit next_breakpoint(formula_debugger &fdb)
 		: base_breakpoint(fdb,"Next",true), level_(fdb.get_call_stack().size())
 	{
 	}

--- a/src/formula/function.hpp
+++ b/src/formula/function.hpp
@@ -169,7 +169,7 @@ typedef std::shared_ptr<function_expression> function_expression_ptr;
 class formula_function
 {
 public:
-	formula_function(const std::string name)
+	explicit formula_function(const std::string name)
 		: name_(name)
 	{
 	}
@@ -210,7 +210,7 @@ template<typename T>
 class builtin_formula_function : public formula_function
 {
 public:
-	builtin_formula_function(const std::string& name)
+	explicit builtin_formula_function(const std::string& name)
 		: formula_function(name)
 	{
 	}
@@ -247,7 +247,7 @@ private:
 	functions_map custom_formulas_;
 
 	enum builtins_tag_t { builtins_tag };
-	function_symbol_table(builtins_tag_t)
+	explicit function_symbol_table(builtins_tag_t)
 	{
 	}
 };
@@ -255,7 +255,7 @@ private:
 class action_function_symbol_table : public function_symbol_table
 {
 public:
-	action_function_symbol_table(std::shared_ptr<function_symbol_table> parent = nullptr);
+	explicit action_function_symbol_table(std::shared_ptr<function_symbol_table> parent = nullptr);
 };
 
 class wrapper_formula : public formula_expression
@@ -266,7 +266,7 @@ public:
 	{
 	}
 
-	wrapper_formula(expression_ptr arg)
+	explicit wrapper_formula(expression_ptr arg)
 		: formula_expression(arg ? arg->get_name() : "")
 		, arg_(arg)
 	{

--- a/src/formula/function_gamestate.hpp
+++ b/src/formula/function_gamestate.hpp
@@ -18,7 +18,7 @@ namespace wfl {
 
 class gamestate_function_symbol_table : public function_symbol_table {
 public:
-	gamestate_function_symbol_table(std::shared_ptr<function_symbol_table> parent = nullptr);
+	explicit gamestate_function_symbol_table(std::shared_ptr<function_symbol_table> parent = nullptr);
 };
 
 }

--- a/src/formula/string_utils.cpp
+++ b/src/formula/string_utils.cpp
@@ -37,7 +37,7 @@ template <typename T>
 class string_map_variable_set : public variable_set
 {
 public:
-	string_map_variable_set(const std::map<std::string,T>& map) : map_(map) {}
+	explicit string_map_variable_set(const std::map<std::string,T>& map) : map_(map) {}
 
 	virtual config::attribute_value get_variable_const(const std::string &key) const
 	{

--- a/src/formula/variant.hpp
+++ b/src/formula/variant.hpp
@@ -38,7 +38,7 @@ public:
 	explicit variant(const std::map<variant, variant>& map);
 
 	template<typename T>
-	variant(std::shared_ptr<T> callable)
+	explicit variant(std::shared_ptr<T> callable)
 		: value_(std::make_shared<variant_callable>(callable))
 	{
 		assert(value_.get());

--- a/src/game_display.cpp
+++ b/src/game_display.cpp
@@ -506,7 +506,7 @@ std::vector<surface> footsteps_images(const map_location& loc, const pathfind::m
 	}
 	const std::string foot_speed_prefix = game_config::foot_speed_prefix[image_number-1];
 
-	surface teleport = nullptr;
+	surface teleport;
 
 	// We draw 2 half-hex (with possibly different directions),
 	// but skip the first for the first step.

--- a/src/game_errors.hpp
+++ b/src/game_errors.hpp
@@ -21,7 +21,7 @@
 namespace game {
 
 struct mp_server_error : public error {
-	mp_server_error(const std::string& msg) : error("MP server error: " + msg) {}
+	explicit mp_server_error(const std::string& msg) : error("MP server error: " + msg) {}
 };
 
 /**
@@ -29,7 +29,7 @@ struct mp_server_error : public error {
  */
 struct load_game_failed : public error {
 	load_game_failed() {}
-	load_game_failed(const std::string& msg) : error("load_game_failed: " + msg) {}
+	explicit load_game_failed(const std::string& msg) : error("load_game_failed: " + msg) {}
 };
 
 /**
@@ -37,21 +37,21 @@ struct load_game_failed : public error {
  */
 struct save_game_failed : public error {
 	save_game_failed() {}
-	save_game_failed(const std::string& msg) : error("save_game_failed: " + msg) {}
+	explicit save_game_failed(const std::string& msg) : error("save_game_failed: " + msg) {}
 };
 
 /**
  * Error used for any general game error, e.g. data files are corrupt.
  */
 struct game_error : public error {
-	game_error(const std::string& msg) : error("game_error: " + msg) {}
+	explicit game_error(const std::string& msg) : error("game_error: " + msg) {}
 };
 
 /**
  * Error used to report an error in a lua script or in the lua interpreter.
  */
 struct lua_error : public error {
-	lua_error(const std::string& msg) : error("lua_error: " + msg) {}
+	explicit lua_error(const std::string& msg) : error("lua_error: " + msg) {}
 	lua_error(const std::string& msg, const std::string& context) : error(context + ":\n  " + msg) {}
 };
 

--- a/src/game_events/action_wml.cpp
+++ b/src/game_events/action_wml.cpp
@@ -541,7 +541,7 @@ WML_HANDLER_FUNCTION(recall,, cfg)
 namespace {
 	struct map_choice : public mp_sync::user_choice
 	{
-		map_choice(const std::string& filename) : filename_(filename) {}
+		explicit map_choice(const std::string& filename) : filename_(filename) {}
 		std::string filename_;
 		virtual config query_user(int /*side*/) const
 		{

--- a/src/game_events/pump.cpp
+++ b/src/game_events/pump.cpp
@@ -98,7 +98,7 @@ struct pump_impl
 
 	manager* my_manager;
 
-	pump_impl(manager& man)
+	explicit pump_impl(manager& man)
 		: events_queue()
 		, internal_wml_tracking(0)
 		, wml_messages_stream()
@@ -115,7 +115,7 @@ namespace
 class pump_manager
 {
 public:
-	pump_manager(pump_impl&);
+	explicit pump_manager(pump_impl&);
 	~pump_manager();
 
 	/// Allows iteration through the queued events.

--- a/src/game_events/pump.hpp
+++ b/src/game_events/pump.hpp
@@ -74,7 +74,7 @@ class wml_event_pump
 	const std::unique_ptr<pump_impl> impl_;
 
 public:
-	wml_event_pump(manager&);
+	explicit wml_event_pump(manager&);
 	~wml_event_pump();
 
 	/**

--- a/src/game_initialization/connect_engine.cpp
+++ b/src/game_initialization/connect_engine.cpp
@@ -351,7 +351,7 @@ bool connect_engine::can_start_game() const
 void connect_engine::send_to_server(const config& cfg) const
 {
 	if(campaign_info_) {
-		campaign_info_->connection.send_data(cfg);
+		campaign_info_->connection.send_data(configr_of(cfg));
 	}
 }
 

--- a/src/game_initialization/create_engine.hpp
+++ b/src/game_initialization/create_engine.hpp
@@ -58,7 +58,7 @@ static bool contains_ignore_case(const std::string& str1, const std::string& str
 class level
 {
 public:
-	level(const config& data);
+	explicit level(const config& data);
 	virtual ~level() = default;
 
 	MAKE_ENUM(TYPE,
@@ -126,7 +126,7 @@ private:
 class scenario : public level
 {
 public:
-	scenario(const config& data);
+	explicit scenario(const config& data);
 
 	bool can_launch_game() const;
 
@@ -188,7 +188,7 @@ private:
 class random_map : public scenario
 {
 public:
-	random_map(const config& data);
+	explicit random_map(const config& data);
 
 	const config& generator_data() const
 	{
@@ -220,7 +220,7 @@ private:
 class campaign : public level
 {
 public:
-	campaign(const config& data);
+	explicit campaign(const config& data);
 
 	bool can_launch_game() const;
 

--- a/src/game_initialization/multiplayer.cpp
+++ b/src/game_initialization/multiplayer.cpp
@@ -157,7 +157,7 @@ std::pair<wesnothd_connection_ptr, config> open_connection(std::string host)
 			config res;
 			cfg["version"] = game_config::version;
 			res.add_child("version", std::move(cfg));
-			sock->send_data(res);
+			sock->send_data(configr_of(res));
 		}
 
 		// Check for gamelist. This *must* be done before the mustlogin check
@@ -204,7 +204,7 @@ std::pair<wesnothd_connection_ptr, config> open_connection(std::string host)
 				sp["selective_ping"] = true;
 			}
 
-			sock->send_data(response);
+			sock->send_data(configr_of(response));
 			sock->wait_and_receive_data(data);
 
 			gui2::dialogs::loading_screen::progress(loading_stage::login_response);
@@ -297,7 +297,7 @@ std::pair<wesnothd_connection_ptr, config> open_connection(std::string host)
 					sp["password_reminder"] = password_reminder;
 
 					// Once again send our request...
-					sock->send_data(response);
+					sock->send_data(configr_of(response));
 					sock->wait_and_receive_data(data);
 
 					gui2::dialogs::loading_screen::progress(loading_stage::login_response);
@@ -444,7 +444,7 @@ void enter_wait_mode(mp_workflow_helper_ptr helper, int game_id, bool observe)
 		gui2::dialogs::mp_join_game dlg(helper->state, *helper->lobby_info, *helper->connection, true, observe);
 
 		if(!dlg.fetch_game_config()) {
-			helper->connection->send_data(config("leave_game"));
+			helper->connection->send_data(configr_of(config("leave_game")));
 			return;
 		}
 
@@ -458,7 +458,7 @@ void enter_wait_mode(mp_workflow_helper_ptr helper, int game_id, bool observe)
 		controller.play_game();
 	}
 
-	helper->connection->send_data(config("leave_game"));
+	helper->connection->send_data(configr_of(config("leave_game")));
 }
 
 void enter_staging_mode(mp_workflow_helper_ptr helper)
@@ -490,7 +490,7 @@ void enter_staging_mode(mp_workflow_helper_ptr helper)
 	}
 
 	if(helper->connection) {
-		helper->connection->send_data(config("leave_game"));
+		helper->connection->send_data(configr_of(config("leave_game")));
 	}
 }
 
@@ -514,7 +514,7 @@ void enter_create_mode(mp_workflow_helper_ptr helper)
 	if(dlg_ok) {
 		enter_staging_mode(helper);
 	} else if(helper->connection) {
-		helper->connection->send_data(config("refresh_lobby"));
+		helper->connection->send_data(configr_of(config("refresh_lobby")));
 	}
 }
 
@@ -565,7 +565,7 @@ bool enter_lobby_mode(mp_workflow_helper_ptr helper, const std::vector<std::stri
 					}
 
 					// Update lobby content
-					helper->connection->send_data(config("refresh_lobby"));
+					helper->connection->send_data(configr_of(config("refresh_lobby")));
 				}
 
 				break;
@@ -582,7 +582,7 @@ bool enter_lobby_mode(mp_workflow_helper_ptr helper, const std::vector<std::stri
 					}
 
 					// Update lobby content
-					helper->connection->send_data(config("refresh_lobby"));
+					helper->connection->send_data(configr_of(config("refresh_lobby")));
 				}
 
 				break;
@@ -645,7 +645,7 @@ void start_client(const config& game_config,	saved_game& state, const std::strin
 
 			installed_addons = ::installed_addons(); // Refresh the installed add-on list for this session.
 
-			connection->send_data(config("refresh_lobby"));
+			connection->send_data(configr_of(config("refresh_lobby")));
 		}
 	} while(re_enter);
 }
@@ -665,7 +665,7 @@ bool goto_mp_wait(saved_game& state, const config& game_config, wesnothd_connect
 	gui2::dialogs::mp_join_game dlg(state, li, *connection, false, observe);
 
 	if(!dlg.fetch_game_config()) {
-		connection->send_data(config("leave_game"));
+		connection->send_data(configr_of(config("leave_game")));
 		return false;
 	}
 

--- a/src/game_initialization/playcampaign.hpp
+++ b/src/game_initialization/playcampaign.hpp
@@ -35,7 +35,7 @@ class config;
 class wesnothd_connection;
 struct mp_campaign_info
 {
-	mp_campaign_info(wesnothd_connection& wdc)
+	explicit mp_campaign_info(wesnothd_connection& wdc)
 		: connected_players()
 		, is_host()
 		, current_turn(0)

--- a/src/generators/cave_map_generator.hpp
+++ b/src/generators/cave_map_generator.hpp
@@ -27,7 +27,7 @@
 class cave_map_generator : public map_generator
 {
 public:
-	cave_map_generator(const config &game_config);
+	explicit cave_map_generator(const config &game_config);
 
 	std::string name() const { return "cave"; }
 

--- a/src/generators/default_map_generator.hpp
+++ b/src/generators/default_map_generator.hpp
@@ -18,7 +18,7 @@
 #include "generators/map_generator.hpp"
 
 struct generator_data {
-	generator_data(const config& cfg);
+	explicit generator_data(const config& cfg);
 
 	int width;
 	int height;
@@ -39,7 +39,7 @@ struct generator_data {
 class default_map_generator : public map_generator
 {
 public:
-	default_map_generator(const config &game_config);
+	explicit default_map_generator(const config &game_config);
 
 	bool allow_user_config() const override;
 	void user_config() override;

--- a/src/generators/default_map_generator_job.hpp
+++ b/src/generators/default_map_generator_job.hpp
@@ -33,7 +33,7 @@ class default_map_generator_job
 {
 public:
 	default_map_generator_job();
-	default_map_generator_job(uint32_t seed);
+	explicit default_map_generator_job(uint32_t seed);
 
 	/** Generate the map. */
 	std::string default_generate_map(generator_data data, std::map<map_location,std::string>* labels, const config& cfg);

--- a/src/generators/lua_map_generator.hpp
+++ b/src/generators/lua_map_generator.hpp
@@ -23,7 +23,7 @@
 
 class lua_map_generator : public map_generator {
 public:
-	lua_map_generator(const config & cfg);
+	explicit lua_map_generator(const config & cfg);
 
 	bool allow_user_config() const override { return !user_config_.empty(); }
 

--- a/src/generators/map_generator.hpp
+++ b/src/generators/map_generator.hpp
@@ -26,7 +26,7 @@ class config;
 
 struct mapgen_exception : public game::error
 {
-	mapgen_exception(const std::string& msg)
+	explicit mapgen_exception(const std::string& msg)
 	: game::error(msg)
 	{}
 };

--- a/src/generic_event.hpp
+++ b/src/generic_event.hpp
@@ -42,7 +42,7 @@ This is the class that notifies the observers and maintains a list of them.
 */
 class generic_event{
 public:
-	generic_event(const std::string& name);
+	explicit generic_event(const std::string& name);
 	virtual ~generic_event() {}
 
 	virtual bool attach_handler(observer* obs);

--- a/src/gui/auxiliary/iterator/iterator.hpp
+++ b/src/gui/auxiliary/iterator/iterator.hpp
@@ -46,7 +46,7 @@ public:
 	 *
 	 * @param root                The widget where to start the iteration.
 	 */
-	iterator(widget& root) : order(root)
+	explicit iterator(widget& root) : order(root)
 	{
 	}
 

--- a/src/gui/core/event/distributor.cpp
+++ b/src/gui/core/event/distributor.cpp
@@ -85,7 +85,7 @@ static uint32_t popup_callback(uint32_t /*interval*/, void* /*param*/)
 class resource_locker
 {
 public:
-	resource_locker(bool& locked) : locked_(locked)
+	explicit resource_locker(bool& locked) : locked_(locked)
 	{
 		assert(!locked_);
 		locked_ = true;

--- a/src/gui/core/timer.cpp
+++ b/src/gui/core/timer.cpp
@@ -66,7 +66,7 @@ static bool executing_id_removed = false;
 class executor
 {
 public:
-	executor(size_t id)
+	explicit executor(size_t id)
 	{
 		executing_id = id;
 		executing_id_removed = false;

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -720,7 +720,7 @@ void addon_manager::publish_addon(const addon_info& addon, window& window)
 	const std::string addon_id = addon.id;
 	config cfg = get_addon_pbl_info(addon_id);
 
-	const version_info& version_to_publish = cfg["version"].str();
+	const version_info version_to_publish(cfg["version"].str());
 
 	if(version_to_publish <= tracking_info_[addon_id].remote_version) {
 		const int res = gui2::show_message(_("Warning"),

--- a/src/gui/dialogs/campaign_difficulty.hpp
+++ b/src/gui/dialogs/campaign_difficulty.hpp
@@ -36,7 +36,7 @@ public:
 	/**
 	 * @param campaign The campaign the difficulty is being chosen for
 	 */
-	campaign_difficulty(const config& campaign);
+	explicit campaign_difficulty(const config& campaign);
 
 	/**
 	 * Returns the selected difficulty define after displaying.

--- a/src/gui/dialogs/chat_log.cpp
+++ b/src/gui/dialogs/chat_log.cpp
@@ -221,7 +221,7 @@ public:
 class chat_log::controller
 {
 public:
-	controller(model& m) : model_(m)
+	explicit controller(model& m) : model_(m)
 	{
 		LOG_CHAT_LOG << "Entering chat_log::controller" << std::endl;
 		LOG_CHAT_LOG << "Exiting chat_log::controller" << std::endl;

--- a/src/gui/dialogs/folder_create.hpp
+++ b/src/gui/dialogs/folder_create.hpp
@@ -34,7 +34,7 @@ public:
 	 *                              entered if the dialog returns @ref
 	 *                              retval::OK; undefined otherwise.
 	 */
-	folder_create(std::string& folder_name);
+	explicit folder_create(std::string& folder_name);
 
 	/** The execute function; see @ref modal_dialog for more information. */
 	DEFINE_SIMPLE_EXECUTE_WRAPPER(folder_create)

--- a/src/gui/dialogs/gamestate_inspector.cpp
+++ b/src/gui/dialogs/gamestate_inspector.cpp
@@ -181,7 +181,7 @@ private:
 class gamestate_inspector::view
 {
 public:
-	view(window& window)
+	explicit view(window& window)
 		: stuff_list_(find_widget<tree_view>(&window, "stuff_list", false, true))
 		, inspect_(find_widget<styled_widget>(&window, "inspect", false, true))
 		, pages_(find_widget<styled_widget>(&window, "page_count", false, true))
@@ -238,7 +238,7 @@ private:
 class single_mode_controller
 {
 public:
-	single_mode_controller(gamestate_inspector::controller& c) : c(c)
+	explicit single_mode_controller(gamestate_inspector::controller& c) : c(c)
 	{
 	}
 
@@ -258,7 +258,7 @@ protected:
 class variable_mode_controller : public single_mode_controller
 {
 public:
-	variable_mode_controller(gamestate_inspector::controller& c)
+	explicit variable_mode_controller(gamestate_inspector::controller& c)
 		: single_mode_controller(c)
 	{
 	}
@@ -271,7 +271,7 @@ public:
 class event_mode_controller : public single_mode_controller
 {
 public:
-	event_mode_controller(gamestate_inspector::controller& c);
+	explicit event_mode_controller(gamestate_inspector::controller& c);
 	void show_list(tree_view_node& node, bool is_wmi);
 	void show_event(tree_view_node& node, bool is_wmi);
 
@@ -282,7 +282,7 @@ private:
 class unit_mode_controller : public single_mode_controller
 {
 public:
-	unit_mode_controller(gamestate_inspector::controller& c)
+	explicit unit_mode_controller(gamestate_inspector::controller& c)
 		: single_mode_controller(c)
 	{
 	}
@@ -294,7 +294,7 @@ public:
 class team_mode_controller : public single_mode_controller
 {
 public:
-	team_mode_controller(gamestate_inspector::controller& c)
+	explicit team_mode_controller(gamestate_inspector::controller& c)
 		: single_mode_controller(c)
 	{
 	}

--- a/src/gui/dialogs/gamestate_inspector.cpp
+++ b/src/gui/dialogs/gamestate_inspector.cpp
@@ -51,7 +51,7 @@ namespace
 inline std::string config_to_string(const config& cfg)
 {
 	std::ostringstream s;
-	write(s, cfg);
+	write(s, configr_of(cfg));
 	return s.str();
 }
 

--- a/src/gui/dialogs/label_settings.hpp
+++ b/src/gui/dialogs/label_settings.hpp
@@ -25,7 +25,7 @@ namespace dialogs
 
 class label_settings : public modal_dialog {
 public:
-	label_settings(display_context& dc);
+	explicit label_settings(display_context& dc);
 
 	/**
 	 * The execute function.

--- a/src/gui/dialogs/loading_screen.hpp
+++ b/src/gui/dialogs/loading_screen.hpp
@@ -73,7 +73,7 @@ namespace dialogs
 class loading_screen : public modal_dialog
 {
 public:
-	loading_screen(std::function<void()> f);
+	explicit loading_screen(std::function<void()> f);
 
 	~loading_screen();
 

--- a/src/gui/dialogs/lua_interpreter.cpp
+++ b/src/gui/dialogs/lua_interpreter.cpp
@@ -132,7 +132,7 @@ private:
 	std::stringstream raw_log_;
 
 public:
-	lua_model (lua_kernel_base & lk)
+	explicit lua_model (lua_kernel_base & lk)
 		: L_(lk)
 		, log_()
 		, raw_log_()
@@ -384,7 +384,7 @@ private:
 	void tab();
 	void search(int direction);
 public:
-	controller(lua_kernel_base & lk)
+	explicit controller(lua_kernel_base & lk)
 		: copy_button(nullptr)
 		, clear_button(nullptr)
 		, text_entry(nullptr)

--- a/src/gui/dialogs/lua_interpreter.hpp
+++ b/src/gui/dialogs/lua_interpreter.hpp
@@ -31,7 +31,7 @@ public:
 	class view;
 	class controller;
 
-	lua_interpreter(lua_kernel_base & lk);
+	explicit lua_interpreter(lua_kernel_base & lk);
 
 	/** Inherited from modal_dialog. */
 	virtual void pre_show(window& window) override;

--- a/src/gui/dialogs/modal_dialog.cpp
+++ b/src/gui/dialogs/modal_dialog.cpp
@@ -44,7 +44,7 @@ modal_dialog::~modal_dialog()
 
 namespace {
 	struct window_stack_handler {
-		window_stack_handler(std::unique_ptr<window>& win) : local_window(win) {
+		explicit window_stack_handler(std::unique_ptr<window>& win) : local_window(win) {
 			open_window_stack.push_back(local_window.get());
 		}
 		~window_stack_handler() {

--- a/src/gui/dialogs/multiplayer/lobby.cpp
+++ b/src/gui/dialogs/multiplayer/lobby.cpp
@@ -156,7 +156,7 @@ mp_lobby::mp_lobby(const config& game_config, mp::lobby_info& info, wesnothd_con
 
 struct lobby_delay_gamelist_update_guard
 {
-	lobby_delay_gamelist_update_guard(mp_lobby& l) : l(l)
+	explicit lobby_delay_gamelist_update_guard(mp_lobby& l) : l(l)
 	{
 		l.delay_gamelist_update_ = true;
 	}

--- a/src/gui/dialogs/multiplayer/lobby.cpp
+++ b/src/gui/dialogs/multiplayer/lobby.cpp
@@ -984,7 +984,7 @@ void mp_lobby::enter_game(const mp::game_info& game, JOIN_MODE mode)
 		join_data["password"] = password;
 	}
 
-	network_connection_.send_data(response);
+	network_connection_.send_data(configr_of(response));
 	joined_game_id_ = game.id;
 
 	// We're all good. Close lobby and proceed to game!
@@ -1021,7 +1021,7 @@ void mp_lobby::enter_selected_game(JOIN_MODE mode)
 
 void mp_lobby::refresh_lobby()
 {
-	network_connection_.send_data(config("refresh_lobby"));
+	network_connection_.send_data(configr_of(config("refresh_lobby")));
 }
 
 void mp_lobby::show_preferences_button_callback(window& window)

--- a/src/gui/dialogs/multiplayer/mp_join_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_join_game.cpp
@@ -90,7 +90,7 @@ bool mp_join_game::fetch_game_config()
 {
 	// Ask for the next scenario data, if applicable
 	if(!first_scenario_) {
-		network_connection_.send_data(config("load_next_scenario"));
+		network_connection_.send_data(configr_of(config("load_next_scenario")));
 	}
 
 	bool has_scenario_and_controllers = false;
@@ -227,7 +227,7 @@ bool mp_join_game::fetch_game_config()
 		change["leader"] = flg.current_leader();
 		change["gender"] = flg.current_gender();
 
-		network_connection_.send_data(faction);
+		network_connection_.send_data(configr_of(faction));
 	}
 
 	return true;
@@ -503,9 +503,9 @@ void mp_join_game::post_show(window& window)
 
 		mp_ui_alerts::game_has_begun();
 	} else if(observe_game_) {
-		network_connection_.send_data(config("observer_quit", config { "name", preferences::login() }));
+		network_connection_.send_data(configr_of(config("observer_quit", config { "name", preferences::login() })));
 	} else {
-		network_connection_.send_data(config("leave_game"));
+		network_connection_.send_data(configr_of(config("leave_game")));
 	}
 }
 

--- a/src/gui/dialogs/network_transmission.hpp
+++ b/src/gui/dialogs/network_transmission.hpp
@@ -56,7 +56,7 @@ private:
 		connection_data*& connection_;
 		virtual void process(events::pump_info&);
 
-		pump_monitor(connection_data*& connection)
+		explicit pump_monitor(connection_data*& connection)
 			: connection_(connection), window_()
 		{
 		}

--- a/src/gui/dialogs/screenshot_notification.hpp
+++ b/src/gui/dialogs/screenshot_notification.hpp
@@ -31,7 +31,7 @@ public:
 	 *                 ensure the file exists, otherwise it will be displayed
 	 *                 with size 0.
 	 */
-	screenshot_notification(const std::string& path);
+	explicit screenshot_notification(const std::string& path);
 
 	/**
 	 * The display function.

--- a/src/gui/dialogs/statistics_dialog.hpp
+++ b/src/gui/dialogs/statistics_dialog.hpp
@@ -27,7 +27,7 @@ namespace dialogs
 class statistics_dialog : public modal_dialog
 {
 public:
-	statistics_dialog(const team& current_team);
+	explicit statistics_dialog(const team& current_team);
 
 	DEFINE_SIMPLE_DISPLAY_WRAPPER(statistics_dialog)
 

--- a/src/gui/dialogs/title_screen.hpp
+++ b/src/gui/dialogs/title_screen.hpp
@@ -37,7 +37,7 @@ extern bool show_debug_clock_button;
 class title_screen : public modal_dialog
 {
 public:
-	title_screen(game_launcher& game);
+	explicit title_screen(game_launcher& game);
 
 	~title_screen();
 

--- a/src/gui/widgets/chatbox.cpp
+++ b/src/gui/widgets/chatbox.cpp
@@ -444,7 +444,7 @@ void chatbox::close_window_button_callback(std::string room_name, bool& handled,
 void chatbox::send_to_server(const ::config& cfg)
 {
 	if(wesnothd_connection_) {
-		wesnothd_connection_->send_data(cfg);
+		wesnothd_connection_->send_data(configr_of(cfg));
 	}
 }
 

--- a/src/gui/widgets/grid.hpp
+++ b/src/gui/widgets/grid.hpp
@@ -453,7 +453,7 @@ public:
 	{
 
 	public:
-		iterator(std::vector<child>::iterator itor) : itor_(itor)
+		explicit iterator(std::vector<child>::iterator itor) : itor_(itor)
 		{
 		}
 

--- a/src/gui/widgets/label.hpp
+++ b/src/gui/widgets/label.hpp
@@ -173,7 +173,7 @@ namespace implementation
 
 struct builder_label : public builder_styled_widget
 {
-	builder_label(const config& cfg);
+	explicit builder_label(const config& cfg);
 
 	using builder_styled_widget::build;
 

--- a/src/gui/widgets/minimap.cpp
+++ b/src/gui/widgets/minimap.cpp
@@ -95,7 +95,7 @@ static bool operator<(const key_type& lhs, const key_type& rhs)
 /** Value type for the cache. */
 struct value_type
 {
-	value_type(const surface& surf) : surf(surf), age(1)
+	explicit value_type(const surface& surf) : surf(surf), age(1)
 	{
 	}
 

--- a/src/gui/widgets/minimap.cpp
+++ b/src/gui/widgets/minimap.cpp
@@ -180,7 +180,7 @@ bool minimap::disable_click_dismiss() const
 const surface minimap::get_image(const int w, const int h) const
 {
 	if(!terrain_) {
-		return nullptr;
+		return surface();
 	}
 
 	if(terrain_ != terrain) {
@@ -225,7 +225,7 @@ const surface minimap::get_image(const int w, const int h) const
 		std::cerr << 'X';
 #endif
 	}
-	return nullptr;
+	return surface();
 }
 
 void minimap::impl_draw_background(surface& frame_buffer,

--- a/src/gui/widgets/styled_widget.hpp
+++ b/src/gui/widgets/styled_widget.hpp
@@ -497,7 +497,7 @@ namespace implementation
 struct builder_styled_widget : public builder_widget
 {
 public:
-	builder_styled_widget(const config& cfg);
+	explicit builder_styled_widget(const config& cfg);
 
 	using builder_widget::build;
 

--- a/src/gui/widgets/window.cpp
+++ b/src/gui/widgets/window.cpp
@@ -92,7 +92,7 @@ namespace implementation
 class builder_window : public builder_styled_widget
 {
 public:
-	builder_window(const config& cfg) : builder_styled_widget(cfg)
+	explicit builder_window(const config& cfg) : builder_styled_widget(cfg)
 	{
 	}
 

--- a/src/gui/widgets/window.hpp
+++ b/src/gui/widgets/window.hpp
@@ -198,7 +198,7 @@ public:
 	class invalidate_layout_blocker
 	{
 	public:
-		invalidate_layout_blocker(window& window);
+		explicit invalidate_layout_blocker(window& window);
 		~invalidate_layout_blocker();
 
 	private:

--- a/src/halo.hpp
+++ b/src/halo.hpp
@@ -39,7 +39,7 @@ const int NO_HALO = 0;
 class manager
 {
 public:
-	manager(display& screen);
+	explicit manager(display& screen);
 
 	/**
 	 * Add a haloing effect using 'image centered on (x,y).

--- a/src/hash.hpp
+++ b/src/hash.hpp
@@ -28,7 +28,7 @@ namespace utils {
 
 struct hash_error : public game::error
 {
-	hash_error(const std::string& message) : game::error(message) {}
+	explicit hash_error(const std::string& message) : game::error(message) {}
 };
 
 class hash_base

--- a/src/help/help.hpp
+++ b/src/help/help.hpp
@@ -24,7 +24,7 @@ class CVideo;
 namespace help {
 
 struct help_manager {
-	help_manager(const config *game_config);
+	explicit help_manager(const config *game_config);
 	~help_manager();
 };
 

--- a/src/help/help_impl.hpp
+++ b/src/help/help_impl.hpp
@@ -72,7 +72,7 @@ public:
 class text_topic_generator: public topic_generator {
 	std::string text_;
 public:
-	text_topic_generator(const std::string& t): text_(t) {}
+	explicit text_topic_generator(const std::string& t): text_(t) {}
 	virtual std::string operator()() const { return text_; }
 };
 
@@ -90,7 +90,7 @@ public:
 	{
 	}
 
-	topic_text(const std::string& t):
+	explicit topic_text(const std::string& t):
 		parsed_text_(),
 		generator_(new text_topic_generator(t))
 	{
@@ -174,7 +174,7 @@ struct section {
 class has_id
 {
 public:
-	has_id(const std::string &id) : id_(id) {}
+	explicit has_id(const std::string &id) : id_(id) {}
 	bool operator()(const topic &t) { return t.id == id_; }
 	bool operator()(const section &s) { return s.id == id_; }
 	bool operator()(const section *s) { return s != nullptr && s->id == id_; }
@@ -220,7 +220,7 @@ struct create_section
 /// Thrown when the help system fails to parse something.
 struct parse_error : public game::error
 {
-	parse_error(const std::string& msg) : game::error(msg) {}
+	explicit parse_error(const std::string& msg) : game::error(msg) {}
 };
 
 // Generator stuff below. Maybe move to a separate file? This one is

--- a/src/help/help_text_area.cpp
+++ b/src/help/help_text_area.cpp
@@ -166,7 +166,7 @@ void help_text_area::handle_ref_cfg(const config &cfg)
 		std::stringstream msg;
 		msg << "Ref markup must have dst attribute. Please submit a bug"
 		       " report if you have not modified the game files yourself. Erroneous config: ";
-		write(msg, cfg);
+		write(msg, configr_of(cfg));
 		throw parse_error(msg.str());
 	}
 

--- a/src/help/help_topic_generators.hpp
+++ b/src/help/help_topic_generators.hpp
@@ -30,7 +30,7 @@ class terrain_topic_generator: public topic_generator
 
 
 public:
-	terrain_topic_generator(const terrain_type& type) : type_(type) {}
+	explicit terrain_topic_generator(const terrain_type& type) : type_(type) {}
 
 	virtual std::string operator()() const;
 };

--- a/src/hotkey/hotkey_command.hpp
+++ b/src/hotkey/hotkey_command.hpp
@@ -234,7 +234,7 @@ struct hotkey_command
 	hotkey_command() = delete;
 
 	/** Constuct a new command from a temporary static hotkey object. */
-	hotkey_command(const hotkey_command_temp& temp_command);
+	explicit hotkey_command(const hotkey_command_temp& temp_command);
 
 	hotkey_command(HOTKEY_COMMAND cmd, const std::string& id, const t_string& desc, bool hidden, bool toggle, hk_scopes scope, HOTKEY_CATEGORY category, const t_string& tooltip);
 

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -563,7 +563,7 @@ static void discard_indexed_palette(surface& surf)
 static void add_localized_overlay(const std::string& ovr_file, surface& orig_surf)
 {
 	filesystem::rwops_ptr rwops = filesystem::make_read_RWops(ovr_file);
-	surface ovr_surf = IMG_Load_RW(rwops.release(), true); // SDL takes ownership of rwops
+	surface ovr_surf(IMG_Load_RW(rwops.release(), true)); // SDL takes ownership of rwops
 	if(ovr_surf.null()) {
 		return;
 	}
@@ -590,7 +590,7 @@ static surface load_image_file(const image::locator& loc)
 			}
 
 			filesystem::rwops_ptr rwops = filesystem::make_read_RWops(location);
-			res = IMG_Load_RW(rwops.release(), true); // SDL takes ownership of rwops
+			res = surface(IMG_Load_RW(rwops.release(), true)); // SDL takes ownership of rwops
 
 			discard_indexed_palette(res);
 
@@ -617,7 +617,7 @@ static surface load_image_sub_file(const image::locator& loc)
 {
 	surface surf = get_image(loc.get_filename(), UNSCALED);
 	if(surf == nullptr) {
-		return nullptr;
+		return surface();
 	}
 
 	modification_queue mods = modification::decode(loc.get_modifications());
@@ -661,7 +661,7 @@ static surface load_image_sub_file(const image::locator& loc)
 			// Safe because those images are only used by terrain rendering
 			// and it filters them out.
 			// A safer and more general way would be to keep only one copy of it
-			surf = nullptr;
+			surf = surface();
 		}
 
 		loc.add_to_cache(is_empty_hex_, is_empty);
@@ -717,9 +717,9 @@ static surface load_image_data_uri(const image::locator& loc)
 		filesystem::rwops_ptr rwops{SDL_RWFromConstMem(image_data.data(), image_data.length()), &SDL_FreeRW};
 
 		if(parsed.mime == "image/png") {
-			surf = IMG_LoadTyped_RW(rwops.release(), true, "PNG");
+			surf = surface(IMG_LoadTyped_RW(rwops.release(), true, "PNG"));
 		} else if(parsed.mime == "image/jpeg") {
-			surf = IMG_LoadTyped_RW(rwops.release(), true, "JPG");
+			surf = surface(IMG_LoadTyped_RW(rwops.release(), true, "JPG"));
 		} else {
 			ERR_DP << "Invalid image MIME type: " << parsed.mime << std::endl;
 		}
@@ -757,7 +757,7 @@ static surface apply_light(surface surf, const light_string& ls)
 	}
 
 	// check if the lightmap is already cached or need to be generated
-	surface lightmap = nullptr;
+	surface lightmap;
 	auto i = lightmaps_.find(ls);
 	if(i != lightmaps_.end()) {
 		lightmap = i->second;
@@ -1339,7 +1339,7 @@ bool save_image(const surface& surf, const std::string& filename)
 	if(!filesystem::ends_with(filename, ".bmp")) {
 		LOG_DP << "Writing a png image to " << filename << std::endl;
 
-		surface tmp = SDL_PNGFormatAlpha(surf.get());
+		surface tmp(SDL_PNGFormatAlpha(surf.get()));
 		const int err = SDL_SavePNG_RW(tmp, filesystem::make_write_RWops(filename).release(), 1); //1 means SDL takes ownership of the RWops
 		return err == 0;
 	}

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -64,7 +64,7 @@ struct cache_item
 	{
 	}
 
-	cache_item(const T& item)
+	explicit cache_item(const T& item)
 		: item(item)
 		, loaded(true)
 	{

--- a/src/image.hpp
+++ b/src/image.hpp
@@ -43,8 +43,8 @@ namespace image {
 		struct value {
 			value();
 			value(const value &a);
-			value(const char *filename);
-			value(const std::string& filename);
+			explicit value(const char *filename);
+			explicit value(const std::string& filename);
 			value(const std::string& filename, const std::string& modifications);
 			value(const std::string& filename, const map_location& loc, int center_x, int center_y, const std::string& modifications);
 

--- a/src/image_modifications.cpp
+++ b/src/image_modifications.cpp
@@ -273,7 +273,7 @@ private:
 surface adjust_alpha_modification::operator()(const surface & src) const
 {
 	if(src == nullptr) {
-		return nullptr;
+		return surface();
 	}
 
 	wfl::formula new_alpha(formula_);
@@ -282,7 +282,7 @@ surface adjust_alpha_modification::operator()(const surface & src) const
 
 	if(nsurf == nullptr) {
 		std::cerr << "could not make neutral surface...\n";
-		return nullptr;
+		return surface();
 	}
 
 	{
@@ -317,7 +317,7 @@ surface adjust_alpha_modification::operator()(const surface & src) const
 surface adjust_channels_modification::operator()(const surface & src) const
 {
 	if(src == nullptr) {
-		return nullptr;
+		return surface();
 	}
 
 	wfl::formula new_red(formulas_[0]);
@@ -329,7 +329,7 @@ surface adjust_channels_modification::operator()(const surface & src) const
 
 	if(nsurf == nullptr) {
 		std::cerr << "could not make neutral surface...\n";
-		return nullptr;
+		return surface();
 	}
 
 	{
@@ -445,7 +445,7 @@ surface mask_modification::operator()(const surface& src) const
 }
 
 surface light_modification::operator()(const surface& src) const {
-	if(src == nullptr) { return nullptr; }
+	if(src == nullptr) { return surface(); }
 
 	// light_surface wants a neutral surface having same dimensions
 	surface nsurf;
@@ -538,7 +538,7 @@ surface o_modification::operator()(const surface& src) const
 
 	if(nsurf == nullptr) {
 		std::cerr << "could not make neutral surface...\n";
-		return nullptr;
+		return surface();
 	}
 
 	uint16_t amount = ftofxp(opacity_);

--- a/src/image_modifications.hpp
+++ b/src/image_modifications.hpp
@@ -72,7 +72,7 @@ public:
 		 * @param message_stream  Stream with the error message regarding
 		 *                        the failed operation.
 		 */
-		imod_exception(const std::stringstream& message_stream);
+		explicit imod_exception(const std::stringstream& message_stream);
 
 		/**
 		 * Constructor.
@@ -82,7 +82,7 @@ public:
 		 * @param message         String with the error message regarding
 		 *                        the failed operation.
 		 */
-		imod_exception(const std::string& message);
+		explicit imod_exception(const std::string& message);
 
 		~imod_exception() NOEXCEPT {}
 
@@ -125,7 +125,7 @@ public:
 	 * RC-map based constructor.
 	 * @param recolor_map The palette switch map.
 	 */
-	rc_modification(const color_range_map& recolor_map)
+	explicit rc_modification(const color_range_map& recolor_map)
 		: rc_map_(recolor_map)
 	{}
 	virtual surface operator()(const surface& src) const;
@@ -228,7 +228,7 @@ public:
 class bw_modification : public modification
 {
 public:
-	bw_modification(int threshold): threshold_(threshold) {}
+	explicit bw_modification(int threshold): threshold_(threshold) {}
 	virtual surface operator()(const surface& src) const;
 private:
 	int threshold_;
@@ -278,7 +278,7 @@ public:
 class adjust_alpha_modification : public modification
 {
 public:
-	adjust_alpha_modification(const std::string& formula)
+	explicit adjust_alpha_modification(const std::string& formula)
 		: formula_(formula)
 	{}
 
@@ -294,7 +294,7 @@ private:
 class adjust_channels_modification : public modification
 {
 public:
-	adjust_channels_modification(const std::vector<std::string>& formulas)
+	explicit adjust_channels_modification(const std::vector<std::string>& formulas)
 		: formulas_(formulas)
 	{
 		if(formulas_.empty()) {
@@ -323,7 +323,7 @@ private:
 class crop_modification : public modification
 {
 public:
-	crop_modification(const SDL_Rect& slice)
+	explicit crop_modification(const SDL_Rect& slice)
 		: slice_(slice)
 	{}
 	virtual surface operator()(const surface& src) const;
@@ -410,7 +410,7 @@ private:
 class light_modification : public modification
 {
 public:
-	light_modification(const surface& surf)
+	explicit light_modification(const surface& surf)
 		: surf_(surf)
 	{}
 	virtual surface operator()(const surface& src) const;
@@ -485,7 +485,7 @@ public:
 class xbrz_modification : public modification
 {
 public:
-	xbrz_modification(int z)
+	explicit xbrz_modification(int z)
 		: z_(z)
 	{}
 
@@ -501,7 +501,7 @@ private:
 class o_modification : public modification
 {
 public:
-	o_modification(float opacity)
+	explicit o_modification(float opacity)
 		: opacity_(opacity)
 	{}
 	virtual surface operator()(const surface& src) const;
@@ -561,7 +561,7 @@ private:
 class bl_modification : public modification
 {
 public:
-	bl_modification(int depth)
+	explicit bl_modification(int depth)
 		: depth_(depth)
 	{}
 	virtual surface operator()(const surface& src) const;
@@ -580,7 +580,7 @@ private:
  */
 struct background_modification : modification
 {
-	background_modification(const color_t& c): color_(c) {}
+	explicit background_modification(const color_t& c): color_(c) {}
 	virtual surface operator()(const surface &src) const;
 
 	const color_t& get_color() const

--- a/src/log_windows.cpp
+++ b/src/log_windows.cpp
@@ -193,7 +193,7 @@ public:
 	log_file_manager(const log_file_manager&) = delete;
 	log_file_manager& operator=(const log_file_manager&) = delete;
 
-	log_file_manager(bool native_console = false);
+	explicit log_file_manager(bool native_console = false);
 	~log_file_manager();
 
 	/**

--- a/src/map/exception.hpp
+++ b/src/map/exception.hpp
@@ -19,5 +19,5 @@
 #include "exceptions.hpp"
 
 struct incorrect_map_format_error : game::error {
-	incorrect_map_format_error(const std::string& message) : error(message) {}
+	explicit incorrect_map_format_error(const std::string& message) : error(message) {}
 };

--- a/src/map/label.hpp
+++ b/src/map/label.hpp
@@ -35,7 +35,7 @@ public:
 	typedef std::map<std::string, label_map> team_label_map;
 
 	map_labels(const map_labels&);
-	map_labels(const team*);
+	explicit map_labels(const team*);
 
 	~map_labels();
 

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -1034,7 +1034,7 @@ class console_handler : public map_command_handler<console_handler>, private cha
 public:
 	// convenience typedef
 	typedef map_command_handler<console_handler> chmap;
-	console_handler(menu_handler& menu_handler)
+	explicit console_handler(menu_handler& menu_handler)
 		: chmap()
 		, chat_command_handler(menu_handler, true)
 		, menu_handler_(menu_handler)
@@ -1486,7 +1486,7 @@ void console_handler::do_theme()
 
 struct save_id_matches
 {
-	save_id_matches(const std::string& save_id)
+	explicit save_id_matches(const std::string& save_id)
 		: save_id_(save_id)
 	{
 	}

--- a/src/movetype.cpp
+++ b/src/movetype.cpp
@@ -98,7 +98,7 @@ public:
 
 	// The copy constructor does not bother copying the cache since
 	// typically the cache will be cleared shortly after the copy.
-	data(const data & that) :
+	explicit data(const data & that) :
 		cfg_(that.cfg_), cache_(), params_(that.params_)
 	{}
 

--- a/src/mp_game_settings.cpp
+++ b/src/mp_game_settings.cpp
@@ -148,19 +148,21 @@ mp_game_settings::addon_version_info::addon_version_info(const config & cfg)
 	, name(cfg["name"])
 {
 	if (!cfg["version"].empty()) {
-		version = cfg["version"].str();
+		const version_info ver(cfg["version"].str());
+		version = ver;
 	}
 	if (!cfg["min_version"].empty()) {
-		min_version = cfg["min_version"].str();
+		const version_info min_ver(cfg["min_version"].str());
+		min_version = min_ver;
 	}
 }
 
 void mp_game_settings::addon_version_info::write(config & cfg) const {
 	if (version) {
-		cfg["version"] = *version;
+		cfg["version"] = version->str();
 	}
 	if (min_version) {
-		cfg["min_version"] = *min_version;
+		cfg["min_version"] = min_version->str();
 	}
 
 	cfg["name"]	= name;

--- a/src/mp_game_settings.hpp
+++ b/src/mp_game_settings.hpp
@@ -26,7 +26,7 @@
 struct mp_game_settings
 {
 	mp_game_settings();
-	mp_game_settings(const config& cfg);
+	explicit mp_game_settings(const config& cfg);
 
 	config to_config() const;
 

--- a/src/network_asio.cpp
+++ b/src/network_asio.cpp
@@ -136,7 +136,7 @@ void connection::transfer(const config& request, config& response)
 	write_buf_.reset(new boost::asio::streambuf);
 	read_buf_.reset(new boost::asio::streambuf);
 	std::ostream os(write_buf_.get());
-	write_gz(os, request);
+	write_gz(os, configr_of(request));
 
 	bytes_to_write_ = write_buf_->size() + 4;
 	bytes_written_ = 0;

--- a/src/network_asio.hpp
+++ b/src/network_asio.hpp
@@ -44,7 +44,7 @@ namespace network_asio
 {
 struct error : public game::error
 {
-	error(const boost::system::error_code& error)
+	explicit error(const boost::system::error_code& error)
 		: game::error(error.message())
 	{
 	}

--- a/src/overlay.hpp
+++ b/src/overlay.hpp
@@ -25,7 +25,7 @@ struct overlay
 	{}
 
 
-	overlay(const config& cfg) :
+	explicit overlay(const config& cfg) :
 		image(cfg["image"]), halo(cfg["halo"]), team_name(cfg["team_name"]),
 		name(cfg["name"].t_str()), id(cfg["id"]),
 		halo_handle(), visible_in_fog(cfg["visible_in_fog"].to_bool())

--- a/src/pathfind/astarsearch.cpp
+++ b/src/pathfind/astarsearch.cpp
@@ -121,7 +121,7 @@ class comp {
 	const std::vector<node>& nodes_;
 
 public:
-	comp(const std::vector<node>& n) : nodes_(n) { }
+	explicit comp(const std::vector<node>& n) : nodes_(n) { }
 	bool operator()(int a, int b) const {
 		return nodes_[b] < nodes_[a];
 	}
@@ -131,7 +131,7 @@ class indexer {
 	size_t w_;
 
 public:
-	indexer(size_t w) : w_(w) { }
+	explicit indexer(size_t w) : w_(w) { }
 	size_t operator()(const map_location& loc) const {
 		return loc.y * w_ + loc.x;
 	}

--- a/src/pathfind/pathfind.cpp
+++ b/src/pathfind/pathfind.cpp
@@ -225,7 +225,7 @@ namespace {
 		const std::vector<findroute_node>& nodes;
 
 		// Constructor:
-		findroute_comp(const std::vector<findroute_node>& n) : nodes(n) { }
+		explicit findroute_comp(const std::vector<findroute_node>& n) : nodes(n) { }
 		// Binary predicate evaluating the order of its arguments:
 		bool operator()(int l, int r) const {
 			return nodes[r] < nodes[l];

--- a/src/pathfind/teleport.cpp
+++ b/src/pathfind/teleport.cpp
@@ -62,7 +62,7 @@ teleport_group::teleport_group(const vconfig& cfg, bool reversed) : cfg_(cfg.get
 
 class ignore_units_display_context : public display_context {
 public:
-	ignore_units_display_context(const display_context & dc)
+	explicit ignore_units_display_context(const display_context & dc)
 		: um_()
 		, gm_(&dc.map())
 		, tm_(&dc.teams())
@@ -85,7 +85,7 @@ private:
 
 class ignore_units_filter_context : public filter_context {
 public:
-	ignore_units_filter_context(const filter_context & fc)
+	explicit ignore_units_filter_context(const filter_context & fc)
 		: dc_(fc.get_disp_context())
 		, tod_(&fc.get_tod_man())
 		, gd_(fc.get_game_data())

--- a/src/pathfind/teleport.hpp
+++ b/src/pathfind/teleport.hpp
@@ -36,7 +36,7 @@ public:
 	 * Constructs the object from a saved file.
 	 * @param cfg	the contents of a [tunnel] tag
 	 */
-	teleport_group(const config& cfg);
+	explicit teleport_group(const config& cfg);
 
 	/*
 	 * Constructs the object from a config file.
@@ -155,7 +155,7 @@ const teleport_map get_teleport_locations(const unit &u, const team &viewing_tea
 class manager
 {
 public:
-	manager(const config &cfg);
+	explicit manager(const config &cfg);
 
 	/*
 	 * @param group		teleport_group to be added

--- a/src/persist_context.hpp
+++ b/src/persist_context.hpp
@@ -111,7 +111,7 @@ protected:
 		, in_transaction_(false)
 	{}
 
-	persist_context(const std::string &name_space)
+	explicit persist_context(const std::string &name_space)
 		: cfg_()
 		, namespace_(name_space,true)
 		, valid_(namespace_.valid())
@@ -167,7 +167,7 @@ private:
 	bool save_context();
 
 public:
-	persist_file_context(const std::string &name_space);
+	explicit persist_file_context(const std::string &name_space);
 	bool clear_var(const std::string &, bool immediate = false);
 	config get_var(const std::string &) const;
 	bool set_var(const std::string &, const config &, bool immediate = false);

--- a/src/play_controller.hpp
+++ b/src/play_controller.hpp
@@ -269,7 +269,7 @@ public:
 protected:
 	struct scoped_savegame_snapshot
 	{
-		scoped_savegame_snapshot(const play_controller& controller);
+		explicit scoped_savegame_snapshot(const play_controller& controller);
 		~scoped_savegame_snapshot();
 		const play_controller& controller_;
 	};

--- a/src/playmp_controller.cpp
+++ b/src/playmp_controller.cpp
@@ -488,7 +488,7 @@ bool playmp_controller::is_networked_mp() const
 void playmp_controller::send_to_wesnothd(const config& cfg, const std::string&) const
 {
 	if (mp_info_ != nullptr) {
-		mp_info_->connection.send_data(cfg);
+		mp_info_->connection.send_data(configr_of(cfg));
 	}
 }
 bool playmp_controller::receive_from_wesnothd(config& cfg) const

--- a/src/playturn_network_adapter.hpp
+++ b/src/playturn_network_adapter.hpp
@@ -25,7 +25,7 @@ class playturn_network_adapter
 public:
 	typedef std::function<bool(config&)> source_type;
 
-	playturn_network_adapter(source_type source);
+	explicit playturn_network_adapter(source_type source);
 	~playturn_network_adapter();
 
 	//returns true on success.

--- a/src/preferences/credentials.cpp
+++ b/src/preferences/credentials.cpp
@@ -34,7 +34,7 @@ static lg::log_domain log_config("config");
 class secure_buffer : public std::vector<unsigned char>
 {
 public:
-	template<typename... T> secure_buffer(T&&... args)
+	template<typename... T> explicit secure_buffer(T&&... args)
 		: vector<unsigned char>(std::forward<T>(args)...)
 	{}
 	~secure_buffer()

--- a/src/preferences/general.cpp
+++ b/src/preferences/general.cpp
@@ -161,7 +161,7 @@ void write_preferences()
 
 	try {
 		filesystem::scoped_ostream prefs_file = filesystem::ostream_file(filesystem::get_prefs_file());
-		write(*prefs_file, prefs);
+		write(*prefs_file, configr_of(prefs));
 	} catch(filesystem::io_exception&) {
 		ERR_FS << "error writing to preferences file '" << filesystem::get_prefs_file() << "'" << std::endl;
 	}

--- a/src/random_deterministic.hpp
+++ b/src/random_deterministic.hpp
@@ -28,7 +28,7 @@ namespace randomness
 	class rng_deterministic : public randomness::rng
 	{
 	public:
-		rng_deterministic(mt_rng& gen);
+		explicit rng_deterministic(mt_rng& gen);
 		virtual ~rng_deterministic();
 
 	protected:
@@ -43,7 +43,7 @@ namespace randomness
 	class set_random_determinstic
 	{
 	public:
-		set_random_determinstic(mt_rng& rng);
+		explicit set_random_determinstic(mt_rng& rng);
 		~set_random_determinstic();
 	private :
 		rng* old_rng_;

--- a/src/random_synced.hpp
+++ b/src/random_synced.hpp
@@ -27,7 +27,7 @@ namespace randomness
 	class synced_rng : public randomness::rng
 	{
 	public:
-		synced_rng(std::function<std::string()> seed_generator);
+		explicit synced_rng(std::function<std::string()> seed_generator);
 		virtual ~synced_rng();
 
 	protected:

--- a/src/replay.hpp
+++ b/src/replay.hpp
@@ -36,7 +36,7 @@ public:
 	const std::string &nick() const { return nick_; }
 	const std::string &color() const { return color_; }
 	const time_t &time() const { return time_; }
-	chat_msg(const config &cfg);
+	explicit chat_msg(const config &cfg);
 	virtual ~chat_msg();
 private:
 	std::string color_;
@@ -167,7 +167,7 @@ REPLAY_RETURN do_replay_handle(bool one_move = false);
 class replay_network_sender
 {
 public:
-	replay_network_sender(replay& obj);
+	explicit replay_network_sender(replay& obj);
 	~replay_network_sender();
 
 	void sync_non_undoable();

--- a/src/replay_controller.cpp
+++ b/src/replay_controller.cpp
@@ -39,7 +39,7 @@ struct replay_play_nostop : public replay_controller::replay_stop_condition
 struct replay_play_moves : public replay_controller::replay_stop_condition
 {
 	int moves_todo_;
-	replay_play_moves(int moves_todo) : moves_todo_(moves_todo) {}
+	explicit replay_play_moves(int moves_todo) : moves_todo_(moves_todo) {}
 	virtual void move_done() { --moves_todo_; }
 	virtual bool should_stop() { return moves_todo_ == 0; }
 };
@@ -48,7 +48,7 @@ struct replay_play_turn : public replay_controller::replay_stop_condition
 {
 	int turn_begin_;
 	int turn_current_;
-	replay_play_turn(int turn_begin) : turn_begin_(turn_begin), turn_current_(turn_begin) {}
+	explicit replay_play_turn(int turn_begin) : turn_begin_(turn_begin), turn_current_(turn_begin) {}
 	virtual void new_side_turn(int , int turn) { turn_current_ = turn; }
 	virtual bool should_stop() { return turn_begin_ != turn_current_; }
 };

--- a/src/save_index.cpp
+++ b/src/save_index.cpp
@@ -101,9 +101,9 @@ void save_index_class::write_save_index()
 
 		if(preferences::save_compression_format() != compression::NONE) {
 			// TODO: maybe allow writing this using bz2 too?
-			write_gz(*stream, data());
+			write_gz(*stream, configr_of(data()));
 		} else {
-			write(*stream, data());
+			write(*stream, configr_of(data()));
 		}
 	} catch(filesystem::io_exception& e) {
 		ERR_SAVE << "error writing to save index file: '" << e.what() << "'" << std::endl;

--- a/src/save_index.cpp
+++ b/src/save_index.cpp
@@ -172,7 +172,7 @@ save_index_class save_index_manager;
 class filename_filter
 {
 public:
-	filename_filter(const std::string& filter)
+	explicit filename_filter(const std::string& filter)
 		: filter_(filter)
 	{
 	}

--- a/src/save_index.hpp
+++ b/src/save_index.hpp
@@ -75,7 +75,7 @@ void delete_game(const std::string& name);
 class create_save_info
 {
 public:
-	create_save_info(const std::string* d = nullptr);
+	explicit create_save_info(const std::string* d = nullptr);
 	save_info operator()(const std::string& filename) const;
 	const std::string dir;
 };

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -147,8 +147,12 @@ bool loadgame::load_game_ingame()
 		return false;
 	}
 
-	if (!loadgame::check_version_compatibility(summary["version"].str())) {
-		return false;
+	{
+		const version_info summary_version (summary["version"].str());
+
+		if (!loadgame::check_version_compatibility(summary_version)) {
+			return false;
+		}
 	}
 
 	throw load_game_exception(std::move(load_data_));
@@ -212,7 +216,8 @@ bool loadgame::load_game()
 
 bool loadgame::check_version_compatibility()
 {
-	return loadgame::check_version_compatibility(gamestate_.classification().version);
+	const version_info game_version(gamestate_.classification().version);
+	return loadgame::check_version_compatibility(game_version);
 }
 
 bool loadgame::check_version_compatibility(const version_info & save_version)

--- a/src/savegame.hpp
+++ b/src/savegame.hpp
@@ -75,13 +75,13 @@ class load_game_exception
 	: public lua_jailbreak_exception, public std::exception
 {
 public:
-	load_game_exception(const std::string& fname)
+	explicit load_game_exception(const std::string& fname)
 		: lua_jailbreak_exception()
 		, data_(fname)
 	{
 	}
 
-	load_game_exception(load_game_metadata&& data)
+	explicit load_game_exception(load_game_metadata&& data)
 		: lua_jailbreak_exception()
 		, data_(data)
 	{

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -157,7 +157,7 @@ int dispatch2(lua_State *L) {
 
 struct map_locker
 {
-	map_locker(game_lua_kernel* kernel) : kernel_(kernel)
+	explicit map_locker(game_lua_kernel* kernel) : kernel_(kernel)
 	{
 		++kernel_->map_locked_;
 	}

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -849,7 +849,7 @@ int game_lua_kernel::intf_set_end_campaign_text(lua_State *L)
 
 int game_lua_kernel::intf_set_next_scenario(lua_State *L)
 {
-	deprecated_message("wesnoth.set_next_scenario", DEP_LEVEL::INDEFINITE, "");
+	deprecated_message("wesnoth.set_next_scenario", DEP_LEVEL::INDEFINITE, version_info());
 	gamedata().set_next_scenario(luaL_checkstring(L, 1));
 	return 0;
 }
@@ -2555,7 +2555,7 @@ int game_lua_kernel::intf_simulate_combat(lua_State *L)
  */
 static int intf_set_music(lua_State *L)
 {
-	deprecated_message("wesnoth.set_music", DEP_LEVEL::INDEFINITE, "", "Use the wesnoth.playlist table instead!");
+	deprecated_message("wesnoth.set_music", DEP_LEVEL::INDEFINITE, version_info(), "Use the wesnoth.playlist table instead!");
 	if (lua_isnoneornil(L, 1)) {
 		sound::commit_music_changes();
 		return 0;

--- a/src/scripting/lua_common.cpp
+++ b/src/scripting/lua_common.cpp
@@ -511,7 +511,7 @@ namespace {
 	struct luaW_pushscalar_visitor : boost::static_visitor<>
 	{
 		lua_State *L;
-		luaW_pushscalar_visitor(lua_State *l): L(l) {}
+		explicit luaW_pushscalar_visitor(lua_State *l): L(l) {}
 
 		void operator()(const boost::blank&) const
 		{ lua_pushnil(L); }

--- a/src/scripting/lua_fileops.cpp
+++ b/src/scripting/lua_fileops.cpp
@@ -183,7 +183,7 @@ int intf_read_file(lua_State *L)
 class lua_filestream
 {
 public:
-	lua_filestream(const std::string& fname)
+	explicit lua_filestream(const std::string& fname)
 		: buff_()
 		, pistream_(filesystem::istream_file(fname))
 	{

--- a/src/scripting/lua_kernel_base.cpp
+++ b/src/scripting/lua_kernel_base.cpp
@@ -287,7 +287,7 @@ static int intf_deprecated_message(lua_State* L) {
 	const DEP_LEVEL level = DEP_LEVEL(luaL_checkinteger(L, 2));
 	const std::string ver_str = lua_isnoneornil(L, 3) ? "" : luaL_checkstring(L, 3);
 	const std::string detail = luaW_checktstring(L, 4);
-	const version_info ver = ver_str.empty() ? game_config::version : ver_str;
+	const version_info ver(ver_str.empty() ? game_config::version : ver_str);
 	const std::string msg = deprecated_message(elem, level, ver, detail);
 	if(level < DEP_LEVEL::INDEFINITE || level >= DEP_LEVEL::REMOVED) {
 		// Invalid deprecation level or level 4 deprecation should raise an interpreter error

--- a/src/scripting/lua_unit.hpp
+++ b/src/scripting/lua_unit.hpp
@@ -90,10 +90,10 @@ class lua_unit
 	friend lua_unit* luaW_pushlocalunit(lua_State *L, unit& u);
 	static void setmetatable(lua_State *L);
 public:
-	lua_unit(size_t u): uid(u), ptr(), side(0), c_ptr() {}
-	lua_unit(unit_ptr u): uid(0), ptr(u), side(0), c_ptr() {}
+	explicit lua_unit(size_t u): uid(u), ptr(), side(0), c_ptr() {}
+	explicit lua_unit(unit_ptr u): uid(0), ptr(u), side(0), c_ptr() {}
 	lua_unit(int s, size_t u): uid(u), ptr(), side(s), c_ptr() {}
-	lua_unit(unit& u): uid(0), ptr(), side(0), c_ptr(&u) {}
+	explicit lua_unit(unit& u): uid(0), ptr(), side(0), c_ptr(&u) {}
 	~lua_unit();
 
 	bool on_map() const { return !ptr && side == 0; }

--- a/src/scripting/lua_unit_attacks.cpp
+++ b/src/scripting/lua_unit_attacks.cpp
@@ -33,8 +33,8 @@ static const char uattackKey[] = "unit attack";
 struct attack_ref {
 	attack_ptr attack;
 	const_attack_ptr cattack;
-	attack_ref(attack_ptr atk) : attack(atk), cattack(atk) {}
-	attack_ref(const_attack_ptr atk) : cattack(atk) {}
+	explicit attack_ref(attack_ptr atk) : attack(atk), cattack(atk) {}
+	explicit attack_ref(const_attack_ptr atk) : cattack(atk) {}
 };
 
 void push_unit_attacks_table(lua_State* L, int idx)

--- a/src/scripting/plugins/context.hpp
+++ b/src/scripting/plugins/context.hpp
@@ -36,7 +36,7 @@ public:
 	typedef std::function<config(config)> accessor_function;
 	struct aReg { char const * name; accessor_function func; };
 
-	plugins_context( const std::string & name );
+	explicit plugins_context( const std::string & name );
 	plugins_context( const std::string & name, const std::vector<Reg>& callbacks, const std::vector<aReg>& accessors);
 	template<int N, int M>
 	plugins_context( const std::string & name, const Reg (& callbacks)[N], const aReg (& accessors)[M])

--- a/src/scripting/plugins/manager.hpp
+++ b/src/scripting/plugins/manager.hpp
@@ -33,7 +33,7 @@ class application_lua_kernel;
 
 class plugins_manager {
 public:
-	plugins_manager(application_lua_kernel *);
+	explicit plugins_manager(application_lua_kernel *);
 	~plugins_manager();
 
 	static plugins_manager * get();	//this class is a singleton

--- a/src/sdl/point.hpp
+++ b/src/sdl/point.hpp
@@ -34,7 +34,7 @@ struct point
 	{
 	}
 
-	point(const SDL_Point& p)
+	explicit point(const SDL_Point& p)
 		: x(p.x)
 		, y(p.y)
 	{

--- a/src/sdl/surface.hpp
+++ b/src/sdl/surface.hpp
@@ -25,7 +25,7 @@ public:
 	surface() : surface_(nullptr)
 	{}
 
-	surface(SDL_Surface* surf) : surface_(surf)
+	explicit surface(SDL_Surface* surf) : surface_(surf)
 	{}
 
 	surface(const surface& s) : surface_(s.get())

--- a/src/sdl/surface.hpp
+++ b/src/sdl/surface.hpp
@@ -131,7 +131,7 @@ private:
 	using pixel_t = utils::const_clone_t<uint32_t, T>;
 
 public:
-	surface_locker(T& surf) : surface_(surf), locked_(false)
+	explicit surface_locker(T& surf) : surface_(surf), locked_(false)
 	{
 		if(SDL_MUSTLOCK(surface_)) {
 			locked_ = SDL_LockSurface(surface_) == 0;

--- a/src/sdl/userevent.hpp
+++ b/src/sdl/userevent.hpp
@@ -28,7 +28,7 @@ public:
 		std::memset(&event_, 0, sizeof(event_));
 	}
 
-	UserEvent(int type) : UserEvent()
+	explicit UserEvent(int type) : UserEvent()
 	{
 		event_.type = type;
 	}

--- a/src/sdl/utils.cpp
+++ b/src/sdl/utils.cpp
@@ -71,10 +71,10 @@ surface make_neutral_surface(const surface &surf)
 {
 	if(surf == nullptr) {
 		std::cerr << "null neutral surface...\n";
-		return nullptr;
+		return surface();
 	}
 
-	surface result = SDL_ConvertSurface(surf,&get_neutral_pixel_format(),0);
+	surface result(SDL_ConvertSurface(surf,&get_neutral_pixel_format(),0));
 
 	return result;
 }
@@ -83,20 +83,25 @@ surface create_neutral_surface(int w, int h)
 {
 	if (w < 0 || h < 0) {
 		std::cerr << "error : neutral surface with negative dimensions\n";
-		return nullptr;
+		return surface();
 	}
 
 	SDL_PixelFormat format = get_neutral_pixel_format();
 
 #if SDL_VERSION_ATLEAST(2, 0, 6)
-	surface result = SDL_CreateRGBSurfaceWithFormat(0, w, h, format.BitsPerPixel, format.format);
+	surface result(SDL_CreateRGBSurfaceWithFormat(0, w, h, format.BitsPerPixel, format.format));
 #else
-	surface result = SDL_CreateRGBSurface(0, w, h,
+	surface result(
+		SDL_CreateRGBSurface(0,
+			w,
+			h,
 			format.BitsPerPixel,
 			format.Rmask,
 			format.Gmask,
 			format.Bmask,
-			format.Amask);
+			format.Amask
+		)
+	);
 #endif
 
 	return result;
@@ -109,7 +114,7 @@ surface stretch_surface_horizontal(
 	assert(SDL_ALPHA_TRANSPARENT==0);
 
 	if(surf == nullptr)
-		return nullptr;
+		return surface();
 
 	if(static_cast<int>(w) == surf->w) {
 		return surf;
@@ -123,7 +128,7 @@ surface stretch_surface_horizontal(
 
 	if(src == nullptr || dst == nullptr) {
 		std::cerr << "Could not create surface to scale onto\n";
-		return nullptr;
+		return surface();
 	}
 
 	{
@@ -154,7 +159,7 @@ surface stretch_surface_vertical(
 	assert(SDL_ALPHA_TRANSPARENT==0);
 
 	if(surf == nullptr)
-		return nullptr;
+		return surface();
 
 	if(static_cast<int>(h) == surf->h) {
 		return surf;
@@ -168,7 +173,7 @@ surface stretch_surface_vertical(
 
 	if(src == nullptr || dst == nullptr) {
 		std::cerr << "Could not create surface to scale onto\n";
-		return nullptr;
+		return surface();
 	}
 
 	{
@@ -193,7 +198,7 @@ surface stretch_surface_vertical(
 surface scale_surface_xbrz(const surface & surf, size_t z)
 {
 	if(surf == nullptr)
-		return nullptr;
+		return surface();
 
 	if (z > 5) {
 		std::cerr << "Cannot use xbrz scaling with zoom factor > 5." << std::endl;
@@ -216,7 +221,7 @@ surface scale_surface_xbrz(const surface & surf, size_t z)
 
 	if(src == nullptr || dst == nullptr) {
 		std::cerr << "Could not create surface to scale onto\n";
-		return nullptr;
+		return surface();
 	}
 
 	{
@@ -235,7 +240,7 @@ surface scale_surface_nn (const surface & surf, int w, int h)
 	assert(SDL_ALPHA_TRANSPARENT==0);
 
 	if (surf == nullptr)
-		return nullptr;
+		return surface();
 
 	if(w == surf->w && h == surf->h) {
 		return surf;
@@ -255,7 +260,7 @@ surface scale_surface_nn (const surface & surf, int w, int h)
 
 	if(src == nullptr || dst == nullptr) {
 		std::cerr << "Could not create surface to scale onto\n";
-		return nullptr;
+		return surface();
 	}
 
 	{
@@ -275,7 +280,7 @@ surface scale_surface(const surface &surf, int w, int h)
 	assert(SDL_ALPHA_TRANSPARENT==0);
 
 	if(surf == nullptr)
-		return nullptr;
+		return surface();
 
 	if(w == surf->w && h == surf->h) {
 		return surf;
@@ -295,7 +300,7 @@ surface scale_surface(const surface &surf, int w, int h)
 
 	if(src == nullptr || dst == nullptr) {
 		std::cerr << "Could not create surface to scale onto\n";
-		return nullptr;
+		return surface();
 	}
 
 	{
@@ -407,7 +412,7 @@ surface scale_surface_legacy(const surface &surf, int w, int h)
 	assert(SDL_ALPHA_TRANSPARENT==0);
 
 	if(surf == nullptr)
-		return nullptr;
+		return surface();
 
 	if(w == surf->w && h == surf->h) {
 		return surf;
@@ -422,7 +427,7 @@ surface scale_surface_legacy(const surface &surf, int w, int h)
 
 	if(src == nullptr || dst == nullptr) {
 		std::cerr << "Could not create surface to scale onto\n";
-		return nullptr;
+		return surface();
 	}
 
 	{
@@ -547,7 +552,7 @@ surface scale_surface_sharp(const surface& surf, int w, int h)
 	assert(SDL_ALPHA_TRANSPARENT==0);
 
 	if(surf == nullptr)
-		return nullptr;
+		return surface();
 
 	if(w == surf->w && h == surf->h) {
 		return surf;
@@ -567,7 +572,7 @@ surface scale_surface_sharp(const surface& surf, int w, int h)
 
 	if(src == nullptr || dst == nullptr) {
 		std::cerr << "Could not create surface to scale onto\n";
-		return nullptr;
+		return surface();
 	}
 
 	{
@@ -645,7 +650,7 @@ surface tile_surface(const surface& surf, int w, int h, bool centered)
 
 	if (src == nullptr || dest == nullptr) {
 		std::cerr << "failed to make neutral surface\n";
-		return nullptr;
+		return surface();
 	}
 
 	{
@@ -681,7 +686,7 @@ surface tile_surface(const surface& surf, int w, int h, bool centered)
 surface adjust_surface_color(const surface &surf, int red, int green, int blue)
 {
 	if(surf == nullptr)
-		return nullptr;
+		return surface();
 
 	if((red == 0 && green == 0 && blue == 0)) {
 		surface temp = surf; // TODO: remove temp surface
@@ -692,7 +697,7 @@ surface adjust_surface_color(const surface &surf, int red, int green, int blue)
 
 	if(nsurf == nullptr) {
 		std::cerr << "failed to make neutral surface\n";
-		return nullptr;
+		return surface();
 	}
 
 	{
@@ -726,12 +731,12 @@ surface adjust_surface_color(const surface &surf, int red, int green, int blue)
 surface greyscale_image(const surface &surf)
 {
 	if(surf == nullptr)
-		return nullptr;
+		return surface();
 
 	surface nsurf(make_neutral_surface(surf));
 	if(nsurf == nullptr) {
 		std::cerr << "failed to make neutral surface\n";
-		return nullptr;
+		return surface();
 	}
 
 	{
@@ -771,12 +776,12 @@ surface greyscale_image(const surface &surf)
 surface monochrome_image(const surface &surf, const int threshold)
 {
 	if(surf == nullptr)
-		return nullptr;
+		return surface();
 
 	surface nsurf(make_neutral_surface(surf));
 	if(nsurf == nullptr) {
 		std::cerr << "failed to make neutral surface\n";
-		return nullptr;
+		return surface();
 	}
 
 	{
@@ -811,12 +816,12 @@ surface monochrome_image(const surface &surf, const int threshold)
 surface sepia_image(const surface &surf)
 {
 	if(surf == nullptr)
-		return nullptr;
+		return surface();
 
 	surface nsurf(make_neutral_surface(surf));
 	if(nsurf == nullptr) {
 		std::cerr << "failed to make neutral surface\n";
-		return nullptr;
+		return surface();
 	}
 
 	{
@@ -853,12 +858,12 @@ surface sepia_image(const surface &surf)
 surface negative_image(const surface &surf, const int thresholdR, const int thresholdG, const int thresholdB)
 {
 	if(surf == nullptr)
-		return nullptr;
+		return surface();
 
 	surface nsurf(make_neutral_surface(surf));
 	if(nsurf == nullptr) {
 		std::cerr << "failed to make neutral surface\n";
-		return nullptr;
+		return surface();
 	}
 
 	{
@@ -896,12 +901,12 @@ surface negative_image(const surface &surf, const int thresholdR, const int thre
 surface alpha_to_greyscale(const surface &surf)
 {
 	if(surf == nullptr)
-		return nullptr;
+		return surface();
 
 	surface nsurf(make_neutral_surface(surf));
 	if(nsurf == nullptr) {
 		std::cerr << "failed to make neutral surface\n";
-		return nullptr;
+		return surface();
 	}
 
 	{
@@ -924,12 +929,12 @@ surface alpha_to_greyscale(const surface &surf)
 surface wipe_alpha(const surface &surf)
 {
 	if(surf == nullptr)
-		return nullptr;
+		return surface();
 
 	surface nsurf(make_neutral_surface(surf));
 	if(nsurf == nullptr) {
 		std::cerr << "failed to make neutral surface\n";
-		return nullptr;
+		return surface();
 	}
 
 	{
@@ -952,14 +957,14 @@ surface wipe_alpha(const surface &surf)
 surface shadow_image(const surface &surf)
 {
 	if(surf == nullptr)
-		return nullptr;
+		return surface();
 
 	// we blur it, and reuse the neutral surface created by the blur function
 	surface nsurf (blur_alpha_surface(surf, 2));
 
 	if(nsurf == nullptr) {
 		std::cerr << "failed to blur the shadow surface\n";
-		return nullptr;
+		return surface();
 	}
 
 	{
@@ -988,12 +993,12 @@ surface shadow_image(const surface &surf)
 
 surface swap_channels_image(const surface& surf, channel r, channel g, channel b, channel a) {
 	if(surf == nullptr)
-		return nullptr;
+		return surface();
 
 	surface nsurf(make_neutral_surface(surf));
 	if(nsurf == nullptr) {
 		std::cerr << "failed to make neutral surface\n";
-		return nullptr;
+		return surface();
 	}
 
 	{
@@ -1024,7 +1029,7 @@ surface swap_channels_image(const surface& surf, channel r, channel g, channel b
 						newRed = alpha;
 						break;
 					default:
-						return nullptr;
+						return surface();
 				}
 
 				switch (g) {
@@ -1041,7 +1046,7 @@ surface swap_channels_image(const surface& surf, channel r, channel g, channel b
 						newGreen = alpha;
 						break;
 					default:
-						return nullptr;
+						return surface();
 				}
 
 				switch (b) {
@@ -1058,7 +1063,7 @@ surface swap_channels_image(const surface& surf, channel r, channel g, channel b
 						newBlue = alpha;
 						break;
 					default:
-						return nullptr;
+						return surface();
 				}
 
 				switch (a) {
@@ -1075,7 +1080,7 @@ surface swap_channels_image(const surface& surf, channel r, channel g, channel b
 						newAlpha = alpha;
 						break;
 					default:
-						return nullptr;
+						return surface();
 				}
 
 				*beg = (newAlpha << 24) | (newRed << 16) | (newGreen << 8) | newBlue;
@@ -1091,7 +1096,7 @@ surface swap_channels_image(const surface& surf, channel r, channel g, channel b
 surface recolor_image(surface surf, const color_range_map& map_rgb)
 {
 	if(surf == nullptr)
-		return nullptr;
+		return surface();
 
 	if(map_rgb.empty()) {
 		return surf;
@@ -1100,7 +1105,7 @@ surface recolor_image(surface surf, const color_range_map& map_rgb)
 	surface nsurf(make_neutral_surface(surf));
 	if(nsurf == nullptr) {
 		std::cerr << "failed to make neutral surface" << std::endl;
-		return nullptr;
+		return surface();
 	}
 
 	surface_lock lock(nsurf);
@@ -1130,14 +1135,14 @@ surface recolor_image(surface surf, const color_range_map& map_rgb)
 surface brighten_image(const surface &surf, fixed_t amount)
 {
 	if(surf == nullptr) {
-		return nullptr;
+		return surface();
 	}
 
 	surface nsurf(make_neutral_surface(surf));
 
 	if(nsurf == nullptr) {
 		std::cerr << "could not make neutral surface...\n";
-		return nullptr;
+		return surface();
 	}
 
 	{
@@ -1181,14 +1186,14 @@ void adjust_surface_alpha(surface& surf, fixed_t amount)
 surface adjust_surface_alpha_add(const surface &surf, int amount)
 {
 	if(surf== nullptr) {
-		return nullptr;
+		return surface();
 	}
 
 	surface nsurf(make_neutral_surface(surf));
 
 	if(nsurf == nullptr) {
 		std::cerr << "could not make neutral surface...\n";
-		return nullptr;
+		return surface();
 	}
 
 	{
@@ -1219,7 +1224,7 @@ surface adjust_surface_alpha_add(const surface &surf, int amount)
 surface mask_surface(const surface &surf, const surface &mask, bool* empty_result, const std::string& filename)
 {
 	if(surf == nullptr) {
-		return nullptr;
+		return surface();
 	}
 	if(mask == nullptr) {
 		return surf;
@@ -1230,7 +1235,7 @@ surface mask_surface(const surface &surf, const surface &mask, bool* empty_resul
 
 	if(nsurf == nullptr || nmask == nullptr) {
 		std::cerr << "could not make neutral surface...\n";
-		return nullptr;
+		return surface();
 	}
 	if (nsurf->w !=  nmask->w) {
 		// we don't support efficiently different width.
@@ -1334,7 +1339,7 @@ bool in_mask_surface(const surface &surf, const surface &mask)
 surface submerge_alpha(const surface &surf, int depth, float alpha_base, float alpha_delta)
 {
 	if(surf== nullptr) {
-		return nullptr;
+		return surface();
 	}
 
 	surface nsurf(make_neutral_surface(surf));
@@ -1396,7 +1401,7 @@ surface submerge_alpha(const surface &surf, int depth, float alpha_base, float a
 surface light_surface(const surface &surf, const surface &lightmap)
 {
 	if(surf == nullptr) {
-		return nullptr;
+		return surface();
 	}
 	if(lightmap == nullptr) {
 		return surf;
@@ -1406,7 +1411,7 @@ surface light_surface(const surface &surf, const surface &lightmap)
 
 	if(nsurf == nullptr) {
 		std::cerr << "could not make neutral surface...\n";
-		return nullptr;
+		return surface();
 	}
 	if (nsurf->w != lightmap->w) {
 		// we don't support efficiently different width.
@@ -1462,14 +1467,14 @@ surface light_surface(const surface &surf, const surface &lightmap)
 surface blur_surface(const surface &surf, int depth)
 {
 	if(surf == nullptr) {
-		return nullptr;
+		return surface();
 	}
 
 	surface res = make_neutral_surface(surf);
 
 	if(res == nullptr) {
 		std::cerr << "could not make neutral surface...\n";
-		return nullptr;
+		return surface();
 	}
 
 	SDL_Rect rect {0, 0, surf->w, surf->h};
@@ -1597,14 +1602,14 @@ void blur_surface(surface& surf, SDL_Rect rect, int depth)
 surface blur_alpha_surface(const surface &surf, int depth)
 {
 	if(surf == nullptr) {
-		return nullptr;
+		return surface();
 	}
 
 	surface res = make_neutral_surface(surf);
 
 	if(res == nullptr) {
 		std::cerr << "could not make neutral surface...\n";
-		return nullptr;
+		return surface();
 	}
 
 	const int max_blur = 256;
@@ -1744,13 +1749,13 @@ surface blur_alpha_surface(const surface &surf, int depth)
 surface cut_surface(const surface &surf, const SDL_Rect& r)
 {
 	if(surf == nullptr)
-		return nullptr;
+		return surface();
 
 	surface res = create_compatible_surface(surf, r.w, r.h);
 
 	if(res == nullptr) {
 		std::cerr << "Could not create a new surface in cut_surface()\n";
-		return nullptr;
+		return surface();
 	}
 
 	size_t sbpp = surf->format->BytesPerPixel;
@@ -1805,14 +1810,14 @@ surface blend_surface(
 		, const color_t color)
 {
 	if(surf== nullptr) {
-		return nullptr;
+		return surface();
 	}
 
 	surface nsurf(make_neutral_surface(surf));
 
 	if(nsurf == nullptr) {
 		std::cerr << "could not make neutral surface...\n";
-		return nullptr;
+		return surface();
 	}
 
 	{
@@ -1960,14 +1965,14 @@ uint32_t get_pixel(const surface& surf, const const_surface_lock& surf_lock, int
 surface rotate_180_surface(const surface &surf)
 {
 	if ( surf == nullptr )
-		return nullptr;
+		return surface();
 
 	// Work with a "neutral" surface.
 	surface nsurf(make_neutral_surface(surf));
 
 	if ( nsurf == nullptr ) {
 		std::cerr << "could not make neutral surface...\n";
-		return nullptr;
+		return surface();
 	}
 
 	{// Code block to limit the scope of the surface lock.
@@ -2002,7 +2007,7 @@ surface rotate_180_surface(const surface &surf)
 surface rotate_90_surface(const surface &surf, bool clockwise)
 {
 	if ( surf == nullptr )
-		return nullptr;
+		return surface();
 
 	// Work with "neutral" surfaces.
 	surface dst(create_neutral_surface(surf->h, surf->w)); // Flipped dimensions.
@@ -2010,7 +2015,7 @@ surface rotate_90_surface(const surface &surf, bool clockwise)
 
 	if ( src == nullptr  ||  dst == nullptr ) {
 		std::cerr << "could not make neutral surface...\n";
-		return nullptr;
+		return surface();
 	}
 
 	{// Code block to limit the scope of the surface locks.
@@ -2039,14 +2044,14 @@ surface rotate_90_surface(const surface &surf, bool clockwise)
 surface flip_surface(const surface &surf)
 {
 	if(surf == nullptr) {
-		return nullptr;
+		return surface();
 	}
 
 	surface nsurf(make_neutral_surface(surf));
 
 	if(nsurf == nullptr) {
 		std::cerr << "could not make neutral surface...\n";
-		return nullptr;
+		return surface();
 	}
 
 	{
@@ -2068,14 +2073,14 @@ surface flip_surface(const surface &surf)
 surface flop_surface(const surface &surf)
 {
 	if(surf == nullptr) {
-		return nullptr;
+		return surface();
 	}
 
 	surface nsurf(make_neutral_surface(surf));
 
 	if(nsurf == nullptr) {
 		std::cerr << "could not make neutral surface...\n";
-		return nullptr;
+		return surface();
 	}
 
 	{
@@ -2097,7 +2102,7 @@ surface flop_surface(const surface &surf)
 surface create_compatible_surface(const surface &surf, int width, int height)
 {
 	if(surf == nullptr)
-		return nullptr;
+		return surface();
 
 	if(width == -1)
 		width = surf->w;
@@ -2106,10 +2111,10 @@ surface create_compatible_surface(const surface &surf, int width, int height)
 		height = surf->h;
 
 #if SDL_VERSION_ATLEAST(2, 0, 6)
-	surface s = SDL_CreateRGBSurfaceWithFormat(0, width, height, surf->format->BitsPerPixel, surf->format->format);
+	surface s(SDL_CreateRGBSurfaceWithFormat(0, width, height, surf->format->BitsPerPixel, surf->format->format));
 #else
-	surface s = SDL_CreateRGBSurface(0, width, height, surf->format->BitsPerPixel,
-		surf->format->Rmask, surf->format->Gmask, surf->format->Bmask, surf->format->Amask);
+	surface s(SDL_CreateRGBSurface(0, width, height, surf->format->BitsPerPixel,
+		surf->format->Rmask, surf->format->Gmask, surf->format->Bmask, surf->format->Amask));
 #endif
 
 	if (surf->format->palette) {
@@ -2271,12 +2276,12 @@ void blit_surface(const surface& surf,
 surface get_surface_portion(const surface &src, SDL_Rect &area)
 {
 	if (src == nullptr) {
-		return nullptr;
+		return surface();
 	}
 
 	// Check if there is something in the portion
 	if(area.x >= src->w || area.y >= src->h || area.x + area.w < 0 || area.y + area.h < 0) {
-		return nullptr;
+		return surface();
 	}
 
 	if(area.x + area.w > src->w) {
@@ -2291,7 +2296,7 @@ surface get_surface_portion(const surface &src, SDL_Rect &area)
 
 	if(dst == nullptr) {
 		std::cerr << "Could not create a new surface in get_surface_portion()\n";
-		return nullptr;
+		return surface();
 	}
 
 	sdl_copy_portion(src, &area, dst, nullptr);

--- a/src/sdl/utils.cpp
+++ b/src/sdl/utils.cpp
@@ -1617,7 +1617,7 @@ surface blur_alpha_surface(const surface &surf, int depth)
 		uint8_t red;
 		uint8_t green;
 		uint8_t blue;
-		Pixel(uint32_t* p)
+		explicit Pixel(uint32_t* p)
 		  : alpha(((*p) >> 24)&0xFF)
 		  , red(((*p) >> 16)&0xFF)
 		  , green(((*p) >> 8)&0xFF)

--- a/src/serialization/binary_or_text.cpp
+++ b/src/serialization/binary_or_text.cpp
@@ -80,13 +80,13 @@ config_writer::~config_writer()
 
 void config_writer::write(const config &cfg)
 {
-	::write(out_, cfg, level_);
+	::write(out_, configr_of(cfg), level_);
 }
 
 void config_writer::write_child(const std::string &key, const config &cfg)
 {
 	open_child(key);
-	::write(out_, cfg, level_);
+	::write(out_, configr_of(cfg), level_);
 	close_child(key);
 }
 

--- a/src/serialization/preprocessor.cpp
+++ b/src/serialization/preprocessor.cpp
@@ -1778,7 +1778,7 @@ void preprocess_resource(const std::string& res_name,
 			filesystem::create_directory_if_missing_recursive(filesystem::directory_name(preproc_res_name));
 			filesystem::scoped_ostream outStream(filesystem::ostream_file(preproc_res_name));
 
-			write(*outStream, cfg);
+			write(*outStream, configr_of(cfg));
 		}
 
 		// Write the plain cfg file

--- a/src/serialization/preprocessor.cpp
+++ b/src/serialization/preprocessor.cpp
@@ -232,7 +232,7 @@ protected:
 	 *
 	 * It relies on preprocessor_streambuf so it's implemented after that class is declared.
 	 */
-	preprocessor(preprocessor_streambuf& t);
+	explicit preprocessor(preprocessor_streambuf& t);
 
 	preprocessor_streambuf& parent_;
 
@@ -279,7 +279,7 @@ private:
 class preprocessor_streambuf : public std::streambuf
 {
 public:
-	preprocessor_streambuf(preproc_map* def)
+	explicit preprocessor_streambuf(preproc_map* def)
 		: std::streambuf()
 		, out_buffer_("")
 		, buffer_()

--- a/src/serialization/preprocessor.hpp
+++ b/src/serialization/preprocessor.hpp
@@ -120,7 +120,7 @@ struct preproc_config
 {
 	struct error : public game::error
 	{
-		error(const std::string& message)
+		explicit error(const std::string& message)
 			: game::error(message)
 		{
 		}

--- a/src/serialization/schema_validator.hpp
+++ b/src/serialization/schema_validator.hpp
@@ -46,7 +46,7 @@ public:
 	 * Initializes validator from file.
 	 * Throws abstract_validator::error if any error.
 	 */
-	schema_validator(const std::string& filename);
+	explicit schema_validator(const std::string& filename);
 
 	void set_create_exceptions(bool value)
 	{

--- a/src/serialization/tag.hpp
+++ b/src/serialization/tag.hpp
@@ -53,7 +53,7 @@ public:
 	{
 	}
 
-	class_key(const config&);
+	explicit class_key(const config&);
 
 	const std::string& get_name() const
 	{
@@ -166,7 +166,7 @@ public:
 	{
 	}
 
-	class_tag(const config&);
+	explicit class_tag(const config&);
 
 	~class_tag()
 	{

--- a/src/serialization/tokenizer.hpp
+++ b/src/serialization/tokenizer.hpp
@@ -55,7 +55,7 @@ struct token
 class tokenizer
 {
 public:
-	tokenizer(std::istream& in);
+	explicit tokenizer(std::istream& in);
 	~tokenizer();
 
 	const token &next_token();

--- a/src/serialization/ucs4_iterator_base.hpp
+++ b/src/serialization/ucs4_iterator_base.hpp
@@ -32,7 +32,7 @@ namespace ucs4
 		typedef ucs4::char_t* pointer;
 		typedef ucs4::char_t& reference;
 
-		iterator_base(const string_type& str)
+		explicit iterator_base(const string_type& str)
 			: current_char(0)
 			, string_end(str.end())
 			, current_substr(std::make_pair(str.begin(), str.begin()))

--- a/src/serialization/unicode_cast.hpp
+++ b/src/serialization/unicode_cast.hpp
@@ -27,7 +27,7 @@ namespace ucs4_convert_impl
 	struct iteratorwriter
 	{
 		oitor_t& out_;
-		iteratorwriter(oitor_t& out) : out_(out) {}
+		explicit iteratorwriter(oitor_t& out) : out_(out) {}
 
 		bool can_push(size_t /*count*/)
 		{

--- a/src/serialization/validator.hpp
+++ b/src/serialization/validator.hpp
@@ -89,6 +89,6 @@ public:
 	 * Supposed to be thrown from the constructor
 	 */
 	struct error : public game::error {
-		error(const std::string& message) : game::error(message) {}
+		explicit error(const std::string& message) : game::error(message) {}
 	};
 };

--- a/src/server/ban.hpp
+++ b/src/server/ban.hpp
@@ -69,7 +69,7 @@ namespace wesnothd {
 
 	public:
 		banned(const std::string& ip, const time_t end_time, const std::string& reason, const std::string& who_banned=who_banned_default_, const std::string& group="", const std::string& nick="");
-		banned(const config&);
+		explicit banned(const config&);
 
 		void read(const config&);
 		void write(config&) const;
@@ -114,7 +114,7 @@ namespace wesnothd {
 		bool operator>(const banned& b) const;
 
 		struct error : public ::game::error {
-			error(const std::string& message) : ::game::error(message) {}
+			explicit error(const std::string& message) : ::game::error(message) {}
 		};
 	};
 

--- a/src/server/forum_user_handler.hpp
+++ b/src/server/forum_user_handler.hpp
@@ -38,7 +38,7 @@
  */
 class fuh : public user_handler {
 	public:
-		fuh(const config& c);
+		explicit fuh(const config& c);
 		~fuh();
 
 		// Throws user_handler::error

--- a/src/server/sample_user_handler.hpp
+++ b/src/server/sample_user_handler.hpp
@@ -27,7 +27,7 @@
  */
 class suh : public user_handler {
 	public:
-		suh(config c);
+		explicit suh(config c);
 
 		void add_user(const std::string& name, const std::string& mail, const std::string& password);
 		void remove_user(const std::string& name);

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -1399,7 +1399,7 @@ void server::handle_player_in_game(socket_ptr socket, std::shared_ptr<simple_wml
 		// If there is no shroud, then tell players in the lobby
 		// what the map looks like.
 		const simple_wml::node& s = *wesnothd::game::starting_pos(g.level().root());
-		desc.set_attr_dup("map_data", s["mp_shroud"].to_bool() ? "" :
+		desc.set_attr_dup("map_data", s["mp_shroud"].to_bool() ? simple_wml::string_span("") :
 																 s["map_data"]);
 		if (const simple_wml::node* e = data.child("era")) {
 			if (!e->attr("require_era").to_bool(true)) {

--- a/src/server/server_base.hpp
+++ b/src/server/server_base.hpp
@@ -29,7 +29,7 @@ typedef std::shared_ptr<boost::asio::ip::tcp::socket> socket_ptr;
 
 struct server_shutdown : public game::error
 {
-	server_shutdown(const std::string& msg) : game::error(msg) {}
+	explicit server_shutdown(const std::string& msg) : game::error(msg) {}
 };
 
 class server_base

--- a/src/server/simple_wml.hpp
+++ b/src/server/simple_wml.hpp
@@ -27,7 +27,7 @@
 namespace simple_wml {
 
 struct error : public game::error {
-	error(const char* msg);
+	explicit error(const char* msg);
 };
 
 class string_span

--- a/src/server/simple_wml.hpp
+++ b/src/server/simple_wml.hpp
@@ -37,7 +37,7 @@ public:
 	{}
 	string_span(const char* str, int size) : str_(str), size_(size)
 	{}
-	string_span(const char* str) : str_(str), size_(strlen(str))
+	explicit string_span(const char* str) : str_(str), size_(strlen(str))
 	{}
 	string_span(const char* begin, const char* end) : str_(begin), size_(end - begin)
 	{}

--- a/src/server/user_handler.hpp
+++ b/src/server/user_handler.hpp
@@ -117,7 +117,7 @@ class user_handler {
 		virtual void set_is_moderator(const std::string& name, const bool& is_moderator) =0;
 
 		struct error : public game::error {
-			error(const std::string& message) : game::error(message) {}
+			explicit error(const std::string& message) : game::error(message) {}
 		};
 
 		/** Initiate the mailer object. */

--- a/src/sound_music_track.hpp
+++ b/src/sound_music_track.hpp
@@ -29,7 +29,7 @@ class music_track
 {
 public:
 	music_track();
-	music_track(const config& node);
+	explicit music_track(const config& node);
 	explicit music_track(const std::string& v_name);
 	void write(config& parent_node, bool append) const;
 

--- a/src/soundsource.hpp
+++ b/src/soundsource.hpp
@@ -56,7 +56,7 @@ public:
 	// chance is a chance ;-) (in %) that the sound source will emit
 	// sound every second after the delay has passed or once the source
 	// becomes visible
-	positional_source(const sourcespec &spec);
+	explicit positional_source(const sourcespec &spec);
 	~positional_source();
 
 	bool is_global() const;
@@ -84,7 +84,7 @@ class manager : public events::observer
 	const display &disp_;
 
 public:
-	manager(const display &disp);
+	explicit manager(const display &disp);
 	~manager();
 
 	// event interface
@@ -143,7 +143,7 @@ public:
 	{}
 
 	/** WML constructor. */
-	sourcespec(const config& cfg);
+	explicit sourcespec(const config& cfg);
 
 	/**
 	 * Serializes information into cfg as a new (appended)

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -68,7 +68,7 @@ namespace statistics
 
 	struct scenario_context
 	{
-		scenario_context(const std::string& name);
+		explicit scenario_context(const std::string& name);
 		~scenario_context();
 	};
 

--- a/src/storyscreen/parser.cpp
+++ b/src/storyscreen/parser.cpp
@@ -106,7 +106,7 @@ void story_parser::resolve_wml(const vconfig& cfg)
 		else if(key == "deprecated_message") {
 			// Won't appear until the scenario start event finishes.
 			DEP_LEVEL level = DEP_LEVEL(node["level"].to_int(2));
-			deprecated_message(node["what"], level, node["version"].str(), node["message"]);
+			deprecated_message(node["what"], level, version_info(node["version"].str()), node["message"]);
 		}
 		// [wml_message]
 		else if(key == "wml_message") {

--- a/src/storyscreen/part.cpp
+++ b/src/storyscreen/part.cpp
@@ -240,7 +240,7 @@ bool part::resolve_wml_helper(const std::string& key, const vconfig& node)
 
 	// [background_layer]
 	if(key == "background_layer") {
-		background_layers_.push_back(node.get_parsed_config());
+		background_layers_.push_back(background_layer(node.get_parsed_config()));
 		found = true;
 	}
 	// [image]

--- a/src/storyscreen/part.cpp
+++ b/src/storyscreen/part.cpp
@@ -245,7 +245,7 @@ bool part::resolve_wml_helper(const std::string& key, const vconfig& node)
 	}
 	// [image]
 	else if(key == "image") {
-		floating_images_.push_back(node.get_parsed_config());
+		floating_images_.push_back(floating_image(node.get_parsed_config()));
 		found = true;
 	}
 

--- a/src/storyscreen/part.hpp
+++ b/src/storyscreen/part.hpp
@@ -42,7 +42,7 @@ public:
 	 * @param cfg Object corresponding to a [image] block's contents from
 	 *            a [part] node.
 	 */
-	floating_image(const config& cfg);
+	explicit floating_image(const config& cfg);
 
 	/**
 	 * Copy constructor.

--- a/src/storyscreen/part.hpp
+++ b/src/storyscreen/part.hpp
@@ -122,7 +122,7 @@ public:
 	 * Constructor. Initializes a background_layer object from a
 	 * [background_layer] WML node.
 	 */
-	background_layer(const config& cfg);
+	explicit background_layer(const config& cfg);
 
 	/** Whether the layer should be scaled horizontally. */
 	bool scale_horizontally() const

--- a/src/storyscreen/part.hpp
+++ b/src/storyscreen/part.hpp
@@ -248,7 +248,7 @@ public:
 	 * Constructs a storyscreen part from a managed WML node.
 	 * @param part_cfg Node object which should correspond to a [part] block's contents.
 	 */
-	part(const vconfig& part_cfg);
+	explicit part(const vconfig& part_cfg);
 
 	/** Whether the story screen title should be displayed or not. */
 	bool show_title() const

--- a/src/synced_checkup.cpp
+++ b/src/synced_checkup.cpp
@@ -84,7 +84,7 @@ namespace
 {
 	struct checkup_choice : public mp_sync::user_choice
 	{
-		checkup_choice(const config& cfg) : cfg_(cfg)
+		explicit checkup_choice(const config& cfg) : cfg_(cfg)
 		{
 		}
 		virtual ~checkup_choice()

--- a/src/synced_checkup.hpp
+++ b/src/synced_checkup.hpp
@@ -42,7 +42,7 @@ public:
 class synced_checkup : public checkup
 {
 public:
-	synced_checkup(config& buffer);
+	explicit synced_checkup(config& buffer);
 	virtual ~synced_checkup();
 	virtual bool local_checkup(const config& expected_data, config& real_data);
 private:

--- a/src/synced_context.hpp
+++ b/src/synced_context.hpp
@@ -194,7 +194,7 @@ public:
 	/*
 		use this constructor if you have multiple synced_context but only one replay entry.
 	*/
-	set_scontext_synced(int num);
+	explicit set_scontext_synced(int num);
 	~set_scontext_synced();
 	int get_random_calls();
 	void do_final_checkup(bool dont_throw = false);

--- a/src/terrain/builder.cpp
+++ b/src/terrain/builder.cpp
@@ -824,7 +824,7 @@ void terrain_builder::parse_mapstring(
 			} else if(terrain.overlay != 0) {
 				anchors.emplace(terrain.overlay, map_location(x, y));
 			} else if(terrain.base == t_translation::TB_STAR) {
-				add_constraints(br.constraints, map_location(x, y), t_translation::STAR, global_images);
+				add_constraints(br.constraints, map_location(x, y), t_translation::ter_match(t_translation::STAR), global_images);
 			} else {
 				ERR_NG << "Invalid terrain (" << t_translation::write_terrain_code(terrain) << ") in builder map"
 					   << std::endl;

--- a/src/terrain/builder.hpp
+++ b/src/terrain/builder.hpp
@@ -286,7 +286,7 @@ public:
 		{
 		}
 
-		terrain_constraint(map_location loc)
+		explicit terrain_constraint(map_location loc)
 			: loc(loc)
 			, terrain_types_match()
 			, set_flag()

--- a/src/terrain/terrain.hpp
+++ b/src/terrain/terrain.hpp
@@ -23,7 +23,7 @@ class terrain_type
 public:
 
 	terrain_type();
-	terrain_type(const config& cfg);
+	explicit terrain_type(const config& cfg);
 	terrain_type(const terrain_type& base, const terrain_type& overlay);
 
 	const std::string& icon_image() const { return icon_image_; }

--- a/src/terrain/translation.hpp
+++ b/src/terrain/translation.hpp
@@ -107,7 +107,7 @@ namespace t_translation {
 	struct ter_match{
 		ter_match();
 		ter_match(const std::string& str, const ter_layer filler = NO_LAYER);
-		ter_match(const terrain_code& tcode);
+		explicit ter_match(const terrain_code& tcode);
 
 		ter_list terrain;
 		ter_list mask;

--- a/src/terrain/translation.hpp
+++ b/src/terrain/translation.hpp
@@ -123,7 +123,7 @@ namespace t_translation {
 	// Note: atm most thrown result in a crash, but I like
 	// an uncatched exception better than an assert.
 	struct error : public game::error {
-		error(const std::string& message) : game::error(message) {}
+		explicit error(const std::string& message) : game::error(message) {}
 	};
 
 	// Some types of terrain which must be known, and can't just

--- a/src/terrain/type_data.hpp
+++ b/src/terrain/type_data.hpp
@@ -28,7 +28,7 @@ private:
 	const config & game_config_;
 
 public:
-	terrain_type_data(const config & game_config);
+	explicit terrain_type_data(const config & game_config);
 
 	const t_translation::ter_list & list() const;
 	const std::map<t_translation::terrain_code, terrain_type> & map() const;

--- a/src/tests/gui/test_gui2.cpp
+++ b/src/tests/gui/test_gui2.cpp
@@ -828,7 +828,7 @@ struct dialog_tester<hotkey_bind>
 
 struct wesnothd_connection_init
 {
-	wesnothd_connection_init(wesnothd_connection& conn)
+	explicit wesnothd_connection_init(wesnothd_connection& conn)
 	{
 		//Swallow the 'cannot connect' execption so that the connection object doesn't throw while we test the dialog.
 		try

--- a/src/tests/test_mp_connect.cpp
+++ b/src/tests/test_mp_connect.cpp
@@ -30,7 +30,7 @@
 
 class test_connect_engine : public ng::connect_engine {
 public:
-	test_connect_engine(saved_game& gamestate) :
+	explicit test_connect_engine(saved_game& gamestate) :
 		ng::connect_engine(gamestate, true, nullptr)
 		{}
 };

--- a/src/theme.hpp
+++ b/src/theme.hpp
@@ -41,7 +41,7 @@ class theme
 	{
 	public:
 		object();
-		object(const config& cfg);
+		explicit object(const config& cfg);
 		virtual ~object() { }
 
 		SDL_Rect& location(const SDL_Rect& screen) const;
@@ -79,7 +79,7 @@ class theme
 	{
 
 		border_t();
-		border_t(const config& cfg);
+		explicit border_t(const config& cfg);
 
 		double size;
 

--- a/src/tooltips.cpp
+++ b/src/tooltips.cpp
@@ -45,7 +45,7 @@ std::map<int, tooltip>::const_iterator current_tooltip = tips.end();
 int tooltip_handle = 0;
 int tooltip_id = 0;
 
-surface current_background = nullptr;
+surface current_background;
 
 }
 

--- a/src/tstring.hpp
+++ b/src/tstring.hpp
@@ -61,10 +61,10 @@ public:
 
 	/** Default implementation, but defined out-of-line for efficiency reasons. */
 	t_string_base(const t_string_base&);
-	t_string_base(const std::string& string);
+	explicit t_string_base(const std::string& string);
 	t_string_base(const std::string& string, const std::string& textdomain);
 	t_string_base(const std::string& sing, const std::string& pl, int count, const std::string& textdomain);
-	t_string_base(const char* string);
+	explicit t_string_base(const char* string);
 
 	static t_string_base from_serialized(const std::string& string);
 	std::string to_serialized() const;

--- a/src/units/animation.cpp
+++ b/src/units/animation.cpp
@@ -58,7 +58,7 @@ typedef std::list<animation_branch> animation_branches;
 
 struct animation_cursor
 {
-	animation_cursor(const config& cfg)
+	explicit animation_cursor(const config& cfg)
 		: itors(cfg.all_children_range()), branches(1), parent(nullptr)
 	{
 		branches.back().attributes.merge_attributes(cfg);

--- a/src/units/animation.cpp
+++ b/src/units/animation.cpp
@@ -496,13 +496,13 @@ void unit_animation::fill_initial_animations(std::vector<unit_animation>& animat
 	const std::string default_image = cfg["image"];
 
 	if(animation_base.empty()) {
-		animation_base.push_back(unit_animation(0, frame_builder().image(default_image).duration(1), "", unit_animation::DEFAULT_ANIM));
+		animation_base.push_back(unit_animation(0, unit_frame(frame_builder().image(default_image).duration(1)), "", unit_animation::DEFAULT_ANIM));
 	}
 
-	animations.push_back(unit_animation(0, frame_builder().image(default_image).duration(1), "_disabled_", 0));
+	animations.push_back(unit_animation(0, unit_frame(frame_builder().image(default_image).duration(1)), "_disabled_", 0));
 	animations.push_back(unit_animation(0,
-		frame_builder().image(default_image).duration(300).blend("0.0~0.3:100,0.3~0.0:200", {255,255,255}),
-		"_disabled_selected_", 0));
+			unit_frame(frame_builder().image(default_image).duration(300).blend("0.0~0.3:100,0.3~0.0:200", {255,255,255})),
+			"_disabled_selected_", 0));
 
 	for(const auto& base : animation_base) {
 		animations.push_back(base);
@@ -572,7 +572,7 @@ void unit_animation::fill_initial_animations(std::vector<unit_animation>& animat
 		animations.back().event_ = { "death" };
 		animations.back().unit_anim_.override(0, 600, particle::NO_CYCLE, "1~0:600");
 		animations.back().sub_anims_["_death_sound"] = particle();
-		animations.back().sub_anims_["_death_sound"].add_frame(1, frame_builder().sound(cfg["die_sound"]), true);
+		animations.back().sub_anims_["_death_sound"].add_frame(1, unit_frame(frame_builder().sound(cfg["die_sound"])), true);
 
 		animations.push_back(base);
 		animations.back().event_ = { "victory" };
@@ -595,13 +595,13 @@ void unit_animation::fill_initial_animations(std::vector<unit_animation>& animat
 
 		const std::string healed_sound = get_heal_sound(cfg);
 
-		animations.back().sub_anims_["_healed_sound"].add_frame(1, frame_builder().sound(healed_sound), true);
+		animations.back().sub_anims_["_healed_sound"].add_frame(1, unit_frame(frame_builder().sound(healed_sound)), true);
 
 		animations.push_back(base);
 		animations.back().event_ = { "poisoned" };
 		animations.back().unit_anim_.override(0, 300, particle::NO_CYCLE, "", "0:30,0.5:30,0:30,0.5:30,0:30,0.5:30,0:30,0.5:30,0:30", {0,255,0});
 		animations.back().sub_anims_["_poison_sound"] = particle();
-		animations.back().sub_anims_["_poison_sound"].add_frame(1, frame_builder().sound(game_config::sounds::status::poisoned), true);
+		animations.back().sub_anims_["_poison_sound"].add_frame(1, unit_frame(frame_builder().sound(game_config::sounds::status::poisoned)), true);
 	}
 }
 
@@ -719,7 +719,7 @@ void unit_animation::add_anims( std::vector<unit_animation> & animations, const 
 		animations.back().sub_anims_["_healed_sound"] = particle();
 
 		const std::string healed_sound = get_heal_sound(cfg);
-		animations.back().sub_anims_["_healed_sound"].add_frame(1,frame_builder().sound(healed_sound),true);
+		animations.back().sub_anims_["_healed_sound"].add_frame(1,unit_frame(frame_builder().sound(healed_sound)),true);
 	}
 
 	for(const animation_branch &ab : prepare_animation(cfg, "poison_anim")) {
@@ -733,7 +733,7 @@ void unit_animation::add_anims( std::vector<unit_animation> & animations, const 
 
 		animations.push_back(unit_animation(anim));
 		animations.back().sub_anims_["_poison_sound"] = particle();
-		animations.back().sub_anims_["_poison_sound"].add_frame(1,frame_builder().sound(game_config::sounds::status::poisoned),true);
+		animations.back().sub_anims_["_poison_sound"].add_frame(1,unit_frame(frame_builder().sound(game_config::sounds::status::poisoned)),true);
 	}
 
 	add_simple_anim(animations, cfg, "pre_movement_anim", "pre_movement", display::LAYER_UNIT_MOVE_DEFAULT);
@@ -777,10 +777,10 @@ void unit_animation::add_anims( std::vector<unit_animation> & animations, const 
 			animations.back().base_score_--;
 
 			image::locator image_loc = animations.back().get_last_frame().end_parameters().image;
-			animations.back().add_frame(225, frame_builder()
+			animations.back().add_frame(225, unit_frame(frame_builder()
 				.image(image_loc.get_filename()+image_loc.get_modifications())
 				.duration(225)
-				.blend("0.0,0.5:75,0.0:75,0.5:75,0.0", {255,0,0}));
+				.blend("0.0,0.5:75,0.0:75,0.5:75,0.0", {255,0,0})));
 		} else {
 			for(const std::string& hit_type : utils::split(anim["hits"])) {
 				config tmp = anim;
@@ -790,10 +790,10 @@ void unit_animation::add_anims( std::vector<unit_animation> & animations, const 
 
 				image::locator image_loc = animations.back().get_last_frame().end_parameters().image;
 				if(hit_type == "yes" || hit_type == "hit" || hit_type=="kill") {
-					animations.back().add_frame(225, frame_builder()
+					animations.back().add_frame(225, unit_frame(frame_builder()
 						.image(image_loc.get_filename() + image_loc.get_modifications())
 						.duration(225)
-						.blend("0.0,0.5:75,0.0:75,0.5:75,0.0", {255,0,0}));
+						.blend("0.0,0.5:75,0.0:75,0.5:75,0.0", {255,0,0})));
 				}
 			}
 		}
@@ -845,14 +845,14 @@ void unit_animation::add_anims( std::vector<unit_animation> & animations, const 
 		animations.push_back(unit_animation(anim));
 		image::locator image_loc = animations.back().get_last_frame().end_parameters().image;
 
-		animations.back().add_frame(600, frame_builder()
+		animations.back().add_frame(600, unit_frame(frame_builder()
 			.image(image_loc.get_filename()+image_loc.get_modifications())
 			.duration(600)
-			.highlight("1~0:600"));
+			.highlight("1~0:600")));
 
 		if(!cfg["die_sound"].empty()) {
 			animations.back().sub_anims_["_death_sound"] = particle();
-			animations.back().sub_anims_["_death_sound"].add_frame(1,frame_builder().sound(cfg["die_sound"]),true);
+			animations.back().sub_anims_["_death_sound"].add_frame(1,unit_frame(frame_builder().sound(cfg["die_sound"])),true);
 		}
 	}
 
@@ -1045,8 +1045,8 @@ void unit_animation::start_animation(int start_time
 
 	if(!text.empty()) {
 		particle crude_build;
-		crude_build.add_frame(1, frame_builder());
-		crude_build.add_frame(1, frame_builder().text(text, text_color), true);
+		crude_build.add_frame(1, unit_frame());
+		crude_build.add_frame(1, unit_frame(frame_builder().text(text, text_color)), true);
 		sub_anims_["_add_text"] = crude_build;
 	}
 

--- a/src/units/animation_component.hpp
+++ b/src/units/animation_component.hpp
@@ -34,7 +34,7 @@ public:
 		STATE_ANIM};      /** normal anims */
 
 	/** Default construct a unit animation component corresponding to a unit. */
-	unit_animation_component(unit & my_unit) :
+	explicit unit_animation_component(unit & my_unit) :
 		u_(my_unit),
 		anim_(nullptr),
 		animations_(),

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -115,7 +115,7 @@ struct unit_filter_xy : public unit_filter_base
 
 struct unit_filter_adjacent : public unit_filter_base
 {
-	unit_filter_adjacent(const vconfig& cfg)
+	explicit unit_filter_adjacent(const vconfig& cfg)
 		: child_(cfg)
 		, cfg_(cfg)
 	{

--- a/src/units/filter.hpp
+++ b/src/units/filter.hpp
@@ -75,7 +75,7 @@ namespace unit_filter_impl
 
 	struct unit_filter_compound : public unit_filter_base
 	{
-		unit_filter_compound(vconfig cfg);
+		explicit unit_filter_compound(vconfig cfg);
 
 		template<typename C, typename F>
 		void create_attribute(const config::attribute_value c, C conv, F func);

--- a/src/units/frame.hpp
+++ b/src/units/frame.hpp
@@ -200,7 +200,7 @@ class unit_frame
 {
 public:
 	// Constructors
-	unit_frame(const frame_builder& builder = frame_builder()) : builder_(builder) {}
+	explicit unit_frame(const frame_builder& builder = frame_builder()) : builder_(builder) {}
 
 	void redraw(const int frame_time, bool on_start_time, bool in_scope_of_frame, const map_location& src, const map_location& dst,
 		halo::handle& halo_id, halo::manager& halo_man, const frame_parameters& animation_val, const frame_parameters& engine_val) const;

--- a/src/units/frame_private.hpp
+++ b/src/units/frame_private.hpp
@@ -28,7 +28,7 @@ class progressive_base
 public:
 	using data_t = std::vector<std::pair<D, int>>;
 
-	progressive_base(const std::string& input)
+	explicit progressive_base(const std::string& input)
 		: data_()
 		, input_(input)
 	{}

--- a/src/units/id.hpp
+++ b/src/units/id.hpp
@@ -45,7 +45,7 @@ namespace n_unit {
 		size_t fake_id_;
 		static id_manager manager_;
 	public:
-		id_manager(size_t next_id) : next_id_(next_id) , fake_id_(0) {}
+		explicit id_manager(size_t next_id) : next_id_(next_id) , fake_id_(0) {}
 		/** returns id for unit that is created */
 		unit_id next_id();
 

--- a/src/units/types.hpp
+++ b/src/units/types.hpp
@@ -45,7 +45,7 @@ public:
 	class error : public game::game_error
 	{
 	public:
-		error(const std::string& msg)
+		explicit error(const std::string& msg)
 			: game::game_error(msg)
 		{
 		}
@@ -403,7 +403,7 @@ extern unit_type_data unit_types;
 void adjust_profile(std::string& profile);
 
 struct unit_experience_accelerator {
-	unit_experience_accelerator(int modifier);
+	explicit unit_experience_accelerator(int modifier);
 	~unit_experience_accelerator();
 	static int get_acceleration();
 private:

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -284,7 +284,7 @@ static unit_race::GENDER generate_gender(const unit_type& u_type, const config& 
 
 struct ptr_vector_pushback
 {
-	ptr_vector_pushback(boost::ptr_vector<config>& vec) : vec_(&vec) {}
+	explicit ptr_vector_pushback(boost::ptr_vector<config>& vec) : vec_(&vec) {}
 
 	void operator()(const config& cfg)
 	{

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -53,7 +53,7 @@ using unit_ability = std::pair<const config*, map_location>;
 class unit_ability_list
 {
 public:
-	unit_ability_list(const map_location& loc = map_location()) : cfgs_() , loc_(loc) {}
+	explicit unit_ability_list(const map_location& loc = map_location()) : cfgs_() , loc_(loc) {}
 
 	// Implemented in unit_abilities.cpp
 	std::pair<int, map_location> highest(const std::string& key, int def=0) const

--- a/src/utils/context_free_grammar_generator.hpp
+++ b/src/utils/context_free_grammar_generator.hpp
@@ -39,12 +39,12 @@ public:
 	/** Initialisation
 	 * @param source the definition of the context-free grammar to use
 	 */
-	context_free_grammar_generator(const std::string& source);
+	explicit context_free_grammar_generator(const std::string& source);
 
 	/** Initialisation
 	 * @param source A map of nonterminals to lists of possibilities
 	 */
-	context_free_grammar_generator(const std::map<std::string, std::vector<std::string>>& source);
+	explicit context_free_grammar_generator(const std::map<std::string, std::vector<std::string>>& source);
 
 	/** Generates a possible word in the grammar set before
 	 * @return the word

--- a/src/utils/functional.hpp
+++ b/src/utils/functional.hpp
@@ -35,8 +35,8 @@ namespace detail {
 	template<typename Ret, typename... T>
 	struct apply {
 		using result_type = void;
-		apply(const std::function<Ret(T...)>& fcn) : fcn(fcn) {}
-		apply(Ret(*fcn)(T...)) : fcn(fcn) {}
+		explicit apply(const std::function<Ret(T...)>& fcn) : fcn(fcn) {}
+		explicit apply(Ret(*fcn)(T...)) : fcn(fcn) {}
 		void operator()(T... params) {
 			fcn(std::forward<T>(params)...);
 		}

--- a/src/utils/name_generator.hpp
+++ b/src/utils/name_generator.hpp
@@ -22,7 +22,7 @@
 
 class name_generator_invalid_exception : public std::exception {
 public:
-	name_generator_invalid_exception(const char* errMessage):errMessage_(errMessage) {}
+	explicit name_generator_invalid_exception(const char* errMessage):errMessage_(errMessage) {}
 	const char* what() const NOEXCEPT { return errMessage_; }
 
 private:
@@ -42,6 +42,6 @@ public:
 class proxy_name_generator : public name_generator {
 	const name_generator& base;
 public:
-	proxy_name_generator(const name_generator& b) : base(b) {}
+	explicit proxy_name_generator(const name_generator& b) : base(b) {}
 	std::string generate() const override { return base.generate(); }
 };

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -296,7 +296,7 @@ namespace {
 	{
 		config::attribute_value &result;
 
-		vconfig_expand_visitor(config::attribute_value &r): result(r) {}
+		explicit vconfig_expand_visitor(config::attribute_value &r): result(r) {}
 		template<typename T> void operator()(const T&) const {}
 		void operator()(const std::string &s) const
 		{

--- a/src/variable.hpp
+++ b/src/variable.hpp
@@ -26,7 +26,7 @@ class unit_map;
 class config_variable_set : public variable_set {
 	const config& cfg_;
 public:
-	config_variable_set(const config& cfg) : cfg_(cfg) {}
+	explicit config_variable_set(const config& cfg) : cfg_(cfg) {}
 	virtual config::attribute_value get_variable_const(const std::string &id) const;
 };
 
@@ -179,7 +179,7 @@ public:
 	};
 
 	struct recursion_error : public config::error {
-		recursion_error(const std::string& msg) : error(msg) {}
+		explicit recursion_error(const std::string& msg) : error(msg) {}
 	};
 
 	/** In-order iteration over all children. */
@@ -204,14 +204,14 @@ private:
 struct vconfig::attribute_iterator::pointer_proxy
 {
 	value_type p;
-	pointer_proxy(value_type p) : p(p) {}
+	explicit pointer_proxy(value_type p) : p(p) {}
 	value_type *operator->() const { return &p; }
 };
 
 struct vconfig::all_children_iterator::pointer_proxy
 {
 	value_type p;
-	pointer_proxy(value_type p) : p(p) {}
+	explicit pointer_proxy(value_type p) : p(p) {}
 	value_type *operator->() const { return &p; }
 };
 
@@ -219,7 +219,7 @@ struct vconfig::all_children_iterator::pointer_proxy
 class scoped_wml_variable
 {
 public:
-	scoped_wml_variable(const std::string& var_name);
+	explicit scoped_wml_variable(const std::string& var_name);
 	virtual ~scoped_wml_variable();
 	const std::string& name() const { return var_name_; }
 	virtual void activate() = 0;

--- a/src/variable_info_detail.hpp
+++ b/src/variable_info_detail.hpp
@@ -128,7 +128,7 @@ struct variable_info_state
 {
 	using child_t = typename maybe_const<config, V>::type;
 
-	variable_info_state(child_t& vars)
+	explicit variable_info_state(child_t& vars)
 		: child_(&vars)
 		, key_()
 		, index_(0)

--- a/src/variable_info_private.hpp
+++ b/src/variable_info_private.hpp
@@ -125,7 +125,7 @@ public:
 	// Import typedefs from base class.
 	using param_t = typename get_variable_key_visitor::param_t;
 
-	get_variable_key_visitor(const std::string& key)
+	explicit get_variable_key_visitor(const std::string& key)
 		: key_(key)
 	{
 		if(!config::valid_attribute(key_)) {
@@ -174,7 +174,7 @@ template<typename V>
 class get_variable_index_visitor : public info_visitor<V, void>
 {
 public:
-	get_variable_index_visitor(int n)
+	explicit get_variable_index_visitor(int n)
 		: n_(n)
 	{
 	}
@@ -303,7 +303,7 @@ public:
 	using result_t = typename as_range_visitor_base::result_t;
 	using param_t = typename as_range_visitor_base::param_t;
 
-	as_range_visitor_base(T&&... args)
+	explicit as_range_visitor_base(T&&... args)
 		: handler_(std::forward<T>(args)...)
 	{
 	}
@@ -329,7 +329,7 @@ public:
 	// Import typedefs from base class.
 	using param_t = typename clear_value_visitor::param_t;
 
-	clear_value_visitor(bool only_tables)
+	explicit clear_value_visitor(bool only_tables)
 		: only_tables_(only_tables)
 	{
 	}
@@ -392,7 +392,7 @@ class replace_range_h
 {
 public:
 	typedef config::child_itors result_t;
-	replace_range_h(std::vector<config>& source)
+	explicit replace_range_h(std::vector<config>& source)
 		: datasource_(source)
 	{
 	}
@@ -435,7 +435,7 @@ class insert_range_h : replace_range_h
 {
 public:
 	typedef config::child_itors result_t;
-	insert_range_h(std::vector<config>& source)
+	explicit insert_range_h(std::vector<config>& source)
 		: replace_range_h(source)
 	{
 	}
@@ -451,7 +451,7 @@ class append_range_h : insert_range_h
 {
 public:
 	typedef config::child_itors result_t;
-	append_range_h(std::vector<config>& source)
+	explicit append_range_h(std::vector<config>& source)
 		: insert_range_h(source)
 	{
 	}
@@ -468,7 +468,7 @@ class merge_range_h
 {
 public:
 	typedef void result_t;
-	merge_range_h(std::vector<config>& source)
+	explicit merge_range_h(std::vector<config>& source)
 		: datasource_(source)
 	{
 	}

--- a/src/version.hpp
+++ b/src/version.hpp
@@ -44,8 +44,14 @@ class version_info
 {
 public:
 	version_info();                    /**< Default constructor. */
-	version_info(const std::string&);  /**< String constructor. */
-	version_info(const char* str) : version_info(std::string(str)) {}
+	explicit version_info(const std::string&);  /**< String constructor. */
+	explicit version_info(const char* str) : version_info(std::string(str)) {}
+	version_info& operator=(const std::string& version_string)
+	{
+			const version_info rhs (version_string);
+			*this = rhs;
+			return *this;
+	}
 
 	/** Simple list constructor. */
 	version_info(unsigned int major, unsigned int minor, unsigned int revision_level,

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -38,7 +38,7 @@ CVideo* CVideo::singleton_ = nullptr;
 
 namespace
 {
-surface frameBuffer = nullptr;
+surface frameBuffer;
 bool fake_interactive = false;
 }
 
@@ -175,9 +175,9 @@ void CVideo::make_fake()
 	refresh_rate_ = 1;
 
 #if SDL_VERSION_ATLEAST(2, 0, 6)
-	frameBuffer = SDL_CreateRGBSurfaceWithFormat(0, 16, 16, 24, SDL_PIXELFORMAT_BGR888);
+	frameBuffer = surface(SDL_CreateRGBSurfaceWithFormat(0, 16, 16, 24, SDL_PIXELFORMAT_BGR888));
 #else
-	frameBuffer = SDL_CreateRGBSurface(0, 16, 16, 24, 0xFF0000, 0xFF00, 0xFF, 0);
+	frameBuffer = surface(SDL_CreateRGBSurface(0, 16, 16, 24, 0xFF0000, 0xFF00, 0xFF, 0));
 #endif
 
 	image::set_pixel_format(frameBuffer->format);
@@ -186,9 +186,9 @@ void CVideo::make_fake()
 void CVideo::make_test_fake(const unsigned width, const unsigned height)
 {
 #if SDL_VERSION_ATLEAST(2, 0, 6)
-	frameBuffer = SDL_CreateRGBSurfaceWithFormat(0, width, height, 32, SDL_PIXELFORMAT_BGR888);
+	frameBuffer = surface(SDL_CreateRGBSurfaceWithFormat(0, width, height, 32, SDL_PIXELFORMAT_BGR888));
 #else
-	frameBuffer = SDL_CreateRGBSurface(0, width, height, 32, 0xFF0000, 0xFF00, 0xFF, 0);
+	frameBuffer = surface(SDL_CreateRGBSurface(0, width, height, 32, 0xFF0000, 0xFF00, 0xFF, 0));
 #endif
 
 	image::set_pixel_format(frameBuffer->format);
@@ -203,7 +203,7 @@ void CVideo::update_framebuffer()
 		return;
 	}
 
-	surface fb = SDL_GetWindowSurface(*window);
+	surface fb = surface(SDL_GetWindowSurface(*window));
 	if(!frameBuffer) {
 		frameBuffer = fb;
 	} else {

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -36,7 +36,7 @@ public:
 
 	enum FAKE_TYPES { NO_FAKE, FAKE, FAKE_TEST };
 
-	CVideo(FAKE_TYPES type = NO_FAKE);
+	explicit CVideo(FAKE_TYPES type = NO_FAKE);
 
 	~CVideo();
 
@@ -308,7 +308,7 @@ private:
 class flip_locker
 {
 public:
-	flip_locker(CVideo& video)
+	explicit flip_locker(CVideo& video)
 		: video_(video)
 	{
 		video_.lock_flips(true);
@@ -328,7 +328,7 @@ namespace video2
 class draw_layering : public events::sdl_handler
 {
 protected:
-	draw_layering(const bool auto_join = true);
+	explicit draw_layering(const bool auto_join = true);
 	virtual ~draw_layering();
 };
 

--- a/src/wesnothd_connection.hpp
+++ b/src/wesnothd_connection.hpp
@@ -202,7 +202,7 @@ class wesnothd_connection_ptr
 private:
 	friend class wesnothd_connection;
 
-	wesnothd_connection_ptr(std::shared_ptr<wesnothd_connection>&& ptr)
+	explicit wesnothd_connection_ptr(std::shared_ptr<wesnothd_connection>&& ptr)
 		: ptr_(std::move(ptr))
 	{
 	}

--- a/src/wesnothd_connection_error.hpp
+++ b/src/wesnothd_connection_error.hpp
@@ -20,7 +20,7 @@
 ///An error occurred during when trying to coommunicate with the wesnothd server.
 struct wesnothd_error : public game::error
 {
-	wesnothd_error(const std::string& error) : game::error(error) {}
+	explicit wesnothd_error(const std::string& error) : game::error(error) {}
 };
 
 /**
@@ -29,7 +29,7 @@ struct wesnothd_error : public game::error
  */
 struct wesnothd_rejected_client_error : public game::error
 {
-    wesnothd_rejected_client_error (const std::string& msg) : game::error (msg) {}
+    explicit wesnothd_rejected_client_error (const std::string& msg) : game::error (msg) {}
 };
 
 ///We received invalid data from wesnothd during a game
@@ -37,7 +37,7 @@ struct wesnothd_rejected_client_error : public game::error
 ///TODO: find a short name
 struct ingame_wesnothd_error : public wesnothd_error ,public lua_jailbreak_exception
 {
-	ingame_wesnothd_error(const std::string& error) : wesnothd_error(error) {}
+	explicit ingame_wesnothd_error(const std::string& error) : wesnothd_error(error) {}
 	IMPLEMENT_LUA_JAILBREAK_EXCEPTION(ingame_wesnothd_error)
 };
 
@@ -46,6 +46,6 @@ struct ingame_wesnothd_error : public wesnothd_error ,public lua_jailbreak_excep
 ///TODO: find a short name
 struct wesnothd_connection_error : public wesnothd_error ,public lua_jailbreak_exception
 {
-	wesnothd_connection_error(const boost::system::error_code& error) : wesnothd_error(error.message()) {}
+	explicit wesnothd_connection_error(const boost::system::error_code& error) : wesnothd_error(error.message()) {}
 	IMPLEMENT_LUA_JAILBREAK_EXCEPTION(wesnothd_connection_error)
 };

--- a/src/whiteboard/action.hpp
+++ b/src/whiteboard/action.hpp
@@ -92,7 +92,7 @@ public:
 
 	struct ctor_err	: public game::error
 	{
-		ctor_err(const std::string& message) : game::error(message){}
+		explicit ctor_err(const std::string& message) : game::error(message){}
 	};
 
 	/**

--- a/src/whiteboard/highlighter.hpp
+++ b/src/whiteboard/highlighter.hpp
@@ -38,7 +38,7 @@ class highlighter
 {
 
 public:
-	highlighter(side_actions_ptr side_actions);
+	explicit highlighter(side_actions_ptr side_actions);
 	virtual ~highlighter();
 
 	void set_mouseover_hex(const map_location& hex);
@@ -92,7 +92,7 @@ private:
 
 class highlighter::highlight_main_visitor: public visitor {
 public:
-	highlight_main_visitor(highlighter &h): highlighter_(h) {}
+	explicit highlight_main_visitor(highlighter &h): highlighter_(h) {}
 	void visit(move_ptr);
 	void visit(attack_ptr);
 	void visit(recruit_ptr);
@@ -105,7 +105,7 @@ private:
 
 class highlighter::highlight_secondary_visitor: public visitor {
 public:
-	highlight_secondary_visitor(highlighter &h): highlighter_(h) {}
+	explicit highlight_secondary_visitor(highlighter &h): highlighter_(h) {}
 	void visit(move_ptr);
 	void visit(attack_ptr);
 	void visit(recruit_ptr){}
@@ -117,7 +117,7 @@ private:
 
 class highlighter::unhighlight_visitor: public visitor {
 public:
-	unhighlight_visitor(highlighter &h): highlighter_(h) {}
+	explicit unhighlight_visitor(highlighter &h): highlighter_(h) {}
 	void visit(move_ptr);
 	void visit(attack_ptr);
 	void visit(recruit_ptr){}

--- a/src/whiteboard/manager.hpp
+++ b/src/whiteboard/manager.hpp
@@ -262,7 +262,7 @@ struct future_map_if
 	/** @param cond If true, applies the planned unit map for the duration of the struct's life and reverts to real unit map on destruction.
 			No effect if cond == false.
 	*/
-	future_map_if(bool cond)
+	explicit future_map_if(bool cond)
 		: future_map_(cond ? new future_map() : nullptr)
 	{}
 };

--- a/src/whiteboard/mapbuilder.hpp
+++ b/src/whiteboard/mapbuilder.hpp
@@ -40,7 +40,7 @@ class mapbuilder
 {
 
 public:
-	mapbuilder(unit_map& unit_map);
+	explicit mapbuilder(unit_map& unit_map);
 	virtual ~mapbuilder();
 
 	/**

--- a/src/whiteboard/utility.hpp
+++ b/src/whiteboard/utility.hpp
@@ -67,7 +67,7 @@ unit* future_visible_unit(int on_side, map_location hex, int viewer_side = wb::v
 int path_cost(const std::vector<map_location>& path, const unit& u);
 
 struct temporary_unit_hider {
-	temporary_unit_hider(unit& u);
+	explicit temporary_unit_hider(unit& u);
 	~temporary_unit_hider();
 	unit* const unit_;
 };

--- a/src/widgets/scrollbar.hpp
+++ b/src/widgets/scrollbar.hpp
@@ -34,7 +34,7 @@ public:
 	//- @param d         the display object
 	//- @param pane      the widget where wheel events take place
 	//- @param callback  a callback interface for warning that the grip has been moved
-	scrollbar(CVideo &video);
+	explicit scrollbar(CVideo &video);
 
 	virtual void hide(bool value = true);
 

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -708,7 +708,7 @@ void textbox::handle_event(const SDL_Event& event, bool was_forwarded)
 	show_cursor_at_ = SDL_GetTicks();
 
 	if(changed || old_cursor != cursor_ || old_selstart != selstart_ || old_selend != selend_) {
-		text_image_ = nullptr;
+		text_image_ = surface();
 		handle_text_changed(text_);
 	}
 


### PR DESCRIPTION
cppcheck (via Codacy) reports several hundred instances of the following class of error:
```
Class 'classname' has a constructor with 1 argument that is not explicit.
```

Failing to use the explicit keyword can lead to subtle, hard-to-find, errors.

This Pull Request is broken down into several commits.

The first adds the explicit keyword to all constructors where it has no other effect. These are perfectly safe and all we're doing is noting that we no longer want implicit instantiation of temporaries.

The remaining commits handle the changes constructor-by-constructor, chasing down the effects. In most cases, the simplest fix is to actually use the temporary, but document it. For all of these, I am open to suggestions to simplify or improve the changes.

As a result of the full set of commits, here, we remain with one specific case I could not easily fix, and a class of cases which I have not looked at.

The general class is every use of the MAKE_ENUM macro. I question why we're using C in a C++ project, but we do. There are not that many places the macro is used, so eliminating it may be an option. My first pass, however, will be to adjust the macro to eliminate the issue.

My main problem is the specific case. This is in `src\config.hpp`, line 205:
```
const_child_iterator(const child_iterator &i): i_(i.i_) {}
```
This has several hundred downstream effects. All but a few may be eliminated by explicitly using a temporary object. The problem is `src\variable_info.cpp` and its headers `src\variable_info.hpp`, `src\variable_info_detail.hpp`, and `src\variable_info_private.hpp`. Specifically, in the private header I ran afoul of template type inference. I will be making another pass at it.