### PR TITLE
Change more mentions of "Shadow Master" to "shadowm"

### DIFF
--- a/data/campaigns/Legend_of_Wesmere/HISTORY
+++ b/data/campaigns/Legend_of_Wesmere/HISTORY
@@ -262,7 +262,7 @@ r1665 | AI0867 | 2008-09-20 09:04:32 -0400 (Sat, 20 Sep 2008) | 1 line
 ------------------------------------------------------------------------
 r1664 | fabi_wesnoth | 2008-09-20 08:34:18 -0400 (Sat, 20 Sep 2008) | 3 lines
 
-added random spawn macro from iftu -- thanks to shadow master
+added random spawn macro from iftu -- thanks to shadowm
 new macro for assigning all villages to one side at scenario prestart
 
 ------------------------------------------------------------------------
@@ -1692,14 +1692,14 @@ still not working because the ai seems to new were the leader is, weather or not
 ------------------------------------------------------------------------
 r1165 | fabi_wesnoth | 2008-08-29 05:04:06 -0400 (Fri, 29 Aug 2008) | 4 lines
 
-fixed Shadow Master's issues
+fixed shadowm's issues
 removed side 4 and 5, ai change is now done with modify_side
 more code cleanups
 
 ------------------------------------------------------------------------
 r1164 | fabi_wesnoth | 2008-08-29 04:57:39 -0400 (Fri, 29 Aug 2008) | 6 lines
 
-fixed the issues mentioned by Shadow Master in the forum.
+fixed the issues mentioned by shadowm in the forum.
 speaker --> id
 removed the usage of the temp variable for switching sides of velon
 removed old wml code

--- a/data/campaigns/Legend_of_Wesmere/utils/low-macros.cfg
+++ b/data/campaigns/Legend_of_Wesmere/utils/low-macros.cfg
@@ -147,7 +147,7 @@ Elvish Shaman, Elvish Shyde, Elvish Enchantress, Elvish Sorceress, Elvish Sylph,
     [/event]
 #enddef
 
-# Thanks to Shadow Master for this macro
+# Thanks to shadowm for this macro
 # !***Macro to random place unit within area***
 #define RANDOM_PLACEMENT _X _Y _RADIUS _WML
     [random_placement]

--- a/doc/design/umcd/introduction.tex
+++ b/doc/design/umcd/introduction.tex
@@ -3,7 +3,7 @@
 
 This paper describes the design and communication protocol of the umcd,
 which stands for \emph{U}ser \emph{M}ade \emph{C}ontent \emph{D}aemon. The
-name was first used by Shadow master.
+name was first used by Shadowm.
 
 The server has several new features planned:
 \begin{description}

--- a/misc/fortunes/wesnoth
+++ b/misc/fortunes/wesnoth
@@ -1,4 +1,4 @@
-<ESR_> Shadow_Master: I found out how your file confuses wmlindent.  It's the frowny face at the end of the comment on line 51. :-)
+<ESR_> Shadowm: I found out how your file confuses wmlindent.  It's the frowny face at the end of the comment on line 51. :-)
 <ESR_> You frowned at wmlindent and it became confused and distraught.
 <ESR_> You hurt its widdle feelings.  You bad person. :-)
   -- #wesnoth-dev, 2008-08-29
@@ -6,7 +6,7 @@
 <Ivanovic> Sirp_: short version: esr has done a whole massacre to WML
 <Ivanovic> ;)
  * esr notes that Ivanovic egged him on.
-<Shadow_Master> *sniff* Long live the MWL!
+<Shadowm> *sniff* Long live the MWL!
 <Ivanovic> esr: you know, i am some kind of psychopath...
 <Sirp_> Ivanovic: ahhh that is okay
 <Ivanovic> esr: every now and then a real massacre is needed...
@@ -40,8 +40,8 @@
 Another consequence of changing the initial implementation of the world:
 
 <zookeeper> interesting bug
-<Shadow_Master> zookeeper: I suppose it's a legacy bug; Wesnoth didn't support female "variations" of units from the beginning IIRC
-<Shadow_Master> so this piece of code was not updated when females were "implemented"
+<Shadowm> zookeeper: I suppose it's a legacy bug; Wesnoth didn't support female "variations" of units from the beginning IIRC
+<Shadowm> so this piece of code was not updated when females were "implemented"
 
   -- #wesnoth-dev, 2008-03-03
 %
@@ -53,23 +53,23 @@ User #4: Summoners came from all Wesnoth to vanquish the remaining heathens, by 
 User #5: Peace returned to the land but many good threads were lost during the fighting, let us never forget their sacrifice.
 User #6: And a few people left. Like turin.
 User #7: May we never forget the many who gave their lives to avert this disaster.
-Shadow Master: Welcome back, O forum Sith! We need to control the vermin who dare hamper our O awesome work by spamming the forums with dreaded FPIs, so thine help is so much appreciated!
+Shadowm: Welcome back, O forum Sith! We need to control the vermin who dare hamper our O awesome work by spamming the forums with dreaded FPIs, so thine help is so much appreciated!
 
   -- From a Wesnoth Off-topic forum thread, 2008-08-25
 %
- * Shadow_Master attacks vonhalenbach. Critical hit! vonhalenbach dies. Shadow_Master gets 10 XP. 60/58 XP reached! Leveling up option: Shadow Master L6, Shadow Lawyer. Chose: Shadow Lawyer! Shadow_Master turns into a Shadow Lawyer
+ * Shikadi_Queen attacks vonhalenbach. Critical hit! vonhalenbach dies. Shikadi_Queen gets 10 XP. 60/58 XP reached! Leveling up option: Shikadi Queen L6, Shikadi Lawyer. Chose: Shikadi Lawyer! Shikadi_Queen turns into a Shikadi Lawyer
 <vonhalenbach>	You are a Lawyer?
 <esr>	AAARRGGHH!  Run for your lives!
-<Shadow_Master>	actually, no :P
+<Shikadi_Queen>	actually, no :P
 <vonhalenbach>	good.
-<Shadow_Master>	esr: :)
+<Shikadi_Queen>	esr: :)
 <esr>	I'm married to a lawyer.
-<Shadow_Master>	is it good?
+<Shikadi_Queen>	is it good?
 <esr>	Except for her brutal work schedule, yes.
-<Shadow_Master>	ah
-<Shadow_Master>	I thought she'd talk about laws all time you'd be with her
+<Shikadi_Queen>	ah
+<Shikadi_Queen>	I thought she'd talk about laws all time you'd be with her
 <esr>	Er, no.  I have ways to distract her ;-)
-<Shadow_Master>	ah :)
+<Shikadi_Queen>	ah :)
 %
 Q: What unites Wesnoth developers?
 A: 3 hours sleep per night
@@ -140,13 +140,13 @@ A number of people have noted a striking similarity in the appearance of the dar
 <Ivanovic> but i am just the release bot, so i don't care about those implementation details...
   -- #wesnoth-dev, 2008-03-06
 %
-01:06 <Shadow_Master> uhm... you can tell me who is the expert on saved games here
+01:06 <Shadowm> uhm... you can tell me who is the expert on saved games here
 01:10 <Sirp> usually it's not so much a matter of an 'expert'. Just a capable programmer who is willing to step up to the plate and dive into the code and work out what is going on.
 01:10 <Sirp> you are welcome to try to go for it yourself. :)
-01:10 <Shadow_Master> I have put my head into the most smelly places of wesnoth trying to get the bug's cause
-01:10 <Shadow_Master> and I haven't succeeded.
+01:10 <Shadowm> I have put my head into the most smelly places of wesnoth trying to get the bug's cause
+01:10 <Shadowm> and I haven't succeeded.
 [...]
-01:27 <Shadow_Master> yipee! I FIXED IT!!!!
+01:27 <Shadowm> yipee! I FIXED IT!!!!
   -- #wesnoth-dev, 2008-05-08
 %
 Dret: I want to expose a strange situation that take effect using teleport feature.
@@ -154,25 +154,25 @@ Dret: I want to expose a strange situation that take effect using teleport featu
 Sapient: sounds like a bug
 Dret: Do You suggest me to send a report to code developers...??
 Sapient: yes, those silly "developer" people probably want to know about it ;)
-Shadow Master: Huh? Hmm...
+Shadowm: Huh? Hmm...
 %
 A 'save the wings' movement? :P
   -- cycholka, on why Desert Elves should not have winged shydes.
 %
-01:19 <Shadow_Master> niice: http://www.wesnoth.org/forum/viewtopic.php?f=5&t=21612
+01:19 <Shadowm> niice: http://www.wesnoth.org/forum/viewtopic.php?f=5&t=21612
 [...]
-20:39 <Shadow_Master> ilor: nice, thanks
+20:39 <Shadowm> ilor: nice, thanks
 [...]
-23:20 <Shadow_Master> nice
+23:20 <Shadowm> nice
 [...]
-23:23 <Shadow_Master> nice
+23:23 <Shadowm> nice
 [...]
-23:23 <Shadow_Master> not nice
+23:23 <Shadowm> not nice
 [...]
-23:24 <Shadow_Master> niiice
+23:24 <Shadowm> niiice
   -- #wesnoth-dev, 2008-08-12
 %
-23:28 -!- Shadow_Master [n=user@host.tld] has quit ["Insert witticism here."]
+23:28 -!- Shadowm [n=user@host.tld] has quit ["Insert witticism here."]
 23:29 -!- loonycyborg [n=user@host.tld] has quit ["Zzzzzzzzzzzzzzzzz"]
 23:36 <isaac> :D
   -- #wesnoth-dev, 2008-08-11
@@ -180,15 +180,15 @@ A 'save the wings' movement? :P
 Battle for Wesnoth, The Open-Source Game With Rampantly High Amounts Of Acronyms Everywhere.
 (BFWTOSGWRHAOAE).
 %
-<Shadow_Master> Admins have complete control over all aspects of the forum,
+<Shadowm> Admins have complete control over all aspects of the forum,
                 AFAICT
  * Kestenvarn is attacked by unwieldy acronym. Unwieldy acronym hits! Critical
    hit! Kest dies!
-<Shadow_Master> AFAICT: As Far As I Can Tell
-<Shadow_Master> not too difficult to guess, is it?
-<Kestenvarn> Shadow_Master: what is the point of peaking a common language you
+<Shadowm> AFAICT: As Far As I Can Tell
+<Shadowm> not too difficult to guess, is it?
+<Kestenvarn> Shadowm: what is the point of peaking a common language you
              still have to translate? >:[
-<Shadow_Master> Um, the acronym is common AFAICT
+<Shadowm> Um, the acronym is common AFAICT
  * Kestenvarn eats your filthy acronyms D:<
   -- #wesnoth-dev, 2007-11-06
 %
@@ -205,15 +205,15 @@ DISCLAIMER:
 cobra: Very cool. When you making the Demolich? Can't wait to see it.
 Orcish Shyde: Sadly, I don't think I'll ever get round to making a Demolition Lich.
 %
-<Shadow_Master> playing IftU scenario 1, both AI players recruited on first turn whole castles, the second AI moved its leader; but on the second turn, only the last AI player moved a unit besides the leader, after moving the leader back to the keep
-<Shadow_Master> I cannot playtest under these conditions. Argh. My plan of releasing before Nov. 10th is spoiled.
-<loonycyborg> Shadow_Master: I'm getting the same.
+<Shadowm> playing IftU scenario 1, both AI players recruited on first turn whole castles, the second AI moved its leader; but on the second turn, only the last AI player moved a unit besides the leader, after moving the leader back to the keep
+<Shadowm> I cannot playtest under these conditions. Argh. My plan of releasing before Nov. 10th is spoiled.
+<loonycyborg> Shadowm: I'm getting the same.
 <loonycyborg> Which kinda breaks the story :)
-<Shadow_Master> {ATTACK_DEPTH 2 2 3} <- perhaps the AI is extremely scared?
+<Shadowm> {ATTACK_DEPTH 2 2 3} <- perhaps the AI is extremely scared?
 <loonycyborg> Or not. Their leader calls them sluggards. That's why they don't move. They're sluggards :)
 [...]
-<Shadow_Master> loonycyborg: can you test if IftU still breaks with the AI?
-<loonycyborg> Shadow_Master: Yes. They're still sluggards :(
+<Shadowm> loonycyborg: can you test if IftU still breaks with the AI?
+<loonycyborg> Shadowm: Yes. They're still sluggards :(
 %
 <mordante> esr removing #include <foo.hpp> from foo.cpp is a really bad idea in general
 <esr> That's the trouble with mechanical tools.
@@ -244,7 +244,7 @@ Those different scenarios will be popular for a while, and then people will retu
   -- Glowing Fish on OCW - The Order of Classical Wesnoth
 %
 grzywacz: You have my bow.
-Shadow Master: And my axe!
+Shadowm: And my axe!
 
   -- The Order of Classical Wesnoth
 %
@@ -252,7 +252,7 @@ Radament: But really, instead of playing isars you could as well roll dice and s
 %
 Let's continue adding samples of our silly sense of humor, and perhaps Debian starts including a fortunes-wesnoth package soon!
 
-  -- Shadow Master
+  -- Shadowm
 %
 What does "Unknown Scenario" mean, other than the obvious?
 
@@ -290,8 +290,8 @@ How about a funny cookie once in a while? :|
 
   -- #wesnoth-dev, 2009-10-06, during the feature-freeze period for 1.8
 %
-<shadowmaster> I'd love to see a WML library that could be used not only by Wesntoh and Frogatto. :(
-<shadowmaster> I am unworthy. I misspelled "Wesnoth".
+<shadowm> I'd love to see a WML library that could be used not only by Wesntoh and Frogatto. :(
+<shadowm> I am unworthy. I misspelled "Wesnoth".
 
   -- #wesnoth-dev, 2009-12-10
 %
@@ -302,14 +302,14 @@ I didn't know these rules. Please don't eat me.
 Ok, i don't find a solution, so i reinstall windows...
   -- Windows user who couldn't run Wesnoth anymore
 
-<shadowmaster> I feel sad for those poor guys ;(
+<shadowm> I feel sad for those poor guys ;(
   -- In some freenode channel, 2009-11-19
 %
 <zookeeper> someone ought to make an era called era of factions
   -- #wesnoth-umc-dev, 2009-12-16
 %
-<shadowmaster> sounds like Windows 1.8 would work very well if released now
-<shadowmaster> ...no, I didn't intend to put "Windows" there. But I believe it works too.
+<shadowm> sounds like Windows 1.8 would work very well if released now
+<shadowm> ...no, I didn't intend to put "Windows" there. But I believe it works too.
   -- #wesnoth-dev, 2010-01-10
 %
 Glowing Fish: Well, I will be man enough to admit that if I saw some women cosplaying as anything from the Elvish Shaman line, it would be the high point of my day.
@@ -319,36 +319,36 @@ Be nice to noobz, you may one day find yourself bowing before one seated on a ni
 
   -- Midnight_Carnival
 %
-<Unnheulu> shadowmaster: anyways, in a sentence can you tell me what makes a good campaign?
-<shadowmaster> um, pasta
+<Unnheulu> shadowm: anyways, in a sentence can you tell me what makes a good campaign?
+<shadowm> um, pasta
 <Unnheulu> ok
-<shadowmaster> stuff pasta into it and it's good enough
+<shadowm> stuff pasta into it and it's good enough
 <Unnheulu> I'll make a spaghetti monster
 <Unnheulu> :-D
 <Unnheulu> it'll sure to be mainline :D
 %
-<shadowmaster> why there was nobody to protect that arrogant b****, why?
-<shadowmaster> I COULD KILL HER WITH ONE SINGLE UNIT AFTER BEATING HER ARMY IN 3 TURNS
+<shadowm> why there was nobody to protect that arrogant b****, why?
+<shadowm> I COULD KILL HER WITH ONE SINGLE UNIT AFTER BEATING HER ARMY IN 3 TURNS
 
-  -- shadowmaster on Battle for Wesnoth (the HttT scenario)
+  -- shadowm on Battle for Wesnoth (the HttT scenario)
 %
 Okay, that will be piece of cake. "*knock knock* Hello! I'm a Wesnoth developer and it turns out that some artist messed up and we need our history modified to delete a certain commit! tee hee!"
 
-  -- shadowmaster on Eleazar's r43606, #wesnoth-dev, 2010-06-20
+  -- shadowm on Eleazar's r43606, #wesnoth-dev, 2010-06-20
 %
 "Hosts ban power abuser!" sounds like a good slogan for an energy drink for some reason.
 
-  -- shadowmaster on some forum thread, #wesnoth, 2010-06-22
+  -- shadowm on some forum thread, #wesnoth, 2010-06-22
 %
-<shadowmaster> I also think that she's too stripperiffic for an elvish princess, as far as Wesnoth standards are concerned.
-<shadowmaster> it *is* possible to have sexy women without having them half-naked
-<shadowmaster> case in point:
-<Aethaeryn> shadowmaster: don't show entirely-naked women in this channel. that's inappropriate
-<shadowmaster> Aethaeryn: I don't care.
-<shadowmaster> this is my channel, I make the rules
-<shadowmaster> http://forums.wesnoth.org/download/file.php?id=25236&mode=view
+<shadowm> I also think that she's too stripperiffic for an elvish princess, as far as Wesnoth standards are concerned.
+<shadowm> it *is* possible to have sexy women without having them half-naked
+<shadowm> case in point:
+<Aethaeryn> shadowm: don't show entirely-naked women in this channel. that's inappropriate
+<shadowm> Aethaeryn: I don't care.
+<shadowm> this is my channel, I make the rules
+<shadowm> http://forums.wesnoth.org/download/file.php?id=25236&mode=view
 
-  -- shadowmaster on a certain Elvish Princess portrait by Valkier, #wesnoth-umc-dev, 2010-07-07
+  -- shadowm on a certain Elvish Princess portrait by Valkier, #wesnoth-umc-dev, 2010-07-07
 %
 <CIA-86> anonymissimus * r47553 /trunk/ (4 files in 4 dirs):
 <CIA-86> Created tag [petrify] (bug #17077).
@@ -359,8 +359,8 @@ Okay, that will be piece of cake. "*knock knock* Hello! I'm a Wesnoth developer 
 
   -- #wesnoth-dev, 2010-11-14
 %
-<Gambit> shadowmaster: make the forums faster
-<shadowmaster> okay
+<Gambit> shadowm: make the forums faster
+<shadowm> okay
   -- Random IRC channel, 2010-11-24
 %
 <Daerun> hi there
@@ -381,7 +381,7 @@ Okay, that will be piece of cake. "*knock knock* Hello! I'm a Wesnoth developer 
 <epyon> woah, what a hangover... spent the night playing Wesnoth O.o
   -- #wesnoth-dev, 2011-04-11
 %
-<shadowmaster> %namegen m demon
+<shadowm> %namegen m demon
 <@Rei2> Noy
   -- Random IRC channel, 2011-10-02
 %


### PR DESCRIPTION
The one that needs a two-word name changes to Shikadi_Queen instead.

Was code-reviewing LoW, and spotted the comment for the RANDOM_PLACEMENT macro.
I also checked if that could be replaced with the core SCATTER_UNITS macro, but
SCATTER_UNITS seems to be overcomplex for the case of placing a single unit.