### PR TITLE
Add a way to launch the map editor with the same desktop file

### DIFF
--- a/packaging/wesnoth.desktop
+++ b/packaging/wesnoth.desktop
@@ -72,3 +72,23 @@ Comment[vi]=Một trò chơi chiến lược dựa trên lượt đi theo phong 
 Icon=wesnoth-icon
 Exec=wesnoth
 Categories=Game;StrategyGame;
+Actions=Editor;
+
+[Desktop Action Editor]
+Name=Map Editor
+Name[cs]=Editor map
+Name[de]=Karteneditor
+Name[es]=Editor de mapas
+Name[fi]=Kenttäeditori
+Name[fr]=Éditeur de cartes
+Name[gl]=Editor de mapas
+Name[hu]=pályaszerkesztő
+Name[it]=Editor delle mappe
+Name[lt]=žemėlapių redaktorius
+Name[pt]=Editor de mapas
+Name[sr]=Уређивач мапа
+Name[sr@ijekavian]=Уређивач мапа
+Name[sr@ijekavianlatin]=Uređivač mapa
+Name[sr@latin]=Uređivač mapa
+Name[tr]=Harita Düzenleyici
+Exec=wesnoth -e


### PR DESCRIPTION
similar to the extra options which Firefox has
with an right click one can launch the editor now
one could as well add an "cheating mode" option for -d
Maybe to some Developers an desktop action for the test scenario is useful too?
(just for inspiration, not to be added to the PR)

Many distributions use modified desktop files, and add a 2nd
to launch the map editor. I think that's a better idea, because
it's less hidden than this feature. However, I think one doesn't
out-rule the other.

The translations are taken from downstream's desktop files for
the map editor - unfortunately they aren't complete

Basically I think this can go in as is.

![actions](https://user-images.githubusercontent.com/21158813/37265070-4c7ac44a-25b1-11e8-814d-71abbfd71f81.png)