### PR TITLE
reset units upkeep on type change

### DIFF
--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -969,6 +969,9 @@ void unit::advance_to(const unit_type& u_type, bool use_traits)
 	max_attacks_ = new_type.max_attacks();
 
 	flag_rgb_ = new_type.flag_rgb();
+	
+	upkeep_ = upkeep_full();
+	parse_upkeep(new_type.get_cfg()["upkeep"]);
 
 	anim_comp_->reset_after_advance(&new_type);
 


### PR DESCRIPTION
this fixes 2 issues:
1) previously code like
```
[object]
  x,y=5,5
  id=a
  [effect]
    apply_to=loyal
  [/effect]
[/object]
[remove_object]
  x,y=5,5
  object_id=a
[/remove_object]
```
would leave the unit at 5,5 with a loyal upkeep even though the object was removed

2) fixes #1779