### PR TITLE
Tutorial: fix the overall translation hint comment

### DIFF
--- a/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
+++ b/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
@@ -1,11 +1,10 @@
 #textdomain wesnoth-tutorial
 
-# po: Hello, translators! The tutorial is meant to be a bit funny at the start,
-# po: welcoming new players. Please keep the friendly fun feeling!
-# po: If you have any questions, ask in the forums or in the #wesnoth-dev channel on the Freenode IRC network.
-
 [tutorial]
     id=tutorial
+    # po: Hello, translators! The tutorial is meant to be a bit funny at the start,
+    # po: welcoming new players. Please keep the friendly fun feeling!
+    # po: If you have any questions, ask in the forums or in the #wesnoth-dev channel on the Freenode IRC network.
     name= _ "Wesnoth Tutorial — Part I"
     map_data="{campaigns/tutorial/maps/01_Tutorial_part_1.map}"
     next_scenario=2_Tutorial


### PR DESCRIPTION
The comment at the start of 01_Tutorial_part_1.cfg wasn't immediately
before a string, so the hint for translators wasn't in the file that
goes to the translators. Fix it so that the tutorial shows working
usage of "# po:" style comments; this is probably more help to people
using the tutorial as a reference for WML, rather than the translators
themselves.