### PR TITLE
Fix #2619, text_box_base: adapt to separated SDL_TextEditingEvent

### DIFF
--- a/src/gui/widgets/text_box_base.hpp
+++ b/src/gui/widgets/text_box_base.hpp
@@ -319,7 +319,6 @@ private:
 	// Values to support input method editors
 	bool ime_in_progress_;
 	int ime_start_point_;
-	int ime_cursor_;
 	int ime_length_;
 
 	size_t cursor_timer_;
@@ -488,7 +487,7 @@ protected:
 									const utf8::string& unicode);
 	virtual void handle_editing(bool& handled,
 								const utf8::string& unicode,
-								int32_t start, int32_t len);
+								int32_t start);
 
 private:
 	/**


### PR DESCRIPTION
In SDL_TextEditingEvent, size of editing_text is limited.
If length of composition text is more than the limit, it is separated to multiple SDL_TextEditingEvent.

Current code don't assume the multiple event so this requests fix it.