### PR TITLE
Use xBRZ in unit preview widget and faction selection dialog

### DIFF
--- a/src/gui/dialogs/multiplayer/faction_select.cpp
+++ b/src/gui/dialogs/multiplayer/faction_select.cpp
@@ -208,7 +208,7 @@ void faction_select::update_leader_image(window& window)
 
 	if(const unit_type* ut = unit_types.find(flg_manager_.current_leader())) {
 		const unit_type& utg = ut->get_gender_unit_type(flg_manager_.current_gender());
-		leader_image = formatter() << utg.image() << "~RC(" << utg.flag_rgb() << ">" << tc_color_ << ")" << "~SCALE_INTO_SHARP(144,144)";
+		leader_image = formatter() << utg.image() << "~RC(" << utg.flag_rgb() << ">" << tc_color_ << ")" << "~XBRZ(2)~SCALE(144,144)";
 	}
 
 	find_widget<image>(&window, "leader_image", false).set_label(leader_image);

--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -250,7 +250,7 @@ void unit_preview_pane::set_displayed_type(const unit_type& type)
 				 + ")";
 		}
 
-		mods += "~SCALE_INTO_SHARP(144,144)" + image_mods_;
+		mods += "~XBRZ(2)~SCALE(144,144)" + image_mods_;
 
 		icon_type_->set_label((type.icon().empty() ? type.image() : type.icon()) + mods);
 	}
@@ -394,7 +394,7 @@ void unit_preview_pane::set_displayed_unit(const unit& u)
 			mods += "~BLIT(" + overlay + ")";
 		}
 
-		mods += "~SCALE_INTO_SHARP(144,144)" + image_mods_;
+		mods += "~XBRZ(2)~SCALE(144,144)" + image_mods_;
 
 		icon_type_->set_label(u.absolute_image() + mods);
 	}


### PR DESCRIPTION
xBRZ scaling looks much better than currently used. Works well for all sprites sizes.

Resolves #1609 