### PR TITLE
NR5_1: Fixes to Malifor attack and secret door events

### DIFF
--- a/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
@@ -1734,7 +1734,7 @@
             terrain=Uu
         [/terrain]
 
-		{PLACE_IMAGE scenery/dwarven-doors-closed.png 22 4}
+        {PLACE_IMAGE scenery/dwarven-doors-closed.png 22 4}
 
         [redraw]
             side=1
@@ -2321,7 +2321,7 @@
         [/terrain]
 
         {VARIABLE main_door_opened yes}
-	[/event]
+    [/event]
 
     # Spider chamber door
     [event]

--- a/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
@@ -1749,9 +1749,9 @@
             speaker=unit
             message= _ "‘Great Chamber’, my foot! This is a death chamber!"
         [/message]
-		
-		   #You can enter from the study, but only if you've already triggered the spiders
-	       [event]
+
+        #You can enter from the study, but only if you've already triggered the spiders
+        [event]
             name=moveto
             first_time_only=no
             [filter]
@@ -2284,7 +2284,7 @@
         [/message]
     [/event]
 	
-	#main gates from inside
+    #main gates from inside
     [event]
         name=moveto
         [filter]
@@ -2301,8 +2301,8 @@
 
         [message]
             speaker=Tallin
-            message= _ "Get those doors open!"
-		[/message]
+            0message= _ "Get those doors open!"
+        [/message]
 
         [sound]
             name=gate-fall.ogg
@@ -2500,7 +2500,7 @@
         [/message]
     [/event]
 	
-	#flooded passage from inside
+    #flooded passage from inside
     [event]
         name=moveto
         first_time_only=no
@@ -2530,8 +2530,8 @@
             terrain=Uu
         [/terrain]
 
-		{VARIABLE back_door_opened yes}
-		
+        {VARIABLE back_door_opened yes}
+
     [/event]
 
 #define MALIFOR_GUARD TYPE X Y

--- a/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
@@ -2592,10 +2592,10 @@
     [event]
         name=attack end
         [filter]
-            id=Father Morvin,Sister Thera
+            id=Father Morvin,Sister Thera,Malifor
         [/filter]
         [filter_second]
-            id=Malifor
+            id=Malifor,Father Morvin,Sister Thera
         [/filter_second]
 
         [message]

--- a/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
@@ -235,7 +235,6 @@
     [/side]
 
     # Whole lot of doors
-    {PLACE_IMAGE scenery/dwarven-doors-closed.png 22 4}
     {PLACE_IMAGE scenery/dwarven-doors-closed.png 33 9}
     {PLACE_IMAGE scenery/dwarven-doors-closed.png 19 3}
     {PLACE_IMAGE scenery/dwarven-doors-closed.png 19 4}
@@ -1735,6 +1734,8 @@
             terrain=Uu
         [/terrain]
 
+		{PLACE_IMAGE scenery/dwarven-doors-closed.png 22 4}
+
         [redraw]
             side=1
         [/redraw]
@@ -1748,6 +1749,42 @@
             speaker=unit
             message= _ "‘Great Chamber’, my foot! This is a death chamber!"
         [/message]
+		
+		   #You can enter from the study, but only if you've already triggered the spiders
+	       [event]
+            name=moveto
+            first_time_only=no
+            [filter]
+                x,y=23,5
+            [/filter]
+            [filter_condition]
+                [variable]
+                    name=spider_door_opened
+                    boolean_equals=no
+                [/variable]
+            [/filter_condition]
+
+            [message]
+                speaker=unit
+                message= _ "Hmmm. The wall appears weak here. I think there might be something on the other side."
+            [/message]
+
+            [sound]
+                name=cave-in.ogg
+            [/sound]
+
+            [terrain]
+                x,y=22,4
+                terrain=Uu
+            [/terrain]
+
+            [message]
+                speaker=unit
+                message= _ "There we go."
+            [/message]
+
+            {VARIABLE spider_door_opened yes}
+        [/event]
     [/event]
 
     # ================================================================
@@ -2246,6 +2283,45 @@
             [/option]
         [/message]
     [/event]
+	
+	#main gates from inside
+    [event]
+        name=moveto
+        [filter]
+            side=1
+            x=24,25,26
+            y=8,9,9
+        [/filter]
+        [filter_condition]
+            [variable]
+                name=main_door_opened
+                boolean_equals=no
+            [/variable]
+        [/filter_condition]
+
+        [message]
+            speaker=Tallin
+            message= _ "Get those doors open!"
+		[/message]
+
+        [sound]
+            name=gate-fall.ogg
+        [/sound]
+		
+        [remove_item]
+            x=23,24,25
+            y=9,9,10
+        [/remove_item]
+
+        [terrain]
+            x=23,24,25
+            y=9,9,10
+            terrain="^" # Intentional, to remove the overlay
+            layer=overlay
+        [/terrain]
+
+        {VARIABLE main_door_opened yes}
+	[/event]
 
     # Spider chamber door
     [event]
@@ -2422,6 +2498,40 @@
                 [/command]
             [/option]
         [/message]
+    [/event]
+	
+	#flooded passage from inside
+    [event]
+        name=moveto
+        first_time_only=no
+        [filter]
+            side=1
+            x=32,32,33
+            y=9,8,8
+        [/filter]
+        [filter_condition]
+            [variable]
+                name=back_door_opened
+                boolean_equals=no
+            [/variable]
+        [/filter_condition]
+
+        [message]
+            speaker=unit
+            message= _ "Hey, check this out, it looks like some sort of lever."
+        [/message]
+
+        [sound]
+            name=cave-in.ogg
+        [/sound]
+
+        [terrain]
+            x,y=33,9
+            terrain=Uu
+        [/terrain]
+
+		{VARIABLE back_door_opened yes}
+		
     [/event]
 
 #define MALIFOR_GUARD TYPE X Y


### PR DESCRIPTION
Fix for #3117: Malifor damage event now occurs on defence as well as attack
Fix for #3116: doors to the study can now be opened from inside