### PR TITLE
Enable use of ccache for xcode build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,6 @@ cache:
 
 matrix:
   include:
-    - os: osx
-      compiler: gcc
-      osx_image: xcode9.2
-      env: TOOL=xcodebuild
-
     - compiler: clang
       env: TOOL=scons CXXSTD=11 NLS=true
       
@@ -37,6 +32,11 @@ matrix:
     - os: osx
       compiler: clang
       env: TOOL=scons CXXSTD=11 NLS=false OPT=-O0
+    
+    - os: osx
+      compiler: clang
+      osx_image: xcode9.2
+      env: TOOL=xcodebuild
       
 before_install:
     - export EXTRA_FLAGS_RELEASE=""
@@ -56,6 +56,7 @@ before_install:
 install:
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
           if [ "$TOOL" = "xcodebuild" ]; then
+              brew install ccache;
               travis_wait ./projectfiles/Xcode/Fix_Xcode_Dependencies;
           else
               travis_wait ./utils/travis/install_deps.sh;
@@ -70,7 +71,17 @@ script:
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
           if [ "$TOOL" = "xcodebuild" ]; then
               cd ./projectfiles/Xcode;
+              
+              export CC=ccache-clang;
+              export CXX=ccache-clang++;
+              export PATH="/usr/local/opt/ccache/libexec:$PWD:$PATH";
+              
+              export CCACHE_MAXSIZE=2G;
+              export CCACHE_COMPILERCHECK=content;
+              
               xcodebuild -project Wesnoth.xcodeproj -target Wesnoth;
+              
+              ccache -s;
           else
               ln -s build-cache/ build;
               ./utils/travis/check_utf8.sh;

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -54,6 +54,9 @@ else
     echo "compiler_check = content" >> $HOME/.ccache/ccache.conf
     
     cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_GAME=true -DENABLE_SERVER=true -DENABLE_CAMPAIGN_SERVER=true -DENABLE_TESTS=true -DENABLE_NLS=false -DEXTRA_FLAGS_CONFIG="-pipe" -DEXTRA_FLAGS_RELEASE="$EXTRA_FLAGS_RELEASE" -DENABLE_STRICT_COMPILATION="$STRICT" -DENABLE_LTO=false -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache && make VERBOSE=1 -j2
+    
+# print ccache statistics
+    ccache -s
   else
     scons wesnoth wesnothd campaignd boost_unit_tests build=release ctool=$CC cxxtool=$CXX --debug=time extra_flags_config="-pipe" extra_flags_release="$EXTRA_FLAGS_RELEASE" strict="$STRICT" cxx_std=$CXXSTD nls=false jobs=2 enable_lto=false
   fi

--- a/projectfiles/Xcode/ccache-clang
+++ b/projectfiles/Xcode/ccache-clang
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+exec ccache clang "$@"
+

--- a/projectfiles/Xcode/ccache-clang++
+++ b/projectfiles/Xcode/ccache-clang++
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+exec ccache clang++ "$@"
+


### PR DESCRIPTION
Also sets it to use clang rather than gcc.

---

[Without cache](https://travis-ci.org/Pentarctagon/wesnoth/builds/345424715)
[With cache](https://travis-ci.org/Pentarctagon/wesnoth/builds/345439211)(best case scenario, no recompiling needed)

`CCACHE_MAXSIZE` is set to 2 GBs here, rather than the 200 MBs used for the cmake+ccache builds, because xcode's Release build contains the `-g` flag.  As a result, the size of ccache's cache (before travis compresses it) is [1.3 GBs](https://travis-ci.org/Pentarctagon/wesnoth/builds/345439211#L5902).