### PR TITLE
Implement Liminal as a twilight bonus instead of night and day malus

### DIFF
--- a/data/core/help.cfg
+++ b/data/core/help.cfg
@@ -333,7 +333,7 @@ If a strike is determined to hit, it will always do at least 1 point of damage. 
 • <bold>text='Lawful'</bold> units get +25% damage in daytime, and −25% damage at night.
 • <bold>text='Chaotic'</bold> units get +25% damage at night, and −25% in daytime.
 • <bold>text='Neutral'</bold> units are unaffected by the time of day.
-• <bold>text='Liminal'</bold> units get −25% damage during both night and daytime." + _ "
+• <bold>text='Liminal'</bold> units get +25% damage during twilight." + _ "
 
 The current time of day can be observed under the minimap in the status pane. For the usual day/night cycle, morning and afternoon count as day, first and second watch count as night:
 

--- a/data/core/units/dunefolk/Apothecary.cfg
+++ b/data/core/units/dunefolk/Apothecary.cfg
@@ -27,7 +27,7 @@
         description= _ "mace"
         type=impact
         range=melee
-        damage=9
+        damage=7
         number=3
     [/attack]
 

--- a/data/core/units/dunefolk/Explorer.cfg
+++ b/data/core/units/dunefolk/Explorer.cfg
@@ -21,7 +21,7 @@
         description= _ "axe"
         type=blade
         range=melee
-        damage=8
+        damage=6
         number=4
     [/attack]
     [attack]
@@ -29,7 +29,7 @@
         description= _ "composite bow"
         type=pierce
         range=ranged
-        damage=8
+        damage=7
         number=4
         icon=attacks/bow-elven.png
     [/attack]

--- a/data/core/units/dunefolk/Harrier.cfg
+++ b/data/core/units/dunefolk/Harrier.cfg
@@ -26,7 +26,7 @@
         icon=attacks/longsword.png
         type=blade
         range=melee
-        damage=10
+        damage=8
         number=5
     [/attack]
 

--- a/data/core/units/dunefolk/Herbalist.cfg
+++ b/data/core/units/dunefolk/Herbalist.cfg
@@ -25,7 +25,7 @@
         description= _ "mace"
         type=impact
         range=melee
-        damage=7
+        damage=6
         number=2
     [/attack]
     [attack_anim]

--- a/data/core/units/dunefolk/Ranger.cfg
+++ b/data/core/units/dunefolk/Ranger.cfg
@@ -22,7 +22,7 @@
         description= _ "axe"
         type=blade
         range=melee
-        damage=10
+        damage=8
         number=4
     [/attack]
     [attack]
@@ -30,7 +30,7 @@
         description= _ "composite bow"
         type=pierce
         range=ranged
-        damage=10
+        damage=8
         number=4
         icon=attacks/bow-elven.png
     [/attack]

--- a/data/core/units/dunefolk/Rider.cfg
+++ b/data/core/units/dunefolk/Rider.cfg
@@ -22,7 +22,7 @@
         description= _ "mace"
         type=impact
         range=melee
-        damage=5
+        damage=4
         number=2
     [/attack]
     [attack]
@@ -31,7 +31,7 @@
         icon=attacks/bow-elven.png
         type=pierce
         range=ranged
-        damage=7
+        damage=6
         number=3
     [/attack]
 

--- a/data/core/units/dunefolk/Rover.cfg
+++ b/data/core/units/dunefolk/Rover.cfg
@@ -21,7 +21,7 @@
         description= _ "axe"
         type=blade
         range=melee
-        damage=5
+        damage=4
         number=3
     [/attack]
     [attack]
@@ -30,7 +30,7 @@
         icon=attacks/bow-elven.png
         type=pierce
         range=ranged
-        damage=6
+        damage=5
         number=3
     [/attack]
     [attack_anim]

--- a/data/core/units/dunefolk/Skirmisher.cfg
+++ b/data/core/units/dunefolk/Skirmisher.cfg
@@ -25,7 +25,7 @@
         icon=attacks/longsword.png
         type=blade
         range=melee
-        damage=9
+        damage=7
         number=4
     [/attack]
 

--- a/data/core/units/dunefolk/Swiftrider.cfg
+++ b/data/core/units/dunefolk/Swiftrider.cfg
@@ -22,7 +22,7 @@
         description= _ "mace"
         type=impact
         range=melee
-        damage=7
+        damage=6
         number=2
     [/attack]
     [attack]
@@ -31,7 +31,7 @@
         icon=attacks/bow-elven.png
         type=pierce
         range=ranged
-        damage=9
+        damage=7
         number=4
     [/attack]
 

--- a/data/core/units/dunefolk/Windrider.cfg
+++ b/data/core/units/dunefolk/Windrider.cfg
@@ -23,7 +23,7 @@
         description= _ "mace"
         type=impact
         range=melee
-        damage=8
+        damage=7
         number=3
     [/attack]
     [attack]
@@ -32,7 +32,7 @@
         icon=attacks/bow-elven.png
         type=pierce
         range=ranged
-        damage=10
+        damage=8
         number=5
     [/attack]
 

--- a/data/english.cfg
+++ b/data/english.cfg
@@ -14,10 +14,9 @@ Night: −25% Damage"
 
 Day: −25% Damage
 Night: +25% Damage"
-    liminal_description= _ "Liminal units only reach their full strength during twilight.
+    liminal_description= _ "Liminal units fight best during the twilight times of day.
 
-Day: −25% Damage
-Night: −25% Damage"
+Twilight: +25% Damage"
 
     #ranges
     range_melee= _ "melee"

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -317,7 +317,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 	int base_damage = weapon->modified_damage(backstab_pos);
 	int damage_multiplier = 100;
 	damage_multiplier
-			+= generic_combat_modifier(lawful_bonus, u_type->alignment(), u_type->musthave_status("fearless"));
+			+= generic_combat_modifier(lawful_bonus, u_type->alignment(), u_type->musthave_status("fearless"), 0);
 	damage_multiplier *= opp_type->resistance_against(weapon->type(), !attacking);
 
 	damage = round_damage(base_damage, damage_multiplier, 10000);
@@ -1608,10 +1608,10 @@ int combat_modifier(const unit_map& units,
 {
 	const tod_manager& tod_m = *resources::tod_manager;
 	int lawful_bonus = tod_m.get_illuminated_time_of_day(units, map, loc).lawful_bonus;
-	return generic_combat_modifier(lawful_bonus, alignment, is_fearless);
+	return generic_combat_modifier(lawful_bonus, alignment, is_fearless, tod_m.get_max_liminal_bonus());
 }
 
-int generic_combat_modifier(int lawful_bonus, unit_type::ALIGNMENT alignment, bool is_fearless)
+int generic_combat_modifier(int lawful_bonus, unit_type::ALIGNMENT alignment, bool is_fearless, int max_liminal_bonus)
 {
 	int bonus;
 
@@ -1626,7 +1626,7 @@ int generic_combat_modifier(int lawful_bonus, unit_type::ALIGNMENT alignment, bo
 		bonus = -lawful_bonus;
 		break;
 	case unit_type::ALIGNMENT::LIMINAL:
-		bonus = -std::abs(lawful_bonus);
+		bonus = std::max(0, max_liminal_bonus-std::abs(lawful_bonus));
 		break;
 	default:
 		bonus = 0;

--- a/src/actions/attack.hpp
+++ b/src/actions/attack.hpp
@@ -282,7 +282,7 @@ int combat_modifier(const unit_map& units,
  * Returns the amount that a unit's damage should be multiplied by
  * due to a given lawful_bonus.
  */
-int generic_combat_modifier(int lawful_bonus, unit_type::ALIGNMENT alignment, bool is_fearless);
+int generic_combat_modifier(int lawful_bonus, unit_type::ALIGNMENT alignment, bool is_fearless, int max_liminal_bonus);
 /**
  * Function to check if an attack will satisfy the requirements for backstab.
  * Input:

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -1106,7 +1106,7 @@ static config time_of_day_at(reports::context & rc, const map_location& mouseove
 	}
 
 	int b = tod.lawful_bonus;
-
+	int l = generic_combat_modifier(b, unit_type::ALIGNMENT::LIMINAL, false, rc.tod().get_max_liminal_bonus());
 	std::string  lawful_color("white");
 	std::string chaotic_color("white");
 	std::string liminal_color("white");
@@ -1114,7 +1114,9 @@ static config time_of_day_at(reports::context & rc, const map_location& mouseove
 	if (b != 0) {
 		lawful_color  = (b > 0) ? "green" : "red";
 		chaotic_color = (b < 0) ? "green" : "red";
-		liminal_color = "red";
+	}
+	if (l != 0) {
+		liminal_color = (l > 0) ? "green" : "red";
 	}
 	tooltip << tod.name << '\n'
 		<< _("Lawful units: ") << "<span foreground=\"" << lawful_color  << "\">"
@@ -1123,7 +1125,7 @@ static config time_of_day_at(reports::context & rc, const map_location& mouseove
 		<< _("Chaotic units: ") << "<span foreground=\"" << chaotic_color << "\">"
 		<< utils::signed_percent(-b) << "</span>\n"
 		<< _("Liminal units: ") << "<span foreground=\"" << liminal_color << "\">"
-		<< utils::signed_percent(-(std::abs(b))) << "</span>\n";
+		<< utils::signed_percent(l) << "</span>\n";
 
 	std::string tod_image = tod.image;
 	if(tod.bonus_modified > 0) {
@@ -1158,6 +1160,7 @@ static config unit_box_at(reports::context & rc, const map_location& mouseover_h
 	}
 
 	int bonus = local_tod.lawful_bonus;
+	int l = generic_combat_modifier(bonus, unit_type::ALIGNMENT::LIMINAL, false, rc.tod().get_max_liminal_bonus());
 
 	std::string  lawful_color("white");
 	std::string chaotic_color("white");
@@ -1166,7 +1169,9 @@ static config unit_box_at(reports::context & rc, const map_location& mouseover_h
 	if (bonus != 0) {
 		lawful_color  = (bonus > 0) ? "green" : "red";
 		chaotic_color = (bonus < 0) ? "green" : "red";
-		liminal_color = "red";
+	}
+	if (l != 0) {
+		liminal_color = (l > 0) ? "green" : "red";
 	}
 	tooltip << local_tod.name << '\n'
 		<< _("Lawful units: ") << "<span foreground=\"" << lawful_color  << "\">"
@@ -1175,7 +1180,7 @@ static config unit_box_at(reports::context & rc, const map_location& mouseover_h
 		<< _("Chaotic units: ") << "<span foreground=\"" << chaotic_color << "\">"
 		<< utils::signed_percent(-bonus) << "</span>\n"
 		<< _("Liminal units: ") << "<span foreground=\"" << liminal_color << "\">"
-		<< utils::signed_percent(-(std::abs(bonus))) << "</span>\n";
+		<< utils::signed_percent(l) << "</span>\n";
 
 	std::string local_tod_image  = "themes/classic/" + local_tod.image;
 	std::string global_tod_image = "themes/classic/" + global_tod.image;

--- a/src/tod_manager.cpp
+++ b/src/tod_manager.cpp
@@ -52,11 +52,9 @@ tod_manager::tod_manager(const config& scenario_cfg):
 		random_tod_ = false;
 
 	time_of_day::parse_times(scenario_cfg,times_);
-	int maybe_liminal_bonus = scenario_cfg["liminal_bonus"].to_int(-1);
-	if (maybe_liminal_bonus < 0) 
-		liminal_bonus_ = calculate_best_liminal_bonus(times_);
-	else {
-		liminal_bonus_ = maybe_liminal_bonus;
+	liminal_bonus_ = calculate_best_liminal_bonus(times_);
+	if (scenario_cfg.has_attribute("liminal_bonus")) {
+		liminal_bonus_ = scenario_cfg["liminal_bonus"].to_int(liminal_bonus_);
 		has_cfg_liminal_bonus_ = true;
 	}
 	//We need to call parse_times before calculate_current_time because otherwise the first parameter will always be 0.

--- a/src/tod_manager.hpp
+++ b/src/tod_manager.hpp
@@ -178,6 +178,8 @@ class tod_manager
 		{ has_turn_event_fired_ = true; }
 		bool has_tod_bonus_changed() const
 		{ return has_tod_bonus_changed_; }
+		int get_max_liminal_bonus() const
+		{ return liminal_bonus_; }
 	private:
 
 		/**
@@ -198,6 +200,10 @@ class tod_manager
 			const int for_turn_number,
 			const int current_time,
 			const bool only_to_allowed_range = false) const;
+		/**
+		 * Computes the maximum absolute value of lawful_bonus in the schedule.
+		 */
+		int calculate_best_liminal_bonus(const std::vector<time_of_day>& schedule) const;
 
 		/**
 		 * For a change of the current turn number, sets the current times of the main time
@@ -230,6 +236,9 @@ class tod_manager
 		std::vector<time_of_day> times_;
 		std::vector<area_time_of_day> areas_;
 
+		//max liminal bonus
+		int liminal_bonus_;
+
 		// current turn
 		int turn_;
 		//turn limit
@@ -237,6 +246,7 @@ class tod_manager
 		//Whether the "turn X" and the "new turn" events were already fired this turn.
 		bool has_turn_event_fired_;
 		bool has_tod_bonus_changed_;
+		bool has_cfg_liminal_bonus_;
 		//
 		config::attribute_value random_tod_;
 };


### PR DESCRIPTION
The first introduction of liminal was a twilight bonus. It didn't work, and was reintroduced as a malus, which works but seems to be considered bad (see [Dunefolk balance discussions](https://forums.wesnoth.org/viewtopic.php?f=15&t=47831&start=15) on the forum). 

This change takes custom schedules into account, liminal bonus is computed as a bonus that is as close as possible to the best of fearless chaotic and fearless lawful averages.