### PR TITLE
Tutorial: add labels to villages and keep

### DIFF
--- a/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
+++ b/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
@@ -447,6 +447,24 @@
             message= _ "There are two villages within your reach. Visiting villages is a good idea, and ending your turn on one will heal you. To a village!"
         [/message]
 
+        [label]
+            immutable=yes
+            text= _ "Village"
+            visible_in_fog=yes
+            visible_in_shroud=no
+            x=10
+            y=3
+        [/label]
+
+        [label]
+            immutable=yes
+            text= _ "Village"
+            visible_in_fog=yes
+            visible_in_shroud=no
+            x=11
+            y=7
+        [/label]
+
         {GENDER (
             {PRINT ( _ "Move Konrad to a nearby village")}
         ) (
@@ -505,6 +523,15 @@
             speaker=Delfador
             message= _ "A splendid idea! It’s probably best not to attempt attacking the quintain this turn. Instead, you should return to the keep and recruit two units; you have plenty of gold for that."
         [/message]
+
+        [label]
+            immutable=yes
+            text= _ "Keep"
+            visible_in_fog=yes
+            visible_in_shroud=no
+            x=9
+            y=6
+        [/label]
 
         {GENDER (
             {PRINT ( _ "Move Konrad to the keep")}


### PR DESCRIPTION
There have been reports of players who mistakenly went back to the keep when they were instructed to go to the village, and vice-versa (see #3039).
This confusion leads them to assume there's a bug in the game when they see they cannot end the turn, sometimes even retrying/undoing but consistently repeating the same thing without realizing they were going to the wrong tile. 
Examples:
- https://steamcommunity.com/app/599390/discussions/0/1696046342853921782/
- https://steamcommunity.com/app/599390/discussions/0/1696046342859863684/

This is just adding labels to make sure people don't confuse where to go.
Some new players might find confusing that what looks like a single house is considered a village.