### PR TITLE
THoT S12 Put the sneak-passageway's door on the right hex (fixes #2804)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
  ### Campaigns
    * Eastern Invasion
      * Fixed some Lua errors in S05.
+   * The Hammer of Thursagan
+     * Fixed a misplaced door image in S12.
    * Under the Burning Suns
      * Hide technical terrains in the Help browser (Human Ship, Lava overlay).
  ### Language and i18n

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/12_The_Underlevels.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/12_The_Underlevels.cfg
@@ -331,7 +331,7 @@
     {PLACE_IMAGE "scenery/dwarven-doors-closed.png" 40 42}
     {PLACE_IMAGE "scenery/dwarven-doors-closed.png" 21 55}
     {PLACE_IMAGE "scenery/dwarven-doors-closed.png" 21 54}
-    {PLACE_IMAGE "scenery/dwarven-doors-closed.png" 53 33}
+    {PLACE_IMAGE "scenery/dwarven-doors-closed.png" 55 34}
     {PLACE_IMAGE "scenery/dwarven-doors-closed.png" 23 4}
     {PLACE_IMAGE "scenery/dwarven-doors-closed.png" 39 13}
     {PLACE_IMAGE "scenery/dwarven-doors-closed.png" 26 5}


### PR DESCRIPTION
This matches with the "Another old caved-in passageway..." event
around line 835, the trigger is on 55,33 and the walls that open are

        [terrain]
            x=55,55
            y=34,35
            terrain=Uu
        [/terrain]

Debian bug #483893, for which the original fix in
4c473187e658607b17c113d66b2bf549e48e41e5 changed the wrong digit.

This is a cherry-pick from 1.14 to master (fixes #2804) of
bcaac1ef (the change) and 5b7aca97 (the changelog).

[ci skip]