### PR TITLE
Adds a c++17 build using the pre-release Ubuntu 18.04.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
       env: TOOL=scons CXXSTD=14 NLS=true LTS=1604 BRANCH=master
 
     - compiler: gcc
+      env: TOOL=scons CXXSTD=17 NLS=false LTS=1804 BRANCH=master
+
+    - compiler: gcc
       env: TOOL=scons CXXSTD=14 NLS=false LTS=1604 BRANCH=master OPT=-O0
 
     - compiler: gcc

--- a/docker/Dockerfile-base-1804-master
+++ b/docker/Dockerfile-base-1804-master
@@ -1,0 +1,19 @@
+FROM ubuntu:18.04
+
+RUN apt update
+
+RUN apt install -y -qq apt-utils
+
+# boost
+RUN apt install -y -qq libboost-filesystem1.65-dev libboost-filesystem1.65.1 libboost-iostreams1.65-dev libboost-iostreams1.65.1 libboost-locale1.65-dev libboost-locale1.65.1 libboost-regex1.65-dev libboost-regex1.65.1 libboost-serialization1.65-dev libboost-serialization1.65.1 libasio-dev libboost-program-options1.65-dev libboost-program-options1.65.1 libboost-random1.65-dev libboost-random1.65.1 libboost-system1.65-dev libboost-system1.65.1 libboost-test-dev
+
+# SDL
+RUN apt install -y -qq libsdl2-2.0-0 libsdl2-dev libsdl2-image-2.0-0 libsdl2-image-dev libsdl2-mixer-2.0-0 libsdl2-mixer-dev
+
+# misc
+RUN apt install -y -qq libpng16-16 libpng-dev libreadline6-dev libvorbis-dev libcairo2 libcairo2-dev libpango-1.0-0 libpango1.0-dev libfribidi0 libfribidi-dev libbz2-1.0 libbz2-dev zlib1g zlib1g-dev libpangocairo-1.0-0 libssl-dev
+
+# programs
+RUN apt install -y -qq openssl gdb xvfb bzip2 git scons cmake make ccache gcc g++ clang
+
+WORKDIR /home/wesnoth-travis

--- a/run_wml_tests
+++ b/run_wml_tests
@@ -188,6 +188,12 @@ run_test()
   fi
   $command 2> error.log
   error_code="$?"
+  # workaround to fix issue in travis+18.04
+  while grep -q 'Could not initialize SDL_video' error.log; do
+    echo "Could not initialize SDL_video error, retrying..."
+    $command 2> error.log
+    error_code="$?"
+  done
   if check_errs $2 $error_code $1; then
     FirstTest=0 #Only start using validcache flag when at least one test has passed without error
     handle_error_log 0
@@ -376,3 +382,4 @@ else
   echo "All tests gave the correct result."
   exit 0
 fi
+

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -49,10 +49,7 @@
 #include "config_attribute_value.hpp"
 #include "exceptions.hpp"
 
-#ifdef HAVE_CXX17
-#include <string_view>
-using config_key_type = std::string_view;
-#elif BOOST_VERSION > 106100
+#if BOOST_VERSION > 106100
 #include <boost/utility/string_view.hpp>
 using config_key_type = boost::string_view;
 #else

--- a/src/gettext.hpp
+++ b/src/gettext.hpp
@@ -63,11 +63,11 @@ namespace translation
 	//const char* sngettext(const char *singular, const char *plural, int n);
 	std::string dsngettext(const char * domainname, const char *singular, const char *plural, int n);
 
-	inline UNUSEDNOWARN static std::string gettext(const char* str)
+	UNUSEDNOWARN inline static std::string gettext(const char* str)
 	{ return translation::dgettext(GETTEXT_DOMAIN, str); }
-	inline UNUSEDNOWARN static std::string sgettext(const char* str)
+	UNUSEDNOWARN inline static std::string sgettext(const char* str)
 	{ return translation::dsgettext(GETTEXT_DOMAIN, str); }
-	inline UNUSEDNOWARN static std::string sngettext(const char* str1, const char* str2, int n)
+	UNUSEDNOWARN inline static std::string sngettext(const char* str1, const char* str2, int n)
 	{ return translation::dsngettext(GETTEXT_DOMAIN, str1, str2 , n); }
 
 
@@ -86,11 +86,11 @@ namespace translation
 }
 
 //#define _(String) translation::dsgettext(GETTEXT_DOMAIN,String)
-inline static UNUSEDNOWARN std::string _(const char* str)
+UNUSEDNOWARN inline static std::string _(const char* str)
 { return translation::dsgettext(GETTEXT_DOMAIN, str); }
 
 //#define _n(String1, String2, Int) translation::dsngettext(GETTEXT_DOMAIN, String1,String2,Int)
-inline UNUSEDNOWARN static std::string _n(const char* str1, const char* str2, int n)
+UNUSEDNOWARN inline static std::string _n(const char* str1, const char* str2, int n)
 { return translation::dsngettext(GETTEXT_DOMAIN, str1, str2, n); }
 
 #define gettext_noop(String) String

--- a/src/serialization/base64.cpp
+++ b/src/serialization/base64.cpp
@@ -15,6 +15,7 @@
 #include "serialization/base64.hpp"
 
 #include <vector>
+#include <string>
 
 namespace {
 const std::string base64_itoa_map = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";

--- a/src/serialization/string_view.hpp
+++ b/src/serialization/string_view.hpp
@@ -27,8 +27,6 @@ that class. */
 /** Use the standard library string_view if building with C++17. */
 #ifdef HAVE_CXX17
 
-#include <string_view>
-
 namespace utils {
 using string_view = std::string_view;
 typedef std::basic_string_view<uint8_t, std::char_traits<uint8_t>> byte_string_view;

--- a/src/serialization/string_view.hpp
+++ b/src/serialization/string_view.hpp
@@ -19,20 +19,10 @@ that class. */
 
 #pragma once
 
-#include "global.hpp"
-
 #include <boost/version.hpp>
 #include <cstdint>
 
-/** Use the standard library string_view if building with C++17. */
-#ifdef HAVE_CXX17
-
-namespace utils {
-using string_view = std::string_view;
-typedef std::basic_string_view<uint8_t, std::char_traits<uint8_t>> byte_string_view;
-}
-
-#elif BOOST_VERSION > 106100
+#if BOOST_VERSION > 106100
 
 /* Boost string_view is available, so we can just use it. */
 #include <boost/utility/string_view.hpp>

--- a/utils/travis/docker_run.sh
+++ b/utils/travis/docker_run.sh
@@ -27,6 +27,10 @@ else
     build_timeout=40
 fi
 
+if [ "$CXXSTD" == "17" ]; then
+    STRICT="true"
+fi
+
 echo "Using configuration:"
 echo "NLS: $NLS"
 echo "TOOL: $TOOL"

--- a/utils/travis/play_test_executor.sh
+++ b/utils/travis/play_test_executor.sh
@@ -1,3 +1,12 @@
 #!/bin/bash
-set -e
-gdb -q -batch -return-child-result -ex "run" -ex "thread apply all bt" -ex "quit" --args ./wesnoth -m --controller 1:ai --controller 2:ai --nogui
+gdb -q -batch -return-child-result -ex "run" -ex "thread apply all bt" -ex "quit" --args ./wesnoth -m --controller 1:ai --controller 2:ai --nogui 2> error.log
+error_code="$?"
+while grep -q 'Could not initialize SDL_video' error.log; do
+  echo "Could not initialize SDL_video error, retrying..."
+  gdb -q -batch -return-child-result -ex "run" -ex "thread apply all bt" -ex "quit" --args ./wesnoth -m --controller 1:ai --controller 2:ai --nogui 2> error.log
+  error_code="$?"
+done
+cat error.log
+
+exit $error_code
+

--- a/utils/travis/test_executor.sh
+++ b/utils/travis/test_executor.sh
@@ -1,3 +1,12 @@
 #!/bin/bash
-set -e
-gdb -q -batch -return-child-result -ex "run" -ex "thread apply all bt" -ex "quit" --args ./boost_unit_tests
+gdb -q -batch -return-child-result -ex "run" -ex "thread apply all bt" -ex "quit" --args ./boost_unit_tests 2> error.log
+error_code="$?"
+while grep -q 'Could not initialize SDL_video' error.log; do
+  echo "Could not initialize SDL_video error, retrying..."
+  gdb -q -batch -return-child-result -ex "run" -ex "thread apply all bt" -ex "quit" --args ./boost_unit_tests 2> error.log
+  error_code="$?"
+done
+cat error.log
+
+exit $error_code
+


### PR DESCRIPTION
Though given 00d87f8fe4078ffd84fcdc0d73fcc2104efef1e7 I would say this is better than nothing.

---

The checks for `Could not initialize SDL_video` were added since, for whatever reason, that error was [showing up at random](https://travis-ci.org/Pentarctagon/wesnoth/jobs/363709778#L2586) for everything *except* the mp tests.  The error never occurs twice in a row, [Xvfb](https://travis-ci.org/Pentarctagon/wesnoth/jobs/365380422#L2350) is running, and explicitly setting [SDL_VIDEODRIVER](https://wiki.libsdl.org/FAQUsingSDL#Linux) to x11 results in it instead saying that [x11 is not available](https://travis-ci.org/Pentarctagon/wesnoth/jobs/365380422#L3099).

Suffice it to say, I assume this is not a Wesnoth issue.