### PR TITLE
LoW: Fix translation error in conjunct list (fixes #2833)

### DIFF
--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg
@@ -263,57 +263,33 @@ Chapter Three"
             [/not]
         [/filter]
     [/store_unit]
-    [switch]
-        variable=l3_store_{NAME}.length
-        [case]
-            value=0
-            [set_variable]
-                name=left_behind_{NAME}
-                value= _ "some experienced warriors" # wmllint: ignore
-            [/set_variable]
-        [/case]
-        [case]
-            value=1
-            [set_variable]
-                name=left_behind_{NAME}
-                value=$l3_store_{NAME}[0].name
-            [/set_variable]
-        [/case]
-        [else]
-            {VARIABLE l3_length $l3_store_{NAME}.length}
-            {VARIABLE_OP l3_length sub 1}
-            [for]
-                array=l3_store_{NAME}
-                # for-case, what a great anti-pattern
-                [do]
-                    [switch]
-                        variable=i
-                        [case]
-                            value=0
-                            [set_variable]
-                                name=left_behind_{NAME}
-                                value=$l3_store_{NAME}[$i].name
-                            [/set_variable]
-                        [/case]
-                        [case]
-                            value=$l3_length
-                            [set_variable]
-                                name=left_behind_{NAME}
-                                value= _ "$left_behind_{NAME} and $l3_store_{NAME}[$i].name" # wmllint: ignore
-                            [/set_variable]
-                        [/case]
-                        [else]
-                            [set_variable]
-                                name=left_behind_{NAME}
-                                value= _ "$left_behind_{NAME}|, $l3_store_{NAME}[$i].name" # wmllint: ignore
-                            [/set_variable]
-                        [/else]
-                    [/switch]
-                [/do]
-            [/for]
-            {CLEAR_VARIABLE l3_length}
-        [/else]
-    [/switch]
+    [lua]
+        code=<<
+            local args = (...)
+            local units = wml.array_access.get(args, "units")
+            local empty_str = args.empty
+            local var = args.variable
+            
+            if #units == 0 then
+                wml.variables[var] = empty_str
+            elseif #units == 1 then
+                wml.variables[var] = units[0].name
+            else
+                for i = 1, #units do
+                    units[i] = units[i].name
+                end
+                wml.variables[var] = wesnoth.format_conjunct_list(units)
+            end
+        >>
+        [args]
+            empty= _ "some experienced warriors" # wmllint: ignore
+            variable=left_behind_{NAME}
+            [insert_tag]
+                name=units
+                variable=l3_store_{NAME}
+            [/insert_tag]
+        [/args]
+    [/lua
 #enddef
 
             {LEAVE_BEHIND_L3 kalenz 1}

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg
@@ -270,16 +270,10 @@ Chapter Three"
             local empty_str = args.empty
             local var = args.variable
             
-            if #units == 0 then
-                wml.variables[var] = empty_str
-            elseif #units == 1 then
-                wml.variables[var] = units[0].name
-            else
-                for i = 1, #units do
-                    units[i] = units[i].name
-                end
-                wml.variables[var] = wesnoth.format_conjunct_list(units)
+            for i = 1, #units do
+                units[i] = units[i].name
             end
+            wml.variables[var] = wesnoth.format_conjunct_list(empty_str, units)
         >>
         [args]
             empty= _ "some experienced warriors" # wmllint: ignore

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg
@@ -266,7 +266,7 @@ Chapter Three"
     [lua]
         code=<<
             local args = (...)
-            local units = wml.array_access.get(args, "units")
+            local units = wml.child_array(args, "units")
             local empty_str = args.empty
             local var = args.variable
             

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg
@@ -289,7 +289,7 @@ Chapter Three"
                 variable=l3_store_{NAME}
             [/insert_tag]
         [/args]
-    [/lua
+    [/lua]
 #enddef
 
             {LEAVE_BEHIND_L3 kalenz 1}


### PR DESCRIPTION
This uses the new `wesnoth.format_conjunct_list` function to implement the functionality. Needs to be tested, but there's no hurry since it's destined for 1.14.1.