### PR TITLE
LoW save the persistent multiplayer data for chapter 2 (fixes #2637)

### DIFF
--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg
@@ -663,6 +663,21 @@
         [/message]
     [/event]
 
+    # There is a story-only scenario remaining in this chapter,
+    # but that doesn't have any fighting, and it doesn't have all
+    # of the mp sides active in it.
+    [event]
+        name=scenario_end
+        [filter_condition]
+            [proceed_to_next_scenario]
+            [/proceed_to_next_scenario]
+        [/filter_condition]
+
+        [persistent_carryover_store]
+            scenario_id = LoW_Chapter_Two
+        [/persistent_carryover_store]
+    [/event]
+
     {DEFAULT_VICTORY 0.4}
     {campaigns/Legend_of_Wesmere/utils/deaths.cfg}
     ###/DEATH EVENTS###

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter2/08_Council_of_Hard_Choices.cfg
@@ -133,15 +133,7 @@
         [/endlevel]
     [/event]
 
-    [event]
-        name=scenario_end
-        [filter_condition]
-            [proceed_to_next_scenario]
-            [/proceed_to_next_scenario]
-        [/filter_condition]
-
-        [persistent_carryover_store]
-            scenario_id = LoW_Chapter_Two
-        [/persistent_carryover_store]
-    [/event]
+    # The [persistent_carryover_store] for LoW_Chapter_Two is done
+    # at the end of 07_Elves_Last_Stand. There's no fighting in
+    # this scenario, and it doesn't have all of the mp sides.
 [/scenario]


### PR DESCRIPTION
In multiplayer mode, the LoW campaign has multiple start points, and some
persistent storage that stores the characters at the end of a chapter, so that
a new game starting from the next chapter starts with those stats.

The data for chapter 2 wasn't saved, because the campaign tried to create it in
a cutscene scenario that doesn't have the expected sides.