### PR TITLE
cmake, scons: Drop option to enable or disable the removed SDL_SavePNG code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,6 @@ option(ENABLE_MYSQL "Enable building MP/add-ons servers with mysql support" OFF)
 option(ENABLE_TESTS "Build unit tests")
 option(ENABLE_NLS "Enable building of translations" ${ENABLE_GAME})
 option(ENABLE_OMP "Enables OpenMP, and has additional dependencies" OFF)
-option(ENABLE_LIBPNG "Enable support for writing png files (screenshots, images)" ON)
 option(ENABLE_HISTORY "Enable using GNU history for history in lua console" ON)
 
 # set what std version to use
@@ -500,13 +499,6 @@ if(ENABLE_GAME)
 	else()
 		unset(LIBDBUS_FOUND CACHE)
 	endif()
-
-	find_package( PNG )
-	if(ENABLE_LIBPNG AND PNG_FOUND)
-		add_definitions(-DHAVE_LIBPNG)
-	else(ENABLE_LIBPNG AND PNG_FOUND)
-		message("Could not find lib PNG. Disabling support for writing PNG images.")
-	endif(ENABLE_LIBPNG AND PNG_FOUND)
 
 	find_package( History )
 	if(ENABLE_HISTORY AND HISTORY_FOUND)

--- a/SConstruct
+++ b/SConstruct
@@ -79,7 +79,6 @@ opts.AddVariables(
     PathVariable('python_site_packages_dir', 'sets the directory where python modules are installed', "lib/python/site-packages/wesnoth", PathVariable.PathAccept),
     BoolVariable('notifications', 'Enable support for desktop notifications', True),
     BoolVariable('nls','enable compile/install of gettext message catalogs',True),
-    BoolVariable('png', 'Clear to disable writing png files for screenshots, images', True),
     PathVariable('prefix', 'autotools-style installation prefix', "/usr/local", PathVariable.PathAccept),
     PathVariable('prefsdir', 'user preferences directory', "", PathVariable.PathAccept),
     PathVariable('default_prefs_file', 'default preferences file name', "", PathVariable.PathAccept),
@@ -408,10 +407,6 @@ if env["prereqs"]:
         client_env['fribidi'] = client_env['fribidi'] and (conf.CheckPKG('fribidi >= 0.10.9') or Warning("Can't find FriBiDi, disabling FriBiDi support."))
         if client_env['fribidi']:
             client_env.Append(CPPDEFINES = ["HAVE_FRIBIDI"])
-
-        env["png"] = env["png"] and conf.CheckLib("png")
-        if env["png"]:
-            client_env.Append(CPPDEFINES = ["HAVE_LIBPNG"])
 
         env["history"] = env["history"] and (conf.CheckLib("history") or Warning("Can't find GNU history, disabling history support."))
         if env["history"]:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,13 +79,6 @@ set(game-external-libs
 	${VORBISFILE_LIBRARIES}
 )
 
-if(ENABLE_LIBPNG AND PNG_FOUND)
-	set(game-external-libs
-		${game-external-libs}
-		${PNG_LIBRARIES}
-	)
-endif(ENABLE_LIBPNG AND PNG_FOUND)
-
 if(ENABLE_HISTORY AND HISTORY_FOUND)
 	set(game-external-libs
 		${game-external-libs}


### PR DESCRIPTION
Commit dfc42e8a8dd550ca04ae16e2d2d7ebffbba0bc21 removed said code since Wesnoth can use `IMG_SavePNG()` from SDL_image 2.0 instead. However, the author left the build-time configuration options intact, and also part of the necessary code for CMake to link Wesnoth against libpng.

Note that this change also eliminates an unnecessary direct link-time dependency on libpng using both CMake and SCons.