### PR TITLE
Explicitly set osx_image for osx+scons job.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ matrix:
 
     - os: osx
       compiler: clang
+      osx_image: xcode8.3
       env: TOOL=scons CXXSTD=14 NLS=false OPT=-O0
 
     - os: osx


### PR DESCRIPTION
This is the current default, and even though the job uses scons this also sets the osx version to use.  Therefore it's better to set it explicitly in case the default changes at some point.

---

https://docs.travis-ci.com/user/reference/osx/#OS-X-Version