### PR TITLE
Attempt to fix suspected race condition when running MP tests.

### DIFF
--- a/utils/travis/mp_test_executor.sh
+++ b/utils/travis/mp_test_executor.sh
@@ -9,8 +9,12 @@ LOOP_TIME=6
 ./wesnothd --port 12345 --log-debug=server --log-warning=config &
 serverpid=$!
 
+sleep 5
+
 ./wesnoth --plugin=host.lua --server=localhost:12345 --username=host --mp-test --noaddons --nogui &
 hostpid=$!
+
+sleep 5
 
 ./wesnoth --plugin=join.lua --server=localhost:12345 --username=join --mp-test --noaddons --nogui &
 joinpid=$!

--- a/utils/travis/steps/script.sh
+++ b/utils/travis/steps/script.sh
@@ -27,8 +27,5 @@ if [ "$TRAVIS_OS_NAME" = "osx" ]; then
         scons wesnoth wesnothd campaignd boost_unit_tests build=release ctool="$CC" cxxtool="$CXX" --debug=time extra_flags_config="-pipe" extra_flags_release="$EXTRA_FLAGS_RELEASE" strict=true cxx_std="$CXXSTD" nls="$NLS" jobs=2 enable_lto=false
     fi
 else
-    export DISPLAY=:99.0
-    /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1024x768x24
-
     docker run -v "$PWD"/build-cache:/home/wesnoth-travis/build -v "$HOME"/.ccache:/root/.ccache wesnoth-repo:16.04 bash -c './utils/travis/docker_run.sh "$@"' bash "$NLS" "$TOOL" "$CC" "$CXX" "$CXXSTD" "$EXTRA_FLAGS_RELEASE" "$WML_TESTS" "$WML_TEST_TIME" "$PLAY_TEST" "$MP_TEST" "$BOOST_TEST"
 fi


### PR DESCRIPTION
Currently the MP unit tests will randomly fail due to one of the two background wesnoth instances failing video initialization.  All unit tests require the display server to be initialized however, or they fail with the same error as the MP tests sometimes fail with.  However, the MP tests are the only tests to randomly fail due to video initialization, while for the same travis job the WML unit tests (which run before) and the boost unit tests (which run after) are still able to be successfully completed.

Therefore, the video initialization failures are not entirely random, and the MP tests are also the only tests that experience this failure while also being the only tests that have more than one instance of wesnoth running simultaneously.

tl;dr: the attempted solution here is to sleep for 5 seconds between starting background processes in the mp unit test script.

Also removes starting the display server prior outside of the docker container, since that's not needed anymore.

---

Example of MP test failure: https://travis-ci.org/wesnoth/wesnoth/jobs/345776363#L2276-L2282
Example of what happens for non-MP tests when the display server isn't started: https://travis-ci.org/Pentarctagon/wesnoth/jobs/348985371#L1138