### PR TITLE
[WIP] filesystem::sanitize_path: fix getting $USER env var.

### DIFF
--- a/src/filesystem_boost.cpp
+++ b/src/filesystem_boost.cpp
@@ -1453,7 +1453,7 @@ std::string sanitize_path(const std::string& path)
 #endif
 
 	std::string canonicalized = filesystem::normalize_path(path, true, false);
-	if(user_name != nullptr) {
+	if(user_name == nullptr) {
 		boost::replace_all(canonicalized, user_name, "USER");
 	}
 


### PR DESCRIPTION
The code was getting the $USER env var and then replacing it with string literal "USER" if it was NOT a nullpointer.
However we only want to replace if it IS a nullpointer.

Fixes #3082