### PR TITLE
LoW Prevent the 'generic loyal' last breath triggering for main chars

### DIFF
--- a/data/campaigns/Legend_of_Wesmere/utils/deaths.cfg
+++ b/data/campaigns/Legend_of_Wesmere/utils/deaths.cfg
@@ -31,7 +31,7 @@
     [/message]
 #endif
     [message]
-        id=Kalenz
+        speaker=Kalenz
         message= _ "Nooo! We cannot continue without Landar!"
     [/message]
     [endlevel]
@@ -53,9 +53,9 @@
         message= _ "I’m sorry I failed you, Kalenz... my beloved..."
     [/message]
     [message]
-        # Ditto.  In the early scenarios, this is Kalenz reralizing
+        # Ditto.  In the early scenarios, this is Kalenz realizing
         # how much she meant to him just as he loses all hope.
-        id=Kalenz
+        speaker=Kalenz
         message= _ "Nooo! Cleodil! Without you I cannot go on!"
     [/message]
     [endlevel]
@@ -72,6 +72,11 @@
         speaker=unit
         message= _ "I go to join my sires in the Halls of Death"
     [/message]
+    [message]
+        # the same string is used for Galtrid's death event
+        speaker=Kalenz
+        message= _ "I cannot fight the orcs alone! It’s all over!"
+    [/message]
     [endlevel]
         result=defeat
     [/endlevel]
@@ -83,7 +88,7 @@
         id=Uradredia
     [/filter]
     [message]
-        id=Kalenz
+        speaker=Kalenz
         message= _ "Our cause is lost. With Uradredia gone, the North Elves will no longer fight!"
     [/message]
     [endlevel]
@@ -97,7 +102,8 @@
         id=Galtrid
     [/filter]
     [message]
-        id=Kalenz
+        # the same string is used for Olurf's death event
+        speaker=Kalenz
         message= _ "I cannot fight the orcs alone! It’s all over!"
     [/message]
     [endlevel]
@@ -119,13 +125,17 @@
                 [/has_unit]
             [/allied_with]
         [/filter_side]
+        [not]
+            # Check it's not someone who has their own last breath event
+            id=Kalenz,Landar,Cleodil,Olurf,Uradredia,Galtrid
+        [/not]
     [/filter]
     [message]
         speaker=unit
         message= _ "I grieve that I have failed you, my lord Kalenz..."
     [/message]
     [message]
-        id=Kalenz
+        speaker=Kalenz
         message= _ "Farewell $unit.name. Your loyal service won’t be forgotten."
     [/message]
     [scroll_to_unit]


### PR DESCRIPTION
For example, when Kalenz died he'd say to himself "I grieve that
I have failed you, my lord Kalenz..." followed by "Farewell Kalenz".
I'm sure that I've already seen this bug reported somewhere, but
can't find it now.

Also use speaker= instead of id=.