### PR TITLE
SotA: Restore fixes for issues #2844 and #2846 on 1.14

### DIFF
--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg
@@ -276,7 +276,7 @@ of Healing"
             image=items/gravestone1.png
         [/item]
 
-        {PLACE_GUARD 10 11 (Spearman) RESILIENT QUICK "Gwillyn" (_"Gwillyn")}
+        {PLACE_GUARD 10 11 (Spearman) RESILIENT QUICK "Gwyllin" (_"Gwyllin")}
         {PLACE_GUARD 10 10 (Spearman) QUICK RESILIENT "Veomyr" (_"Veomyr")}
         {PLACE_GUARD 8 10 (Spearman) STRONG RESILIENT "Syrillin" (_"Syrillin")}
         {PLACE_GUARD 7 10 (Bowman) STRONG INTELLIGENT "Glant" (_"Glant")}
@@ -293,7 +293,7 @@ of Healing"
 #endif
 
         # We don't want the guard on the village to move from there:
-        {FREEZE_UNIT Gwillyn}
+        {FREEZE_UNIT Gwyllin}
 
         [store_locations]
             terrain=*^Gryv

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg
@@ -89,7 +89,7 @@ After several days of travel, he approached the frontier town of Carcyn."
         [unit]
             type=Shadow
             side=1
-            name= _ "Vash Gorn"
+            name= _ "Vash-Gorn"
         [/unit]
         [unit]
             type=Ghost


### PR DESCRIPTION
**(NOTE: a changelog patch is not provided in order since it's going to become a merge conflicts minefield in a matter of days.)**

This restores the changes from the following commits:

 * "SotA S2: fixed inconsistency between unit name and dialog (fixes #2844)" - commit ab9f29a7a44372a3e3703fd842740a9b425b6f5f
 * "SotA S8: fixed inconsistent Ghost name (fixes #2846)" - commit fc6c3ac04b899b4c7f629a1cd8d80101c7cbb20c