### PR TITLE
Fix cmake compiling with spaces in directory names.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,7 +176,7 @@ set_source_files_properties(${lua_STAT_SRC} PROPERTIES LANGUAGE CXX)
 # Inject a header into the Lua sources for Wesnoth-specific changes
 # makedepend won't see it so we have to specifically add it as a dependency.
 file(GLOB wesnoth_lua_config wesnoth_lua_config.h)
-set_source_files_properties(${lua_STAT_SRC} PROPERTIES COMPILE_FLAGS "-include ${wesnoth_lua_config}")
+set_source_files_properties(${lua_STAT_SRC} PROPERTIES COMPILE_FLAGS "-include \"${wesnoth_lua_config}\"")
 set_source_files_properties(${lua_STAT_SRC} PROPERTIES OBJECT_DEPENDS ${wesnoth_lua_config})
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
Fix for an issue reported [here](https://forums.wesnoth.org/viewtopic.php?f=5&t=48065#p627097).  I assume this should be cherry-picked over to 1.14 as well.