### PR TITLE
Fix for failed ccache builds being considered successful.

### DIFF
--- a/utils/travis/docker_run.sh
+++ b/utils/travis/docker_run.sh
@@ -54,16 +54,10 @@ else
     echo "compiler_check = content" >> $HOME/.ccache/ccache.conf
     
     cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_GAME=true -DENABLE_SERVER=true -DENABLE_CAMPAIGN_SERVER=true -DENABLE_TESTS=true -DENABLE_NLS=false -DEXTRA_FLAGS_CONFIG="-pipe" -DEXTRA_FLAGS_RELEASE="$EXTRA_FLAGS_RELEASE" -DENABLE_STRICT_COMPILATION="$STRICT" -DENABLE_LTO=false -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache && make VERBOSE=1 -j2
-    
-# print ccache statistics
-    ccache -s
-# clear ccache statistics, so only per run info is printed rather than cumulative
-    ccache -z
   else
     scons wesnoth wesnothd campaignd boost_unit_tests build=release ctool=$CC cxxtool=$CXX --debug=time extra_flags_config="-pipe" extra_flags_release="$EXTRA_FLAGS_RELEASE" strict="$STRICT" cxx_std=$CXXSTD nls=false jobs=2 enable_lto=false
   fi
   
-# check if the build was successful
   BUILD_RET=$?
   if [ $BUILD_RET != 0 ]; then
     exit $BUILD_RET

--- a/utils/travis/steps/script.sh
+++ b/utils/travis/steps/script.sh
@@ -12,9 +12,6 @@ if [ "$TRAVIS_OS_NAME" = "osx" ]; then
         export CCACHE_COMPILERCHECK=content
 
         xcodebuild -project Wesnoth.xcodeproj -target Wesnoth
-
-        ccache -s
-        ccache -z
     else
         ln -s build-cache/ build
         ./utils/travis/check_utf8.sh


### PR DESCRIPTION
Travis looks at the return code of the final command run, and since printing the ccache statistics never fails, building would never be considered as failing.