### PR TITLE
fixes Issue #3051 (Recruitable Peasants in TSG)

### DIFF
--- a/data/campaigns/The_South_Guard/scenarios/02_Proven_by_the_Sword.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/02_Proven_by_the_Sword.cfg
@@ -644,6 +644,14 @@
             {NEW_GOLD_CARRYOVER 40}
         [/endlevel]
     [/event]
+
+    [event]
+        name=victory
+        [disallow_recruit]
+            type=Peasant
+            side=1
+        [/disallow_recruit]
+    [/event]
 [/scenario]
 
 #undef URZA_NALMATH_AI_PARAMS

--- a/data/campaigns/The_South_Guard/scenarios/07a_Into_the_Depths.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/07a_Into_the_Depths.cfg
@@ -261,7 +261,7 @@
 
         [set_recruit]
             side=1
-            recruit=Bowman,Spearman,Cavalryman,Elvish Shaman,Elvish Fighter,Peasant
+            recruit=Bowman,Spearman,Cavalryman,Elvish Shaman,Elvish Fighter
         [/set_recruit]
 
         [recall]


### PR DESCRIPTION
 Deoran is able to recruit peasants during the whole campaign, it was discussed to remove them from the recruit list after they leave Westin (Sc2).