### PR TITLE
Fix dialogue not triggering in TSG 'Into the Depths'

### DIFF
--- a/data/campaigns/The_South_Guard/scenarios/07a_Into_the_Depths.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/07a_Into_the_Depths.cfg
@@ -667,7 +667,7 @@
         [/filter]
 
         [filter_second]
-            side=1
+            side=1,5
         [/filter_second]
 
         [redraw][/redraw]


### PR DESCRIPTION
Closes #3030. Since the trolls are on a different side, the event wouldn't trigger if they spotted Mal M'brin.