### PR TITLE
fix typo in german translation (for master)

### DIFF
--- a/po/wesnoth-lib/de.po
+++ b/po/wesnoth-lib/de.po
@@ -3326,7 +3326,7 @@ msgstr "Spielverzeichnisse"
 #. [widget]: id=tab_label
 #: data/gui/window/game_stats.cfg:793 src/gui/dialogs/game_stats.cpp:255
 msgid "Scenario Settings"
-msgstr "Szenrioeinstellungen"
+msgstr "Szenarioeinstellungen"
 
 #. [button]: id=ok
 #: data/gui/window/game_stats.cfg:832 data/gui/window/unit_list.cfg:436


### PR DESCRIPTION
This string appears in the status dialog.
I hope editing this file is the right way to go – if not, please tell me what is the correct one.

(This is the same change as #2899 – that one is for 1.14, this one is for master.)