### PR TITLE
DW 5 - Tirigaz : Changes to orc leader death

### DIFF
--- a/data/campaigns/Dead_Water/scenarios/05_Tirigaz.cfg
+++ b/data/campaigns/Dead_Water/scenarios/05_Tirigaz.cfg
@@ -696,38 +696,51 @@
         [filter]
             id=Marg-Tonz
         [/filter]
+		[if]
+			[have_unit]
+				x,y=$x2,$y2
+				side=1
+			[/have_unit]
+			
+			[then]
+				# The chest looks better when it's offset 10px to the north
+				[item]
+					x,y=$x1,$y1
+					image=misc/blank-hex.png~BLIT(items/chest-open.png~CROP(0,10,72,62),0,0)
+				[/item]
+		
+				[if]
+					[have_unit]
+						x,y=$x2,$y2
+						race=bats
+					[/have_unit]
 
-        # The chest looks better when it's offset 10px to the north
-        [item]
-            x,y=$x1,$y1
-            image=misc/blank-hex.png~BLIT(items/chest-open.png~CROP(0,10,72,62),0,0)
-        [/item]
+					[then]
+						[message]
+							speaker=second_unit
+							message= _ "Neep, neep!"
+						[/message]
 
-        [if]
-            [have_unit]
-                x,y=$x2,$y2
-                race=bats
-            [/have_unit]
-
-            [then]
-                [message]
-                    speaker=second_unit
-                    message= _ "Neep, neep!"
-                [/message]
-
-                [message]
-                    speaker=Kai Krellis
-                    message= _ "It seems that orc was rich! He has a chest here with over 100 pieces of gold!"
-                [/message]
-            [/then]
-            [else]
-                [message]
-                    speaker=second_unit
-                    message= _ "It seems that orc was rich! He has a chest here with over 100 pieces of gold!"
-                [/message]
-            [/else]
-        [/if]
-
+						[message]
+							speaker=Kai Krellis
+							message= _ "It seems that orc was rich! He has a chest here with over 100 pieces of gold!"
+						[/message]
+					[/then]
+					[else]
+						[message]
+							speaker=second_unit
+							message= _ "It seems that orc was rich! He has a chest here with over 100 pieces of gold!"
+						[/message]
+					[/else]
+				[/if]
+			[/then]
+			[else]
+				[message]
+					speaker=Kai Krellis
+					message= _ "Now we must defeat the undead."
+				[/message]
+			[/else]
+		[/if]
         [sound]
             name=gold.ogg
         [/sound]
@@ -748,7 +761,22 @@
                     {NEW_GOLD_CARRYOVER 40}
                 [/endlevel]
             [/then]
-        [/if]
+        
+			[else]
+				[objectives]
+					side=1
+					{HOW_TO_LOSE}
+					[objective]
+						description= _ "Destroy all the undead"+{EARLY_FINISH_BONUS_FOOTNOTE}
+						condition=win
+					[/objective]
+
+					[gold_carryover]
+						carryover_percentage=40
+					[/gold_carryover]
+				[/objectives]
+			[/else]
+		[/if]
     [/event]
 
     [event]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg
@@ -673,16 +673,19 @@
                 [/message]
             [/then]
         [/if]
-
-        [move_unit_fake]
+		[unit]
             type=Dwarvish Fighter
             side=4
-            x=25,24,23,22,21
-            y=28,28,29,28,29
-        [/move_unit_fake]
-
-        #TODO maybe the wounded dwarf should really be wounded?
-        {NAMED_NOTRAIT_UNIT 4 (Dwarvish Fighter) 21 29 (Wounded Dwarf) ( _ "Wounded Dwarf")}
+			hitpoints=12
+			id=Wounded Dwarf
+			x=25
+			y=28
+		[/unit]
+        [move_unit]
+            id=Wounded Dwarf
+            to_x=25,24,23,22,21
+            to_y=28,28,29,28,29
+        [/move_unit]
 
         [message]
             speaker=Wounded Dwarf
@@ -1479,10 +1482,10 @@
                 # (on easier difficulties, remove trolls closest to elves)
 
 #ifdef HARD
-                {NAMED_GENERIC_UNIT 2 (Troll Whelp) 25 37 () ( _ "Troll Skirmisher")}
+                {NAMED_GENERIC_UNIT 2 (Troll Whelp) 25 36 () ( _ "Troll Skirmisher")}
 #endif
                 {NAMED_GENERIC_UNIT 3 (Troll Whelp) 33 38 () ( _ "Troll Skirmisher")}
-                {NAMED_GENERIC_UNIT 3 (Troll Whelp) 42 36 () ( _ "Troll Skirmisher")}
+                {NAMED_GENERIC_UNIT 3 (Troll Whelp) 42 35 () ( _ "Troll Skirmisher")}
 
                 {NAMED_GENERIC_UNIT 3 (Troll Whelp) 46 35 () ( _ "Troll Skirmisher")}
             [/then]
@@ -1608,14 +1611,14 @@
             [/else]
         [/if]
 
-        #create 2 dwarf leaders (23,11) (45,10)
+        #create 2 dwarf leaders (26,12) (45,13)
         [unit]
             type=Dwarvish Explorer
             id=Fundin
             name= _ "Fundin"
             canrecruit=yes
-            x=23
-            y=11
+            x=26
+            y=12
             side=4
             [modifications]
                 {TRAIT_RESILIENT}
@@ -1628,7 +1631,7 @@
             name= _ "Nori"
             canrecruit=yes
             x=45
-            y=10
+            y=13
             side=5
             [modifications]
                 {TRAIT_STRONG}
@@ -1636,14 +1639,14 @@
             [/modifications]
         [/unit]
 
-        #create 2 troll leaders (32,70) (52,72)
+        #create 2 troll leaders (26,40) (46,42)
         [unit]
             type=Troll Warrior
             id=Thungar
             name= _ "Thungar"
             canrecruit=yes
             x=26
-            y=43
+            y=40
             side=2
             [modifications]
                 {TRAIT_RESILIENT}
@@ -1656,7 +1659,7 @@
             name= _ "Gnarl"
             canrecruit=yes
             x=46
-            y=45
+            y=42
             side=3
             [modifications]
                 {TRAIT_STRONG}
@@ -1676,7 +1679,7 @@
 
         # in main cavern
         [capture_village]
-            x,y=31,30
+            x,y=36,32
             side=2
         [/capture_village]
 
@@ -1690,12 +1693,12 @@
 
         # in main cavern
         [capture_village]
-            x,y=36,32
+            x,y=31,30
             side=3
         [/capture_village]
-
+		
         [capture_village]
-            x,y=40,26
+            x,y=26,28
             side=3
         [/capture_village]
 
@@ -1712,6 +1715,11 @@
             x,y=28,24
             side=4
         [/capture_village]
+		
+        [capture_village]
+            x,y=35,27
+            side=4
+        [/capture_village]
 
         # dwarf 2 (side5)
 
@@ -1723,7 +1731,7 @@
 
         # in main cavern
         [capture_village]
-            x,y=35,27
+            x,y=40,26
             side=5
         [/capture_village]
 
@@ -1759,8 +1767,8 @@
                 [move_unit_fake]
                     type=Troll Shaman
                     side=2
-                    x=22,23,24,25,26,27,27,27,28
-                    y=37,37,36,36,35,35,34,33,32
+                    x=27,27,28
+                    y=39,33,32
                 [/move_unit_fake]
 
                 {NAMED_GENERIC_UNIT 2 (Troll Shaman) 28 32 (Troll Flamecaster) ( _ "Troll Flamecaster")}
@@ -1770,8 +1778,8 @@
                 [move_unit_fake]
                     type=Troll Shaman
                     side=2
-                    x=32,33,34,34,34,34,33,32,31,30
-                    y=38,38,37,36,35,34,34,33,33,32
+                    x=33,33,32
+                    y=39,33,32
                 [/move_unit_fake]
 
                 {NAMED_GENERIC_UNIT 2 (Troll Shaman) 32 32 () ( _ "Troll Flamecaster")}
@@ -1782,8 +1790,8 @@
                 [move_unit_fake]
                     type=Troll Shaman
                     side=3
-                    x=47,47,47,46,45,44,43,42,42,42,42,41
-                    y=37,36,35,34,34,33,33,32,31,30,29,29
+                    x=38,42,42,41
+                    y=37,35,29,29
                 [/move_unit_fake]
 
                 {NAMED_GENERIC_UNIT 3 (Troll Shaman) 41 29 () ( _ "Troll Flamecaster")}
@@ -1793,11 +1801,11 @@
                 [move_unit_fake]
                     type=Troll Shaman
                     side=3
-                    x=47,47,47,46,45,44,43,43,43,43
-                    y=27,26,25,24,24,23,23,22,21,20
+                    x=45,45
+                    y=40,30
                 [/move_unit_fake]
 
-                {NAMED_GENERIC_UNIT 3 (Troll Shaman) 43 20 () ( _ "Troll Flamecaster")}
+                {NAMED_GENERIC_UNIT 3 (Troll Shaman) 45 30 () ( _ "Troll Flamecaster")}
 #endif
 
                 [message]


### PR DESCRIPTION
Fixes #3093 - If ghosts kill the orc, gold event does not fire and there's alternate dialogue.
Fixes #3092 - Objectives update on death of orc leader.

NB: learning pull requests, let me know if I'm doing it wrong 