### PR TITLE
Remove debugging symbols from Travis xcode build.

### DIFF
--- a/utils/travis/steps/script.sh
+++ b/utils/travis/steps/script.sh
@@ -8,10 +8,10 @@ if [ "$TRAVIS_OS_NAME" = "osx" ]; then
 
         cd ./projectfiles/Xcode
 
-        export CCACHE_MAXSIZE=2G
+        export CCACHE_MAXSIZE=200M
         export CCACHE_COMPILERCHECK=content
 
-        xcodebuild -project Wesnoth.xcodeproj -target Wesnoth
+        xcodebuild GCC_GENERATE_DEBUGGING_SYMBOLS=NO -project Wesnoth.xcodeproj -target Wesnoth
 
         BUILD_RET=$?
 


### PR DESCRIPTION
This removes the -g option from the xcode travis build, since debugging information isn't needed and the increased size was causing the cache to timeout when compressing and uploading it.  ccache max cache size is also decreased from 2 GBs to 200 MBs, which matches the linux+cmake builds.  Fixes #2670.

---

This also supersedes #2714, since I didn't know I could set this myself.