### PR TITLE
Replace deprecated Lua code

### DIFF
--- a/data/ai/lua/ai_helper.lua
+++ b/data/ai/lua/ai_helper.lua
@@ -1092,9 +1092,9 @@ end
 function ai_helper.has_ability(unit, ability)
     -- Returns true/false depending on whether unit has the given ability
     local has_ability = false
-    local abilities = H.get_child(unit.__cfg, "abilities")
+    local abilities = wml.get_child(unit.__cfg, "abilities")
     if abilities then
-        if H.get_child(abilities, ability) then has_ability = true end
+        if wml.get_child(abilities, ability) then has_ability = true end
     end
     return has_ability
 end

--- a/data/ai/lua/battle_calcs.lua
+++ b/data/ai/lua/battle_calcs.lua
@@ -38,11 +38,11 @@ function battle_calcs.unit_attack_info(unit, cache)
         resist_mod = {},
         alignment = unit_cfg.alignment
     }
-    for attack in H.child_range(unit_cfg, 'attack') do
+    for attack in wml.child_range(unit_cfg, 'attack') do
         -- Extract information for specials; we do this first because some
         -- custom special might have the same name as one of the default scalar fields
         local a = {}
-        for special in H.child_range(attack, 'specials') do
+        for special in wml.child_range(attack, 'specials') do
             for _,sp in ipairs(special) do
                 if (sp[1] == 'damage') then  -- this is 'backstab'
                     if (sp[2].id == 'backstab') then

--- a/data/ai/lua/generic_recruit_engine.lua
+++ b/data/ai/lua/generic_recruit_engine.lua
@@ -24,7 +24,6 @@ return {
         math.randomseed(os.time())
 
         local H = wesnoth.require "helper"
-        local W = H.set_wml_action_metatable {}
         local AH = wesnoth.require "ai/lua/ai_helper.lua"
         local LS = wesnoth.require "location_set"
         local M = wesnoth.map
@@ -443,7 +442,7 @@ return {
         end
 
         function ai_cas:recruit_rushers_exec()
-            if AH.show_messages() then W.message { speaker = 'narrator', message = 'Recruiting' } end
+            if AH.show_messages() then wesnoth.wml_actions.message { speaker = 'narrator', message = 'Recruiting' } end
 
             local enemy_counts = recruit_data.recruit.enemy_counts
             local enemy_types = recruit_data.recruit.enemy_types

--- a/data/ai/lua/generic_recruit_engine.lua
+++ b/data/ai/lua/generic_recruit_engine.lua
@@ -63,7 +63,7 @@ return {
             local abilities = wml.get_child(unit.__cfg, "abilities")
             local regen_amount = 0
             if abilities then
-                for regen in H.child_range(abilities, "regenerate") do
+                for regen in wml.child_range(abilities, "regenerate") do
                     if regen.value > regen_amount then
                         regen_amount = regen.value
                     end
@@ -121,14 +121,14 @@ return {
                 -- This may be rectifiable by looking at retaliation damage as well.
                 local steadfast = false
 
-                for attack in H.child_range(wesnoth.unit_types[attacker.type].__cfg, "attack") do
+                for attack in wml.child_range(wesnoth.unit_types[attacker.type].__cfg, "attack") do
                     local defense = defender_defense
                     local poison = false
                     local damage_multiplier = 1
                     local damage_bonus = 0
                     local weapon_damage = attack.damage
 
-                    for special in H.child_range(attack, 'specials') do
+                    for special in wml.child_range(attack, 'specials') do
                         local mod
                         if wml.get_child(special, 'poison') and can_poison then
                             poison = true
@@ -195,9 +195,9 @@ return {
 
                     -- Handle drain for defender
                     local drain_recovery = 0
-                    for defender_attack in H.child_range(defender.__cfg, 'attack') do
+                    for defender_attack in wml.child_range(defender.__cfg, 'attack') do
                         if (defender_attack.range == attack.range) then
-                            for special in H.child_range(defender_attack, 'specials') do
+                            for special in wml.child_range(defender_attack, 'specials') do
                                 if wml.get_child(special, 'drains') and drainable(attacker) then
                                     -- TODO: calculate chance to hit
                                     -- currently assumes 50% chance to hit using supplied constant
@@ -293,8 +293,8 @@ return {
         end
 
         function can_slow(unit)
-            for defender_attack in H.child_range(unit.__cfg, 'attack') do
-                for special in H.child_range(defender_attack, 'specials') do
+            for defender_attack in wml.child_range(unit.__cfg, 'attack') do
+                for special in wml.child_range(defender_attack, 'specials') do
                     if wml.get_child(special, 'slow') then
                         return true
                     end

--- a/data/ai/lua/generic_recruit_engine.lua
+++ b/data/ai/lua/generic_recruit_engine.lua
@@ -23,7 +23,6 @@ return {
         end
         math.randomseed(os.time())
 
-        local H = wesnoth.require "helper"
         local AH = wesnoth.require "ai/lua/ai_helper.lua"
         local LS = wesnoth.require "location_set"
         local M = wesnoth.map

--- a/data/ai/lua/generic_recruit_engine.lua
+++ b/data/ai/lua/generic_recruit_engine.lua
@@ -60,7 +60,7 @@ return {
                 random_gender = false
             }
             -- Find the best regeneration ability and use it to estimate hp regained by regeneration
-            local abilities = H.get_child(unit.__cfg, "abilities")
+            local abilities = wml.get_child(unit.__cfg, "abilities")
             local regen_amount = 0
             if abilities then
                 for regen in H.child_range(abilities, "regenerate") do
@@ -130,12 +130,12 @@ return {
 
                     for special in H.child_range(attack, 'specials') do
                         local mod
-                        if H.get_child(special, 'poison') and can_poison then
+                        if wml.get_child(special, 'poison') and can_poison then
                             poison = true
                         end
 
                         -- Handle marksman and magical
-                        mod = H.get_child(special, 'chance_to_hit')
+                        mod = wml.get_child(special, 'chance_to_hit')
                         if mod then
                             if mod.value then
                                 if mod.cumulative then
@@ -157,7 +157,7 @@ return {
                         end
 
                         -- Handle most damage specials (assumes all are cumulative)
-                        mod = H.get_child(special, 'damage')
+                        mod = wml.get_child(special, 'damage')
                         if mod and mod.active_on ~= "defense" then
                             local special_multiplier = 1
                             local special_bonus = 0
@@ -198,7 +198,7 @@ return {
                     for defender_attack in H.child_range(defender.__cfg, 'attack') do
                         if (defender_attack.range == attack.range) then
                             for special in H.child_range(defender_attack, 'specials') do
-                                if H.get_child(special, 'drains') and drainable(attacker) then
+                                if wml.get_child(special, 'drains') and drainable(attacker) then
                                     -- TODO: calculate chance to hit
                                     -- currently assumes 50% chance to hit using supplied constant
                                     local attacker_resistance = wesnoth.unit_resistance(attacker, defender_attack.type)
@@ -295,7 +295,7 @@ return {
         function can_slow(unit)
             for defender_attack in H.child_range(unit.__cfg, 'attack') do
                 for special in H.child_range(defender_attack, 'specials') do
-                    if H.get_child(special, 'slow') then
+                    if wml.get_child(special, 'slow') then
                         return true
                     end
                 end
@@ -936,7 +936,7 @@ return {
             local test_units, num_recruits = {}, 0
             local movetypes = {}
             for x,id in ipairs(wesnoth.sides[wesnoth.current.side].recruit) do
-                local custom_movement = H.get_child(wesnoth.unit_types[id].__cfg, "movement_costs")
+                local custom_movement = wml.get_child(wesnoth.unit_types[id].__cfg, "movement_costs")
                 local movetype = wesnoth.unit_types[id].__cfg.movement_type
                 if custom_movement
                 or (not movetypes[movetype])

--- a/data/ai/lua/generic_rush_engine.lua
+++ b/data/ai/lua/generic_rush_engine.lua
@@ -6,7 +6,6 @@ return {
 
         -- More generic grunt rush (and can, in fact, be used with other unit types as well)
 
-        local H = wesnoth.require "helper"
         local AH = wesnoth.require "ai/lua/ai_helper.lua"
         local BC = wesnoth.require "ai/lua/battle_calcs.lua"
         local LS = wesnoth.require "location_set"

--- a/data/ai/lua/generic_rush_engine.lua
+++ b/data/ai/lua/generic_rush_engine.lua
@@ -7,7 +7,6 @@ return {
         -- More generic grunt rush (and can, in fact, be used with other unit types as well)
 
         local H = wesnoth.require "helper"
-        local W = H.set_wml_action_metatable {}
         local AH = wesnoth.require "ai/lua/ai_helper.lua"
         local BC = wesnoth.require "ai/lua/battle_calcs.lua"
         local LS = wesnoth.require "location_set"
@@ -256,7 +255,7 @@ return {
             local leader = wesnoth.get_units { side = wesnoth.current.side, canrecruit = 'yes' }[1]
 
             if AH.print_exec() then print_time('   Executing castle_switch CA') end
-            if AH.show_messages() then W.message { speaker = leader.id, message = 'Switching castles' } end
+            if AH.show_messages() then wesnoth.wml_actions.message { speaker = leader.id, message = 'Switching castles' } end
 
             AH.checked_move(ai, leader, self.data.leader_target[1], self.data.leader_target[2])
             self.data.leader_target = nil
@@ -395,7 +394,7 @@ return {
 
         function generic_rush:grab_villages_exec()
             if AH.print_exec() then print_time('   Executing grab_villages CA') end
-            if AH.show_messages() then W.message { speaker = self.data.unit.id, message = 'Grab villages' } end
+            if AH.show_messages() then wesnoth.wml_actions.message { speaker = self.data.unit.id, message = 'Grab villages' } end
 
             AH.movefull_stopunit(ai, self.data.unit, self.data.village)
             self.data.unit, self.data.village = nil, nil
@@ -492,7 +491,7 @@ return {
             local is_poisoner, poison_weapon = AH.has_weapon_special(attacker, "poison")
 
             if AH.print_exec() then print_time('   Executing spread_poison CA') end
-            if AH.show_messages() then W.message { speaker = attacker.id, message = 'Poison attack' } end
+            if AH.show_messages() then wesnoth.wml_actions.message { speaker = attacker.id, message = 'Poison attack' } end
 
             AH.robust_move_and_attack(ai, attacker, self.data.attack.dst, self.data.attack.target, { weapon = poison_weapon })
 

--- a/data/ai/lua/retreat.lua
+++ b/data/ai/lua/retreat.lua
@@ -85,7 +85,7 @@ function retreat_functions.get_healing_locations()
             local heal_amount = 0
             local cure = 0
             local abilities = wml.get_child(u.__cfg, "abilities") or {}
-            for ability in H.child_range(abilities, "heals") do
+            for ability in wml.child_range(abilities, "heals") do
                 heal_amount = ability.value
                 if ability.poison == "slowed" then
                     cure = 1

--- a/data/ai/lua/retreat.lua
+++ b/data/ai/lua/retreat.lua
@@ -84,7 +84,7 @@ function retreat_functions.get_healing_locations()
         if u.moves == 0 or u.side ~= wesnoth.current.side then
             local heal_amount = 0
             local cure = 0
-            local abilities = H.get_child(u.__cfg, "abilities") or {}
+            local abilities = wml.get_child(u.__cfg, "abilities") or {}
             for ability in H.child_range(abilities, "heals") do
                 heal_amount = ability.value
                 if ability.poison == "slowed" then

--- a/data/ai/micro_ais/cas/ca_assassin_move.lua
+++ b/data/ai/micro_ais/cas/ca_assassin_move.lua
@@ -5,12 +5,12 @@ local LS = wesnoth.require "location_set"
 local function get_units_target(cfg)
     local units = AH.get_units_with_moves {
         side = wesnoth.current.side,
-        { "and", H.get_child(cfg, "filter") }
+        { "and", wml.get_child(cfg, "filter") }
     }
 
     local target = wesnoth.get_units {
         { "filter_side", { { "enemy_of", { side = wesnoth.current.side } } } },
-        { "and", H.get_child(cfg, "filter_second") }
+        { "and", wml.get_child(cfg, "filter_second") }
     }[1]
 
     return units, target
@@ -55,7 +55,7 @@ function ca_assassin_move:execution(cfg)
 
     local enemies = AH.get_visible_units(wesnoth.current.side, {
         { "filter_side", { { "enemy_of", { side = wesnoth.current.side } } } },
-        { "not", H.get_child(cfg, "filter_second") }
+        { "not", wml.get_child(cfg, "filter_second") }
     })
 
     -- Maximum damage the enemies can theoretically do for all hexes they can attack
@@ -128,7 +128,7 @@ function ca_assassin_move:execution(cfg)
     -- Preferred hexes (do this here once for all hexes, so that it does not need
     -- to get done for every step of the a* search.
     -- We only need to know whether a hex is preferred or not, there's no additional rating.
-    local prefer_slf = H.get_child(cfg, "prefer")
+    local prefer_slf = wml.get_child(cfg, "prefer")
     local prefer_map -- want this to be nil, not empty LS if [prefer] tag not given
     if prefer_slf then
         local preferred_hexes = wesnoth.get_locations(prefer_slf)

--- a/data/ai/micro_ais/cas/ca_big_animals.lua
+++ b/data/ai/micro_ais/cas/ca_big_animals.lua
@@ -6,7 +6,7 @@ local MAIUV = wesnoth.require "ai/micro_ais/micro_ai_unit_variables.lua"
 local function get_big_animals(cfg)
     local big_animals = AH.get_units_with_moves {
         side = wesnoth.current.side,
-        { "and" , H.get_child(cfg, "filter") }
+        { "and" , wml.get_child(cfg, "filter") }
     }
     return big_animals
 end
@@ -24,7 +24,7 @@ function ca_big_animals:execution(cfg)
 
     local unit = get_big_animals(cfg)[1]
 
-    local avoid_tag = H.get_child(cfg, "avoid_unit")
+    local avoid_tag = wml.get_child(cfg, "avoid_unit")
     local avoid_map = LS.create()
     if avoid_tag then
         local enemies_to_be_avoided = AH.get_attackable_enemies(avoid_tag)
@@ -41,7 +41,7 @@ function ca_big_animals:execution(cfg)
     -- Unit gets a new goal if none is set or on any move with a 10% random chance
     local r = math.random(10)
     if (not goal.goal_x) or (r == 1) then
-        local locs = AH.get_passable_locations(H.get_child(cfg, "filter_location") or {})
+        local locs = AH.get_passable_locations(wml.get_child(cfg, "filter_location") or {})
         local rand = math.random(#locs)
 
         goal.goal_x, goal.goal_y = locs[rand][1], locs[rand][2]
@@ -49,7 +49,7 @@ function ca_big_animals:execution(cfg)
     end
 
     local reach_map = AH.get_reachable_unocc(unit)
-    local wander_terrain = H.get_child(cfg, "filter_location_wander") or {}
+    local wander_terrain = wml.get_child(cfg, "filter_location_wander") or {}
     reach_map:iter( function(x, y, v)
         -- Remove tiles that do not comform to the wander terrain filter
         if (not wesnoth.match_location(x, y, wander_terrain)) then

--- a/data/ai/micro_ais/cas/ca_coward.lua
+++ b/data/ai/micro_ais/cas/ca_coward.lua
@@ -2,7 +2,7 @@ local H = wesnoth.require "helper"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 
 local function get_coward(cfg)
-    local filter = H.get_child(cfg, "filter") or { id = cfg.id }
+    local filter = wml.get_child(cfg, "filter") or { id = cfg.id }
     local coward = AH.get_units_with_moves {
         side = wesnoth.current.side,
         { "and", filter }
@@ -23,7 +23,7 @@ function ca_coward:execution(cfg)
     local reach = wesnoth.find_reach(coward)
 
     local filter_second =
-        H.get_child(cfg, "filter_second")
+        wml.get_child(cfg, "filter_second")
         or { { "filter_side", { { "enemy_of", { side = wesnoth.current.side } } } } }
     local enemies = AH.get_live_units {
         { "and", filter_second },

--- a/data/ai/micro_ais/cas/ca_fast_attack_utils.lua
+++ b/data/ai/micro_ais/cas/ca_fast_attack_utils.lua
@@ -22,7 +22,7 @@ function ca_fast_attack_utils.get_avoid_map(cfg)
     -- Use [micro_ai][avoid] tag with priority over [ai][avoid].
     -- If neither is given, return an empty location set.
 
-    local avoid_tag = H.get_child(cfg, "avoid")
+    local avoid_tag = wml.get_child(cfg, "avoid")
 
     if not avoid_tag then
         return LS.of_pairs(ai.aspects.avoid)
@@ -118,7 +118,7 @@ function ca_fast_attack_utils.single_unit_info(unit_proxy)
     }
 
     -- Include the ability type, such as: hides, heals, regenerate, skirmisher (set up as 'hides = true')
-    local abilities = H.get_child(unit_proxy.__cfg, "abilities")
+    local abilities = wml.get_child(unit_proxy.__cfg, "abilities")
     if abilities then
         for _,ability in ipairs(abilities) do
             single_unit_info[ability[1]] = true

--- a/data/ai/micro_ais/cas/ca_fast_attack_utils.lua
+++ b/data/ai/micro_ais/cas/ca_fast_attack_utils.lua
@@ -128,11 +128,11 @@ function ca_fast_attack_utils.single_unit_info(unit_proxy)
     -- Information about the attacks indexed by weapon number,
     -- including specials (e.g. 'poison = true')
     single_unit_info.attacks = {}
-    for attack in H.child_range(unit_cfg, 'attack') do
+    for attack in wml.child_range(unit_cfg, 'attack') do
         -- Extract information for specials; we do this first because some
         -- custom special might have the same name as one of the default scalar fields
         local a = {}
-        for special in H.child_range(attack, 'specials') do
+        for special in wml.child_range(attack, 'specials') do
             for _,sp in ipairs(special) do
                 if (sp[1] == 'damage') then  -- this is 'backstab'
                     if (sp[2].id == 'backstab') then

--- a/data/ai/micro_ais/cas/ca_fast_attack_utils.lua
+++ b/data/ai/micro_ais/cas/ca_fast_attack_utils.lua
@@ -1,4 +1,3 @@
-local H = wesnoth.require "helper"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local LS = wesnoth.require "location_set"
 local T = wml.tag

--- a/data/ai/micro_ais/cas/ca_fast_combat.lua
+++ b/data/ai/micro_ais/cas/ca_fast_combat.lua
@@ -9,8 +9,8 @@ function ca_fast_combat:evaluation(cfg, data)
     data.move_cache = { turn = wesnoth.current.turn }
     data.gamedata = FAU.gamedata_setup()
 
-    local filter_own = H.get_child(cfg, "filter")
-    local filter_enemy = H.get_child(cfg, "filter_second")
+    local filter_own = wml.get_child(cfg, "filter")
+    local filter_enemy = wml.get_child(cfg, "filter_second")
 
     local enemies
     local units_sorted = true

--- a/data/ai/micro_ais/cas/ca_fast_combat.lua
+++ b/data/ai/micro_ais/cas/ca_fast_combat.lua
@@ -1,4 +1,3 @@
-local H = wesnoth.require "helper"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local FAU = wesnoth.require "ai/micro_ais/cas/ca_fast_attack_utils.lua"
 local LS = wesnoth.require "location_set"

--- a/data/ai/micro_ais/cas/ca_fast_combat_leader.lua
+++ b/data/ai/micro_ais/cas/ca_fast_combat_leader.lua
@@ -18,8 +18,8 @@ function ca_fast_combat_leader:evaluation(cfg, data)
     data.move_cache = { turn = wesnoth.current.turn }
     data.gamedata = FAU.gamedata_setup()
 
-    local filter_own = H.get_child(cfg, "filter")
-    local filter_enemy = H.get_child(cfg, "filter_second")
+    local filter_own = wml.get_child(cfg, "filter")
+    local filter_enemy = wml.get_child(cfg, "filter_second")
 
     local enemies, leader
     if (not filter_own) and (not filter_enemy) then

--- a/data/ai/micro_ais/cas/ca_forest_animals_move.lua
+++ b/data/ai/micro_ais/cas/ca_forest_animals_move.lua
@@ -46,7 +46,7 @@ function ca_forest_animals_move:execution(cfg)
 
     -- Get the locations of all the rabbit holes
     W.store_items { variable = 'holes_wml' }
-    local all_items = H.get_variable_array('holes_wml')
+    local all_items = wml.array_access.get('holes_wml')
     W.clear_variable { name = 'holes_wml' }
 
     -- If cfg.rabbit_hole_img is set, only items with that image or halo count as holes

--- a/data/ai/micro_ais/cas/ca_forest_animals_move.lua
+++ b/data/ai/micro_ais/cas/ca_forest_animals_move.lua
@@ -1,4 +1,3 @@
-local H = wesnoth.require "helper"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local LS = wesnoth.require "location_set"
 local M = wesnoth.map

--- a/data/ai/micro_ais/cas/ca_forest_animals_move.lua
+++ b/data/ai/micro_ais/cas/ca_forest_animals_move.lua
@@ -1,5 +1,4 @@
 local H = wesnoth.require "helper"
-local W = H.set_wml_action_metatable {}
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local LS = wesnoth.require "location_set"
 local M = wesnoth.map
@@ -45,9 +44,9 @@ function ca_forest_animals_move:execution(cfg)
     local enemies = AH.get_attackable_enemies()
 
     -- Get the locations of all the rabbit holes
-    W.store_items { variable = 'holes_wml' }
+    wesnoth.wml_actions.store_items { variable = 'holes_wml' }
     local all_items = wml.array_access.get('holes_wml')
-    W.clear_variable { name = 'holes_wml' }
+    wesnoth.wml_actions.clear_variable { name = 'holes_wml' }
 
     -- If cfg.rabbit_hole_img is set, only items with that image or halo count as holes
     local holes

--- a/data/ai/micro_ais/cas/ca_forest_animals_move.lua
+++ b/data/ai/micro_ais/cas/ca_forest_animals_move.lua
@@ -73,7 +73,7 @@ function ca_forest_animals_move:execution(cfg)
     end
 
     -- If no close enemies, do a random move
-    local wander_terrain = H.get_child(cfg, "filter_location") or {}
+    local wander_terrain = wml.get_child(cfg, "filter_location") or {}
     if (not close_enemies[1]) then
         local reach = AH.get_reachable_unocc(unit)
         local width, height = wesnoth.get_map_size()

--- a/data/ai/micro_ais/cas/ca_forest_animals_new_rabbit.lua
+++ b/data/ai/micro_ais/cas/ca_forest_animals_new_rabbit.lua
@@ -1,5 +1,4 @@
 local H = wesnoth.require "helper"
-local W = H.set_wml_action_metatable {}
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local T = wml.tag
 
@@ -18,9 +17,9 @@ function ca_forest_animals_new_rabbit:execution(cfg)
     local rabbit_enemy_distance = cfg.rabbit_enemy_distance or 3
 
     -- Get the locations of all items on that map (which could be rabbit holes)
-    W.store_items { variable = 'holes_wml' }
+    wesnoth.wml_actions.store_items { variable = 'holes_wml' }
     local all_items = wml.array_access.get('holes_wml')
-    W.clear_variable { name = 'holes_wml' }
+    wesnoth.wml_actions.clear_variable { name = 'holes_wml' }
 
     -- Eliminate all holes that have an enemy within 'rabbit_enemy_distance' hexes
     -- We also add a random number to the ones we keep, for selection of the holes later

--- a/data/ai/micro_ais/cas/ca_forest_animals_new_rabbit.lua
+++ b/data/ai/micro_ais/cas/ca_forest_animals_new_rabbit.lua
@@ -19,7 +19,7 @@ function ca_forest_animals_new_rabbit:execution(cfg)
 
     -- Get the locations of all items on that map (which could be rabbit holes)
     W.store_items { variable = 'holes_wml' }
-    local all_items = H.get_variable_array('holes_wml')
+    local all_items = wml.array_access.get('holes_wml')
     W.clear_variable { name = 'holes_wml' }
 
     -- Eliminate all holes that have an enemy within 'rabbit_enemy_distance' hexes

--- a/data/ai/micro_ais/cas/ca_forest_animals_new_rabbit.lua
+++ b/data/ai/micro_ais/cas/ca_forest_animals_new_rabbit.lua
@@ -1,4 +1,3 @@
-local H = wesnoth.require "helper"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local T = wml.tag
 

--- a/data/ai/micro_ais/cas/ca_goto.lua
+++ b/data/ai/micro_ais/cas/ca_goto.lua
@@ -31,7 +31,7 @@ function ca_goto:evaluation(cfg, data)
     local all_locs = wesnoth.get_locations {
         x = '1-' .. width,
         y = '1-' .. height,
-        { "and", H.get_child(cfg, "filter_location") }
+        { "and", wml.get_child(cfg, "filter_location") }
     }
     if (#all_locs == 0) then return 0 end
 
@@ -62,7 +62,7 @@ function ca_goto:evaluation(cfg, data)
 
     local all_units = AH.get_units_with_moves {
         side = wesnoth.current.side,
-        { "and", H.get_child(cfg, "filter") }
+        { "and", wml.get_child(cfg, "filter") }
     }
 
     local units = {}

--- a/data/ai/micro_ais/cas/ca_hang_out.lua
+++ b/data/ai/micro_ais/cas/ca_hang_out.lua
@@ -66,7 +66,7 @@ function ca_hang_out:execution(cfg)
         avoid_map = LS.of_pairs(wesnoth.get_locations(avoid_tag))
     else
         local ai_tag = wml.get_child(wesnoth.sides[wesnoth.current.side].__cfg, 'ai')
-        for aspect in H.child_range(ai_tag, 'aspect') do
+        for aspect in wml.child_range(ai_tag, 'aspect') do
             if (aspect.id == 'avoid') then
                 local facet = wml.get_child(aspect, 'facet')
                 if facet or aspect.name ~= "composite_aspect" then

--- a/data/ai/micro_ais/cas/ca_hang_out.lua
+++ b/data/ai/micro_ais/cas/ca_hang_out.lua
@@ -1,4 +1,3 @@
-local H = wesnoth.require "helper"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local LS = wesnoth.require "location_set"
 local MAIUV = wesnoth.require "ai/micro_ais/micro_ai_unit_variables.lua"

--- a/data/ai/micro_ais/cas/ca_hang_out.lua
+++ b/data/ai/micro_ais/cas/ca_hang_out.lua
@@ -8,7 +8,7 @@ local M = wesnoth.map
 local function get_hang_out_units(cfg)
     local units = AH.get_units_with_moves {
         side = wesnoth.current.side,
-        { "and", H.get_child(cfg, "filter") }
+        { "and", wml.get_child(cfg, "filter") }
     }
     return units
 end
@@ -22,14 +22,14 @@ function ca_hang_out:evaluation(cfg, data)
     end
 
     -- Otherwise check if any of the mobilize conditions are now met
-    local mobilize_condition = H.get_child(cfg, "mobilize_condition")
+    local mobilize_condition = wml.get_child(cfg, "mobilize_condition")
     if (mobilize_condition and wesnoth.eval_conditional(mobilize_condition))
         or (cfg.mobilize_on_gold_less_than and (wesnoth.sides[wesnoth.current.side].gold < cfg.mobilize_on_gold_less_than))
     then
         MAISD.insert_mai_self_data(data, cfg.ai_id, { mobilize_units = true })
 
         -- Need to unmark all units also (all units, with and without moves)
-        local units = wesnoth.get_units { side = wesnoth.current.side, { "and", H.get_child(cfg, "filter") } }
+        local units = wesnoth.get_units { side = wesnoth.current.side, { "and", wml.get_child(cfg, "filter") } }
         for _,unit in ipairs(units) do
             MAIUV.delete_mai_unit_variables(unit, cfg.ai_id)
         end
@@ -46,7 +46,7 @@ function ca_hang_out:execution(cfg)
 
     -- Get the locations close to which the units should hang out
     -- cfg.filter_location defaults to the location of the side leader(s)
-    local filter_location = H.get_child(cfg, "filter_location") or {
+    local filter_location = wml.get_child(cfg, "filter_location") or {
         { "filter", { side = wesnoth.current.side, canrecruit = "yes" } }
     }
 
@@ -60,15 +60,15 @@ function ca_hang_out:execution(cfg)
     -- Get map of locations to be avoided.
     -- Use [micro_ai][avoid] tag with priority over [ai][avoid].
     -- If neither is given, default to all castle terrain.
-    local avoid_tag = H.get_child(cfg, "avoid")
+    local avoid_tag = wml.get_child(cfg, "avoid")
     local avoid_map
     if avoid_tag then
         avoid_map = LS.of_pairs(wesnoth.get_locations(avoid_tag))
     else
-        local ai_tag = H.get_child(wesnoth.sides[wesnoth.current.side].__cfg, 'ai')
+        local ai_tag = wml.get_child(wesnoth.sides[wesnoth.current.side].__cfg, 'ai')
         for aspect in H.child_range(ai_tag, 'aspect') do
             if (aspect.id == 'avoid') then
-                local facet = H.get_child(aspect, 'facet')
+                local facet = wml.get_child(aspect, 'facet')
                 if facet or aspect.name ~= "composite_aspect" then
                     -- If there's a [facet] child, it's set as a composite aspect,
                     -- with at least one facet.

--- a/data/ai/micro_ais/cas/ca_healer_initialize.lua
+++ b/data/ai/micro_ais/cas/ca_healer_initialize.lua
@@ -1,5 +1,3 @@
-local H = wesnoth.require "helper"
-
 local ca_healer_initialize = {}
 
 function ca_healer_initialize:evaluation()

--- a/data/ai/micro_ais/cas/ca_healer_initialize.lua
+++ b/data/ai/micro_ais/cas/ca_healer_initialize.lua
@@ -19,7 +19,7 @@ function ca_healer_initialize:execution(cfg, data)
             id = "no_healers_attack",
             invalidate_on_gamestate_change = "yes",
             { "filter_own", {
-               { "not", { ability = "healing", { "and", H.get_child(cfg, "filter") } } }
+               { "not", { ability = "healing", { "and", wml.get_child(cfg, "filter") } } }
             } }
         }
     )

--- a/data/ai/micro_ais/cas/ca_healer_move.lua
+++ b/data/ai/micro_ais/cas/ca_healer_move.lua
@@ -16,7 +16,7 @@ function ca_healer_move:evaluation(cfg, data)
     local all_healers = wesnoth.get_units {
         side = wesnoth.current.side,
         ability = "healing",
-        { "and", H.get_child(cfg, "filter") }
+        { "and", wml.get_child(cfg, "filter") }
     }
 
     local healers, healers_noMP = {}, {}
@@ -31,7 +31,7 @@ function ca_healer_move:evaluation(cfg, data)
 
     local all_healees = wesnoth.get_units {
         side = wesnoth.current.side,
-        { "and", H.get_child(cfg, "filter_second") }
+        { "and", wml.get_child(cfg, "filter_second") }
     }
 
     local healees, healees_MP = {}, {}

--- a/data/ai/micro_ais/cas/ca_healer_move.lua
+++ b/data/ai/micro_ais/cas/ca_healer_move.lua
@@ -1,4 +1,3 @@
-local H = wesnoth.require "helper"
 local LS = wesnoth.require "location_set"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local BC = wesnoth.require "ai/lua/battle_calcs.lua"

--- a/data/ai/micro_ais/cas/ca_herding_attack_close_enemy.lua
+++ b/data/ai/micro_ais/cas/ca_herding_attack_close_enemy.lua
@@ -1,4 +1,3 @@
-local H = wesnoth.require "helper"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local M = wesnoth.map
 

--- a/data/ai/micro_ais/cas/ca_herding_attack_close_enemy.lua
+++ b/data/ai/micro_ais/cas/ca_herding_attack_close_enemy.lua
@@ -5,7 +5,7 @@ local M = wesnoth.map
 local function get_sheep(cfg)
     local sheep = wesnoth.get_units {
         side = wesnoth.current.side,
-        { "and", H.get_child(cfg, "filter_second") }
+        { "and", wml.get_child(cfg, "filter_second") }
     }
     return sheep
 end
@@ -13,7 +13,7 @@ end
 local function get_dogs(cfg)
     local dogs = AH.get_units_with_attacks {
         side = wesnoth.current.side,
-        { "and", H.get_child(cfg, "filter") }
+        { "and", wml.get_child(cfg, "filter") }
     }
     return dogs
 end
@@ -22,7 +22,7 @@ local function get_enemies(cfg, radius)
     local enemies = AH.get_attackable_enemies {
         { "filter_location",
             { radius = radius,
-            { "filter", { side = wesnoth.current.side, { "and", H.get_child(cfg, "filter_second") } } } }
+            { "filter", { side = wesnoth.current.side, { "and", wml.get_child(cfg, "filter_second") } } } }
         }
     }
     return enemies

--- a/data/ai/micro_ais/cas/ca_herding_dog_move.lua
+++ b/data/ai/micro_ais/cas/ca_herding_dog_move.lua
@@ -1,4 +1,3 @@
-local H = wesnoth.require "helper"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local LS = wesnoth.require "location_set"
 local M = wesnoth.map

--- a/data/ai/micro_ais/cas/ca_herding_dog_move.lua
+++ b/data/ai/micro_ais/cas/ca_herding_dog_move.lua
@@ -6,8 +6,8 @@ local M = wesnoth.map
 local function get_dog(cfg)
     local dogs = AH.get_units_with_moves {
         side = wesnoth.current.side,
-        { "and", H.get_child(cfg, "filter") },
-        { "not", { { "filter_adjacent", { side = wesnoth.current.side, { "and", H.get_child(cfg, "filter_second") } } } } }
+        { "and", wml.get_child(cfg, "filter") },
+        { "not", { { "filter_adjacent", { side = wesnoth.current.side, { "and", wml.get_child(cfg, "filter_second") } } } } }
     }
     return dogs[1]
 end
@@ -23,7 +23,7 @@ end
 function ca_herding_dog_move:execution(cfg)
     -- We simply move the first dog first, order does not matter
     local dog = get_dog(cfg)
-    local herding_perimeter = LS.of_pairs(wesnoth.get_locations(H.get_child(cfg, "filter_location")))
+    local herding_perimeter = LS.of_pairs(wesnoth.get_locations(wml.get_child(cfg, "filter_location")))
 
     -- Find average distance of herding_perimeter from center
     local av_dist = 0

--- a/data/ai/micro_ais/cas/ca_herding_dog_stopmove.lua
+++ b/data/ai/micro_ais/cas/ca_herding_dog_stopmove.lua
@@ -1,4 +1,3 @@
-local H = wesnoth.require "helper"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 
 local function get_dog(cfg)

--- a/data/ai/micro_ais/cas/ca_herding_dog_stopmove.lua
+++ b/data/ai/micro_ais/cas/ca_herding_dog_stopmove.lua
@@ -4,7 +4,7 @@ local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local function get_dog(cfg)
     local dogs = AH.get_units_with_moves {
         side = wesnoth.current.side,
-        { "and", H.get_child(cfg, "filter") },
+        { "and", wml.get_child(cfg, "filter") },
     }
     return dogs[1]
 end

--- a/data/ai/micro_ais/cas/ca_herding_f_herding_area.lua
+++ b/data/ai/micro_ais/cas/ca_herding_f_herding_area.lua
@@ -4,7 +4,7 @@ local LS = wesnoth.require "location_set"
 return function(cfg)
     -- Find the area that the sheep can occupy
     -- First, find all contiguous hexes around center hex that are inside herding_perimeter
-    local location_filter = H.get_child(cfg, "filter_location")
+    local location_filter = wml.get_child(cfg, "filter_location")
     local herding_area = LS.of_pairs(wesnoth.get_locations {
         x = cfg.herd_x,
         y = cfg.herd_y,

--- a/data/ai/micro_ais/cas/ca_herding_herd_sheep.lua
+++ b/data/ai/micro_ais/cas/ca_herding_herd_sheep.lua
@@ -1,4 +1,3 @@
-local H = wesnoth.require "helper"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local M = wesnoth.map
 

--- a/data/ai/micro_ais/cas/ca_herding_herd_sheep.lua
+++ b/data/ai/micro_ais/cas/ca_herding_herd_sheep.lua
@@ -7,7 +7,7 @@ local herding_area = wesnoth.require "ai/micro_ais/cas/ca_herding_f_herding_area
 local function get_dogs(cfg)
     local dogs = AH.get_units_with_moves {
         side = wesnoth.current.side,
-        { "and", H.get_child(cfg, "filter") }
+        { "and", wml.get_child(cfg, "filter") }
     }
     return dogs
 end
@@ -15,8 +15,8 @@ end
 local function get_sheep_to_herd(cfg)
     local all_sheep = wesnoth.get_units {
         side = wesnoth.current.side,
-        { "and", H.get_child(cfg, "filter_second") },
-        { "not", { { "filter_adjacent", { side = wesnoth.current.side, { "and", H.get_child(cfg, "filter") } } } } }
+        { "and", wml.get_child(cfg, "filter_second") },
+        { "not", { { "filter_adjacent", { side = wesnoth.current.side, { "and", wml.get_child(cfg, "filter") } } } } }
     }
 
     local sheep_to_herd = {}
@@ -63,7 +63,7 @@ function ca_herding_herd_sheep:execution(cfg)
                 -- And the closer dog goes first (so that it might be able to chase another sheep afterward)
                 rating = rating - M.distance_between(x, y, dog.x, dog.y) / 100.
                 -- Finally, prefer to stay on path, if possible
-                if (wesnoth.match_location(x, y, H.get_child(cfg, "filter_location")) ) then rating = rating + 0.001 end
+                if (wesnoth.match_location(x, y, wml.get_child(cfg, "filter_location")) ) then rating = rating + 0.001 end
 
                 reach_map:insert(x, y, rating)
 

--- a/data/ai/micro_ais/cas/ca_herding_sheep_move.lua
+++ b/data/ai/micro_ais/cas/ca_herding_sheep_move.lua
@@ -6,7 +6,7 @@ local herding_area = wesnoth.require "ai/micro_ais/cas/ca_herding_f_herding_area
 local function get_next_sheep(cfg)
     local sheep = AH.get_units_with_moves {
         side = wesnoth.current.side,
-        { "and", H.get_child(cfg, "filter_second") }
+        { "and", wml.get_child(cfg, "filter_second") }
     }
     return sheep[1]
 end
@@ -24,7 +24,7 @@ function ca_herding_sheep_move:execution(cfg)
     local sheep = get_next_sheep(cfg)
 
     local reach_map = AH.get_reachable_unocc(sheep)
-    local dogs_filter = H.get_child(cfg, "filter")
+    local dogs_filter = wml.get_child(cfg, "filter")
     -- Exclude those that are next to a dog
     reach_map:iter( function(x, y, v)
         for xa, ya in H.adjacent_tiles(x, y) do

--- a/data/ai/micro_ais/cas/ca_herding_sheep_runs_dog.lua
+++ b/data/ai/micro_ais/cas/ca_herding_sheep_runs_dog.lua
@@ -1,4 +1,3 @@
-local H = wesnoth.require "helper"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local M = wesnoth.map
 

--- a/data/ai/micro_ais/cas/ca_herding_sheep_runs_dog.lua
+++ b/data/ai/micro_ais/cas/ca_herding_sheep_runs_dog.lua
@@ -5,8 +5,8 @@ local M = wesnoth.map
 local function get_next_sheep(cfg)
     local sheep = AH.get_units_with_moves {
         side = wesnoth.current.side,
-        { "and", H.get_child(cfg, "filter_second") },
-        { "filter_adjacent", { side = wesnoth.current.side, { "and", H.get_child(cfg, "filter") } } }
+        { "and", wml.get_child(cfg, "filter_second") },
+        { "filter_adjacent", { side = wesnoth.current.side, { "and", wml.get_child(cfg, "filter") } } }
     }
     return sheep[1]
 end
@@ -24,7 +24,7 @@ function ca_herding_sheep_runs_dog:execution(cfg)
     local sheep = get_next_sheep(cfg)
 
     -- Get the first dog that the sheep is adjacent to
-    local dog = wesnoth.get_units { side = wesnoth.current.side, { "and", H.get_child(cfg, "filter") },
+    local dog = wesnoth.get_units { side = wesnoth.current.side, { "and", wml.get_child(cfg, "filter") },
         { "filter_adjacent", { x = sheep.x, y = sheep.y } }
     }[1]
 

--- a/data/ai/micro_ais/cas/ca_herding_sheep_runs_enemy.lua
+++ b/data/ai/micro_ais/cas/ca_herding_sheep_runs_enemy.lua
@@ -1,4 +1,3 @@
-local H = wesnoth.require "helper"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local M = wesnoth.map
 

--- a/data/ai/micro_ais/cas/ca_herding_sheep_runs_enemy.lua
+++ b/data/ai/micro_ais/cas/ca_herding_sheep_runs_enemy.lua
@@ -5,7 +5,7 @@ local M = wesnoth.map
 local function get_next_sheep_enemies(cfg)
     local sheep = AH.get_units_with_moves {
         side = wesnoth.current.side,
-        { "and", H.get_child(cfg, "filter_second") }
+        { "and", wml.get_child(cfg, "filter_second") }
     }
     if (not sheep[1]) then return end
 

--- a/data/ai/micro_ais/cas/ca_hunter.lua
+++ b/data/ai/micro_ais/cas/ca_hunter.lua
@@ -1,5 +1,4 @@
 local H = wesnoth.require "helper"
-local W = H.set_wml_action_metatable {}
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local MAIUV = wesnoth.require "ai/micro_ais/micro_ai_unit_variables.lua"
 local M = wesnoth.map
@@ -121,7 +120,7 @@ function ca_hunter:execution(cfg)
             MAIUV.set_mai_unit_variables(hunter, cfg.ai_id, hunter_vars)
 
             if cfg.show_messages then
-                W.message { speaker = hunter.id, message = 'Now that I have eaten, I will go back home.' }
+                wesnoth.wml_actions.message { speaker = hunter.id, message = 'Now that I have eaten, I will go back home.' }
             end
         end
 
@@ -142,7 +141,7 @@ function ca_hunter:execution(cfg)
                 local enemy = wesnoth.get_unit(cfg.home_x, cfg.home_y)
                 if AH.is_attackable_enemy(enemy) then
                     if cfg.show_messages then
-                        W.message { speaker = hunter.id, message = 'Get out of my home!' }
+                        wesnoth.wml_actions.message { speaker = hunter.id, message = 'Get out of my home!' }
                     end
 
                     AH.checked_attack(ai, hunter, enemy)
@@ -162,7 +161,7 @@ function ca_hunter:execution(cfg)
             MAIUV.set_mai_unit_variables(hunter, cfg.ai_id, hunter_vars)
 
             if cfg.show_messages then
-                W.message { speaker = hunter.id, message = 'I made it home - resting now until the end of Turn ' .. hunter_vars.resting_until .. ' or until fully healed.' }
+                wesnoth.wml_actions.message { speaker = hunter.id, message = 'I made it home - resting now until the end of Turn ' .. hunter_vars.resting_until .. ' or until fully healed.' }
             end
         end
 
@@ -185,7 +184,7 @@ function ca_hunter:execution(cfg)
             MAIUV.set_mai_unit_variables(hunter, cfg.ai_id, hunter_vars)
 
             if cfg.show_messages then
-                W.message { speaker = hunter.id, message = 'I am done resting. It is time to go hunting again next turn.' }
+                wesnoth.wml_actions.message { speaker = hunter.id, message = 'I am done resting. It is time to go hunting again next turn.' }
             end
         end
         return

--- a/data/ai/micro_ais/cas/ca_hunter.lua
+++ b/data/ai/micro_ais/cas/ca_hunter.lua
@@ -36,7 +36,7 @@ local function hunter_attack_weakest_adj_enemy(ai, hunter)
 end
 
 local function get_hunter(cfg)
-    local filter = H.get_child(cfg, "filter") or { id = cfg.id }
+    local filter = wml.get_child(cfg, "filter") or { id = cfg.id }
     local hunter = AH.get_units_with_moves {
         side = wesnoth.current.side,
         { "and", filter }
@@ -65,7 +65,7 @@ function ca_hunter:execution(cfg)
         local rand = math.random(10)
         if (not hunter_vars.goal_x) or (rand == 1) then
             -- 'locs' includes border hexes, but that does not matter here
-            locs = AH.get_passable_locations((H.get_child(cfg, "filter_location") or {}), hunter)
+            locs = AH.get_passable_locations((wml.get_child(cfg, "filter_location") or {}), hunter)
             local rand = math.random(#locs)
 
             hunter_vars.goal_x, hunter_vars.goal_y = locs[rand][1], locs[rand][2]

--- a/data/ai/micro_ais/cas/ca_lurkers.lua
+++ b/data/ai/micro_ais/cas/ca_lurkers.lua
@@ -1,6 +1,5 @@
 local LS = wesnoth.require "location_set"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
-local H = wesnoth.require "helper"
 
 local function get_lurker(cfg)
     -- We simply pick the first of the lurkers, they have no strategy

--- a/data/ai/micro_ais/cas/ca_lurkers.lua
+++ b/data/ai/micro_ais/cas/ca_lurkers.lua
@@ -6,7 +6,7 @@ local function get_lurker(cfg)
     -- We simply pick the first of the lurkers, they have no strategy
     local lurker = AH.get_units_with_moves {
         side = wesnoth.current.side,
-        { "and", H.get_child(cfg, "filter") }
+        { "and", wml.get_child(cfg, "filter") }
     }[1]
     return lurker
 end
@@ -26,7 +26,7 @@ function ca_lurkers:execution(cfg)
     table.sort(targets, function(a, b) return (a.hitpoints < b.hitpoints) end)
 
     local reach = LS.of_pairs(wesnoth.find_reach(lurker.x, lurker.y))
-    local lurk_area = H.get_child(cfg, "filter_location")
+    local lurk_area = wml.get_child(cfg, "filter_location")
     local reachable_attack_terrain =
          LS.of_pairs(wesnoth.get_locations  {
             { "and", { x = lurker.x, y = lurker.y, radius = lurker.moves } },
@@ -66,7 +66,7 @@ function ca_lurkers:execution(cfg)
         local reachable_wander_terrain =
             LS.of_pairs( wesnoth.get_locations {
                 { "and", { x = lurker.x, y = lurker.y, radius = lurker.moves } },
-                { "and", H.get_child(cfg, "filter_location_wander") or lurk_area }
+                { "and", wml.get_child(cfg, "filter_location_wander") or lurk_area }
             })
         reachable_wander_terrain:inter(reach)
 

--- a/data/ai/micro_ais/cas/ca_messenger_attack.lua
+++ b/data/ai/micro_ais/cas/ca_messenger_attack.lua
@@ -45,11 +45,11 @@ local function messenger_find_clearing_attack(messenger, goal_x, goal_y, cfg)
     local enemy_in_way = messenger_find_enemies_in_way(messenger, goal_x, goal_y)
     if (not enemy_in_way) then return end
 
-    local filter = H.get_child(cfg, "filter") or { id = cfg.id }
+    local filter = wml.get_child(cfg, "filter") or { id = cfg.id }
     local units = AH.get_units_with_attacks {
         side = wesnoth.current.side,
         { "not", filter },
-        { "and", H.get_child(cfg, "filter_second") }
+        { "and", wml.get_child(cfg, "filter_second") }
     }
     if (not units[1]) then return end
 

--- a/data/ai/micro_ais/cas/ca_messenger_escort_move.lua
+++ b/data/ai/micro_ais/cas/ca_messenger_escort_move.lua
@@ -1,4 +1,3 @@
-local H = wesnoth.require "helper"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local LS = wesnoth.require "location_set"
 local MAIUV = wesnoth.require "ai/micro_ais/micro_ai_unit_variables.lua"

--- a/data/ai/micro_ais/cas/ca_messenger_escort_move.lua
+++ b/data/ai/micro_ais/cas/ca_messenger_escort_move.lua
@@ -9,7 +9,7 @@ local messenger_next_waypoint = wesnoth.require "ai/micro_ais/cas/ca_messenger_f
 local function get_escorts(cfg)
     local escorts = AH.get_units_with_moves {
         side = wesnoth.current.side,
-        { "and", H.get_child(cfg, "filter_second") }
+        { "and", wml.get_child(cfg, "filter_second") }
     }
     return escorts
 end

--- a/data/ai/micro_ais/cas/ca_messenger_f_next_waypoint.lua
+++ b/data/ai/micro_ais/cas/ca_messenger_f_next_waypoint.lua
@@ -10,7 +10,7 @@ return function(cfg)
     -- Returns nil for first 3 arguments if no messenger has moves left
     -- Returns nil for all arguments if there are no messengers on the map
 
-    local filter = H.get_child(cfg, "filter") or { id = cfg.id }
+    local filter = wml.get_child(cfg, "filter") or { id = cfg.id }
     local messengers = wesnoth.get_units { side = wesnoth.current.side, { "and", filter } }
     if (not messengers[1]) then return end
 

--- a/data/ai/micro_ais/cas/ca_messenger_f_next_waypoint.lua
+++ b/data/ai/micro_ais/cas/ca_messenger_f_next_waypoint.lua
@@ -1,4 +1,3 @@
-local H = wesnoth.require "helper"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local MAIUV = wesnoth.require "ai/micro_ais/micro_ai_unit_variables.lua"
 

--- a/data/ai/micro_ais/cas/ca_patrol.lua
+++ b/data/ai/micro_ais/cas/ca_patrol.lua
@@ -3,7 +3,7 @@ local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local MAIUV = wesnoth.require "ai/micro_ais/micro_ai_unit_variables.lua"
 
 local function get_patrol(cfg)
-    local filter = H.get_child(cfg, "filter") or { id = cfg.id }
+    local filter = wml.get_child(cfg, "filter") or { id = cfg.id }
     local patrol = AH.get_units_with_moves {
         side = wesnoth.current.side,
         { "and", filter }

--- a/data/ai/micro_ais/cas/ca_patrol.lua
+++ b/data/ai/micro_ais/cas/ca_patrol.lua
@@ -1,4 +1,3 @@
-local H = wesnoth.require "helper"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local MAIUV = wesnoth.require "ai/micro_ais/micro_ai_unit_variables.lua"
 

--- a/data/ai/micro_ais/cas/ca_protect_unit_attack.lua
+++ b/data/ai/micro_ais/cas/ca_protect_unit_attack.lua
@@ -1,4 +1,3 @@
-local H = wesnoth.require "helper"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local BC = wesnoth.require "ai/lua/battle_calcs.lua"
 

--- a/data/ai/micro_ais/cas/ca_protect_unit_attack.lua
+++ b/data/ai/micro_ais/cas/ca_protect_unit_attack.lua
@@ -10,7 +10,7 @@ function ca_protect_unit_attack:evaluation(cfg)
     -- or the counter attack on the enemy turn, it does not attack, even if that's really unlikely
 
     local units = {}
-    for u in H.child_range(cfg, "unit") do
+    for u in wml.child_range(cfg, "unit") do
         table.insert(units, AH.get_units_with_attacks { id = u.id }[1])
     end
     if (not units[1]) then return 0 end

--- a/data/ai/micro_ais/cas/ca_protect_unit_finish.lua
+++ b/data/ai/micro_ais/cas/ca_protect_unit_finish.lua
@@ -5,7 +5,7 @@ local ca_protect_unit_finish, PU_unit, PU_goal = {}
 
 function ca_protect_unit_finish:evaluation(cfg)
     -- If a unit can make it to the goal, this is the first thing that happens
-    for u in H.child_range(cfg, "unit") do
+    for u in wml.child_range(cfg, "unit") do
         local unit = AH.get_units_with_moves { id = u.id }[1]
         if unit then
             local path, cost = AH.find_path_with_shroud(unit, u.goal_x, u.goal_y)

--- a/data/ai/micro_ais/cas/ca_protect_unit_finish.lua
+++ b/data/ai/micro_ais/cas/ca_protect_unit_finish.lua
@@ -1,4 +1,3 @@
-local H = wesnoth.require "helper"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 
 local ca_protect_unit_finish, PU_unit, PU_goal = {}

--- a/data/ai/micro_ais/cas/ca_protect_unit_move.lua
+++ b/data/ai/micro_ais/cas/ca_protect_unit_move.lua
@@ -1,4 +1,3 @@
-local H = wesnoth.require "helper"
 local LS = wesnoth.require "location_set"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local BC = wesnoth.require "ai/lua/battle_calcs.lua"

--- a/data/ai/micro_ais/cas/ca_protect_unit_move.lua
+++ b/data/ai/micro_ais/cas/ca_protect_unit_move.lua
@@ -5,7 +5,7 @@ local BC = wesnoth.require "ai/lua/battle_calcs.lua"
 
 local function get_protected_units(cfg)
     local units = {}
-    for u in H.child_range(cfg, "unit") do
+    for u in wml.child_range(cfg, "unit") do
         table.insert(units, AH.get_units_with_moves { id = u.id }[1])
     end
     return units
@@ -38,7 +38,7 @@ function ca_protect_unit_move:execution(cfg, data)
     -- We move the weakest (fewest HP unit) first
     local unit = AH.choose(protected_units, function(u) return - u.hitpoints end)
     local goal = {}
-    for u in H.child_range(cfg, "unit") do
+    for u in wml.child_range(cfg, "unit") do
         if (unit.id == u.id) then goal = { u.goal_x, u.goal_y } end
     end
 

--- a/data/ai/micro_ais/cas/ca_recruit_random.lua
+++ b/data/ai/micro_ais/cas/ca_recruit_random.lua
@@ -59,7 +59,7 @@ function ca_recruit_random:evaluation(cfg)
     local probabilities, probability_sum  = {}, 0
 
     -- Go through all the types listed in [probability] tags (which can be comma-separated lists)
-    for prob in H.child_range(cfg, "probability") do
+    for prob in wml.child_range(cfg, "probability") do
         types = AH.split(prob.type, ",")
         for _,typ in ipairs(types) do  -- 'type' is a reserved keyword in Lua
             -- If this type is in the recruit list, add it

--- a/data/ai/micro_ais/cas/ca_return_guardian.lua
+++ b/data/ai/micro_ais/cas/ca_return_guardian.lua
@@ -2,7 +2,7 @@ local H = wesnoth.require "helper"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 
 local function get_guardian(cfg)
-    local filter = H.get_child(cfg, "filter") or { id = cfg.id }
+    local filter = wml.get_child(cfg, "filter") or { id = cfg.id }
     local guardian = AH.get_units_with_moves {
         side = wesnoth.current.side,
         { "and", filter }

--- a/data/ai/micro_ais/cas/ca_return_guardian.lua
+++ b/data/ai/micro_ais/cas/ca_return_guardian.lua
@@ -1,4 +1,3 @@
-local H = wesnoth.require "helper"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 
 local function get_guardian(cfg)

--- a/data/ai/micro_ais/cas/ca_simple_attack.lua
+++ b/data/ai/micro_ais/cas/ca_simple_attack.lua
@@ -8,13 +8,13 @@ local ca_simple_attack, best_attack = {}
 function ca_simple_attack:evaluation(cfg)
     local units = AH.get_units_with_attacks {
         side = wesnoth.current.side,
-        { "and", H.get_child(cfg, "filter") }
+        { "and", wml.get_child(cfg, "filter") }
     }
     if (not units[1]) then return 0 end
 
     -- If cfg.filter_second is set, set up a map (location set)
     -- of enemies that it is okay to attack
-    local enemy_filter = H.get_child(cfg, "filter_second")
+    local enemy_filter = wml.get_child(cfg, "filter_second")
     local enemy_map
     if enemy_filter then
         local enemies = AH.get_attackable_enemies(enemy_filter)

--- a/data/ai/micro_ais/cas/ca_simple_attack.lua
+++ b/data/ai/micro_ais/cas/ca_simple_attack.lua
@@ -1,4 +1,3 @@
-local H = wesnoth.require "helper"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local BC = wesnoth.require "ai/lua/battle_calcs.lua"
 local LS = wesnoth.require "location_set"

--- a/data/ai/micro_ais/cas/ca_stationed_guardian.lua
+++ b/data/ai/micro_ais/cas/ca_stationed_guardian.lua
@@ -3,7 +3,7 @@ local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local M = wesnoth.map
 
 local function get_guardian(cfg)
-    local filter = H.get_child(cfg, "filter") or { id = cfg.id }
+    local filter = wml.get_child(cfg, "filter") or { id = cfg.id }
     local guardian = AH.get_units_with_moves {
         side = wesnoth.current.side,
         { "and", filter }

--- a/data/ai/micro_ais/cas/ca_wolves_move.lua
+++ b/data/ai/micro_ais/cas/ca_wolves_move.lua
@@ -1,4 +1,3 @@
-local H = wesnoth.require "helper"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local BC = wesnoth.require "ai/lua/battle_calcs.lua"
 local M = wesnoth.map

--- a/data/ai/micro_ais/cas/ca_wolves_move.lua
+++ b/data/ai/micro_ais/cas/ca_wolves_move.lua
@@ -6,15 +6,15 @@ local M = wesnoth.map
 local function get_wolves(cfg)
     local wolves = AH.get_units_with_moves {
         side = wesnoth.current.side,
-        { "and", H.get_child(cfg, "filter") }
+        { "and", wml.get_child(cfg, "filter") }
     }
     return wolves
 end
 
 local function get_prey(cfg)
-    -- Note: we cannot pass H.get_child() directly to AH.get_attackable_enemies()
+    -- Note: we cannot pass wml.get_child() directly to AH.get_attackable_enemies()
     -- as the former returns two values and the latter takes optional arguments
-    local filter_second = H.get_child(cfg, "filter_second")
+    local filter_second = wml.get_child(cfg, "filter_second")
     local prey = AH.get_attackable_enemies(filter_second)
     return prey
 end

--- a/data/ai/micro_ais/cas/ca_wolves_wander.lua
+++ b/data/ai/micro_ais/cas/ca_wolves_wander.lua
@@ -6,7 +6,7 @@ local LS = wesnoth.require "location_set"
 local function get_wolves(cfg)
     local wolves = AH.get_units_with_moves {
         side = wesnoth.current.side,
-        { "and", H.get_child(cfg, "filter") }
+        { "and", wml.get_child(cfg, "filter") }
     }
     return wolves
 end

--- a/data/ai/micro_ais/cas/ca_wolves_wander.lua
+++ b/data/ai/micro_ais/cas/ca_wolves_wander.lua
@@ -1,4 +1,3 @@
-local H = wesnoth.require "helper"
 local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local BC = wesnoth.require "ai/lua/battle_calcs.lua"
 local LS = wesnoth.require "location_set"

--- a/data/ai/micro_ais/cas/ca_zone_guardian.lua
+++ b/data/ai/micro_ais/cas/ca_zone_guardian.lua
@@ -4,7 +4,7 @@ local LS = wesnoth.require "location_set"
 local M = wesnoth.map
 
 local function get_guardian(cfg)
-    local filter = H.get_child(cfg, "filter") or { id = cfg.id }
+    local filter = wml.get_child(cfg, "filter") or { id = cfg.id }
     local guardian = AH.get_units_with_moves {
         side = wesnoth.current.side,
         { "and", filter }
@@ -23,8 +23,8 @@ function ca_zone_guardian:execution(cfg)
     local guardian = get_guardian(cfg)
     local reach = wesnoth.find_reach(guardian)
 
-    local zone = H.get_child(cfg, "filter_location")
-    local zone_enemy = H.get_child(cfg, "filter_location_enemy") or zone
+    local zone = wml.get_child(cfg, "filter_location")
+    local zone_enemy = wml.get_child(cfg, "filter_location_enemy") or zone
     local enemies = AH.get_attackable_enemies { { "filter_location", zone_enemy } }
     if enemies[1] then
         local min_dist, target = 9e99

--- a/data/ai/micro_ais/engines/priority_target_engine.lua
+++ b/data/ai/micro_ais/engines/priority_target_engine.lua
@@ -33,7 +33,7 @@ return {
                     moves = "current",
                     variable = "tmp_locs"
                 }
-                attack_locs = H.get_variable_array("tmp_locs")
+                attack_locs = wml.array_access.get("tmp_locs")
                 W.clear_variable { name = "tmp_locs" }
                 if (#attack_locs > 0) then break end
             end

--- a/data/ai/micro_ais/mai-defs/animals.lua
+++ b/data/ai/micro_ais/mai-defs/animals.lua
@@ -30,7 +30,7 @@ function wesnoth.micro_ais.wolves(cfg)
 					id = "mai_wolves_" .. (cfg.ca_id or "default") .. "_dont_attack",
 					invalidate_on_gamestate_change = "yes",
 					{ "filter_enemy", {
-						{ "and", H.get_child(cfg, "filter_second") }
+						{ "and", wml.get_child(cfg, "filter_second") }
 					} }
 				}
 			}
@@ -165,7 +165,7 @@ function wesnoth.micro_ais.wolves_multipacks(cfg)
 end
 
 function wesnoth.micro_ais.hunter(cfg)
-	if (cfg.action ~= 'delete') and (not cfg.id) and (not H.get_child(cfg, "filter")) then
+	if (cfg.action ~= 'delete') and (not cfg.id) and (not wml.get_child(cfg, "filter")) then
 		H.wml_error("Hunter [micro_ai] tag requires either id= key or [filter] tag")
 	end
 	local required_keys = { "home_x", "home_y" }

--- a/data/ai/micro_ais/mai-defs/escort.lua
+++ b/data/ai/micro_ais/mai-defs/escort.lua
@@ -1,7 +1,7 @@
 local H = wesnoth.require "helper"
 
 function wesnoth.micro_ais.messenger_escort(cfg)
-	if (cfg.action ~= 'delete') and (not cfg.id) and (not H.get_child(cfg, "filter")) then
+	if (cfg.action ~= 'delete') and (not cfg.id) and (not wml.get_child(cfg, "filter")) then
 		H.wml_error("Messenger [micro_ai] tag requires either id= key or [filter] tag")
 	end
 	local required_keys = { "waypoint_x", "waypoint_y" }

--- a/data/ai/micro_ais/mai-defs/fast.lua
+++ b/data/ai/micro_ais/mai-defs/fast.lua
@@ -1,5 +1,3 @@
-local H = wesnoth.require "helper"
-
 function wesnoth.micro_ais.fast_ai(cfg)
 	local optional_keys = {
 		"attack_hidden_enemies", "[avoid]", "dungeon_mode",

--- a/data/ai/micro_ais/mai-defs/guardian.lua
+++ b/data/ai/micro_ais/mai-defs/guardian.lua
@@ -1,7 +1,7 @@
 local H = wesnoth.require "helper"
 
 function wesnoth.micro_ais.stationed_guardian(cfg)
-	if (cfg.action ~= 'delete') and (not cfg.id) and (not H.get_child(cfg, "filter")) then
+	if (cfg.action ~= 'delete') and (not cfg.id) and (not wml.get_child(cfg, "filter")) then
 		H.wml_error("Stationed Guardian [micro_ai] tag requires either id= key or [filter] tag")
 	end
 	local required_keys = { "distance", "station_x", "station_y" }
@@ -14,7 +14,7 @@ function wesnoth.micro_ais.stationed_guardian(cfg)
 end
 
 function wesnoth.micro_ais.zone_guardian(cfg)
-	if (cfg.action ~= 'delete') and (not cfg.id) and (not H.get_child(cfg, "filter")) then
+	if (cfg.action ~= 'delete') and (not cfg.id) and (not wml.get_child(cfg, "filter")) then
 		H.wml_error("Zone Guardian [micro_ai] tag requires either id= key or [filter] tag")
 	end
 	local required_keys = { "[filter_location]" }
@@ -27,7 +27,7 @@ function wesnoth.micro_ais.zone_guardian(cfg)
 end
 
 function wesnoth.micro_ais.return_guardian(cfg)
-	if (cfg.action ~= 'delete') and (not cfg.id) and (not H.get_child(cfg, "filter")) then
+	if (cfg.action ~= 'delete') and (not cfg.id) and (not wml.get_child(cfg, "filter")) then
 		H.wml_error("Return Guardian [micro_ai] tag requires either id= key or [filter] tag")
 	end
 	local required_keys = { "return_x", "return_y" }
@@ -40,7 +40,7 @@ function wesnoth.micro_ais.return_guardian(cfg)
 end
 
 function wesnoth.micro_ais.coward(cfg)
-	if (cfg.action ~= 'delete') and (not cfg.id) and (not H.get_child(cfg, "filter")) then
+	if (cfg.action ~= 'delete') and (not cfg.id) and (not wml.get_child(cfg, "filter")) then
 		H.wml_error("Coward [micro_ai] tag requires either id= key or [filter] tag")
 	end
 	local required_keys = { "distance" }

--- a/data/ai/micro_ais/mai-defs/patrol.lua
+++ b/data/ai/micro_ais/mai-defs/patrol.lua
@@ -1,7 +1,7 @@
 local H = wesnoth.require "helper"
 
 function wesnoth.micro_ais.patrol(cfg)
-	if (cfg.action ~= 'delete') and (not cfg.id) and (not H.get_child(cfg, "filter")) then
+	if (cfg.action ~= 'delete') and (not cfg.id) and (not wml.get_child(cfg, "filter")) then
 		H.wml_error("Patrol [micro_ai] tag requires either id= key or [filter] tag")
 	end
 	local required_keys = { "waypoint_x", "waypoint_y" }

--- a/data/ai/micro_ais/mai-defs/protect.lua
+++ b/data/ai/micro_ais/mai-defs/protect.lua
@@ -11,7 +11,7 @@ function wesnoth.micro_ais.protect_unit(cfg)
 	}
 
 	local unit_ids = {}
-	for u in H.child_range(cfg, "unit") do
+	for u in wml.child_range(cfg, "unit") do
 		if not u.id then
 			H.wml_error("Protect Unit Micro AI missing id key in [unit] tag")
 		end

--- a/data/ai/micro_ais/mai-defs/recruiting.lua
+++ b/data/ai/micro_ais/mai-defs/recruiting.lua
@@ -1,5 +1,3 @@
-local H = wesnoth.require "helper"
-
 local function handle_default_recruitment(cfg)
 	-- Also need to delete/add the default recruitment CA
 	if cfg.action == 'add' then

--- a/data/ai/micro_ais/micro_ai_helper.lua
+++ b/data/ai/micro_ais/micro_ai_helper.lua
@@ -169,7 +169,7 @@ function micro_ai_helper.micro_ai_setup(cfg, CA_parms, required_keys, optional_k
     for _,v in pairs(required_keys) do
         if v:match('%[[a-zA-Z0-9_]+%]')  then
             v = v:sub(2,-2)
-            if not H.get_child(cfg, v) then
+            if not wml.get_child(cfg, v) then
                 H.wml_error("[micro_ai] tag (" .. cfg.ai_type .. ") is missing required parameter: [" .. v .. "]")
             end
             for child in H.child_range(cfg, v) do

--- a/data/ai/micro_ais/micro_ai_helper.lua
+++ b/data/ai/micro_ais/micro_ai_helper.lua
@@ -39,9 +39,9 @@ function micro_ai_helper.add_CAs(side, ca_id_core, CA_parms, CA_cfg)
     while id_found do -- This is really just a precaution
         id_found = false
 
-        for ai_tag in H.child_range(wesnoth.sides[side].__cfg, 'ai') do
-            for stage in H.child_range(ai_tag, 'stage') do
-                for ca in H.child_range(stage, 'candidate_action') do
+        for ai_tag in wml.child_range(wesnoth.sides[side].__cfg, 'ai') do
+            for stage in wml.child_range(ai_tag, 'stage') do
+                for ca in wml.child_range(stage, 'candidate_action') do
                     if string.find(ca.name, ai_id .. '_') then
                         id_found = true
                         break
@@ -54,10 +54,10 @@ function micro_ai_helper.add_CAs(side, ca_id_core, CA_parms, CA_cfg)
         -- AI's data variable. However, the MAI can be changed while it is not
         -- the AI's turn, when this is not possible. So instead, we check for the
         -- existence of such tags and make sure we are using a different ai_id.
-        for ai_tag in H.child_range(wesnoth.sides[side].__cfg, 'ai') do
-            for engine in H.child_range(ai_tag, 'engine') do
-                for data in H.child_range(engine, 'data') do
-                    for mai in H.child_range(data, 'micro_ai') do
+        for ai_tag in wml.child_range(wesnoth.sides[side].__cfg, 'ai') do
+            for engine in wml.child_range(ai_tag, 'engine') do
+                for data in wml.child_range(engine, 'data') do
+                    for mai in wml.child_range(data, 'micro_ai') do
                         if (mai.ai_id == ai_id) then
                             id_found = true
                             break
@@ -172,7 +172,7 @@ function micro_ai_helper.micro_ai_setup(cfg, CA_parms, required_keys, optional_k
             if not wml.get_child(cfg, v) then
                 H.wml_error("[micro_ai] tag (" .. cfg.ai_type .. ") is missing required parameter: [" .. v .. "]")
             end
-            for child in H.child_range(cfg, v) do
+            for child in wml.child_range(cfg, v) do
                 table.insert(CA_cfg, T[v](child))
             end
         else
@@ -187,7 +187,7 @@ function micro_ai_helper.micro_ai_setup(cfg, CA_parms, required_keys, optional_k
     for _,v in pairs(optional_keys) do
         if v:match('%[[a-zA-Z0-9_]+%]')  then
             v = v:sub(2,-2)
-            for child in H.child_range(cfg, v) do
+            for child in wml.child_range(cfg, v) do
                 table.insert(CA_cfg, T[v](child))
             end
         else

--- a/data/ai/micro_ais/micro_ai_self_data.lua
+++ b/data/ai/micro_ais/micro_ai_self_data.lua
@@ -79,7 +79,7 @@ function micro_ai_self_data.get_mai_self_data(self_data, ai_id, key)
     --     table of key=value pairs (including the ai_id key)
     --   - If no such tag is found: nil (if @key is set), otherwise empty table
 
-    for mai in H.child_range(self_data, "micro_ai") do
+    for mai in wml.child_range(self_data, "micro_ai") do
         if (mai.ai_id == ai_id) then
             if key then
                 return mai[key]

--- a/data/ai/micro_ais/micro_ai_self_data.lua
+++ b/data/ai/micro_ais/micro_ai_self_data.lua
@@ -13,8 +13,6 @@
 -- same side).
 -- For the time being, we only allow key=value style variables.
 
-local H = wesnoth.require "helper"
-
 local micro_ai_self_data = {}
 
 function micro_ai_self_data.modify_mai_self_data(self_data, ai_id, action, vars_table)

--- a/data/ai/micro_ais/micro_ai_unit_variables.lua
+++ b/data/ai/micro_ais/micro_ai_unit_variables.lua
@@ -9,8 +9,6 @@
 -- with different ai_CA values affecting the same unit)
 -- For the time being, we only allow key=value style variables.
 
-local H = wesnoth.require "helper"
-
 local micro_ai_unit_variables = {}
 
 function micro_ai_unit_variables.modify_mai_unit_variables(unit, ai_id, action, vars_table)

--- a/data/ai/micro_ais/micro_ai_unit_variables.lua
+++ b/data/ai/micro_ais/micro_ai_unit_variables.lua
@@ -70,7 +70,7 @@ function micro_ai_unit_variables.get_mai_unit_variables(unit, ai_id, key)
     --     table of key=value pairs (including the ai_id key)
     --   - If no such tag is found: nil (if @key is set), otherwise empty table
 
-    for mai in H.child_range(unit.variables.__cfg, "micro_ai") do
+    for mai in wml.child_range(unit.variables.__cfg, "micro_ai") do
         if (mai.ai_id == ai_id) then
             if key then
                 return mai[key]

--- a/data/ai/scenarios/scenario-AI_Arena_small.cfg
+++ b/data/ai/scenarios/scenario-AI_Arena_small.cfg
@@ -23,7 +23,6 @@
             code = <<
             H = wesnoth.dofile("lua/helper.lua")
             W = H.set_wml_action_metatable({})
-            H.set_wml_var_metatable(_G)
             local tests_table = {}
             function register_test(_name, _description)
             tests_table[_name] = _description

--- a/data/ai/scenarios/scenario-AI_Arena_small.cfg
+++ b/data/ai/scenarios/scenario-AI_Arena_small.cfg
@@ -21,7 +21,6 @@
         first_time_only=no
         [lua]
             code = <<
-            H = wesnoth.dofile("lua/helper.lua")
             local tests_table = {}
             function register_test(_name, _description)
             tests_table[_name] = _description

--- a/data/ai/scenarios/scenario-AI_Arena_small.cfg
+++ b/data/ai/scenarios/scenario-AI_Arena_small.cfg
@@ -70,7 +70,7 @@
                     name="_replace_ai_2"
                 [/fire_event]
                 [lua]
-                    code= <<  W.fire_event {name=wesnoth.get_variable("test_id") } >>
+                    code= <<  W.fire_event {name=wml.variables["test_id"] } >>
                 [/lua]
             [/command]
         [/set_menu_item]
@@ -163,7 +163,7 @@
             [/fire_event]
         [/command]
         [lua]
-            code= <<  W.fire_event {name=wesnoth.get_variable("test_id") } >>
+            code= <<  W.fire_event {name=wml.variables["test_id"] } >>
         [/lua]
     [/event]
 

--- a/data/ai/scenarios/scenario-AI_Arena_small.cfg
+++ b/data/ai/scenarios/scenario-AI_Arena_small.cfg
@@ -22,7 +22,6 @@
         [lua]
             code = <<
             H = wesnoth.dofile("lua/helper.lua")
-            W = H.set_wml_action_metatable({})
             local tests_table = {}
             function register_test(_name, _description)
             tests_table[_name] = _description
@@ -69,7 +68,7 @@
                     name="_replace_ai_2"
                 [/fire_event]
                 [lua]
-                    code= <<  W.fire_event {name=wml.variables["test_id"] } >>
+                    code= <<  wesnoth.wml_actions.fire_event {name=wml.variables["test_id"] } >>
                 [/lua]
             [/command]
         [/set_menu_item]
@@ -153,7 +152,7 @@
             local cmd = { "command", {{ "set_variable", {name="test_id", value= k } } } }
             table.insert(opts, { "option", { label = v, cmd } } )
             end
-            W.message { speaker="narrator", message="Which test do you wish to run, O Mighty AI Developer?", table.unpack(opts) }
+            wesnoth.wml_actions.message { speaker="narrator", message="Which test do you wish to run, O Mighty AI Developer?", table.unpack(opts) }
             >>
         [/lua]
         [command]
@@ -162,7 +161,7 @@
             [/fire_event]
         [/command]
         [lua]
-            code= <<  W.fire_event {name=wml.variables["test_id"] } >>
+            code= <<  wesnoth.wml_actions.fire_event {name=wml.variables["test_id"] } >>
         [/lua]
     [/event]
 

--- a/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
@@ -654,7 +654,6 @@
             # wmllint: markcheck off
             code= <<
                 local ai_helper = wesnoth.require "ai/lua/ai_helper.lua"
-                local H = wesnoth.require "helper"
                 local delf = wesnoth.get_units { id = 'Delfador' }[1]
                 local sceptre_loc= wesnoth.special_locations.sceptre
                 local path = wesnoth.find_path(delf, sceptre_loc[1], sceptre_loc[2], {ignore_units = true, viewing_side = 0}) -- # wmllint: noconvert

--- a/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
@@ -655,7 +655,6 @@
             code= <<
                 local ai_helper = wesnoth.require "ai/lua/ai_helper.lua"
                 local H = wesnoth.require "helper"
-                local W = H.set_wml_action_metatable {}
                 local delf = wesnoth.get_units { id = 'Delfador' }[1]
                 local sceptre_loc= wesnoth.special_locations.sceptre
                 local path = wesnoth.find_path(delf, sceptre_loc[1], sceptre_loc[2], {ignore_units = true, viewing_side = 0}) -- # wmllint: noconvert
@@ -672,7 +671,7 @@
 
                 local goal = { x = path[6][1], y = path[6][2] }
 
-                W.message{ speaker = 'Delfador', message= dirs[ai_helper.get_direction_index(delf, goal, 8, true)]}
+                wesnoth.wml_actions.message{ speaker = 'Delfador', message= dirs[ai_helper.get_direction_index(delf, goal, 8, true)]}
             >>
             # wmllint: markcheck on
         [/lua]

--- a/data/campaigns/Legend_of_Wesmere/lua/wml_tags.lua
+++ b/data/campaigns/Legend_of_Wesmere/lua/wml_tags.lua
@@ -4,7 +4,6 @@ local labels = {}
 local wml_label = wesnoth.wml_actions.label
 local replace_map = wesnoth.wml_actions.replace_map
 
-local helper = wesnoth.require "helper"
 local wml_actions = wesnoth.wml_actions
 local T = wml.tag
 local vars = wml.variables

--- a/data/campaigns/tutorial/lua/character_selection.lua
+++ b/data/campaigns/tutorial/lua/character_selection.lua
@@ -3,7 +3,6 @@
 -- Allows the player to choose whether they want to play Konrad or Li’sar
 -- for the tutorial
 
-local helper = wesnoth.require "helper"
 local T = wml.tag
 local wml_actions = wesnoth.wml_actions
 local _ = wesnoth.textdomain "wesnoth-tutorial"

--- a/data/lua/backwards-compatibility.lua
+++ b/data/lua/backwards-compatibility.lua
@@ -8,5 +8,5 @@ wesnoth.set_music = wesnoth.deprecate_api('wesnoth.set_music', 'wesnoth.music_li
 -- which also provides "constness" of the passed wml object from the point of view of the caller.
 -- So please don't remove since it's not deprecated.
 function wesnoth.fire(name, cfg)
-	wesnoth.wml_actions[name](wesnoth.tovconfig(cfg or {}))
+	wesnoth.wml_actions[name](wml.tovconfig(cfg or {}))
 end

--- a/data/lua/core.lua
+++ b/data/lua/core.lua
@@ -253,14 +253,18 @@ if wesnoth.kernel_type() == "Game Lua Kernel" then
 		end
 	})
 
+	-- So that definition of wml.variables does not cause deprecation warnings:
+	local get_variable_local = wesnoth.get_variable
+	local set_variable_local = wesnoth.set_variable
+
 	-- Get and set variables via wml.variables[variable_path]
 	wml.variables = setmetatable({}, {
 		__metatable = "WML variables",
 		__index = function(_, key)
-			return wesnoth.get_variable(key)
+			return get_variable_local(key)
 		end,
 		__newindex = function(_, key, value)
-			wesnoth.set_variable(key, value)
+			set_variable_local(key, value)
 		end
 	})
 
@@ -325,7 +329,7 @@ if wesnoth.kernel_type() == "Game Lua Kernel" then
 
 	local function resolve_variable_context(ctx, err_hint)
 		if ctx == nil then
-			return {get = wesnoth.get_variable, set = wesnoth.set_variable}
+			return {get = get_variable_local, set = set_variable_local}
 		elseif type(ctx) == 'number' and ctx > 0 and ctx <= #wesnoth.sides then
 			return resolve_variable_context(wesnoth.sides[ctx])
 		elseif type(ctx) == 'string' then

--- a/data/lua/core.lua
+++ b/data/lua/core.lua
@@ -286,7 +286,7 @@ if wesnoth.kernel_type() == "Game Lua Kernel" then
 		if getmetatable(v) == "WML variable proxy" then
 			v = wml.variables[v.__varname]
 		end
-		wesnoth.set_variable(k, v)
+		wml.variables[k] = v
 	end
 
 	function variable_mt.__index(t, k)

--- a/data/lua/core.lua
+++ b/data/lua/core.lua
@@ -236,11 +236,12 @@ if wesnoth.kernel_type() == "Game Lua Kernel" then
 	--[========[Basic variable access]========]
 
 	-- Get all variables via wml.all_variables (read-only)
+	local get_all_vars_local = wesnoth.get_all_vars
 	setmetatable(wml, {
 		__metatable = "WML module",
 		__index = function(self, key)
 			if key == 'all_variables' then
-				return wesnoth.get_all_vars()
+				return get_all_vars_local()
 			end
 			return rawget(self, key)
 		end,

--- a/data/lua/core.lua
+++ b/data/lua/core.lua
@@ -271,7 +271,7 @@ if wesnoth.kernel_type() == "Game Lua Kernel" then
 	}
 
 	local function get_variable_proxy(k)
-		local v = wesnoth.get_variable(k)
+		local v = wml.variables[k]
 		if type(v) == "table" then
 			v = setmetatable({ __varname = k }, variable_mt)
 		end
@@ -280,7 +280,7 @@ if wesnoth.kernel_type() == "Game Lua Kernel" then
 
 	local function set_variable_proxy(k, v)
 		if getmetatable(v) == "WML variable proxy" then
-			v = wesnoth.get_variable(v.__varname)
+			v = wml.variables[v.__varname]
 		end
 		wesnoth.set_variable(k, v)
 	end
@@ -378,7 +378,7 @@ if wesnoth.kernel_type() == "Game Lua Kernel" then
 	--! @returns a table containing all the variable proxies (starting at index 1).
 	function wml.array_access.get_proxy(var)
 		local result = {}
-		for i = 1, wesnoth.get_variable(var .. ".length") do
+		for i = 1, wml.variables[var .. ".length"] do
 			result[i] = get_variable_proxy(string.format("%s[%d]", var, i - 1))
 		end
 		return result

--- a/data/lua/helper.lua
+++ b/data/lua/helper.lua
@@ -47,14 +47,14 @@ function helper.modify_unit(filter, vars)
 	for i = 0, wml.variables["LUA_modify_unit.length"] - 1 do
 		local u = string.format("LUA_modify_unit[%d]", i)
 		for k, v in pairs(vars) do
-			wesnoth.set_variable(u .. '.' .. k, v)
+			wml.variables[u .. '.' .. k] = v
 		end
 		wml_actions.unstore_unit({
 			variable = u,
 			find_vacant = false
 		})
 	end
-	wesnoth.set_variable("LUA_modify_unit")
+	wml.variables["LUA_modify_unit"] = nil
 end
 
 --! Fakes the move of a unit satisfying the given @a filter to position @a x, @a y.
@@ -71,12 +71,12 @@ function helper.move_unit_fake(filter, to_x, to_y)
 	wml_actions.scroll_to({ x=from_x, y=from_y })
 
 	if to_x < from_x then
-		wesnoth.set_variable("LUA_move_unit.facing", "sw")
+		wml.variables["LUA_move_unit.facing"] = "sw"
 	elseif to_x > from_x then
-		wesnoth.set_variable("LUA_move_unit.facing", "se")
+		wml.variables["LUA_move_unit.facing"] = "se"
 	end
-	wesnoth.set_variable("LUA_move_unit.x", to_x)
-	wesnoth.set_variable("LUA_move_unit.y", to_y)
+	wml.variables["LUA_move_unit.x"] = to_x
+	wml.variables["LUA_move_unit.y"] = to_y
 
 	wml_actions.kill({
 		x = from_x,
@@ -96,7 +96,7 @@ function helper.move_unit_fake(filter, to_x, to_y)
 
 	wml_actions.unstore_unit({ variable="LUA_move_unit", find_vacant=true })
 	wml_actions.redraw({})
-	wesnoth.set_variable("LUA_move_unit")
+	wml.variables["LUA_move_unit"] = nil
 end
 
 -- Metatable that redirects access to wml.variables_proxy

--- a/data/lua/helper.lua
+++ b/data/lua/helper.lua
@@ -44,7 +44,7 @@ function helper.modify_unit(filter, vars)
 		variable = "LUA_modify_unit",
 		kill = true
 	})
-	for i = 0, wesnoth.get_variable("LUA_modify_unit.length") - 1 do
+	for i = 0, wml.variables["LUA_modify_unit.length"] - 1 do
 		local u = string.format("LUA_modify_unit[%d]", i)
 		for k, v in pairs(vars) do
 			wesnoth.set_variable(u .. '.' .. k, v)
@@ -65,8 +65,8 @@ function helper.move_unit_fake(filter, to_x, to_y)
 		variable = "LUA_move_unit",
 		kill = false
 	})
-	local from_x = wesnoth.get_variable("LUA_move_unit.x")
-	local from_y = wesnoth.get_variable("LUA_move_unit.y")
+	local from_x = wml.variables["LUA_move_unit.x"]
+	local from_y = wml.variables["LUA_move_unit.y"]
 
 	wml_actions.scroll_to({ x=from_x, y=from_y })
 

--- a/data/lua/location_set.lua
+++ b/data/lua/location_set.lua
@@ -145,8 +145,8 @@ end
 
 function methods:of_wml_var(name)
 	local values = self.values
-	for i = 0, wesnoth.get_variable(name .. ".length") - 1 do
-		local t = wesnoth.get_variable(string.format("%s[%d]", name, i))
+	for i = 0, wml.variables[name .. ".length"] - 1 do
+		local t = wml.variables[string.format("%s[%d]", name, i)]
 		local x, y = t.x, t.y
 		t.x, t.y = nil, nil
 		values[index(x, y)] = next(t) and t or true

--- a/data/lua/location_set.lua
+++ b/data/lua/location_set.lua
@@ -175,13 +175,13 @@ end
 
 function methods:to_wml_var(name)
 	local i = 0
-	wesnoth.set_variable(name)
+	wml.variables[name] = nil
 	self:stable_iter(function(x, y, v)
 		if type(v) == 'table' then
-			wesnoth.set_variable(string.format("%s[%d]", name, i), v)
+			wml.variables[string.format("%s[%d]", name, i)] = v
 		end
-		wesnoth.set_variable(string.format("%s[%d].x", name, i), x)
-		wesnoth.set_variable(string.format("%s[%d].y", name, i), y)
+		wml.variables[string.format("%s[%d].x", name, i)] = x
+		wml.variables[string.format("%s[%d].y", name, i)] = y
 		i = i + 1
 	end)
 end

--- a/data/lua/wml-flow.lua
+++ b/data/lua/wml-flow.lua
@@ -101,7 +101,7 @@ wesnoth.wml_actions["for"] = function(cfg)
 		loop_lim.last = cfg_lit["end"] or first
 		loop_lim.step = cfg_lit.step or 1
 	end
-	loop_lim = wesnoth.tovconfig(loop_lim)
+	loop_lim = wml.tovconfig(loop_lim)
 	if loop_lim.step == 0 then -- Sanity check
 		helper.wml_error("[for] has a step of 0!")
 	end

--- a/data/lua/wml-flow.lua
+++ b/data/lua/wml-flow.lua
@@ -85,7 +85,7 @@ wesnoth.wml_actions["for"] = function(cfg)
 	local first
 	if cfg.array ~= nil then
 		if cfg.reverse then
-			first = wesnoth.get_variable(cfg.array .. ".length") - 1
+			first = wml.variables[cfg.array .. ".length"] - 1
 			loop_lim.last = 0
 			loop_lim.step = -1
 		else
@@ -119,16 +119,16 @@ wesnoth.wml_actions["for"] = function(cfg)
 		if loop_lim.step then
 			sentinel = sentinel + loop_lim.step
 			if loop_lim.step > 0 then
-				return wesnoth.get_variable(i_var) < sentinel
+				return wml.variables[i_var] < sentinel
 			else
-				return wesnoth.get_variable(i_var) > sentinel
+				return wml.variables[i_var] > sentinel
 			end
 		elseif loop_lim.last < first then
 			sentinel = sentinel - 1
-			return wesnoth.get_variable(i_var) > sentinel
+			return wml.variables[i_var] > sentinel
 		else
 			sentinel = sentinel + 1
-			return wesnoth.get_variable(i_var) < sentinel
+			return wml.variables[i_var] < sentinel
 		end
 	end
 	while loop_condition() do
@@ -144,7 +144,7 @@ wesnoth.wml_actions["for"] = function(cfg)
 				goto exit
 			end
 		end
-		wesnoth.set_variable(i_var, wesnoth.get_variable(i_var) + loop_lim.step)
+		wesnoth.set_variable(i_var, wml.variables[i_var] + loop_lim.step)
 	end
 	::exit::
 	utils.end_var_scope(i_var, save_i)
@@ -184,12 +184,12 @@ function wml_actions.foreach(cfg)
 	local this_item = utils.start_var_scope(item_name) -- if this_item is already set
 	local i_name = cfg.index_var or "i"
 	local i = utils.start_var_scope(i_name) -- if i is already set
-	local array_length = wesnoth.get_variable(array_name .. ".length")
+	local array_length = wml.variables[array_name .. ".length"]
 
 	for index, value in ipairs(array) do
 		-- Some protection against external modification
 		-- It's not perfect, though - it'd be nice if *any* change could be detected
-		if array_length ~= wesnoth.get_variable(array_name .. ".length") then
+		if array_length ~= wml.variables[array_name .. ".length"] then
 			helper.wml_error("WML array length changed during [foreach] iteration")
 		end
 		wesnoth.set_variable(item_name, value)
@@ -210,7 +210,7 @@ function wml_actions.foreach(cfg)
 		end
 		-- set back the content, in case the author made some modifications
 		if not cfg.readonly then
-			array[index] = wesnoth.get_variable(item_name)
+			array[index] = wml.variables[item_name]
 		end
 	end
 	::exit::
@@ -236,7 +236,7 @@ function wml_actions.foreach(cfg)
 end
 
 function wml_actions.switch(cfg)
-	local var_value = wesnoth.get_variable(cfg.variable)
+	local var_value = wml.variables[cfg.variable]
 	local found = false
 
 	-- Execute all the [case]s where the value matches.

--- a/data/lua/wml-flow.lua
+++ b/data/lua/wml-flow.lua
@@ -113,7 +113,7 @@ wesnoth.wml_actions["for"] = function(cfg)
 	end
 	local i_var = cfg.variable or "i"
 	local save_i = utils.start_var_scope(i_var)
-	wesnoth.set_variable(i_var, first)
+	wml.variables[i_var] = first
 	local function loop_condition()
 		local sentinel = loop_lim.last
 		if loop_lim.step then
@@ -144,7 +144,7 @@ wesnoth.wml_actions["for"] = function(cfg)
 				goto exit
 			end
 		end
-		wesnoth.set_variable(i_var, wml.variables[i_var] + loop_lim.step)
+		wml.variables[i_var] = wml.variables[i_var] + loop_lim.step
 	end
 	::exit::
 	utils.end_var_scope(i_var, save_i)
@@ -192,9 +192,9 @@ function wml_actions.foreach(cfg)
 		if array_length ~= wml.variables[array_name .. ".length"] then
 			helper.wml_error("WML array length changed during [foreach] iteration")
 		end
-		wesnoth.set_variable(item_name, value)
+		wml.variables[item_name] = value
 		-- set index variable
-		wesnoth.set_variable(i_name, index-1) -- here -1, because of WML array
+		wml.variables[i_name] = index-1 -- here -1, because of WML array
 		-- perform actions
 		for do_child in wml.child_range(cfg, "do") do
 			local action = utils.handle_event_commands(do_child, "loop")

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -26,17 +26,17 @@ function wml_actions.sync_variable(cfg)
 			local res = {}
 			for name_raw in utils.split(names) do
 				local name = utils.trim(name_raw)
-				local variable_type = string.sub(name, string.len(name)) == "]" and "indexed" or ( wesnoth.get_variable(name .. ".length") > 0 and "array" or "attribute")
+				local variable_type = string.sub(name, string.len(name)) == "]" and "indexed" or ( wml.variables[name .. ".length"] > 0 and "array" or "attribute")
 				local variable_info = { name = name, type = variable_type }
 				table.insert(res, { "variable", variable_info })
 				if variable_type == "indexed" then
-					table.insert(variable_info, { "value", wesnoth.get_variable(name) } )
+					table.insert(variable_info, { "value", wml.variables[name] } )
 				elseif variable_type == "array" then
-					for i = 1, wesnoth.get_variable(name .. ".length") do
-						table.insert(variable_info, { "value",  wesnoth.get_variable(string.format("%s[%d]", name, i - 1)) } )
+					for i = 1, wml.variables[name .. ".length"] do
+						table.insert(variable_info, { "value",  wml.variables[string.format("%s[%d]", name, i - 1)] } )
 					end
 				else
-					variable_info.value = wesnoth.get_variable(name)
+					variable_info.value = wml.variables[name]
 				end
 			end
 			return res
@@ -821,7 +821,7 @@ end
 
 wml_actions.unstore_unit = function(cfg)
 	local variable = cfg.variable or helper.wml_error("[unstore_unit] missing required 'variable' attribute")
-	local unit_cfg = wesnoth.get_variable(variable) or helper.wml_error("[unstore_unit]: variable '" .. variable .. "' doesn't exist")
+	local unit_cfg = wml.variables[variable] or helper.wml_error("[unstore_unit]: variable '" .. variable .. "' doesn't exist")
 	if type(unit_cfg) ~= "table" or unit_cfg.type == nil then
 		helper.wml_error("[unstore_unit]: variable '" .. variable .. "' doesn't contain unit data")
 	end

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -46,13 +46,13 @@ function wml_actions.sync_variable(cfg)
 		local name = variable.name
 
 		if variable.type == "indexed" then
-			wesnoth.set_variable(name, variable[1][2])
+			wml.variables[name] = variable[1][2]
 		elseif variable.type == "array" then
 			for index, cfg_pair in ipairs(variable) do
-				wesnoth.set_variable( string.format("%s[%d]", name, index - 1), cfg_pair[2])
+				wml.variables[string.format("%s[%d]", name, index - 1)] = cfg_pair[2]
 			end
 		else
-			wesnoth.set_variable(name, variable.value)
+			wml.variables[name] = variable.value
 		end
 	end
 end
@@ -102,14 +102,14 @@ end
 --since the gold is stored in a scalar variable, not a container (there's no key).
 function wml_actions.store_gold(cfg)
 	local team = wesnoth.get_sides(cfg)[1]
-	if team then wesnoth.set_variable(cfg.variable or "gold", team.gold) end
+	if team then wml.variables[cfg.variable or "gold"] = team.gold end
 end
 
 function wml_actions.clear_variable(cfg)
 	local names = cfg.name or
 		helper.wml_error "[clear_variable] missing required name= attribute."
 	for w in utils.split(names) do
-		wesnoth.set_variable(utils.trim(w))
+		wml.variables[utils.trim(w)] = nil
 	end
 end
 
@@ -120,7 +120,7 @@ function wml_actions.store_unit_type_ids(cfg)
 	end
 	table.sort(types)
 	types = table.concat(types, ',')
-	wesnoth.set_variable(cfg.variable or "unit_type_ids", types)
+	wml.variables[cfg.variable or "unit_type_ids"] = types
 end
 
 function wml_actions.store_unit_type(cfg)
@@ -241,9 +241,9 @@ end
 function wml_actions.store_map_dimensions(cfg)
 	local var = cfg.variable or "map_size"
 	local w, h, b = wesnoth.get_map_size()
-	wesnoth.set_variable(var .. ".width", w)
-	wesnoth.set_variable(var .. ".height", h)
-	wesnoth.set_variable(var .. ".border_size", b)
+	wml.variables[var .. ".width"] = w
+	wml.variables[var .. ".height"] = h
+	wml.variables[var .. ".border_size"] = b
 end
 
 function wml_actions.unit_worth(cfg)
@@ -257,12 +257,12 @@ function wml_actions.unit_worth(cfg)
 		local uta = wesnoth.unit_types[w]
 		if uta and uta.cost > best_adv then best_adv = uta.cost end
 	end
-	wesnoth.set_variable("cost", ut.cost)
-	wesnoth.set_variable("next_cost", best_adv)
-	wesnoth.set_variable("health", math.floor(hp * 100))
-	wesnoth.set_variable("experience", math.floor(xp * 100))
-	wesnoth.set_variable("recall_cost", ut.recall_cost)
-	wesnoth.set_variable("unit_worth", math.floor(math.max(ut.cost * hp, best_adv * xp)))
+	wml.variables["cost"] = ut.cost
+	wml.variables["next_cost"] = best_adv
+	wml.variables["health"] = math.floor(hp * 100)
+	wml.variables["experience"] = math.floor(xp * 100)
+	wml.variables["recall_cost"] = ut.recall_cost
+	wml.variables["unit_worth"] = math.floor(math.max(ut.cost * hp, best_adv * xp))
 end
 
 function wml_actions.lua(cfg)
@@ -373,7 +373,7 @@ end
 
 function wml_actions.store_turns(cfg)
 	local var = cfg.variable or "turns"
-	wesnoth.set_variable(var, wesnoth.game_config.last_turn)
+	wml.variables[var] = wesnoth.game_config.last_turn
 end
 
 function wml_actions.store_unit(cfg)
@@ -941,5 +941,5 @@ function wesnoth.wml_actions.store_unit_defense(cfg)
 	else
 		defense = wesnoth.unit_defense(unit, wesnoth.get_terrain(unit.x, unit.y))
 	end
-	wesnoth.set_variable(cfg.variable or "terrain_defense", defense)
+	wml.variables[cfg.variable or "terrain_defense"] = defense
 end

--- a/data/lua/wml-utils.lua
+++ b/data/lua/wml-utils.lua
@@ -32,7 +32,7 @@ function utils.vwriter.init(cfg, default_variable)
 	elseif mode == "append" then
 		index = wml.variables[variable .. ".length"]
 	elseif mode ~= "replace" then
-		wesnoth.set_variable(variable)
+		wml.variables[variable] = nil
 	end
 	return {
 		variable = variable,
@@ -43,9 +43,9 @@ end
 
 function utils.vwriter.write(self, container)
 	if self.is_explicit_index then
-		wesnoth.set_variable(self.variable, container)
+		wml.variables[self.variable] = container
 	else
-		wesnoth.set_variable(string.format("%s[%u]", self.variable, self.index), container)
+		wml.variables[string.format("%s[%u]", self.variable, self.index)] = container
 	end
 	self.index = self.index + 1
 end
@@ -194,16 +194,16 @@ end
 function utils.start_var_scope(name)
 	local var = wml.array_access.get(name) --containers and arrays
 	if #var == 0 then var = wml.variables[name] end --scalars (and nil/empty)
-	wesnoth.set_variable(name)
+	wml.variables[name] = nil
 	return var
 end
 
 function utils.end_var_scope(name, var)
-	wesnoth.set_variable(name)
+	wml.variables[name] = nil
 	if type(var) == "table" then
 		wml.array_access.set(name, var)
 	else
-		wesnoth.set_variable(name, var)
+		wml.variables[name] = var
 	end
 end
 

--- a/data/lua/wml-utils.lua
+++ b/data/lua/wml-utils.lua
@@ -127,7 +127,7 @@ function utils.handle_event_commands(cfg, scope_type)
 			elseif string.sub(from, -1) ~= ']' then
 				insert_from = from
 			end
-			arg = wesnoth.tovconfig(arg)
+			arg = wml.tovconfig(arg)
 		end
 		if not string.find(cmd, "^filter") then
 			cmd = wesnoth.wml_actions[cmd] or
@@ -139,7 +139,7 @@ function utils.handle_event_commands(cfg, scope_type)
 					if current_exit ~= "none" then break end
 					j = j + 1
 					if j >= wesnoth.get_variable(insert_from .. ".length") then break end
-					arg = wesnoth.tovconfig(wesnoth.get_variable(string.format("%s[%d]", insert_from, j)))
+					arg = wml.tovconfig(wesnoth.get_variable(string.format("%s[%d]", insert_from, j)))
 				until false
 			else
 				cmd(arg)

--- a/data/lua/wml-utils.lua
+++ b/data/lua/wml-utils.lua
@@ -30,7 +30,7 @@ function utils.vwriter.init(cfg, default_variable)
 	if is_explicit_index then
 		-- explicit indexes behave always like "replace"
 	elseif mode == "append" then
-		index = wesnoth.get_variable(variable .. ".length")
+		index = wml.variables[variable .. ".length"]
 	elseif mode ~= "replace" then
 		wesnoth.set_variable(variable)
 	end
@@ -119,7 +119,7 @@ function utils.handle_event_commands(cfg, scope_type)
 			local from = arg.variable or
 				helper.wml_error("[insert_tag] found with no variable= field")
 
-			arg = wesnoth.get_variable(from)
+			arg = wml.variables[from]
 			if type(arg) ~= "table" then
 				-- Corner case: A missing variable is replaced
 				-- by an empty container rather than being ignored.
@@ -138,8 +138,8 @@ function utils.handle_event_commands(cfg, scope_type)
 					cmd(arg)
 					if current_exit ~= "none" then break end
 					j = j + 1
-					if j >= wesnoth.get_variable(insert_from .. ".length") then break end
-					arg = wml.tovconfig(wesnoth.get_variable(string.format("%s[%d]", insert_from, j)))
+					if j >= wml.variables[insert_from .. ".length"] then break end
+					arg = wml.tovconfig(wml.variables[string.format("%s[%d]", insert_from, j)])
 				until false
 			else
 				cmd(arg)
@@ -193,7 +193,7 @@ end
 --note: when using these, make sure that nothing can throw over the call to end_var_scope
 function utils.start_var_scope(name)
 	local var = wml.array_access.get(name) --containers and arrays
-	if #var == 0 then var = wesnoth.get_variable(name) end --scalars (and nil/empty)
+	if #var == 0 then var = wml.variables[name] end --scalars (and nil/empty)
 	wesnoth.set_variable(name)
 	return var
 end

--- a/data/lua/wml/find_path.lua
+++ b/data/lua/wml/find_path.lua
@@ -9,8 +9,8 @@ function wesnoth.wml_actions.find_path(cfg)
 	-- support for $this_unit
 	local this_unit = utils.start_var_scope("this_unit")
 
-	wesnoth.set_variable ( "this_unit" ) -- clearing this_unit
-	wesnoth.set_variable("this_unit", unit.__cfg) -- cfg field needed
+	wml.variables["this_unit"] = nil -- clearing this_unit
+	wml.variables["this_unit"] = unit.__cfg -- cfg field needed
 
 	local variable = cfg.variable or "path"
 	local ignore_units = false
@@ -78,28 +78,27 @@ function wesnoth.wml_actions.find_path(cfg)
 		end
 
 		if cost >= 42424242 then -- it's the high value returned for unwalkable or busy terrains
-			wesnoth.set_variable ( tostring(variable), { hexes = 0 } ) -- set only length, nil all other values
+			wml.variables[tostring(variable)] = { hexes = 0 } -- set only length, nil all other values
 			-- support for $this_unit
-			wesnoth.set_variable ( "this_unit" ) -- clearing this_unit
+			wml.variables["this_unit"] = nil -- clearing this_unit
 			utils.end_var_scope("this_unit", this_unit)
 		return end
 
 		if not allow_multiple_turns and turns > 1 then -- location cannot be reached in one turn
-			wesnoth.set_variable ( tostring(variable), { hexes = 0 } )
+			wml.variables[tostring(variable)] = { hexes = 0 }
 			-- support for $this_unit
-			wesnoth.set_variable ( "this_unit" ) -- clearing this_unit
+			wml.variables["this_unit"] = nil -- clearing this_unit
 			utils.end_var_scope("this_unit", this_unit)
 		return end -- skip the cycles below
 
-		wesnoth.set_variable (
-			tostring( variable ),
+		wml.variables[tostring( variable )] =
 			{
 				hexes = current_distance,
 				from_x = unit.x, from_y = unit.y,
 				to_x = current_location[1], to_y = current_location[2],
 				movement_cost = cost,
 				required_turns = turns
-			} )
+			}
 
 		for index, path_loc in ipairs(path) do
 			local sub_path, sub_cost = wesnoth.find_path(
@@ -120,18 +119,17 @@ function wesnoth.wml_actions.find_path(cfg)
 				sub_turns = math.ceil( ( ( sub_cost - unit.moves ) / unit.max_moves ) + 1 )
 			end
 
-			wesnoth.set_variable (
-				string.format( "%s.step[%d]", variable, index - 1 ),
+			wml.variables[string.format( "%s.step[%d]", variable, index - 1 )] =
 				{  -- this structure takes less space in the inspection window
 					x = path_loc[1], y = path_loc[2],
 					terrain = wesnoth.get_terrain( path_loc[1], path_loc[2] ),
 					movement_cost = sub_cost,
 					required_turns = sub_turns
-				} )
+				}
 		end
 	end
 
 	-- support for $this_unit
-	wesnoth.set_variable ( "this_unit" ) -- clearing this_unit
+	wml.variables["this_unit"] = nil -- clearing this_unit
 	utils.end_var_scope("this_unit", this_unit)
 end

--- a/data/lua/wml/harm_unit.lua
+++ b/data/lua/wml/harm_unit.lua
@@ -24,8 +24,8 @@ function wml_actions.harm_unit(cfg)
 	for index, unit_to_harm in ipairs(wesnoth.get_units(filter)) do
 		if unit_to_harm.valid then
 			-- block to support $this_unit
-			wesnoth.set_variable ( "this_unit" ) -- clearing this_unit
-			wesnoth.set_variable("this_unit", unit_to_harm.__cfg) -- cfg field needed
+			wml.variables["this_unit"] = nil -- clearing this_unit
+			wml.variables["this_unit"] = unit_to_harm.__cfg -- cfg field needed
 			local amount = tonumber(cfg.amount)
 			local animate = cfg.animate -- attacker and defender are special values
 			local delay = cfg.delay or 500
@@ -187,7 +187,7 @@ function wml_actions.harm_unit(cfg)
 			end
 
 			if variable then
-				wesnoth.set_variable(string.format("%s[%d]", variable, index - 1), { harm_amount = damage })
+				wml.variables[string.format("%s[%d]", variable, index - 1)] = { harm_amount = damage }
 			end
 
 			-- both units may no longer be alive at this point, so double check
@@ -203,6 +203,6 @@ function wml_actions.harm_unit(cfg)
 		wml_actions.redraw {}
 	end
 
-	wesnoth.set_variable ( "this_unit" ) -- clearing this_unit
+	wml.variables["this_unit"] = nil -- clearing this_unit
 	utils.end_var_scope("this_unit", this_unit)
 end

--- a/data/lua/wml/heal_unit.lua
+++ b/data/lua/wml/heal_unit.lua
@@ -67,7 +67,7 @@ function wesnoth.wml_actions.heal_unit(cfg)
 
 		if not heal_amount_set then
 			heal_amount_set = true
-			wesnoth.set_variable("heal_amount", heal_amount)
+			wml.variables["heal_amount"] = heal_amount
 		end
 	end
 end

--- a/data/lua/wml/items.lua
+++ b/data/lua/wml/items.lua
@@ -75,7 +75,7 @@ function wml_actions.item(cfg)
 	local redraw = cfg.redraw
 	if redraw == nil then redraw = true end
 	if redraw then wml_actions.redraw {} end
-	if cfg.write_name then wesnoth.set_variable(cfg.write_name, cfg.name) end
+	if cfg.write_name then wml.variables[cfg.write_name] = cfg.name end
 	return cfg.name
 end
 
@@ -89,13 +89,13 @@ end
 function wml_actions.store_items(cfg)
 	local variable = cfg.variable or "items"
 	variable = tostring(variable or helper.wml_error("invalid variable= in [store_items]"))
-	wesnoth.set_variable(variable)
+	wml.variables[variable] = nil
 	local index = 0
 	for i, loc in ipairs(wesnoth.get_locations(cfg)) do
 		local items = scenario_items[loc[1] * 10000 + loc[2]]
 		if items then
 			for j, item in ipairs(items) do
-				wesnoth.set_variable(string.format("%s[%u]", variable, index), item)
+				wml.variables[string.format("%s[%u]", variable, index)] = item
 				index = index + 1
 			end
 		end

--- a/data/lua/wml/message.lua
+++ b/data/lua/wml/message.lua
@@ -398,7 +398,7 @@ function wesnoth.wml_actions.message(cfg)
 
 		if text_input ~= nil then
 			-- Implement the consequences of the choice
-			wesnoth.set_variable(text_input.variable or "input", choice.text)
+			wml.variables[text_input.variable or "input"] = choice.text
 		end
 	end
 
@@ -416,9 +416,9 @@ function wesnoth.wml_actions.message(cfg)
 
 		if cfg.variable ~= nil then
 			if options[option_chosen].value == nil then
-				wesnoth.set_variable(cfg.variable, option_chosen)
+				wml.variables[cfg.variable] = option_chosen
 			else
-				wesnoth.set_variable(cfg.variable, options[option_chosen].value)
+				wml.variables[cfg.variable] = options[option_chosen].value
 			end
 		end
 

--- a/data/lua/wml/modify_unit.lua
+++ b/data/lua/wml/modify_unit.lua
@@ -33,7 +33,7 @@ function wml_actions.modify_unit(cfg)
 	local function handle_unit(unit_num)
 		local children_handled = {}
 		local unit_path = string.format("%s[%u]", unit_variable, unit_num)
-		local this_unit = wesnoth.get_variable(unit_path)
+		local this_unit = wml.variables[unit_path]
 		wesnoth.set_variable("this_unit", this_unit)
 		handle_attributes(cfg, unit_path, true)
 
@@ -48,7 +48,7 @@ function wml_actions.modify_unit(cfg)
 				else
 					mod = wml.parsed(mod)
 				end
-				local unit = wesnoth.get_variable(unit_path)
+				local unit = wml.variables[unit_path]
 				unit = wesnoth.create_unit(unit)
 				wesnoth.add_modification(unit, current_tag, mod)
 				unit = unit.__cfg;
@@ -57,7 +57,7 @@ function wml_actions.modify_unit(cfg)
 				local mod = current_table[2]
 				local apply_to = mod.apply_to
 				if wesnoth.effects[apply_to] then
-					local unit = wesnoth.get_variable(unit_path)
+					local unit = wml.variables[unit_path]
 					unit = wesnoth.create_unit(unit)
 					wesnoth.effects[apply_to](unit, mod)
 					unit = unit.__cfg;
@@ -78,14 +78,14 @@ function wml_actions.modify_unit(cfg)
 
 		if cfg.type then
 			if cfg.type ~= "" then wesnoth.set_variable(unit_path .. ".advances_to", cfg.type) end
-			wesnoth.set_variable(unit_path .. ".experience", wesnoth.get_variable(unit_path .. ".max_experience"))
+			wesnoth.set_variable(unit_path .. ".experience", wml.variables[unit_path .. ".max_experience"])
 		end
 		wml_actions.kill({ id = this_unit.id, animate = false })
 		wml_actions.unstore_unit { variable = unit_path }
 	end
 
 	wml_actions.store_unit { {"filter", filter}, variable = unit_variable }
-	local max_index = wesnoth.get_variable(unit_variable .. ".length") - 1
+	local max_index = wml.variables[unit_variable .. ".length"] - 1
 
 	local this_unit = utils.start_var_scope("this_unit")
 	for current_unit = 0, max_index do

--- a/data/lua/wml/objectives.lua
+++ b/data/lua/wml/objectives.lua
@@ -205,7 +205,7 @@ end
 local function maybe_parsed(cfg)
 	if cfg == nil then return nil end
 	if cfg.delayed_variable_substitution == true then
-		return wesnoth.tovconfig(cfg)
+		return wml.tovconfig(cfg)
 	end
 	return cfg
 end

--- a/data/lua/wml/random_placement.lua
+++ b/data/lua/wml/random_placement.lua
@@ -29,10 +29,10 @@ wesnoth.wml_actions.random_placement = function(cfg)
 		end
 		local index = wesnoth.random(size)
 		local point = locs[index]
-		wesnoth.set_variable(variable .. ".x", point[1])
-		wesnoth.set_variable(variable .. ".y", point[2])
-		wesnoth.set_variable(variable .. ".n", i)
-		wesnoth.set_variable(variable .. ".terrain", wesnoth.get_terrain(point[1], point[2]))
+		wml.variables[variable .. ".x"] = point[1]
+		wml.variables[variable .. ".y"] = point[2]
+		wml.variables[variable .. ".n"] = i
+		wml.variables[variable .. ".terrain"] = wesnoth.get_terrain(point[1], point[2])
 		if distance < 0 then
 			-- optimisation: nothing to do for distance < 0
 		elseif distance == 0 then

--- a/data/lua/wml/set_variable.lua
+++ b/data/lua/wml/set_variable.lua
@@ -12,59 +12,59 @@ function wesnoth.wml_actions.set_variable(cfg)
 	end
 
 	if cfg.to_variable then
-		wesnoth.set_variable(name, wesnoth.get_variable(cfg.to_variable))
+		wesnoth.set_variable(name, wml.variables[cfg.to_variable])
 	end
 
 	if cfg.suffix then
-		wesnoth.set_variable(name, (wesnoth.get_variable(name) or '') .. (cfg.suffix or ''))
+		wesnoth.set_variable(name, (wml.variables[name] or '') .. (cfg.suffix or ''))
 	end
 
 	if cfg.prefix then
-		wesnoth.set_variable(name, (cfg.prefix or '') .. (wesnoth.get_variable(name) or ''))
+		wesnoth.set_variable(name, (cfg.prefix or '') .. (wml.variables[name] or ''))
 	end
 
 	if cfg.add then
-		wesnoth.set_variable(name, (tonumber(wesnoth.get_variable(name)) or 0) + (tonumber(cfg.add) or 0))
+		wesnoth.set_variable(name, (tonumber(wml.variables[name]) or 0) + (tonumber(cfg.add) or 0))
 	end
 
 	if cfg.sub then
-		wesnoth.set_variable(name, (tonumber(wesnoth.get_variable(name)) or 0) - (tonumber(cfg.sub) or 0))
+		wesnoth.set_variable(name, (tonumber(wml.variables[name]) or 0) - (tonumber(cfg.sub) or 0))
 	end
 
 	if cfg.multiply then
-		wesnoth.set_variable(name, (tonumber(wesnoth.get_variable(name)) or 0) * (tonumber(cfg.multiply) or 0))
+		wesnoth.set_variable(name, (tonumber(wml.variables[name]) or 0) * (tonumber(cfg.multiply) or 0))
 	end
 
 	if cfg.divide then
 		local divide = tonumber(cfg.divide) or 0
 		if divide == 0 then helper.wml_error("division by zero on variable " .. name) end
-		wesnoth.set_variable(name, (tonumber(wesnoth.get_variable(name)) or 0) / divide)
+		wesnoth.set_variable(name, (tonumber(wml.variables[name]) or 0) / divide)
 	end
 
 	if cfg.modulo then
 		local modulo = tonumber(cfg.modulo) or 0
 		if modulo == 0 then helper.wml_error("division by zero on variable " .. name) end
-		wesnoth.set_variable(name, (tonumber(wesnoth.get_variable(name)) or 0) % modulo)
+		wesnoth.set_variable(name, (tonumber(wml.variables[name]) or 0) % modulo)
 	end
 
 	if cfg.abs then
-		wesnoth.set_variable(name, math.abs(tonumber(wesnoth.get_variable(name)) or 0))
+		wesnoth.set_variable(name, math.abs(tonumber(wml.variables[name]) or 0))
 	end
 
 	if cfg.root then
 		if cfg.root == "square" then
-			local radicand = tonumber(wesnoth.get_variable(name)) or 0
+			local radicand = tonumber(wml.variables[name]) or 0
 			if radicand < 0 then helper.wml_error("square root of negative number on variable " .. name) end
 			wesnoth.set_variable(name, math.sqrt(radicand))
 		end
 	end
 
 	if cfg.power then
-		wesnoth.set_variable(name, (tonumber(wesnoth.get_variable(name)) or 0) ^ (tonumber(cfg.power) or 0))
+		wesnoth.set_variable(name, (tonumber(wml.variables[name]) or 0) ^ (tonumber(cfg.power) or 0))
 	end
 
 	if cfg.round then
-		local var = tonumber(wesnoth.get_variable(name) or 0)
+		local var = tonumber(wml.variables[name] or 0)
 		local round_val = cfg.round
 		if round_val == "ceil" then
 			wesnoth.set_variable(name, math.ceil(var))
@@ -108,7 +108,7 @@ function wesnoth.wml_actions.set_variable(cfg)
 
 	if cfg.formula then
 		local fcn = wesnoth.compile_formula(cfg.formula)
-		wesnoth.set_variable(name, fcn(wesnoth.get_variable(name)))
+		wesnoth.set_variable(name, fcn(wml.variables[name]))
 	end
 
 	local join_child = wml.get_child(cfg, "join")

--- a/data/lua/wml/set_variable.lua
+++ b/data/lua/wml/set_variable.lua
@@ -4,78 +4,78 @@ function wesnoth.wml_actions.set_variable(cfg)
 	local name = cfg.name or helper.wml_error "trying to set a variable with an empty name"
 
 	if cfg.value ~= nil then -- check for nil because user may try to set a variable as false
-		wesnoth.set_variable(name, cfg.value)
+		wml.variables[name] = cfg.value
 	end
 
 	if cfg.literal ~= nil then
-		wesnoth.set_variable(name, wml.shallow_literal(cfg).literal)
+		wml.variables[name] = wml.shallow_literal(cfg).literal
 	end
 
 	if cfg.to_variable then
-		wesnoth.set_variable(name, wml.variables[cfg.to_variable])
+		wml.variables[name] = wml.variables[cfg.to_variable]
 	end
 
 	if cfg.suffix then
-		wesnoth.set_variable(name, (wml.variables[name] or '') .. (cfg.suffix or ''))
+		wml.variables[name] = (wml.variables[name] or '') .. (cfg.suffix or '')
 	end
 
 	if cfg.prefix then
-		wesnoth.set_variable(name, (cfg.prefix or '') .. (wml.variables[name] or ''))
+		wml.variables[name] = (cfg.prefix or '') .. (wml.variables[name] or '')
 	end
 
 	if cfg.add then
-		wesnoth.set_variable(name, (tonumber(wml.variables[name]) or 0) + (tonumber(cfg.add) or 0))
+		wml.variables[name] = (tonumber(wml.variables[name]) or 0) + (tonumber(cfg.add) or 0)
 	end
 
 	if cfg.sub then
-		wesnoth.set_variable(name, (tonumber(wml.variables[name]) or 0) - (tonumber(cfg.sub) or 0))
+		wml.variables[name] = (tonumber(wml.variables[name]) or 0) - (tonumber(cfg.sub) or 0)
 	end
 
 	if cfg.multiply then
-		wesnoth.set_variable(name, (tonumber(wml.variables[name]) or 0) * (tonumber(cfg.multiply) or 0))
+		wml.variables[name] = (tonumber(wml.variables[name]) or 0) * (tonumber(cfg.multiply) or 0)
 	end
 
 	if cfg.divide then
 		local divide = tonumber(cfg.divide) or 0
 		if divide == 0 then helper.wml_error("division by zero on variable " .. name) end
-		wesnoth.set_variable(name, (tonumber(wml.variables[name]) or 0) / divide)
+		wml.variables[name] = (tonumber(wml.variables[name]) or 0) / divide
 	end
 
 	if cfg.modulo then
 		local modulo = tonumber(cfg.modulo) or 0
 		if modulo == 0 then helper.wml_error("division by zero on variable " .. name) end
-		wesnoth.set_variable(name, (tonumber(wml.variables[name]) or 0) % modulo)
+		wml.variables[name] = (tonumber(wml.variables[name]) or 0) % modulo
 	end
 
 	if cfg.abs then
-		wesnoth.set_variable(name, math.abs(tonumber(wml.variables[name]) or 0))
+		wml.variables[name] = math.abs(tonumber(wml.variables[name]) or 0)
 	end
 
 	if cfg.root then
 		if cfg.root == "square" then
 			local radicand = tonumber(wml.variables[name]) or 0
 			if radicand < 0 then helper.wml_error("square root of negative number on variable " .. name) end
-			wesnoth.set_variable(name, math.sqrt(radicand))
+			wml.variables[name] = math.sqrt(radicand)
 		end
 	end
 
 	if cfg.power then
-		wesnoth.set_variable(name, (tonumber(wml.variables[name]) or 0) ^ (tonumber(cfg.power) or 0))
+		wml.variables[name] = (tonumber(wml.variables[name]) or 0) ^ (tonumber(cfg.power) or 0)
 	end
 
 	if cfg.round then
 		local var = tonumber(wml.variables[name] or 0)
 		local round_val = cfg.round
 		if round_val == "ceil" then
-			wesnoth.set_variable(name, math.ceil(var))
+			wml.variables[name] = math.ceil(var)
 		elseif round_val == "floor" then
-			wesnoth.set_variable(name, math.floor(var))
+			wml.variables[name] = math.floor(var)
 		else
 			local decimals = math.modf(tonumber(round_val) or 0)
 			local value = var * (10 ^ decimals)
 			value = helper.round(value)
 			value = value * (10 ^ -decimals)
-			wesnoth.set_variable(name, value)
+			wml.variables[name] = value
 		end
 	end
 
@@ -84,31 +84,31 @@ function wesnoth.wml_actions.set_variable(cfg)
 	-- but on the value assigned to the respective key
 	if cfg.ipart then
 		local ivalue = math.modf(tonumber(cfg.ipart) or 0)
-		wesnoth.set_variable(name, ivalue)
+		wml.variables[name] = ivalue
 	end
 
 	if cfg.fpart then
 		local ivalue, fvalue = math.modf(tonumber(cfg.fpart) or 0)
-		wesnoth.set_variable(name, fvalue)
+		wml.variables[name] = fvalue
 	end
 
 	if cfg.string_length ~= nil then
-		wesnoth.set_variable(name, string.len(tostring(cfg.string_length)))
+		wml.variables[name] = string.len(tostring(cfg.string_length))
 	end
 
 	if cfg.time then
 		if cfg.time == "stamp" then
-			wesnoth.set_variable(name, wesnoth.get_time_stamp())
+			wml.variables[name] = wesnoth.get_time_stamp()
 		end
 	end
 
 	if cfg.rand then
-		wesnoth.set_variable(name, helper.rand(tostring(cfg.rand)))
+		wml.variables[name] = helper.rand(tostring(cfg.rand))
 	end
 
 	if cfg.formula then
 		local fcn = wesnoth.compile_formula(cfg.formula)
-		wesnoth.set_variable(name, fcn(wml.variables[name]))
+		wml.variables[name] = fcn(wml.variables[name])
 	end
 
 	local join_child = wml.get_child(cfg, "join")
@@ -129,6 +129,6 @@ function wesnoth.wml_actions.set_variable(cfg)
 			end
 		end
 
-		wesnoth.set_variable(name, string_to_join)
+		wml.variables[name] = string_to_join
 	end
 end

--- a/data/lua/wml/test_condition.lua
+++ b/data/lua/wml/test_condition.lua
@@ -34,7 +34,7 @@ local function explain(current_cfg, expect, logger)
 			end
 			explanation = string.format("%s\n\t[/%s]", explanation, tag)
 			if tag == "variable" then
-				explanation = string.format("%s\n\tNote: The variable %s currently has the value %q.", explanation, this_cfg.name, tostring(wesnoth.get_variable(this_cfg.name)))
+				explanation = string.format("%s\n\tNote: The variable %s currently has the value %q.", explanation, this_cfg.name, tostring(wml.variables[this_cfg.name]))
 			end
 			wesnoth.log(logger, explanation, true)
 			return true

--- a/data/multiplayer/eras.lua
+++ b/data/multiplayer/eras.lua
@@ -3,7 +3,7 @@ local T = wml.tag
 local res = {}
 
 res.quick_4mp_leaders = function(args)
-	local make_4mp_leaders_quick = wesnoth.get_variable("make_4mp_leaders_quick")
+	local make_4mp_leaders_quick = wml.variables["make_4mp_leaders_quick"]
 	if make_4mp_leaders_quick == nil then
 		make_4mp_leaders_quick = wesnoth.game_config.mp_settings and (wesnoth.game_config.mp_settings.mp_campaign == "")
 	end
@@ -22,7 +22,7 @@ res.quick_4mp_leaders = function(args)
 end
 
 res.turns_over_advantage = function()
-	local show_turns_over_advantage = wesnoth.get_variable("show_turns_over_advantage")
+	local show_turns_over_advantage = wml.variables["show_turns_over_advantage"]
 	if show_turns_over_advantage == nil then
 		show_turns_over_advantage = wesnoth.game_config.mp_settings and (wesnoth.game_config.mp_settings.mp_campaign == "")
 	end
@@ -67,7 +67,7 @@ res.turns_over_advantage = function()
 				for i, unit in ipairs( wesnoth.get_units { side = side } ) do
 					if not unit.__cfg.canrecruit then
 						wesnoth.fire("unit_worth", { id = unit.id })
-						units = units + wesnoth.get_variable("unit_worth")
+						units = units + wml.variables["unit_worth"]
 					end
 				end
 				-- Up to here

--- a/data/multiplayer/scenarios/2p_Dark_Forecast.lua
+++ b/data/multiplayer/scenarios/2p_Dark_Forecast.lua
@@ -191,22 +191,22 @@ local function create_timed_spaws(interval, num_spawns, base_gold_amount, gold_i
 					break
 				end
 			end
-			wesnoth.set_variable(string.format("timed_spawn[%d]", spawn_number - 1), {
+			wml.variables[string.format("timed_spawn[%d]", spawn_number - 1)] = {
 				units = math.ceil(units),
 				turn = turn,
 				gold = helper.round(gold * configure_gold_factor),
 				pool_num = random_spawn_numbers[spawn_number],
-			})
+			}
 		else
-			wesnoth.set_variable(string.format("timed_spawn[%d]", spawn_number - 1), {
+			wml.variables[string.format("timed_spawn[%d]", spawn_number - 1)] = {
 				units = units_amount + 1,
 				turn = turn,
 				gold = gold,
 				pool_num = random_spawn_numbers[spawn_number],
-			})
+			}
 		end
 	end
-	wesnoth.set_variable("final_turn", final_turn)
+	wml.variables["final_turn"] = final_turn
 end
 
 -- @a unittypes: a array of strings
@@ -249,7 +249,7 @@ local function final_spawn()
 	end
 	local spawn_index = wesnoth.random(spawns_left) - 1
 	local spawn = wml.variables[string.format("fixed_spawn[%d]", spawn_index)]
-	wesnoth.set_variable(string.format("fixed_spawn[%d]", spawn_index))
+	wml.variables[string.format("fixed_spawn[%d]", spawn_index)] = nil
 	local types = {}
 	for tag in helper.child_range(spawn, "type") do
 		table.insert(types, tag.type)
@@ -285,7 +285,7 @@ on_event("new turn", function()
 	if wesnoth.current.turn ~= next_spawn.turn then
 		return
 	end
-	wesnoth.set_variable("timed_spawn[0]")
+	wml.variables["timed_spawn[0]"] = nil
 	local unit_types = get_spawn_types(next_spawn.units, next_spawn.gold, random_spawns[next_spawn.pool_num])
 	local spawn_areas = {{"3-14", "15"}, {"1", "4-13"}, {"2-13", "1"}, {"1", "2-15"}}
 	local spawn_area = spawn_areas[wesnoth.random(#spawn_areas)]
@@ -320,7 +320,7 @@ on_event("new turn", function()
 		return
 	end
 	final_spawn()
-	wesnoth.set_variable("next_final_spawn", wesnoth.current.turn + wesnoth.random(1,2))
+	wml.variables["next_final_spawn"] = wesnoth.current.turn + wesnoth.random(1,2)
 end)
 
 -- The victory condition: win when there are no enemy unit after the first final spawn appeared.
@@ -395,29 +395,29 @@ on_event("prestart", function()
 		if weather_to_dispense[index].turns_left <= 0 then
 			table.remove(weather_to_dispense, index)
 		end
-		wesnoth.set_variable(string.format("weather_event[%d]", event_num), {
+		wml.variables[string.format("weather_event[%d]", event_num)] = {
 			turn = turn,
 			weather_id = weather_id,
-		})
+		}
 		event_num = event_num + 1
 		turn = turn + num_turns
 		-- Second snow happens half the time.
 		if weather_id == "snowfall" and heavy_snowfall_turns_left >= 0 and wesnoth.random(2) == 2 then
 			num_turns = get_weather_duration(heavy_snowfall_turns_left)
-			wesnoth.set_variable(string.format("weather_event[%d]", event_num), {
+			wml.variables[string.format("weather_event[%d]", event_num)] = {
 				turn = turn,
 				weather_id = "heavy snowfall",
-			})
+			}
 			event_num = event_num + 1
 			turn = turn + num_turns
 			heavy_snowfall_turns_left = heavy_snowfall_turns_left - num_turns
 		end
 		-- Go back to clear weather.
 		num_turns = get_weather_duration(clear_turns_left)
-		wesnoth.set_variable(string.format("weather_event[%d]", event_num), {
+		wml.variables[string.format("weather_event[%d]", event_num)] = {
 			turn = turn,
 			weather_id = "clear",
-		})
+		}
 		event_num = event_num + 1
 		turn = turn + num_turns
 		clear_turns_left = clear_turns_left - num_turns
@@ -456,7 +456,7 @@ on_event("side 3 turn", function()
 		return
 	end
 	-- remove the to-be-consumed weather event from the todo list.
-	wesnoth.set_variable("weather_event[0]")
+	wml.variables["weather_event[0]"] = nil
 	if weather_event.weather_id == "clear" then
 		weather_map("multiplayer/maps/Dark_Forecast_basic.map")
 		wesnoth.wml_actions.sound {

--- a/data/multiplayer/scenarios/2p_Dark_Forecast.lua
+++ b/data/multiplayer/scenarios/2p_Dark_Forecast.lua
@@ -160,7 +160,7 @@ end
 -- @a base_gold_amount, gold_increment: used to cauculate the amount of gold available for each timed spawn
 -- @a units_amount, gold_per_unit_amount: used to cauculate the number of units spawned in each timed spawn
 local function create_timed_spaws(interval, num_spawns, base_gold_amount, gold_increment, units_amount, gold_per_unit_amount)
-	local configure_gold_factor = ((wesnoth.get_variable("enemey_gold_factor") or 0) + 100)/100
+	local configure_gold_factor = ((wml.variables["enemey_gold_factor"] or 0) + 100)/100
 	local random_spawn_numbers = {}
 	for i = 1, #random_spawns do
 		table.insert(random_spawn_numbers, i)
@@ -243,12 +243,12 @@ local function place_units(unittypes, x, y)
 end
 
 local function final_spawn()
-	local spawns_left = wesnoth.get_variable("fixed_spawn.length")
+	local spawns_left = wml.variables["fixed_spawn.length"]
 	if spawns_left == 0 then
 		return
 	end
 	local spawn_index = wesnoth.random(spawns_left) - 1
-	local spawn = wesnoth.get_variable(string.format("fixed_spawn[%d]", spawn_index))
+	local spawn = wml.variables[string.format("fixed_spawn[%d]", spawn_index)]
 	wesnoth.set_variable(string.format("fixed_spawn[%d]", spawn_index))
 	local types = {}
 	for tag in helper.child_range(spawn, "type") do
@@ -278,7 +278,7 @@ end)
 --   when they appear is defined in the 'timed_spawn' wml array. which is created at prestart
 --   which unit types get spawned is defined in the 'main_spawn' wml array which is also spawned at prestart
 on_event("new turn", function()
-	local next_spawn = wesnoth.get_variable("timed_spawn[0]")
+	local next_spawn = wml.variables["timed_spawn[0]"]
 	if next_spawn == nil then
 		return
 	end
@@ -296,7 +296,7 @@ end)
 
 -- on turn 'final_turn' the first 'final spawn' appears
 on_event("new turn", function()
-	if wesnoth.current.turn ~= wesnoth.get_variable("final_turn") then
+	if wesnoth.current.turn ~= wml.variables["final_turn"] then
 		return
 	end
 	wesnoth.wml_actions.music {
@@ -316,7 +316,7 @@ end)
 
 -- after the first final spawn, spawn a new final spawn every 1 or 2 turns.
 on_event("new turn", function()
-	if wesnoth.current.turn ~= wesnoth.get_variable("next_final_spawn") then
+	if wesnoth.current.turn ~= wml.variables["next_final_spawn"] then
 		return
 	end
 	final_spawn()
@@ -325,7 +325,7 @@ end)
 
 -- The victory condition: win when there are no enemy unit after the first final spawn appeared.
 on_event("die", function()
-	if wesnoth.current.turn < wesnoth.get_variable("final_turn") then
+	if wesnoth.current.turn < wml.variables["final_turn"] then
 		return
 	end
 	if wesnoth.wml_conditionals.have_unit { side = "1,2"} then
@@ -448,7 +448,7 @@ end
 -- change weather at side 3 turns, TODO: consider the case that side 3 is empty.
 on_event("side 3 turn", function()
 	-- get next weather event
-	local weather_event = wesnoth.get_variable("weather_event[0]")
+	local weather_event = wml.variables["weather_event[0]"]
 	if weather_event == nil then
 		return
 	end

--- a/data/multiplayer/scenarios/2p_Dark_Forecast.lua
+++ b/data/multiplayer/scenarios/2p_Dark_Forecast.lua
@@ -251,7 +251,7 @@ local function final_spawn()
 	local spawn = wml.variables[string.format("fixed_spawn[%d]", spawn_index)]
 	wml.variables[string.format("fixed_spawn[%d]", spawn_index)] = nil
 	local types = {}
-	for tag in helper.child_range(spawn, "type") do
+	for tag in wml.child_range(spawn, "type") do
 		table.insert(types, tag.type)
 	end
 	place_units(types, spawn.x, spawn.y)

--- a/data/multiplayer/scenarios/2p_Dark_Forecast.lua
+++ b/data/multiplayer/scenarios/2p_Dark_Forecast.lua
@@ -355,7 +355,7 @@ on_event("prestart", function()
 		end
 		return res
 	end
-	helper.set_variable_array("fixed_spawn", {
+	wml.array_access.set("fixed_spawn", {
 		fixed_spawn(1, 15, "Fire Dragon", "Gryphon Master", "Hurricane Drake"),
 		fixed_spawn(5, 1, "Yeti", "Elvish Druid", "Elvish Druid"),
 		fixed_spawn(1, 7, "Lich", "Walking Corpse", "Walking Corpse", "Walking Corpse", "Ghoul", "Soulless", "Walking Corpse", "Walking Corpse", "Walking Corpse"),

--- a/data/multiplayer/scenarios/2p_Hornshark_Island.lua
+++ b/data/multiplayer/scenarios/2p_Hornshark_Island.lua
@@ -1,3 +1,3 @@
 for i, side in ipairs(wesnoth.get_sides({})) do
-	wesnoth.set_variable("p" .. tostring(i) .. "_faction", side.faction)
+	wml.variables["p" .. tostring(i) .. "_faction"] = side.faction
 end

--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -3669,7 +3669,6 @@ unplagueable: $wml_unit.status.unplagueable"
 
         [lua]
             code = <<
-                local helper = wesnoth.require "helper"
                 for i, v in ipairs(wml.array_access.get_proxy("temp_villages_area")) do
                     wesnoth.put_unit({ type = "Goblin Spearman", side = 2 }, v.x, v.y)
                 end

--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -1150,7 +1150,7 @@ end
                         x = t.x, y = t.y })
                 end
                 function wml_actions.check_substitution(t)
-                    wesnoth.set_variable("substitution_variable", 1)
+                    wml.variables["substitution_variable"] = 1
                     if t.value ~= "Number 2" then
                         wesnoth.message("Substitution is not delayed! " .. tostring(t.value))
                     end
@@ -3673,7 +3673,7 @@ unplagueable: $wml_unit.status.unplagueable"
                 for i, v in ipairs(helper.get_variable_proxy_array "temp_villages_area") do
                     wesnoth.put_unit({ type = "Goblin Spearman", side = 2 }, v.x, v.y)
                 end
-                wesnoth.set_variable "temp_villages_area"
+                wml.variables["temp_villages_area"] = nil
             >>
         [/lua]
     [/event]

--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -3615,7 +3615,7 @@ unplagueable: $wml_unit.status.unplagueable"
                                 { "command", {
                                     { "set_variable", { name = "choice", value = "done" } } } } } }
                         })
-                        local choice = wesnoth.get_variable("choice")
+                        local choice = wml.variables["choice"]
                         -- debug :unit will reapply musthave traits, breaking these modifications for undead
                         -- if you want something more permanent, give the unit an object
                         if choice == "not_living" then

--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -3670,7 +3670,7 @@ unplagueable: $wml_unit.status.unplagueable"
         [lua]
             code = <<
                 local helper = wesnoth.require "helper"
-                for i, v in ipairs(helper.get_variable_proxy_array "temp_villages_area") do
+                for i, v in ipairs(wml.array_access.get_proxy("temp_villages_area")) do
                     wesnoth.put_unit({ type = "Goblin Spearman", side = 2 }, v.x, v.y)
                 end
                 wml.variables["temp_villages_area"] = nil

--- a/data/test/scenarios/ai/_main.cfg
+++ b/data/test/scenarios/ai/_main.cfg
@@ -13,7 +13,7 @@
 #define ASPECT_NOTIFICATION
     <<
 local H = wesnoth.require('helper')
-local expected = H.get_variable_array('expected')
+local expected = wml.array_access.get('expected')
 local aspect = wml.variables['test_attribute']
 if ai.aspects[aspect] ~= expected[wesnoth.current.turn].value then
 	wml.variables['is_valid'] = false

--- a/data/test/scenarios/ai/_main.cfg
+++ b/data/test/scenarios/ai/_main.cfg
@@ -16,7 +16,7 @@ local H = wesnoth.require('helper')
 local expected = H.get_variable_array('expected')
 local aspect = wml.variables['test_attribute']
 if ai.aspects[aspect] ~= expected[wesnoth.current.turn].value then
-	wesnoth.set_variable('is_valid', false)
+	wml.variables['is_valid'] = false
 	local msg = 'Failed on turn ' .. tostring(wesnoth.current.turn)
 	msg = msg .. ' (time: ' .. wesnoth.get_time_of_day().id .. ')'
 	msg = msg .. '; ' .. aspect

--- a/data/test/scenarios/ai/_main.cfg
+++ b/data/test/scenarios/ai/_main.cfg
@@ -12,7 +12,6 @@
 
 #define ASPECT_NOTIFICATION
     <<
-local H = wesnoth.require('helper')
 local expected = wml.array_access.get('expected')
 local aspect = wml.variables['test_attribute']
 if ai.aspects[aspect] ~= expected[wesnoth.current.turn].value then

--- a/data/test/scenarios/ai/_main.cfg
+++ b/data/test/scenarios/ai/_main.cfg
@@ -14,7 +14,7 @@
     <<
 local H = wesnoth.require('helper')
 local expected = H.get_variable_array('expected')
-local aspect = wesnoth.get_variable('test_attribute')
+local aspect = wml.variables['test_attribute']
 if ai.aspects[aspect] ~= expected[wesnoth.current.turn].value then
 	wesnoth.set_variable('is_valid', false)
 	local msg = 'Failed on turn ' .. tostring(wesnoth.current.turn)

--- a/data/test/scenarios/break_replay_with_lua_random.cfg
+++ b/data/test/scenarios/break_replay_with_lua_random.cfg
@@ -70,7 +70,7 @@
 {TEST_BREAK_REPLAY "break_replay_with_lua_random" (
     [lua]
         code =<<
-                wesnoth.set_variable("rnd_num", math.random(200))
+                wml.variables["rnd_num"] = math.random(200)
             >>
     [/lua]
 )}
@@ -82,7 +82,7 @@
                   function()
                     return { value = math.random(200) }
                   end)
-                wesnoth.set_variable("rnd_num", result.value)
+                wml.variables["rnd_num"] = result.value
             >>
     [/lua]
 )}

--- a/data/test/scenarios/interrupts.cfg
+++ b/data/test/scenarios/interrupts.cfg
@@ -76,7 +76,6 @@
         name=start
         [lua]
             code=<<
-				local H = wesnoth.require "helper"
 				local function continue()
 					wesnoth.wml_actions.continue{}
 				end

--- a/data/test/scenarios/interrupts.cfg
+++ b/data/test/scenarios/interrupts.cfg
@@ -77,9 +77,8 @@
         [lua]
             code=<<
 				local H = wesnoth.require "helper"
-				local A = H.set_wml_action_metatable{}
 				local function continue()
-					A.continue{}
+					wesnoth.wml_actions.continue{}
 				end
 				-- Use pcall() to trap the WML error raised by continue in global scope
 				local err, res = pcall(continue)

--- a/data/test/scenarios/recruit_facing.cfg
+++ b/data/test/scenarios/recruit_facing.cfg
@@ -8,7 +8,7 @@
                       function()
                         return { value = temp.facing }
                       end)
-                    wesnoth.set_variable("synced_temp", result.value)
+                    wml.variables["synced_temp"] = result.value
                 >>
         [/lua]
         {ASSERT ({VARIABLE_CONDITIONAL unit.facing equals $synced_temp})}

--- a/data/test/scenarios/recruit_facing.cfg
+++ b/data/test/scenarios/recruit_facing.cfg
@@ -3,7 +3,7 @@
         name=recruit
         [lua]
             code =<<
-                    local temp = wesnoth.get_variable("unit")
+                    local temp = wml.variables["unit"]
                     local result = wesnoth.synchronize_choice(
                       function()
                         return { value = temp.facing }

--- a/data/test/scenarios/test_clear.cfg
+++ b/data/test/scenarios/test_clear.cfg
@@ -12,7 +12,7 @@
 
         [lua]
             code = << local a,b,c = false,false,false
-			  for k,v in pairs(wesnoth.get_all_vars()) do
+			  for k,v in pairs(wml.all_variables) do
 			    if k == "A" then
 			      a = true
 			    elseif (k == "B") and (v == 10) then
@@ -40,7 +40,7 @@
 
         [lua]
             code = << local a,b,c = false,false,false
-			  for k,v in pairs(wesnoth.get_all_vars()) do
+			  for k,v in pairs(wml.all_variables) do
 			    if k == "A" then
 			      a = true
 			    elseif (k == "B") and (v == 10) then

--- a/data/test/scenarios/test_clear.cfg
+++ b/data/test/scenarios/test_clear.cfg
@@ -21,7 +21,7 @@
 			      c = true
 			    end
 			  end
-			  wesnoth.set_variable("result", (not a) and b and (not c)) >>
+			  wml.variables["result"] = (not a) and b and (not c) >>
         [/lua]
 
         {RETURN {VARIABLE_CONDITIONAL result boolean_equals true}}
@@ -49,7 +49,7 @@
 			      c = true
 			    end
 			  end
-			  wesnoth.set_variable("result", (not a) and b and (not c)) >>
+			  wml.variables["result"] = (not a) and b and (not c) >>
         [/lua]
 
         {RETURN {VARIABLE_CONDITIONAL result boolean_equals true}}

--- a/data/test/scenarios/test_dofile.cfg
+++ b/data/test/scenarios/test_dofile.cfg
@@ -3,10 +3,10 @@
         name = prestart
         [lua]
             code = << a,b,c,d = wesnoth.dofile("test/macros/test.lua")
-                wesnoth.set_variable("a", a)
-                wesnoth.set_variable("b", b)
-                wesnoth.set_variable("c", c)
-                wesnoth.set_variable("d", d) >>
+                wml.variables["a"] = a
+                wml.variables["b"] = b
+                wml.variables["c"] = c
+                wml.variables["d"] = d >>
         [/lua]
 
         {ASSERT ({VARIABLE_CONDITIONAL a equals 1})}

--- a/data/test/scenarios/test_lua.cfg
+++ b/data/test/scenarios/test_lua.cfg
@@ -4,7 +4,7 @@
         [lua]
             code = << local s = wesnoth.get_sides({})
 		local result = (s[1].side == 1) and (s[2].side == 2)
-                wesnoth.set_variable("result", result) >>
+                wml.variables["result"] = result >>
         [/lua]
 
         {RETURN ({VARIABLE_CONDITIONAL result boolean_equals true})}

--- a/data/test/scenarios/test_lua_wml.cfg
+++ b/data/test/scenarios/test_lua_wml.cfg
@@ -5,7 +5,7 @@
             code = <<
 				function wesnoth.wml_actions.foo(cfg)
 					if cfg.bar then
-						wesnoth.set_variable("result", cfg.bar)
+						wml.variables["result"] = cfg.bar
 					end
 				end
 				>>

--- a/data/test/scenarios/test_menu_items.cfg
+++ b/data/test/scenarios/test_menu_items.cfg
@@ -57,7 +57,7 @@
 				  r = r and not wesnoth.fire_wml_menu_item("test2", 3, 3)
 				  r = r and wesnoth.fire_wml_menu_item("test2", 4, 4)
 				  r = r and not wesnoth.fire_wml_menu_item("test2", 4, 4)
-				  wesnoth.set_variable("result", r) >>
+				  wml.variables["result"] = r >>
         [/lua]
 
         {RETURN {VARIABLE_CONDITIONAL result boolean_equals true}}
@@ -115,7 +115,7 @@
         )}
 
         [lua]
-            code = << wesnoth.set_variable("result", r) >>
+            code = << wml.variables["result"] = r >>
         [/lua]
         {RETURN {VARIABLE_CONDITIONAL result boolean_equals true}}
     [/event]

--- a/data/test/scenarios/test_require.cfg
+++ b/data/test/scenarios/test_require.cfg
@@ -5,7 +5,7 @@
             code = << H = wesnoth.require("lua/helper.lua")
 		A = wesnoth.require("ai/lua/extCAexample.lua")
 		result = H and A and true
-                wesnoth.set_variable("result", result and "true" or "false") >>
+                wml.variables["result"] = result and "true" or "false" >>
         [/lua]
 
         {RETURN ({VARIABLE_CONDITIONAL result boolean_equals true})}

--- a/join.lua
+++ b/join.lua
@@ -16,7 +16,7 @@ local function plugin()
   local function find_test_game(info)
     local g = info.game_list()
     if g then
-      local gamelist = helper.get_child(g, "gamelist")
+      local gamelist = wml.get_child(g, "gamelist")
       if gamelist then
         for i = 1, #gamelist do
           local t = gamelist[i]

--- a/join.lua
+++ b/join.lua
@@ -11,8 +11,6 @@ local function plugin()
 
   local events, context, info
 
-  local helper = wesnoth.require "helper"
-
   local function find_test_game(info)
     local g = info.game_list()
     if g then


### PR DESCRIPTION
There are three deprecated Lua functions that still need to be replaced in 1.14: wesnoth.tovconfig(), wesnoth.get_variable() and wesnoth.set_variable().  tovconfig() is done and the deprecation message disappears.

get_variable() is mostly done, but I've hit a problem that I do not know how to solve.  It's the [definition of wml.variables in data/lua/core.lua](https://github.com/wesnoth/wesnoth/blob/master/data/lua/core.lua#L260) itself that causes the remaining deprecation message.  Obviously, this is the one instance where the old function is still needed, and I am not familiar enough with how this works at this time to know what to do.  Any advice?

I'll do set_variable() once I have figured this out.