### PR TITLE
THoT S12 Fix some "x=" tests that should be "x,y=" tests (and changelog)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 ## Version 1.13.13+dev
+ ### Campaigns
+   * The Hammer of Thursagan
+     * S12 Fixed enemies from ai6 (south-east lich) going to the book (spider) room
+     * S12 Fixed north treasure chest disappearing
 
 ## Version 1.13.13
  ### Campaigns

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/12_The_Underlevels.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/12_The_Underlevels.cfg
@@ -800,7 +800,7 @@
         [/gold]
 
         [remove_item]
-            x=15,38
+            x,y=15,38
         [/remove_item]
     [/event]
 
@@ -827,7 +827,7 @@
         name=moveto
         [filter]
             side=1
-            x=55,33
+            x,y=55,33
         [/filter]
 
         [message]

--- a/players_changelog.md
+++ b/players_changelog.md
@@ -3,7 +3,9 @@ changes may be omitted). For a complete list of changes, see the main
 changelog: https://github.com/wesnoth/wesnoth/blob/1.14/changelog.md
 
 ## Version 1.13.13+dev
-
+ ### Campaigns
+   * The Hammer of Thursagan
+     * S12 Fixed enemies from ai6 going to the book room
 
 ## Version 1.13.13
  ### Language and i18n


### PR DESCRIPTION
The change itself should cherry-pick without conflicts to the master
branch, but as this starts the 1.13.13+dev changelog, the changelog
update will need a manual merge.

THoT S12 Fix some "x=" tests that should be "x,y=" tests

Taking the chest south of the start hid the door and chest that are
north of the start.

The sneak-door opened much earlier in the level, allowing the undead
from the south-east lich to go north to the spider room.  The ghosts
and nightstalkers that are supposed to ambush the player's forces in
the south (after opening the 3-hex door) instead go north and end up
joining the spider fight.  The slower-moving undead also go north,
and are easily fought one-by-one in the sneak passage instead of the
south-east.