### PR TITLE
cmake: if sanitizers are enabled, also add -fno-omit-frame-pointer and -fno-optimize-sibling-calls.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,6 +232,8 @@ endif(ENABLE_PEDANTIC_COMPILATION)
 if(SANITIZE)
 	set(COMPILER_FLAGS "${COMPILER_FLAGS} -fsanitize=${SANITIZE}")
 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=${SANITIZE}")
+# manually disable some optimizations to get better stacktraces if sanitizers are used
+	set(COMPILER_FLAGS "${COMPILER_FLAGS} -fno-omit-frame-pointer -fno-optimize-sibling-calls")
 endif(SANITIZE)
 
 ### Set the final compiler flags.

--- a/SConstruct
+++ b/SConstruct
@@ -480,7 +480,8 @@ for env in [test_env, client_env, env]:
             env.AppendUnique(CXXFLAGS = Split("-Wctor-dtor-privacy -Wuseless-cast -Wnoexcept"))
         if env['sanitize']:
             env.AppendUnique(CCFLAGS = ["-fsanitize=" + env["sanitize"]], LINKFLAGS = ["-fsanitize=" + env["sanitize"]])
-    
+            env.AppendUnique(CCFLAGS = Split("-fno-omit-frame-pointer -fno-optimize-sibling-calls"))
+
 # #
 # Determine optimization level
 # #
@@ -493,7 +494,7 @@ for env in [test_env, client_env, env]:
             else:
                 env["opt"] = "-O0 "
         else:
-            env["opt"] = env["opt"]+" " 
+            env["opt"] = env["opt"]+" "
 
 # #
 # Start determining options for debug build


### PR DESCRIPTION
Otherwise, if we build with sanitizers and optimizations, the sanitizer stacktraces can become quite hard to read.