### PR TITLE
Drop duplicate hotkey commands

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
    * Made Faction Select button's purpose more clear in MP Staging.
  ### Miscellaneous and bug fixes
    * Removed the Font Scaling preference. It was too buggy (issues #2792 and #1624).
+   * Fixed some hotkeys triggering multiple commands on GNU/Linux (bug #1736).
    * Fixed regression where unit filters in [disable] weapon specials would not
      match the attacking unit.
    * Fixed images with no alpha channel rendering incorrectly.

--- a/players_changelog.md
+++ b/players_changelog.md
@@ -10,6 +10,8 @@ changelog: https://github.com/wesnoth/wesnoth/blob/1.14/changelog.md
      * New set of story art.
  ### Language and i18n
    * Updated translations: Chinese (Simplified), French, Galician, Polish.
+ ### Miscellaneous and bug fixes
+   * Fixed some hotkeys triggering multiple commands on GNU/Linux (bug #1736).
 
 
 ## Version 1.13.13

--- a/src/controller_base.cpp
+++ b/src/controller_base.cpp
@@ -142,6 +142,15 @@ void controller_base::handle_event(const SDL_Event& event)
 	}
 }
 
+void controller_base::process(events::pump_info&)
+{
+	if(gui::in_dialog()) {
+		return;
+	}
+
+	hotkey::run_events(get_hotkey_command_executor());
+}
+
 void controller_base::keyup_listener::handle_event(const SDL_Event& event)
 {
 	if(event.type == SDL_KEYUP) {

--- a/src/controller_base.hpp
+++ b/src/controller_base.hpp
@@ -60,7 +60,7 @@ namespace soundsource
 class manager;
 }
 
-class controller_base : public video2::draw_layering
+class controller_base : public video2::draw_layering, public events::pump_monitor
 {
 public:
 	controller_base(const config& game_config);
@@ -147,12 +147,14 @@ protected:
 	 * Calls various virtual function to allow specialized
 	 * behavior of derived classes.
 	 */
-	void handle_event(const SDL_Event& event);
+	void handle_event(const SDL_Event& event) override;
 
-	void handle_window_event(const SDL_Event& /*event*/)
+	void handle_window_event(const SDL_Event& /*event*/) override
 	{
 		// No action by default
 	}
+
+	virtual void process(events::pump_info&) override;
 
 	/** Process keydown (only when the general map display does not have focus). */
 	virtual void process_focus_keydown_event(const SDL_Event& /*event*/)

--- a/src/hotkey/command_executor.hpp
+++ b/src/hotkey/command_executor.hpp
@@ -134,7 +134,8 @@ public:
 	void execute_action(const std::vector<std::string>& items_arg, int xloc, int yloc, bool context_menu, display& gui);
 
 	virtual bool can_execute_command(const hotkey_command& command, int index=-1) const = 0;
-	void execute_command(const SDL_Event& event, int index = -1);
+	void queue_command(const SDL_Event& event, int index = -1);
+	void run_queued_commands();
 	void execute_quit_command()
 	{
 		const hotkey_command& quit_hotkey = hotkey_command::get_command_by_command(hotkey::HOTKEY_QUIT_GAME);
@@ -150,7 +151,23 @@ protected:
 	virtual bool do_execute_command(const hotkey_command& command, int index=-1, bool press=true, bool release=false);
 
 private:
+	struct queued_command
+	{
+		queued_command(const hotkey_command& command_, int index_, bool press_, bool release_)
+			: command(&command_), index(index_), press(press_), release(release_)
+		{}
+
+		const hotkey_command* command;
+		int index;
+		bool press;
+		bool release;
+	};
+
+	void execute_command_wrap(const queued_command& command);
+	std::vector<queued_command> filter_command_queue();
+
 	bool press_event_sent_ = false;
+	std::vector<queued_command> command_queue_;
 };
 class command_executor_default : public command_executor
 {
@@ -176,5 +193,7 @@ void jhat_event(const SDL_Event& event, command_executor* executor);
 void key_event(const SDL_Event& event, command_executor* executor);
 void keyup_event(const SDL_Event& event, command_executor* executor);
 void mbutton_event(const SDL_Event& event, command_executor* executor);
+// Function to call to process the events.
+void run_events(command_executor* executor);
 
 }


### PR DESCRIPTION
This is a fix for #1736. I have verified locally on GNU/Linux that the commit fixes it.

The underlying problem in #1736 is that two input events are generated for the same keypress, and this pull request drops the duplicates at the hotkey manager level.

Because the hotkey manager has traditionally received input events one-by-one, I needed to add a queue of input events. `controller_base` is now a pump monitor: when the event pump is done sending events, `controller_base` tells the hotkey manager to run queued commands. The hotkey manager drops duplicate commands at that point, before running the remaining commands.