### PR TITLE
Add support for disabling log domains in the Logging Options UI

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -119,6 +119,7 @@
    * Fixed locations not being added to the palette when loading a map (#1023)
    * Fixed an AI assertion when a unit with one disabled attack attacked a unit
      with no attacks or a single disabled attack.
+   * It is now possible to disable logdomains in the Logging Options dialog.
 
 ## Version 1.13.12
  ### Security fixes

--- a/data/gui/window/logging.cfg
+++ b/data/gui/window/logging.cfg
@@ -1,7 +1,7 @@
 #textdomain wesnoth-lib
 ###
 ### Definition of the window to select logging options.
-### These first five things match the names from logging.cpp
+### These first six strings match the names from logging.cpp
 ###
 #define _NAME
 "label"#enddef
@@ -13,6 +13,8 @@
 "warn"#enddef
 #define _ERR
 "err"#enddef
+#define _NONE
+"none"#enddef
 
 #define _GUI_LOGGER_RADIOS GROUP TOOLTIP
 	[column]
@@ -64,6 +66,11 @@
 
 		[linked_group]
 			id = {_ERR}
+			fixed_width = true
+		[/linked_group]
+
+		[linked_group]
+			id = {_NONE}
 			fixed_width = true
 		[/linked_group]
 
@@ -130,6 +137,7 @@
 												{_GUI_LOGGER_RADIOS {_INFO}  ( _ "Info level logging: more information")}
 												{_GUI_LOGGER_RADIOS {_WARN}  ( _ "Warning level logging: less information")}
 												{_GUI_LOGGER_RADIOS {_ERR}   ( _ "Error level logging: minimum information")}
+												{_GUI_LOGGER_RADIOS {_NONE}  ( _ "Disable logging")}
 
 											[/row]
 										[/grid]

--- a/src/gui/dialogs/log_settings.cpp
+++ b/src/gui/dialogs/log_settings.cpp
@@ -34,6 +34,7 @@ REGISTER_DIALOG(log_settings)
 log_settings::log_settings()
 {
 	//list of names must match those in logging.cfg
+	widget_id_.push_back("none");
 	widget_id_.push_back("err");
 	widget_id_.push_back("warn");
 	widget_id_.push_back("info");
@@ -75,9 +76,11 @@ void log_settings::pre_show(window& window)
 				group.add_member(button, this_id);
 			}
 		}
-		int current_sev, max_sev = widget_id_.size() - 1;
-		if (lg::get_log_domain_severity(this_domain, current_sev) && current_sev >= 0 && current_sev <= max_sev){
-			group.set_member_states(widget_id_[current_sev]);
+		int current_sev, max_sev = widget_id_.size();
+		if (lg::get_log_domain_severity(this_domain, current_sev)) {
+			if (current_sev <= max_sev) {
+				group.set_member_states(widget_id_[current_sev + 1]);
+			}
 		}
 	}
 }
@@ -93,14 +96,16 @@ void log_settings::set_logger(const std::string log_domain)
 {
 	std::string active_value = groups_[log_domain].get_active_member_value();
 
-	if(active_value == widget_id_[1]){ //default value, level1: warning
+	if(active_value == widget_id_[2]){ //default value, level1: warning
 		lg::set_log_domain_severity(log_domain, lg::warn());
-	} else if(active_value == widget_id_[3]){ //level3: debug
+	} else if(active_value == widget_id_[4]){ //level3: debug
 		lg::set_log_domain_severity(log_domain, lg::debug());
-	} else if(active_value == widget_id_[2]){ //level2: info
+	} else if(active_value == widget_id_[3]){ //level2: info
 		lg::set_log_domain_severity(log_domain, lg::info());
-	} else if(active_value == widget_id_[0]){ //level0: error
+	} else if(active_value == widget_id_[1]){ //level0: error
 		lg::set_log_domain_severity(log_domain, lg::err());
+	} else if(active_value == widget_id_[0]){ //level-1: disable
+		lg::set_log_domain_severity(log_domain, -1);
 	}
 }
 


### PR DESCRIPTION
This adds a fifth radio button for disabling individual log domains in the Logging Options dialog from Advanced Preferences.

Once approved and merged I can backport it to 1.14 if this is something that would be deemed useful to have there.