### PR TITLE
Adds a flag to globally enable or disable unit tests.

### DIFF
--- a/utils/travis/docker_run.sh
+++ b/utils/travis/docker_run.sh
@@ -17,6 +17,7 @@ PLAY_TEST="$9"
 MP_TEST="${10}"
 BOOST_TEST="${11}"
 LTO="${12}"
+UNIT_TESTS="${13}"
 
 # only enable strict builds when no optimizations are done
 if [ "$EXTRA_FLAGS_RELEASE" == "-O0" ]; then
@@ -38,6 +39,7 @@ echo "PLAY_TEST: $PLAY_TEST"
 echo "MP_TEST: $MP_TEST"
 echo "BOOST_TEST: $BOOST_TEST"
 echo "LTO: $LTO"
+echo "UNIT_TESTS: $UNIT_TESTS"
 
 $CXX --version
 
@@ -75,7 +77,7 @@ else
 # needed since docker returns the exit code of the final comman executed, so a failure needs to be returned if any unit tests fail
     EXIT_VAL=0
 
-    if [ "$WML_TESTS" == "true" ]; then
+    if [ "$WML_TESTS" == "true" ] && [ "$UNIT_TESTS" == "true" ]; then
         echo "Executing run_wml_tests"
 
         ./run_wml_tests -g -v -c -t "$WML_TEST_TIME"
@@ -87,7 +89,7 @@ else
         fi
     fi
 
-    if [ "$PLAY_TEST" == "true" ]; then
+    if [ "$PLAY_TEST" == "true" ] && [ "$UNIT_TESTS" == "true" ]; then
         echo "Executing play_test_executor.sh"
 
         ./utils/travis/play_test_executor.sh
@@ -99,7 +101,7 @@ else
         fi
     fi
 
-    if [ "$MP_TEST" == "true" ]; then
+    if [ "$MP_TEST" == "true" ] && [ "$UNIT_TESTS" == "true" ]; then
         echo "Executing mp_test_executor.sh"
 
         ./utils/travis/mp_test_executor.sh
@@ -111,7 +113,7 @@ else
         fi
     fi
 
-    if [ "$BOOST_TEST" == "true" ]; then
+    if [ "$BOOST_TEST" == "true" ] && [ "$UNIT_TESTS" == "true" ]; then
         echo "Executing boost unit tests"
 
         ./utils/travis/test_executor.sh

--- a/utils/travis/steps/script.sh
+++ b/utils/travis/steps/script.sh
@@ -33,5 +33,5 @@ else
     docker run -v "$HOME"/build-cache:/home/wesnoth-travis/build \
                -v "$HOME"/.ccache:/root/.ccache wesnoth-repo:16.04 \
                bash -c './utils/travis/docker_run.sh "$@"' \
-               bash "$NLS" "$TOOL" "$CC" "$CXX" "$CXXSTD" "$EXTRA_FLAGS_RELEASE" "$WML_TESTS" "$WML_TEST_TIME" "$PLAY_TEST" "$MP_TEST" "$BOOST_TEST" "$LTO"
+               bash "$NLS" "$TOOL" "$CC" "$CXX" "$CXXSTD" "$EXTRA_FLAGS_RELEASE" "$WML_TESTS" "$WML_TEST_TIME" "$PLAY_TEST" "$MP_TEST" "$BOOST_TEST" "$LTO" "$UNIT_TESTS"
 fi


### PR DESCRIPTION
This flag is set from the Travis settings page, so in the future this value can be flipped on or off without needing to make a commit.  This is mostly motivated by the fact that running the unit tests on master at the moment is fairly pointless, and disabling unit tests until fixing them is a priority will allow the builds to succeed if there are at least no compile errors rather than always failing every single time like they are now, as well as in some cases erroring out entirely which results in the cache not being uploaded.