### PR TITLE
add bar_offset_x/y to [unit_type]

### DIFF
--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -224,9 +224,22 @@ void unit_drawer::redraw_unit (const unit & u) const
 	}
 	if(draw_bars) {
 		const image::locator* orb_img = nullptr;
-		const surface unit_img = image::get_image(u.default_anim_image(), image::SCALED_TO_ZOOM);
-		const int xoff = unit_img.null() ? hex_size_by_2 : (hex_size - unit_img->w)/2;
-		const int yoff = unit_img.null() ? hex_size_by_2 : (hex_size - unit_img->h)/2;
+
+		const auto& type_cfg = u.type().get_cfg();
+		const auto& cfg_offset_x = type_cfg["bar_offset_x"];
+		const auto& cfg_offset_y = type_cfg["bar_offset_y"];
+		int xoff;
+		int yoff;
+		if(cfg_offset_x.empty() && cfg_offset_y.empty()) {
+			const surface unit_img = image::get_image(u.default_anim_image(), image::SCALED_TO_ZOOM);
+			const int xoff = unit_img.null() ? hex_size_by_2 : (hex_size - unit_img->w)/2;
+			const int yoff = unit_img.null() ? hex_size_by_2 : (hex_size - unit_img->h)/2;
+		}
+		else {
+			const int xoff = hex_size_by_2 + cfg_offset_x;
+			const int yoff = hex_size_by_2 + cfg_offset_y;
+		}
+
 		/*static*/ const image::locator partmoved_orb(game_config::images::orb + "~RC(magenta>" +
 						preferences::partial_color() + ")"  );
 		/*static*/ const image::locator moved_orb(game_config::images::orb + "~RC(magenta>" +

--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -232,12 +232,12 @@ void unit_drawer::redraw_unit (const unit & u) const
 		int yoff;
 		if(cfg_offset_x.empty() && cfg_offset_y.empty()) {
 			const surface unit_img = image::get_image(u.default_anim_image(), image::SCALED_TO_ZOOM);
-			const int xoff = unit_img.null() ? hex_size_by_2 : (hex_size - unit_img->w)/2;
-			const int yoff = unit_img.null() ? hex_size_by_2 : (hex_size - unit_img->h)/2;
+			xoff = unit_img.null() ? hex_size_by_2 : (hex_size - unit_img->w)/2;
+			yoff = unit_img.null() ? hex_size_by_2 : (hex_size - unit_img->h)/2;
 		}
 		else {
-			const int xoff = hex_size_by_2 + cfg_offset_x;
-			const int yoff = hex_size_by_2 + cfg_offset_y;
+			xoff = hex_size_by_2 + cfg_offset_x.to_int();
+			yoff = hex_size_by_2 + cfg_offset_y.to_int();
 		}
 
 		/*static*/ const image::locator partmoved_orb(game_config::images::orb + "~RC(magenta>" +

--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -232,12 +232,12 @@ void unit_drawer::redraw_unit (const unit & u) const
 		int yoff;
 		if(cfg_offset_x.empty() && cfg_offset_y.empty()) {
 			const surface unit_img = image::get_image(u.default_anim_image(), image::SCALED_TO_ZOOM);
-			xoff = unit_img.null() ? hex_size_by_2 : (hex_size - unit_img->w)/2;
-			yoff = unit_img.null() ? hex_size_by_2 : (hex_size - unit_img->h)/2;
+			xoff = unit_img.null() ? 0 : (hex_size - unit_img->w)/2;
+			yoff = unit_img.null() ? 0 : (hex_size - unit_img->h)/2;
 		}
 		else {
-			xoff = hex_size_by_2 + cfg_offset_x.to_int();
-			yoff = hex_size_by_2 + cfg_offset_y.to_int();
+			xoff = cfg_offset_x.to_int();
+			yoff = cfg_offset_y.to_int();
 		}
 
 		/*static*/ const image::locator partmoved_orb(game_config::images::orb + "~RC(magenta>" +


### PR DESCRIPTION
this should probably be opimized later so that it does not need the config lookup on each redraw, but that can be done 1.13.12