### PR TITLE
text_box_base: Fix segfault when type characters more than limit by IME

### DIFF
--- a/src/font/text.cpp
+++ b/src/font/text.cpp
@@ -195,6 +195,11 @@ point pango_text::get_cursor_position(
 	return point(PANGO_PIXELS(rect.x), PANGO_PIXELS(rect.y));
 }
 
+size_t pango_text::get_maximum_length() const
+{
+	return maximum_length_;
+}
+
 std::string pango_text::get_token(const point & position, const char * delim) const
 {
 	this->recalculate();

--- a/src/font/text.hpp
+++ b/src/font/text.hpp
@@ -158,6 +158,14 @@ public:
 		const unsigned column, const unsigned line = 0) const;
 
 	/**
+	 * Get maximum length.
+	 * 
+	 * @returns                   The maximum length of the text. The length of text
+	 *                            should not over this value.
+	 */
+	size_t get_maximum_length() const;
+
+	/**
 	 * Gets the largest collection of characters, including the token at position,
 	 * and not including any characters from the delimiters set.
 	 *

--- a/src/font/text.hpp
+++ b/src/font/text.hpp
@@ -161,7 +161,7 @@ public:
 	 * Get maximum length.
 	 * 
 	 * @returns                   The maximum length of the text. The length of text
-	 *                            should not over this value.
+	 *                            should not exceed this value.
 	 */
 	size_t get_maximum_length() const;
 

--- a/src/gui/widgets/text_box_base.cpp
+++ b/src/gui/widgets/text_box_base.cpp
@@ -440,25 +440,23 @@ void text_box_base::handle_editing(bool& handled, const utf8::string& unicode, i
 			}
 			SDL_SetTextInputRect(&rect);
 		}
-		
-		std::string new_text;
+
 		// In SDL_TextEditingEvent, size of editing_text is limited
 		// If length of composition text is more than the limit, it is separated to multiple SDL_TextEditingEvent
 		// start is start position of the separated event in entire composition text
 		if(start == 0) {
-			ime_length_ = new_len;
-			new_text = text_cached_;
-		} else {
-			ime_length_ += new_len;
-			new_text = text_.text();
+			ime_length_ = 0;
+			text_.set_text(text_cached_, false);
 		}
-		utf8::insert(new_text, ime_start_point_ + start, unicode);
-		text_.set_text(new_text, false);
+		ime_length_ += new_len;
+		text_.insert_text(ime_start_point_ + start, unicode);
 
 		// Update status
 		set_cursor(ime_start_point_, false);
 		if(ime_length_ > 0) {
-			set_cursor(ime_start_point_ + ime_length_, true);
+			int maximum_length = text_.get_maximum_length();
+			int cursor_end = std::min(maximum_length, ime_start_point_ + ime_length_);
+			set_cursor(cursor_end, true);
 		}
 		update_canvas();
 		set_is_dirty(true);


### PR DESCRIPTION
This commit fixes segfault when type characters more than limit by Input Method Editor.

pango_text.set_text() is not check whether the text over the maximum length, so change it to insert_text()