### PR TITLE
Remove slows notes for Quenoth Scout

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Scout.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Scout.cfg
@@ -14,7 +14,7 @@
     advances_to=Quenoth Pathfinder,Quenoth Archer
     cost=17
     usage=scout
-    description= _ "The Quenoth Scouts move swiftly across the sands. Their riding skill are unmatched, and these they use to harry and incapacitate enemies."+{SPECIAL_NOTES}+{SPECIAL_NOTES_DISENGAGE}+{SPECIAL_NOTES_SLOW}
+    description= _ "The Quenoth Scouts move swiftly across the sands. Their riding skills are unmatched, and these they use to harry and incapacitate enemies."+{SPECIAL_NOTES}+{SPECIAL_NOTES_DISENGAGE}
     die_sound=horse-die.ogg
     [abilities]
         {ABILITY_DISENGAGE}


### PR DESCRIPTION
Since they have no slows attack. Also "riding skill" needed to be plural.