### PR TITLE
fix no_leader having no effect

### DIFF
--- a/src/game_initialization/flg_manager.cpp
+++ b/src/game_initialization/flg_manager.cpp
@@ -36,8 +36,8 @@ flg_manager::flg_manager(const std::vector<const config*>& era_factions,
 	, side_(side)
 	, saved_game_(saved_game)
 	, has_no_recruits_(get_original_recruits(side_).empty() && side_["previous_recruits"].empty())
-	, faction_lock_(side_["faction_lock"].to_bool(lock_settings) && (use_map_settings || lock_settings))
-	, leader_lock_(side_["leader_lock"].to_bool(lock_settings) && (use_map_settings || lock_settings))
+	, faction_lock_(side_["faction_lock"].to_bool(lock_settings))
+	, leader_lock_(side_["leader_lock"].to_bool(lock_settings))
 	, available_factions_()
 	, available_leaders_()
 	, available_genders_()
@@ -80,6 +80,9 @@ flg_manager::flg_manager(const std::vector<const config*>& era_factions,
 			default_leader_cfg_ = nullptr;
 		}
 	}
+		
+	leader_lock_ = leader_lock_ && (use_map_settings || lock_settings || default_leader_type_.empty());
+	faction_lock_ = faction_lock_ && (use_map_settings || lock_settings);
 
 	update_available_factions();
 

--- a/src/game_initialization/flg_manager.cpp
+++ b/src/game_initialization/flg_manager.cpp
@@ -275,7 +275,7 @@ void flg_manager::update_available_leaders()
 {
 	available_leaders_.clear();
 
-	if(!default_leader_type_.empty() || !side_["no_leader"].to_bool() || !leader_lock_) {
+	if(!default_leader_type_.empty() || !(side_["no_leader"].to_bool() || leader_lock_)) {
 
 		int random_pos = 0;
 		// Add a default leader if there is one.

--- a/src/game_initialization/flg_manager.hpp
+++ b/src/game_initialization/flg_manager.hpp
@@ -29,7 +29,7 @@ class flg_manager
 {
 public:
 	flg_manager(const std::vector<const config*>& era_factions,
-		const config& side, const bool faction_lock, const bool leader_lock, const bool saved_game);
+		const config& side, bool lock_settings, bool use_map_settings, bool saved_game);
 
 	void set_current_faction(const unsigned index);
 	void set_current_faction(const std::string& id);
@@ -109,8 +109,8 @@ private:
 	const bool saved_game_;
 	const bool has_no_recruits_;
 
-	const bool faction_lock_;
-	const bool leader_lock_;
+	bool faction_lock_;
+	bool leader_lock_;
 
 	// All factions which could be played by a side (including Random).
 	std::vector<const config*> available_factions_;


### PR DESCRIPTION
it previously only worked if both leader_lock and no_leader were set to yes.

from looking at the code i wonder what currently is the point of no_leader at all. I think no type= attribute together with leader_lock=yes should have the same effect? 

#2604