### PR TITLE
Fix #2694, text_box: deleted text is restored during input method is activated

### DIFF
--- a/src/gui/widgets/text_box_base.cpp
+++ b/src/gui/widgets/text_box_base.cpp
@@ -382,6 +382,12 @@ void text_box_base::handle_key_backspace(SDL_Keymod /*modifier*/, bool& handled)
 		delete_selection();
 	} else if(selection_start_) {
 		delete_char(true);
+		if(ime_in_progress_) {
+			if(utf8::size(text_.text()) <= utf8::size(text_cached_)) {
+				ime_in_progress_ = false;
+				ime_length_ = 0;
+			}
+		}
 	}
 	fire(event::NOTIFY_MODIFIED, *this, nullptr);
 }
@@ -395,6 +401,12 @@ void text_box_base::handle_key_delete(SDL_Keymod /*modifier*/, bool& handled)
 		delete_selection();
 	} else if(selection_start_ < text_.get_length()) {
 		delete_char(false);
+		if(ime_in_progress_) {
+			if(utf8::size(text_.text()) <= utf8::size(text_cached_)) {
+				ime_in_progress_ = false;
+				ime_length_ = 0;
+			}
+		}
 	}
 	fire(event::NOTIFY_MODIFIED, *this, nullptr);
 }

--- a/src/gui/widgets/text_box_base.cpp
+++ b/src/gui/widgets/text_box_base.cpp
@@ -165,7 +165,7 @@ void text_box_base::insert_char(const utf8::string& unicode)
 
 size_t text_box_base::get_composition_length() const
 {
-	if(!ime_in_progress_) {
+	if(!is_composing()) {
 		return 0;
 	}
 	
@@ -395,7 +395,7 @@ void text_box_base::handle_key_backspace(SDL_Keymod /*modifier*/, bool& handled)
 		delete_selection();
 	} else if(selection_start_) {
 		delete_char(true);
-		if(ime_in_progress_) {
+		if(is_composing()) {
 			if(get_composition_length() == 0) {
 				ime_in_progress_ = false;
 			}
@@ -413,7 +413,7 @@ void text_box_base::handle_key_delete(SDL_Keymod /*modifier*/, bool& handled)
 		delete_selection();
 	} else if(selection_start_ < text_.get_length()) {
 		delete_char(false);
-		if(ime_in_progress_) {
+		if(is_composing()) {
 			if(get_composition_length() == 0) {
 				ime_in_progress_ = false;
 			}
@@ -428,7 +428,7 @@ void text_box_base::handle_commit(bool& handled, const utf8::string& unicode)
 
 	if(unicode.size() > 1 || unicode[0] != 0) {
 		handled = true;
-		if(ime_in_progress_) {
+		if(is_composing()) {
 			set_selection(ime_start_point_ + get_composition_length(), 0);
 			ime_in_progress_ = false;
 		} else {
@@ -447,7 +447,7 @@ void text_box_base::handle_editing(bool& handled, const utf8::string& unicode, i
 	if(unicode.size() > 1 || unicode[0] != 0) {
 		handled = true;
 		size_t new_len = utf8::size(unicode);
-		if(!ime_in_progress_) {
+		if(!is_composing()) {
 			ime_in_progress_ = true;
 			delete_selection();
 			ime_start_point_ = selection_start_;
@@ -608,7 +608,7 @@ void text_box_base::signal_handler_sdl_key_down(const event::ui_event event,
 
 		case SDLK_RETURN:
 		case SDLK_KP_ENTER:
-			if(!ime_in_progress_ || (modifier & (KMOD_CTRL | KMOD_ALT | KMOD_GUI | KMOD_SHIFT))) {
+			if(!is_composing() || (modifier & (KMOD_CTRL | KMOD_ALT | KMOD_GUI | KMOD_SHIFT))) {
 				return;
 			}
 			// The IME will handle it, we just need to make sure nothing else handles it too.
@@ -616,7 +616,7 @@ void text_box_base::signal_handler_sdl_key_down(const event::ui_event event,
 			break;
 
 		case SDLK_ESCAPE:
-			if(!ime_in_progress_ || (modifier & (KMOD_CTRL | KMOD_ALT | KMOD_GUI | KMOD_SHIFT))) {
+			if(!is_composing() || (modifier & (KMOD_CTRL | KMOD_ALT | KMOD_GUI | KMOD_SHIFT))) {
 				return;
 			}
 			interrupt_composition();

--- a/src/gui/widgets/text_box_base.cpp
+++ b/src/gui/widgets/text_box_base.cpp
@@ -37,7 +37,7 @@ text_box_base::text_box_base(const implementation::builder_styled_widget& builde
 	, text_()
 	, selection_start_(0)
 	, selection_length_(0)
-	, ime_in_progress_(false)
+	, ime_composing_(false)
 	, ime_start_point_(0)
 	, cursor_timer_(0)
 	, cursor_alpha_(0)
@@ -180,7 +180,7 @@ size_t text_box_base::get_composition_length() const
 
 void text_box_base::interrupt_composition()
 {
-	ime_in_progress_ = false;
+	ime_composing_ = false;
 	// We need to inform the IME that text input is no longer in progress.
 	SDL_StopTextInput();
 	SDL_StartTextInput();
@@ -397,7 +397,7 @@ void text_box_base::handle_key_backspace(SDL_Keymod /*modifier*/, bool& handled)
 		delete_char(true);
 		if(is_composing()) {
 			if(get_composition_length() == 0) {
-				ime_in_progress_ = false;
+				ime_composing_ = false;
 			}
 		}
 	}
@@ -415,7 +415,7 @@ void text_box_base::handle_key_delete(SDL_Keymod /*modifier*/, bool& handled)
 		delete_char(false);
 		if(is_composing()) {
 			if(get_composition_length() == 0) {
-				ime_in_progress_ = false;
+				ime_composing_ = false;
 			}
 		}
 	}
@@ -430,7 +430,7 @@ void text_box_base::handle_commit(bool& handled, const utf8::string& unicode)
 		handled = true;
 		if(is_composing()) {
 			set_selection(ime_start_point_ + get_composition_length(), 0);
-			ime_in_progress_ = false;
+			ime_composing_ = false;
 		} else {
 			insert_char(unicode);
 		}
@@ -448,7 +448,7 @@ void text_box_base::handle_editing(bool& handled, const utf8::string& unicode, i
 		handled = true;
 		size_t new_len = utf8::size(unicode);
 		if(!is_composing()) {
-			ime_in_progress_ = true;
+			ime_composing_ = true;
 			delete_selection();
 			ime_start_point_ = selection_start_;
 			text_cached_ = text_.text();

--- a/src/gui/widgets/text_box_base.cpp
+++ b/src/gui/widgets/text_box_base.cpp
@@ -39,7 +39,6 @@ text_box_base::text_box_base(const implementation::builder_styled_widget& builde
 	, selection_length_(0)
 	, ime_in_progress_(false)
 	, ime_start_point_(0)
-	, ime_length_(0)
 	, cursor_timer_(0)
 	, cursor_alpha_(0)
 	, cursor_blink_rate_ms_(750)
@@ -164,10 +163,24 @@ void text_box_base::insert_char(const utf8::string& unicode)
 	}
 }
 
+size_t text_box_base::get_composition_length() const
+{
+	if(!ime_in_progress_) {
+		return 0;
+	}
+	
+	size_t text_length = utf8::size(text_.text());
+	size_t text_cached_length = utf8::size(text_cached_);
+	if(text_length < text_cached_length) {
+		return 0;
+	}
+	
+	return utf8::size(text_.text()) - utf8::size(text_cached_);
+}
+
 void text_box_base::interrupt_composition()
 {
 	ime_in_progress_ = false;
-	ime_length_ = 0;
 	// We need to inform the IME that text input is no longer in progress.
 	SDL_StopTextInput();
 	SDL_StartTextInput();
@@ -383,9 +396,8 @@ void text_box_base::handle_key_backspace(SDL_Keymod /*modifier*/, bool& handled)
 	} else if(selection_start_) {
 		delete_char(true);
 		if(ime_in_progress_) {
-			if(utf8::size(text_.text()) <= utf8::size(text_cached_)) {
+			if(get_composition_length() == 0) {
 				ime_in_progress_ = false;
-				ime_length_ = 0;
 			}
 		}
 	}
@@ -402,9 +414,8 @@ void text_box_base::handle_key_delete(SDL_Keymod /*modifier*/, bool& handled)
 	} else if(selection_start_ < text_.get_length()) {
 		delete_char(false);
 		if(ime_in_progress_) {
-			if(utf8::size(text_.text()) <= utf8::size(text_cached_)) {
+			if(get_composition_length() == 0) {
 				ime_in_progress_ = false;
-				ime_length_ = 0;
 			}
 		}
 	}
@@ -418,9 +429,8 @@ void text_box_base::handle_commit(bool& handled, const utf8::string& unicode)
 	if(unicode.size() > 1 || unicode[0] != 0) {
 		handled = true;
 		if(ime_in_progress_) {
-			set_selection(ime_start_point_ + ime_length_, 0);
+			set_selection(ime_start_point_ + get_composition_length(), 0);
 			ime_in_progress_ = false;
-			ime_length_ = 0;
 		} else {
 			insert_char(unicode);
 		}
@@ -457,17 +467,16 @@ void text_box_base::handle_editing(bool& handled, const utf8::string& unicode, i
 		// If length of composition text is more than the limit, it is separated to multiple SDL_TextEditingEvent
 		// start is start position of the separated event in entire composition text
 		if(start == 0) {
-			ime_length_ = 0;
 			text_.set_text(text_cached_, false);
 		}
-		ime_length_ += new_len;
 		text_.insert_text(ime_start_point_ + start, unicode);
 
 		// Update status
 		set_cursor(ime_start_point_, false);
-		if(ime_length_ > 0) {
+		int ime_length = get_composition_length();
+		if(ime_length > 0) {
 			int maximum_length = text_.get_maximum_length();
-			int cursor_end = std::min(maximum_length, ime_start_point_ + ime_length_);
+			int cursor_end = std::min(maximum_length, ime_start_point_ + ime_length);
 			set_cursor(cursor_end, true);
 		}
 		update_canvas();

--- a/src/gui/widgets/text_box_base.hpp
+++ b/src/gui/widgets/text_box_base.hpp
@@ -118,6 +118,9 @@ public:
 	void set_selection(size_t start, int length);
 
 protected:
+	/** Get length of composition text by IME **/
+	size_t get_composition_length() const;
+	
 	/**
 	 * Moves the cursor to the end of the line.
 	 *
@@ -259,11 +262,6 @@ protected:
 		return ime_start_point_;
 	}
 
-	size_t get_composition_length() const
-	{
-		return ime_length_;
-	}
-
 public:
 	bool is_composing() const
 	{
@@ -319,7 +317,6 @@ private:
 	// Values to support input method editors
 	bool ime_in_progress_;
 	int ime_start_point_;
-	int ime_length_;
 
 	size_t cursor_timer_;
 

--- a/src/gui/widgets/text_box_base.hpp
+++ b/src/gui/widgets/text_box_base.hpp
@@ -265,7 +265,7 @@ protected:
 public:
 	bool is_composing() const
 	{
-		return ime_in_progress_;
+		return ime_composing_;
 	}
 
 	void interrupt_composition();
@@ -315,7 +315,7 @@ private:
 	int selection_length_;
 
 	// Values to support input method editors
-	bool ime_in_progress_;
+	bool ime_composing_;
 	int ime_start_point_;
 
 	size_t cursor_timer_;


### PR DESCRIPTION
The cause of #2694 is that ime_in_progress_ is not disable when text is deleted by Backspace or Delete key.

This PR fixes it and several code cleanup:
* Remove ime_length_
* Rename ime_in_progress_ to ime_composing_
* Use is_composing() instead of raw ime_in_progress_ 

The cleanup above shouldn't affect behavior of text_box.