### PR TITLE
Create travis dockerfile in the travis script step.

### DIFF
--- a/docker/Dockerfile-travis-1604-master
+++ b/docker/Dockerfile-travis-1604-master
@@ -1,5 +1,0 @@
-FROM wesnoth/wesnoth:1604-master
-
-COPY ./ /home/wesnoth-travis/
-
-WORKDIR /home/wesnoth-travis

--- a/utils/travis/steps/install.sh
+++ b/utils/travis/steps/install.sh
@@ -30,5 +30,9 @@ if [ "$TRAVIS_OS_NAME" = "osx" ]; then
         export LDFLAGS="-L/usr/local/opt/openssl/lib $LDFLAGS"
     fi
 else
+    echo "FROM wesnoth/wesnoth:$LTS-$BRANCH" > docker/Dockerfile-travis-"$LTS"-"$BRANCH"
+    echo "COPY ./ /home/wesnoth-travis/" >> docker/Dockerfile-travis-"$LTS"-"$BRANCH"
+    echo "WORKDIR /home/wesnoth-travis" >> docker/Dockerfile-travis-"$LTS"-"$BRANCH"
+
     docker build -t wesnoth-repo:"$LTS"-"$BRANCH" -f docker/Dockerfile-travis-"$LTS"-"$BRANCH" .
 fi


### PR DESCRIPTION
This allows having multiple Dockerfile-base-* files without also needing to add a separate Dockerfile-travis-* file due to the FROM line changing.