### PR TITLE
LoW S09 Fix a bug introduced in Lua cleanup 3783693cb

### DIFF
--- a/data/campaigns/Legend_of_Wesmere/lua/wml_tags.lua
+++ b/data/campaigns/Legend_of_Wesmere/lua/wml_tags.lua
@@ -94,7 +94,7 @@ function wesnoth.wml_actions.persistent_carryover_store(cfg)
 end
 
 function wesnoth.wml_actions.persistent_carryover_unstore(cfg)
-	if V.side_number then
+	if vars.side_number then
 		-- Only do this if we begin from this chapter.
 		return
 	end


### PR DESCRIPTION
3783693cbe95be6c51553dfa71bf0ecd5ed8116f was a general rename of
'V' to 'vars', and this line was missed. It caused an error at the
start of S09.

[ci skip]