### PR TITLE
Add support for data URIs as images

### DIFF
--- a/src/image.hpp
+++ b/src/image.hpp
@@ -52,6 +52,7 @@ namespace image {
 			bool operator<(const value& a) const;
 
 			type type_;
+			bool is_data_uri_;
 			std::string filename_;
 			map_location loc_;
 			std::string modifications_;
@@ -83,6 +84,7 @@ namespace image {
 		bool operator<(const locator &a) const { return index_ < a.index_; }
 
 		const std::string &get_filename() const { return val_.filename_; }
+		bool is_data_uri() const { return val_.is_data_uri_; }
 		const map_location& get_loc() const { return val_.loc_ ; }
 		int get_center_x() const { return val_.center_x_; }
 		int get_center_y() const { return val_.center_y_; }


### PR DESCRIPTION
Add support for using a [Data URI](https://en.wikipedia.org/wiki/Data_URI_scheme) in place of a filename. Addresses #1098.

There are currently 2 test add-ons on the 1.13 server using this for their icons (1 along with an IPF).