### PR TITLE
LoW S14 Objectives and edit repetitive dialog (ok for string freeze)

### DIFF
--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg
@@ -271,6 +271,10 @@ Chapter Four"
                 description= _ "Death of Aldar"
                 condition=lose
             [/objective]
+            [objective]
+                description= _ "Death of Galtrid"
+                condition=lose
+            [/objective]
 
             [gold_carryover]
                 bonus=no
@@ -484,7 +488,7 @@ Chapter Four"
                     id=$this_item.id
                 [/role]
                 {MODIFY_UNIT (id=$this_item.id) facing ne}
-                {MODIFY_UNIT (id=$this_item.id) side 13}
+                {MODIFY_UNIT (id=$this_item.id) side 5}
             [/do]
         [/foreach]
 #endif
@@ -512,28 +516,18 @@ Chapter Four"
                     message= _ "Kalenz! We come to fight beside you!"
                 [/message]
                 [message]
-                    id=Kalenz
-                    message= _ "Where is the rest of the elvish army? They were promised and should be here!"
-                [/message]
-                [message]
-                    role=l3_store
-                    message= _ "The Great Council has decided it was too risky to send troops here. But some of us dissented and have come to fight beside you."
-                [/message]
-                [message]
+                    # The player already knows that the kalian refused to help, Galtrid said it on turn 1.
+                    # Repeat Landar's comment from then, but not the rest of the conversation; if too much text is repeated the player may think a bug has triggered the event twice.
                     id=Landar
                     message= _ "That is well! If the Ka’lian is too fearful or blind to see what is needed, we must do it ourselves."
                 [/message]
                 [message]
-                    id=Cleodil
-                    message= _ "It is not well that we have become so divided as this."
-                [/message]
-                [message]
+                    # This text is from 04_The_Elvish_Treasury, reused unchanged because of the string freeze
                     id=Kalenz
-                    message= _ "No, it is not. But if we do not defeat these orcs here and now our divisions will all be moot. I will take every sword-arm I can get and be glad of them."
+                    message= _ "I accept your service gratefully, for I will need every sword and bow and spell with which to defeat these invaders. There will be time for talk later; now, we must fight."
                 [/message]
             [/then]
         [/if]
-        #TODO else -- the player has to know that the kalian refused help.
         {CLEAR_VARIABLE l3_store_kalenz}
 #ifdef MULTIPLAYER
         {CLEAR_VARIABLE l3_store_landar}


### PR DESCRIPTION
Objectives: note that the death of Galtrid is a losing condition

Dialog: the following conversation happened on both turn 1 and turn 9.
Having 6 repeated messages in a row gave a strong sense of deja vu,
and I thought that a bug had repeated an event. This commit cuts the
repetition.

* Elf: "Kalenz! We come to fight beside you!"
* Kalenz: "Where is the rest of the elvish army? ...
* Elf: "The Great Council has decided it was too risky ...
* Landar: "That is well! If the Ka’lian is too fearful or blind ...
* Cleodil: "It is not well that we have become so divided as this."
* Kalenz: "No, it is not. But ...