### PR TITLE
Adjust the weapon names of the heroes to better fit their portraits

### DIFF
--- a/data/campaigns/Liberty/scenarios/01_The_Raid.cfg
+++ b/data/campaigns/Liberty/scenarios/01_The_Raid.cfg
@@ -57,6 +57,20 @@
         unrenamable=yes
         experience=25
         gold=0
+        [modifications]
+            [object]
+                duration=forever
+                silent=yes
+                [effect]
+                    apply_to=attack
+                    name=mace-spiked
+                    #textdomain wesnoth-units
+                    set_description= _ "mace"
+                    set_icon=attacks/mace.png
+                    #textdomain wesnoth-l
+                [/effect]
+            [/object]
+        [/modifications]
     [/side]
 
     {STARTING_VILLAGES 1 4}
@@ -212,6 +226,18 @@
             side=1
             random_traits=no
             [modifications]
+                [object]
+                    duration=forever
+                    silent=yes
+                    [effect]
+                        apply_to=attack
+                        name=mace-spiked
+                        #textdomain wesnoth-units
+                        set_description= _ "club"
+                        set_icon=attacks/club.png
+                        #textdomain wesnoth-l
+                    [/effect]
+                [/object]
                 {TRAIT_LOYAL}
             [/modifications]
             {IS_HERO}


### PR DESCRIPTION
... Quite some time ago I had a few PRs about weapon name changes for core units, mostly bandits.

This adjusts the weapon names of the campaign heroes to better match their portraits:
Harpers weapon is called club on the higher levels as well.
Baldras weapon is clearly a mace.
The female village leader .... ... well, what is it? I changed it for mace too, instead of a morning star.