### PR TITLE
Change year numbers in SotBE according to timeline tweaks

### DIFF
--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg
@@ -95,7 +95,7 @@
 
     [story]
         [part]
-            story= _ "Rahul I, Lord Protector of the Northern Alliance, concluded peace with enemy orcs during the fourth year of his leadership. He ended a 15-year war with Black-Eye Karun, ruler of the enemy orcs. A peace treaty between the Alliance and the orcs settled their territorial disputes."
+            story= _ "Rahul I, Lord Protector of the Northern Alliance, concluded peace with enemy orcs during the fourteenth year of his leadership. He ended a 15-year war with Black-Eye Karun, ruler of the enemy orcs. A peace treaty between the Alliance and the orcs settled their territorial disputes."
             {SOTBE_BIGMAP}
         [/part]
 

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg
@@ -456,7 +456,7 @@
 
         [message]
             speaker=Howgarth III
-            message= _ "The hell I don’t, Earl Lanbec’h, the Northern Alliance was witness to a treaty some twenty seven years ago between your people and the orcs, which both of you are no doubt violating. It is our duty as the orchestrator and witness of this treaty to see that it is honored."
+            message= _ "The hell I don’t, Earl Lanbec’h, the Northern Alliance was witness to a treaty some seventeen years ago between your people and the orcs, which both of you are no doubt violating. It is our duty as the orchestrator and witness of this treaty to see that it is honored."
         [/message]
 
         [message]
@@ -483,7 +483,7 @@
 
         [message]
             speaker="Kapou'e"
-            message= _ "I am Kapou’e, son of the Black-Eye Karun. Twenty-seven years ago you people assassinated my father after inviting him to join the Northern Alliance."
+            message= _ "I am Kapou’e, son of the Black-Eye Karun. Seventeen years ago you people assassinated my father after inviting him to join the Northern Alliance."
             image=portraits/kapoue-angry.png
         [/message]
 


### PR DESCRIPTION
To fit the tweaks suggested in this thread: (https://forums.wesnoth.org/viewtopic.php?f=12&t=46460#p614551), there are three changed to make in the campaign Son of the Black Eye.

1. In the story of Scenario 1, it says "fourth year of his leadership" (from Rahul). It need to be changed to the fourteenth.

2. & 3. In Scenario 17, Kapou'e says, the killing of his father was twenty seven years ago. According to the tweaked timeline, it is just seventeen years ago.

I checked the surrounding campaigns, but didn't find anything else to be tweaked due to the timeline changes.
Why exactly I suggested the changes in the first place, can be read in the linked thread.

If these changes get accepted, then the timeline in the wiki has to be updated accordingly.