### PR TITLE
Moves a nice, but unused macro from anl to deprecated

### DIFF
--- a/data/core/macros/deprecated-utils.cfg
+++ b/data/core/macros/deprecated-utils.cfg
@@ -448,3 +448,41 @@ _"No gold carried over to the next scenario."#enddef
     #deprecated 3 1.15 Use DUNEFOLK_NAMES instead.
     {DUNEFOLK_NAMES}
 #enddef
+
+#textdomain wesnoth-anl
+#define OPEN_CHEST X Y TREASURE_VALUE
+    [sound]
+        name=open-chest.wav
+    [/sound]
+
+    [remove_item]
+        x={X}
+        y={Y}
+        image=items/chest-plain-closed.png
+    [/remove_item]
+    [item]
+        x={X}
+        y={Y}
+        image=items/chest-plain-open.png
+    [/item]
+
+    [set_variable]
+        name=oc_treasure
+        value={TREASURE_VALUE}
+    [/set_variable]
+    [message]
+        speaker=narrator
+        image=items/chest-plain-open.png
+        message= _ "The chest contains $oc_treasure gold."
+    [/message]
+
+    [clear_variable]
+        name=oc_treasure
+    [/clear_variable]
+
+    [gold]
+        side=$side_number
+        amount={TREASURE_VALUE}
+    [/gold]
+#enddef
+#textdomain wesnoth

--- a/data/multiplayer/scenarios/ANL_utils/ANL_general_macros.cfg
+++ b/data/multiplayer/scenarios/ANL_utils/ANL_general_macros.cfg
@@ -8,42 +8,6 @@
     [/capture_village]
 #enddef
 
-#define OPEN_CHEST X Y TREASURE_VALUE
-    [sound]
-        name=open-chest.wav
-    [/sound]
-
-    [remove_item]
-        x={X}
-        y={Y}
-        image=items/chest-plain-closed.png
-    [/remove_item]
-    [item]
-        x={X}
-        y={Y}
-        image=items/chest-plain-open.png
-    [/item]
-
-    [set_variable]
-        name=oc_treasure
-        value={TREASURE_VALUE}
-    [/set_variable]
-    [message]
-        speaker=narrator
-        image=items/chest-plain-open.png
-        message= _ "The chest contains $oc_treasure gold."
-    [/message]
-
-    [clear_variable]
-        name=oc_treasure
-    [/clear_variable]
-
-    [gold]
-        side=$side_number
-        amount={TREASURE_VALUE}
-    [/gold]
-#enddef
-
 #define MOVEMENT_RESTRICTION TERR1_NAME TERR2_NAME
     [object]
         silent=yes


### PR DESCRIPTION
Nice macro, but it's not used in ANL.
Moving to deprecated for now, since ANL has lot's of macros and is maybe not the best place for dead code.

I guess it could be useful to content creator if it were in core. How about that?
And in case we do, is it possible to change the textdomain during string freeze with the pot fix scrip?
