### PR TITLE
THoT S12 Fix some "x=" tests that should be "x,y=" tests (for master branch)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
      * Fixed some Lua errors in S05.
    * The Hammer of Thursagan
      * Fixed a misplaced door image in S12.
+     * S12 Fixed enemies from ai6 (south-east lich) going to the book (spider) room
+     * S12 Fixed north treasure chest disappearing
    * Under the Burning Suns
      * Hide technical terrains in the Help browser (Human Ship, Lava overlay).
  ### Language and i18n

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/12_The_Underlevels.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/12_The_Underlevels.cfg
@@ -800,7 +800,7 @@
         [/gold]
 
         [remove_item]
-            x=15,38
+            x,y=15,38
         [/remove_item]
     [/event]
 
@@ -827,7 +827,7 @@
         name=moveto
         [filter]
             side=1
-            x=55,33
+            x,y=55,33
         [/filter]
 
         [message]


### PR DESCRIPTION
Taking the chest south of the start hid the door and chest that are
north of the start.

The sneak-door opened much earlier in the level, allowing the undead
from the south-east lich to go north to the spider room.  The ghosts
and nightstalkers that are supposed to ambush the player's forces in
the south (after opening the 3-hex door) instead go north and end up
joining the spider fight.  The slower-moving undead also go north,
and are easily fought one-by-one in the sneak passage instead of the
south-east.

[ci skip]