### PR TITLE
gui2/log_settings: Make log options tooltips translatable

### DIFF
--- a/data/gui/window/logging.cfg
+++ b/data/gui/window/logging.cfg
@@ -126,10 +126,10 @@
 
 												[/column]
 
-												{_GUI_LOGGER_RADIOS {_DEBUG} "Debug level logging: maximum information"}
-												{_GUI_LOGGER_RADIOS {_INFO} "Info level logging: more information"}
-												{_GUI_LOGGER_RADIOS {_WARN} "Warning level logging: less information"}
-												{_GUI_LOGGER_RADIOS {_ERR} "Error level logging: minimum information"}
+												{_GUI_LOGGER_RADIOS {_DEBUG} ( _ "Debug level logging: maximum information")}
+												{_GUI_LOGGER_RADIOS {_INFO}  ( _ "Info level logging: more information")}
+												{_GUI_LOGGER_RADIOS {_WARN}  ( _ "Warning level logging: less information")}
+												{_GUI_LOGGER_RADIOS {_ERR}   ( _ "Error level logging: minimum information")}
 
 											[/row]
 										[/grid]


### PR DESCRIPTION
Fixes #2837 on 1.14. This cannot be merged in 1.14 until after 1.14.0 is tagged and announced because of the active string freeze.

The master version is already merged (see commit 3967fd190e60b59cb9017bf4013a177dfcb44fdd).