### PR TITLE
gui2/lua_interpreter: Maintain a raw console log for copy-to-clipboard

### DIFF
--- a/changelog
+++ b/changelog
@@ -22,6 +22,9 @@ Version 1.13.11+dev:
    * New game theme music by Mattias Westlund.
    * The unit advancement prompt is no longer shown for droided sides.
    * Fixed custom game titles being lost when reloading MP games.
+   * The copy-to-clipboard function on the Lua console now produces plain text
+     without Pango markup or entities for special characters (<, > and &)
+     (bug #2434).
 
 Version 1.13.11:
  * Add-ons client:


### PR DESCRIPTION
Fixes #2434.

Not much to say here since the code is pretty self-explanatory. The regular log is still needed since the UI needs to display text with markup enabled.