### PR TITLE
don't generate [side]s if the [multiplayer] has at least one [side] defined

### DIFF
--- a/src/game_initialization/create_engine.cpp
+++ b/src/game_initialization/create_engine.cpp
@@ -106,12 +106,14 @@ void scenario::set_sides()
 		// starting positions, then generate the additional sides
 		const int map_positions = map_->num_valid_starting_positions();
 
-		for(int pos = data_.child_count("side"); pos < map_positions; ++pos) {
-			config& side = data_.add_child("side");
-			side["side"] = pos + 1;
-			side["team_name"] = "Team " + std::to_string(pos + 1);
-			side["canrecruit"] = true;
-			side["controller"] = "human";
+		if(data_.child_count("side") == 0) {
+			for(int pos = 0; pos < map_positions; ++pos) {
+				config& side = data_.add_child("side");
+				side["side"] = pos + 1;
+				side["team_name"] = "Team " + std::to_string(pos + 1);
+				side["canrecruit"] = true;
+				side["controller"] = "human";
+			}
 		}
 
 		num_players_ = 0;


### PR DESCRIPTION
as suggested in #2604 this prevents the engine form adding more [side]s if the scenario has at least one [side] defined. The usecase given in #2604 is that one migth for example want to reuse one map with 6 starting positions in multiple different [multiplayer] tags, one with 6 sides and one with 3 sides.

But there might also be usecases where the old bahviour is helpful, so i'm leaving this open for now.