### PR TITLE
add a filter_weapon filter for targetting the attacks affected by leader

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -49,6 +49,8 @@
      MP game.
    * The Toggle Fullscreen hotkey now works everywhere.
  ### WML engine
+   * Leaderships abilities have now a [filter_weapon] filter for select the 
+     weapon to units affected by the leadership.
    * Fixed units shown with [move_units_fake] disappearing between steps
      (bug #1516).
    * [modify_side] now supports side_name

--- a/data/core/macros/abilities.cfg
+++ b/data/core/macros/abilities.cfg
@@ -117,40 +117,67 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
     [/leadership]
 #enddef
 
-#define ABILITY_LEADERSHIP_TARGET ID ATTACK
-    # Canned definition of the Leadership ability to be included in an
-	    [leadership]
+#define ABILITY_LEADERSHIP_MELEE
+[leadership]
        value=25 * (level - other.level))"
         cumulative=no
-         id={ID}
-        name= _ {ID}+" leadership"
-        female_name= _ "female^"+{ID}+" leadership"
+         id=melee_leadership
+        name= _ "melee leadership"
+        female_name= _ "female^melee leadership"
         description= _ "This unit can lead our allied  units that are next to it, making them fight better.
-
-Adjacent own units of lower level will do more damage in battle. When a unit adjacent to, of a lower level than, and on the same side as a unit with Leadership engages in combat, its "+{ID}+" attacks do 15% more damage times the difference in their levels."
+Adjacent own units of lower level will do more damage in battle. When a unit adjacent to, of a lower level than, and on the same side as a unit with Leadership engages in combat, its melees attacks do 15% more damage times the difference in their levels."
         affect_self=no
 		[filter_weapon]
-		{ATTACK}
+		range=melee
 		[/filter_weapon]
         [affect_adjacent]
 		[filter]
-		
                  formula="level < other.level"
             [/filter]
         [/affect_adjacent]
     [/leadership]
 #enddef
 
-#define ABILITY_LEADERSHIP_MELEE
-{ABILITY_LEADERSHIP_TARGET melee (range=melee)}
-#enddef
-
 #define ABILITY_LEADERSHIP_RANGED
-{ABILITY_LEADERSHIP_TARGET ranged (range=ranged)}
+[leadership]
+       value=25 * (level - other.level))"
+        cumulative=no
+         id=ranged_leadership
+        name= _ "ranged leadership"
+        female_name= _ "female^ranged leadership"
+        description= _ "This unit can lead our allied  units that are next to it, making them fight better.
+Adjacent own units of lower level will do more damage in battle. When a unit adjacent to, of a lower level than, and on the same side as a unit with Leadership engages in combat, its rangeds attacks do 15% more damage times the difference in their levels."
+        affect_self=no
+		[filter_weapon]
+		range=ranged
+		[/filter_weapon]
+        [affect_adjacent]
+		[filter]
+                 formula="level < other.level"
+            [/filter]
+        [/affect_adjacent]
+    [/leadership]
 #enddef
 
 #define ABILITY_LEADERSHIP_MAGICAL
-{ABILITY_LEADERSHIP_TARGET magical (special=magical)}
+{[leadership]
+       value=25 * (level - other.level))"
+        cumulative=no
+         id=magical_leadership
+        name= _ "magical leadership"
+        female_name= _ "female^magical leadership"
+        description= _ "This unit can lead our allied  units that are next to it, making them fight better.
+Adjacent own units of lower level will do more damage in battle. When a unit adjacent to, of a lower level than, and on the same side as a unit with Leadership engages in combat, its magicals attacks do 15% more damage times the difference in their levels."
+        affect_self=no
+		[filter_weapon]
+		special=magical
+		[/filter_weapon]
+        [affect_adjacent]
+		[filter]
+                 formula="level < other.level"
+            [/filter]
+        [/affect_adjacent]
+    [/leadership]
 #enddef
 
 #define ABILITY_SKIRMISHER

--- a/data/core/macros/abilities.cfg
+++ b/data/core/macros/abilities.cfg
@@ -117,6 +117,30 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
     [/leadership]
 #enddef
 
+#define ABILITY_TARGET_LEADERSHIP ID ATTACK
+    # Canned definition of the Leadership ability to be included in an
+	    [leadership]
+       value=25 * (level - other.level))"
+        cumulative=no
+         id={ID}
+        name= _ {ID}+" leadership"
+        female_name= _ "female^"+{ID}+" leadership"
+        description= _ "This unit can lead our allied  units that are next to it, making them fight better.
+
+Adjacent own units of lower level will do more damage in battle. When a unit adjacent to, of a lower level than, and on the same side as a unit with Leadership engages in combat, its "+{ID}+" attacks do 15% more damage times the difference in their levels."
+        affect_self=no
+		[filter_weapon]
+		{ATTACK}
+		[/filter_weapon]
+        [affect_adjacent]
+		[filter]
+		
+                 formula="level < other.level"
+            [/filter]
+        [/affect_adjacent]
+    [/leadership]
+#enddef
+
 #define ABILITY_SKIRMISHER
     # Canned definition of the Skirmisher ability to be included in an [abilities]
     # clause.

--- a/data/core/macros/abilities.cfg
+++ b/data/core/macros/abilities.cfg
@@ -117,7 +117,7 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
     [/leadership]
 #enddef
 
-#define ABILITY_TARGET_LEADERSHIP ID ATTACK
+#define ABILITY_LEADERSHIP_TARGET ID ATTACK
     # Canned definition of the Leadership ability to be included in an
 	    [leadership]
        value=25 * (level - other.level))"
@@ -139,6 +139,18 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
             [/filter]
         [/affect_adjacent]
     [/leadership]
+#enddef
+
+#define ABILITY_LEADERSHIP_MELEE
+{ABILITY_LEADERSHIP_TARGET melee (range=melee)}
+#enddef
+
+#define ABILITY_LEADERSHIP_RANGED
+{ABILITY_LEADERSHIP_TARGET ranged (range=ranged)}
+#enddef
+
+#define ABILITY_LEADERSHIP_MAGICAL
+{ABILITY_LEADERSHIP_TARGET magical (special=magical)}
 #enddef
 
 #define ABILITY_SKIRMISHER

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -183,7 +183,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 			resources::gameboard->units(), resources::gameboard->map(), u_loc, u.alignment(), u.is_fearless());
 
 	// Leadership bonus.
-	int leader_bonus = under_leadership(units, u_loc).first;
+	int leader_bonus = under_leadership(units, u_loc, weapon).first;
 	if(leader_bonus != 0) {
 		damage_multiplier += leader_bonus;
 	}
@@ -1579,14 +1579,14 @@ void attack_unit_and_advance(const map_location& attacker,
 	}
 }
 
-std::pair<int, map_location> under_leadership(const unit_map& units, const map_location& loc)
+std::pair<int, map_location> under_leadership(const unit_map& units, const map_location& loc, const_attack_ptr weapon)
 {
 	const unit_map::const_iterator un = units.find(loc);
 	if(un == units.end()) {
 		return {0, map_location::null_location()};
 	}
 
-	unit_ability_list abil = un->get_abilities("leadership");
+	unit_ability_list abil = un->get_abilities("leadership", weapon);
 	return abil.highest("value");
 }
 

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -189,7 +189,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 	}
 
 	// Resistance modifier.
-	damage_multiplier *= opp.damage_from(*weapon, !attacking, opp_loc);
+	damage_multiplier *= opp.damage_from(*weapon, !attacking, opp_loc ,weapon);
 
 	// Compute both the normal and slowed damage.
 	damage = round_damage(base_damage, damage_multiplier, 10000);

--- a/src/actions/attack.hpp
+++ b/src/actions/attack.hpp
@@ -266,7 +266,7 @@ void attack_unit_and_advance(const map_location& attacker,
  * Returns a pair of bonus percentage and the leader's location if the unit is affected,
  * or 0 and map_location::null_location() otherwise.
  */
-std::pair<int, map_location> under_leadership(const unit_map& units, const map_location& loc);
+std::pair<int, map_location> under_leadership(const unit_map& units, const map_location& loc, const_attack_ptr weapon);
 
 /**
  * Returns the amount that a unit's damage should be multiplied by

--- a/src/gui/dialogs/attack_predictions.cpp
+++ b/src/gui/dialogs/attack_predictions.cpp
@@ -217,7 +217,7 @@ void attack_predictions::set_data(window& window, const combatant_data& attacker
 	}
 
 	// Leadership bonus.
-	const int leadership_bonus = under_leadership(resources::gameboard->units(), attacker.unit_.get_location()).first;
+	const int leadership_bonus = under_leadership(resources::gameboard->units(), attacker.unit_.get_location(), weapon).first;
 
 	if(leadership_bonus != 0) {
 		set_label_helper("leadership_modifier", utils::signed_percent(leadership_bonus));

--- a/src/gui/dialogs/attack_predictions.cpp
+++ b/src/gui/dialogs/attack_predictions.cpp
@@ -182,7 +182,7 @@ void attack_predictions::set_data(window& window, const combatant_data& attacker
 	ss.str("");
 
 	// Resistance modifier.
-	const int resistance_modifier = defender.unit_.damage_from(*weapon, !attacker.stats_.is_attacker, defender.unit_.get_location());
+	const int resistance_modifier = defender.unit_.damage_from(*weapon, !attacker.stats_.is_attacker, defender.unit_.get_location(), weapon);
 	if(resistance_modifier != 100) {
 		if(attacker.stats_.is_attacker) {
 			ss << _("Defender resistance vs") << " ";

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -661,9 +661,10 @@ static int attack_info(reports::context & rc, const attack_type &at, config &res
 		int base_damage = at.damage();
 		int specials_damage = at.modified_damage(false);
 		int damage_multiplier = 100;
+		const_attack_ptr  = at.shared_from_this();
 		int tod_bonus = combat_modifier(rc.units(), rc.map(), displayed_unit_hex, u.alignment(), u.is_fearless());
 		damage_multiplier += tod_bonus;
-		int leader_bonus = under_leadership(rc.units(), displayed_unit_hex).first;
+		int leader_bonus = under_leadership(rc.units(), displayed_unit_hex, weapon).first;
 		if (leader_bonus != 0)
 			damage_multiplier += leader_bonus;
 

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -661,7 +661,7 @@ static int attack_info(reports::context & rc, const attack_type &at, config &res
 		int base_damage = at.damage();
 		int specials_damage = at.modified_damage(false);
 		int damage_multiplier = 100;
-		const_attack_ptr  = at.shared_from_this();
+		const_attack_ptr weapon  = at.shared_from_this();
 		int tod_bonus = combat_modifier(rc.units(), rc.map(), displayed_unit_hex, u.alignment(), u.is_fearless());
 		damage_multiplier += tod_bonus;
 		int leader_bonus = under_leadership(rc.units(), displayed_unit_hex, weapon).first;

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -453,6 +453,17 @@ bool unit::ability_affects_self(const std::string& ability,const config& cfg,con
 	return unit_filter(vconfig(filter)).set_use_flat_tod(ability == "illuminates").matches(*this, loc);
 }
 
+bool unit::ability_affects_weapon(const std::string& ability,const config& cfg,const map_location& loc, const_attack_ptr weapon) const
+{
+  const config &filter = cfg.child("filter_weapon");
+  if (!filter ) return true;
+			if ( !weapon || !weapon->matches_filter(filter) )
+				return false;
+
+	return unit_filter(vconfig(filter)).set_use_flat_tod(ability == "illuminates").matches(*this, loc);
+}
+
+
 bool unit::has_ability_type(const std::string& ability) const
 {
 	return !abilities_.child_range(ability).empty();

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -415,11 +415,9 @@ bool unit::ability_affects_self(const std::string& ability,const config& cfg,con
 bool unit::ability_affects_weapon(const std::string& ability,const config& cfg,const map_location& loc, const_attack_ptr weapon) const
 {
   const config &filter = cfg.child("filter_weapon");
-  if (!filter ) return true;
-			if ( !weapon || !weapon->matches_filter(filter) )
+  if (!filter || weapon->matches_filter(filter)) return true;
+			if ( !weapon )
 				return false;
-
-	return unit_filter(vconfig(filter)).set_use_flat_tod(ability == "illuminates").matches(*this, loc);
 }
 
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -176,47 +176,6 @@ bool unit::get_ability_bool(const std::string& tag_name, const map_location& loc
 
 	return false;
 }
-unit_ability_list unit::get_abilities(const std::string& tag_name, const map_location& loc) const
-{
-	unit_ability_list res(loc_);
-
-	for (const config &i : this->abilities_.child_range(tag_name)) {
-		if (ability_active(tag_name, i, loc) &&
-			ability_affects_self(tag_name, i, loc))
-		{
-			res.push_back(unit_ability(&i, loc));
-		}
-	}
-
-	assert(display::get_singleton());
-	const unit_map& units = display::get_singleton()->get_units();
-
-	adjacent_loc_array_t adjacent;
-	get_adjacent_tiles(loc,adjacent.data());
-	for(unsigned i = 0; i < adjacent.size(); ++i) {
-		const unit_map::const_iterator it = units.find(adjacent[i]);
-		if (it == units.end() || it->incapacitated())
-			continue;
-		// Abilities may be tested at locations other than the unit's current
-		// location. This is intentional to allow for less messing with the unit
-		// map during calculations, particularly with regards to movement.
-		// Thus, we need to make sure the adjacent unit (*it) is not actually
-		// ourself.
-		if ( &*it == this )
-			continue;
-		for (const config &j : it->abilities_.child_range(tag_name)) {
-			if (affects_side(j, resources::gameboard->teams(), side(), it->side()) &&
-			    it->ability_active(tag_name, j, adjacent[i]) &&
-			    ability_affects_adjacent(tag_name, j, i, loc, *it))
-			{
-				res.push_back(unit_ability(&j, adjacent[i]));
-			}
-		}
-	}
-
-
-	return res;
-}
 
 unit_ability_list unit::get_abilities(const std::string& tag_name, const map_location& loc, const_attack_ptr weapon) const
 {

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1589,11 +1589,11 @@ bool unit::resistance_filter_matches(const config& cfg, bool attacker, const std
 	return true;
 }
 
-int unit::resistance_against(const std::string& damage_name,bool attacker,const map_location& loc) const
+int unit::resistance_against(const std::string& damage_name,bool attacker,const map_location& loc, const_attack_ptr weapon) const
 {
 	int res = movement_type_.resistance_against(damage_name);
 
-	unit_ability_list resistance_abilities = get_abilities("resistance",loc);
+	unit_ability_list resistance_abilities = get_abilities("resistance",loc, weapon);
 	for(unit_ability_list::iterator i = resistance_abilities.begin(); i != resistance_abilities.end();) {
 		if(!resistance_filter_matches(*i->first, attacker, damage_name, 100-res)) {
 			i = resistance_abilities.erase(i);

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1479,6 +1479,13 @@ public:
 	{
 		return get_abilities(tag_name, loc_);
 	}
+	
+	unit_ability_list get_abilities(const std::string& tag_name, const map_location& loc, const_attack_ptr weapon) const;
+
+	unit_ability_list get_abilities(const std::string& tag_name, const_attack_ptr weapon) const
+	{
+		return get_abilities(tag_name, loc_, weapon);
+	}
 
 	/**
 	 * Gets the names and descriptions of this unit's abilities.

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -845,9 +845,9 @@ public:
 	 *
 	 * @returns                   The expected damage.
 	 */
-	int damage_from(const attack_type& attack, bool attacker, const map_location& loc) const
+	int damage_from(const attack_type& attack, bool attacker, const map_location& loc, const_attack_ptr weapon=nullptr) const
 	{
-		return resistance_against(attack, attacker, loc);
+		return resistance_against(attack, attacker, loc, weapon);
 	}
 
 	/** The maximum number of attacks this unit may perform per turn, usually 1. */
@@ -887,7 +887,7 @@ public:
 	 * @param attacker True if this unit is on the offensive (to resolve [resistance] abilities)
 	 * @param loc The unit's location (to resolve [resistance] abilities)
 	 */
-	int resistance_against(const std::string& damage_name, bool attacker, const map_location& loc) const;
+	int resistance_against(const std::string& damage_name, bool attacker, const map_location& loc, const_attack_ptr weapon=nullptr) const;
 
 	/**
 	 * The unit's resistance against a given attack
@@ -895,9 +895,9 @@ public:
 	 * @param attacker True if this unit is on the offensive (to resolve [resistance] abilities)
 	 * @param loc The unit's location (to resolve [resistance] abilities)
 	 */
-	int resistance_against(const attack_type& atk, bool attacker, const map_location& loc) const
+	int resistance_against(const attack_type& atk, bool attacker, const map_location& loc, const_attack_ptr weapon=nullptr) const
 	{
-		return resistance_against(atk.type(), attacker, loc);
+		return resistance_against(atk.type(), attacker, loc , weapon);
 	}
 
 	/** Gets resistances without any abilities applied. */
@@ -1468,24 +1468,18 @@ public:
 	 * @param loc The location to use for resolving abilities
 	 * @return A list of active abilities, paired with the location they are active on
 	 */
-	unit_ability_list get_abilities(const std::string& tag_name, const map_location& loc) const;
+	unit_ability_list get_abilities(const std::string& tag_name, const map_location& loc, const_attack_ptr weapon=nullptr) const;
 
 	/**
 	 * Gets the unit's active abilities of a particular type.
 	 * @param tag_name The type of ability to check for
 	 * @return A list of active abilities, paired with the location they are active on
 	 */
-	unit_ability_list get_abilities(const std::string& tag_name) const
-	{
-		return get_abilities(tag_name, loc_);
-	}
-	
-	unit_ability_list get_abilities(const std::string& tag_name, const map_location& loc, const_attack_ptr weapon) const;
-
-	unit_ability_list get_abilities(const std::string& tag_name, const_attack_ptr weapon) const
+	unit_ability_list get_abilities(const std::string& tag_name, const_attack_ptr weapon=nullptr) const
 	{
 		return get_abilities(tag_name, loc_, weapon);
 	}
+	
 
 	/**
 	 * Gets the names and descriptions of this unit's abilities.

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1549,6 +1549,8 @@ private:
 	 * @param loc The location on which to resolve the ability
 	 */
 	bool ability_affects_self(const std::string& ability, const config& cfg, const map_location& loc) const;
+	
+	bool ability_affects_weapon(const std::string& ability,const config& cfg,const map_location& loc, const_attack_ptr weapon) const;
 
 public:
 	/** Get the unit formula manager. */


### PR DESCRIPTION
With that, i want extent the use of leadership to other unit what mixed fighter like leader. By example
a mage could helped this apprentice in battle with his magical attack but not the physical attack.
Or an melee fighter with the melee attack only. I hope permit to addon devellopper to create new unit lines with this new leaderships in example.