### PR TITLE
Don't source steps/script.sh.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
     - . ./utils/travis/steps/install.sh
 
 script:
-    - . ./utils/travis/steps/script.sh
+    - ./utils/travis/steps/script.sh
 
 notifications:
     email: false

--- a/utils/travis/docker_run.sh
+++ b/utils/travis/docker_run.sh
@@ -54,11 +54,15 @@ else
     echo "compiler_check = content" >> $HOME/.ccache/ccache.conf
     
     cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_GAME=true -DENABLE_SERVER=true -DENABLE_CAMPAIGN_SERVER=true -DENABLE_TESTS=true -DENABLE_NLS=false -DEXTRA_FLAGS_CONFIG="-pipe" -DEXTRA_FLAGS_RELEASE="$EXTRA_FLAGS_RELEASE" -DENABLE_STRICT_COMPILATION="$STRICT" -DENABLE_LTO=false -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache && make VERBOSE=1 -j2
+    BUILD_RET=$?
+    
+    ccache -s
+    ccache -z
   else
     scons wesnoth wesnothd campaignd boost_unit_tests build=release ctool=$CC cxxtool=$CXX --debug=time extra_flags_config="-pipe" extra_flags_release="$EXTRA_FLAGS_RELEASE" strict="$STRICT" cxx_std=$CXXSTD nls=false jobs=2 enable_lto=false
+    BUILD_RET=$?
   fi
   
-  BUILD_RET=$?
   if [ $BUILD_RET != 0 ]; then
     exit $BUILD_RET
   fi

--- a/utils/travis/steps/script.sh
+++ b/utils/travis/steps/script.sh
@@ -12,6 +12,13 @@ if [ "$TRAVIS_OS_NAME" = "osx" ]; then
         export CCACHE_COMPILERCHECK=content
 
         xcodebuild -project Wesnoth.xcodeproj -target Wesnoth
+        
+        BUILD_RET=$?
+        
+        ccache -s
+        ccache -z
+        
+        exit $BUILD_RET
     else
         ln -s build-cache/ build
         ./utils/travis/check_utf8.sh


### PR DESCRIPTION
Travis runs all commands in .travis.yml in its own wrapper script, so by sourcing steps/script.sh and then using exit explicitly, it resulted in the entire travis wrapper immediately terminating.  With steps/script.sh no longer sourced, using exit works as expected again, and only exits steps/script.sh rather than quitting everything.

With that addressed, it's also possible to re-add printing the ccache statistics after the build ends.

---

An example of when it quit immediately: https://travis-ci.org/wesnoth/wesnoth/jobs/348757536
A test with this fix where I hard-coded it to exit with 0: https://travis-ci.org/Pentarctagon/wesnoth/jobs/348801187
And another test hard-coded to exit with 65(xcodebuild's compile failure exit code): https://travis-ci.org/Pentarctagon/wesnoth/jobs/348805244