### PR TITLE
campaignd: Add support for free-form tags on add-ons

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,7 @@
 Version 1.13.11+dev:
+ * Add-ons server:
+   * Added support for adding free-form comma-separated tags to add-ons in
+     their publishing info (bug #2565).
  * Language and i18n:
    * Updated translations: British English, Spanish
  * Lua API:

--- a/src/addon/info.cpp
+++ b/src/addon/info.cpp
@@ -79,6 +79,7 @@ void addon_info::read(const config& cfg)
 
 	this->core = cfg["core"].str();
 	this->depends = utils::split(cfg["dependencies"].str());
+	this->tags = utils::split(cfg["tags"].str());
 	this->feedback_url = cfg["feedback_url"].str();
 
 	this->updated = cfg["timestamp"].to_time_t();
@@ -106,6 +107,7 @@ void addon_info::write(config& cfg) const
 
 	cfg["core"] = this->core;
 	cfg["dependencies"] = utils::join(this->depends);
+	cfg["tags"] = utils::join(this->tags);
 	cfg["feedback_url"] = this->feedback_url;
 
 	cfg["timestamp"] = this->updated;

--- a/src/addon/info.hpp
+++ b/src/addon/info.hpp
@@ -44,6 +44,7 @@ struct addon_info
 
 	ADDON_TYPE type;
 
+	std::vector<std::string> tags;
 	std::vector<std::string> locales;
 
 	std::string core;
@@ -68,7 +69,7 @@ struct addon_info
 	addon_info()
 		: id(), title(), description(), icon()
 		, version(), author(), size(), downloads()
-		, uploads(), type(), locales()
+		, uploads(), type(), tags(), locales()
 		, core()
 		, depends()
 		, feedback_url()
@@ -81,7 +82,7 @@ struct addon_info
 	explicit addon_info(const config& cfg)
 		: id(), title(), description(), icon()
 		, version(), author(), size(), downloads()
-		, uploads(), type(), locales()
+		, uploads(), type(), tags(), locales()
 		, core()
 		, depends()
 		, feedback_url()
@@ -105,6 +106,7 @@ struct addon_info
 			this->downloads = o.downloads;
 			this->uploads = o.uploads;
 			this->type = o.type;
+			this->tags = o.tags;
 			this->locales = o.locales;
 			this->core = o.core;
 			this->depends = o.depends;

--- a/src/campaign_server/campaign_server.cpp
+++ b/src/campaign_server/campaign_server.cpp
@@ -765,6 +765,7 @@ void server::handle_upload(const server::request& req)
 		(*campaign)["dependencies"] = upload["dependencies"];
 		(*campaign)["upload_ip"] = req.addr;
 		(*campaign)["type"] = upload["type"];
+		(*campaign)["tags"] = upload["tags"];
 		(*campaign)["email"] = upload["email"];
 
 		if(!existing_upload) {
@@ -795,6 +796,7 @@ void server::handle_upload(const server::request& req)
 		data["original_timestamp"] = (*campaign)["original_timestamp"];
 		data["icon"] = (*campaign)["icon"];
 		data["type"] = (*campaign)["type"];
+		data["tags"] = (*campaign)["tags"];
 		(*campaign).clear_children("translation");
 		find_translations(data, *campaign);
 


### PR DESCRIPTION
This adds a `tags=` attribute to the pbl WML that can be used to specify comma-separated tags to let users filter on them on the Add-ons Manager.

We don't do anything fancy with the tags at the moment since they can be matched with the existing filter algorithm without any changes, with the caveat that the word separator the filter box uses is whitespace instead of commas -- meaning that to match multiple tags they must be specified with spaces between them, in any order, and that pasting the tags from the WML into the filter box will not yield a match as some people might expect.

There is also no UI for the tags right now other than the filter box, so they are little more than an implementation detail hidden from the user.

See also issue #2565.