### PR TITLE
MP Faction Select dialog: Show leader unit details.

### DIFF
--- a/data/gui/window/mp_faction_select.cfg
+++ b/data/gui/window/mp_faction_select.cfg
@@ -132,6 +132,15 @@
 
 						[/column]
 
+						[column]
+							[button]
+								id = "type_profile"
+								definition = "action_about"
+
+								label = _ "Profile"
+							[/button]
+						[/column]
+
 					[/row]
 
 				[/grid]

--- a/src/gui/dialogs/multiplayer/faction_select.cpp
+++ b/src/gui/dialogs/multiplayer/faction_select.cpp
@@ -34,6 +34,7 @@
 #include "game_config_manager.hpp"
 #include "gettext.hpp"
 #include "help/help.hpp"
+#include "preferences/game.hpp"	// for encountered_units
 #include "units/types.hpp"
 
 #include "utils/functional.hpp"
@@ -212,6 +213,7 @@ void faction_select::profile_button_callback(window& window)
 	const std::string& leader_type = find_widget<menu_button>(&window, "leader_menu", false).get_value_string();
 	const unit_type* ut = unit_types.find(leader_type);
 	if(ut != nullptr) {
+		preferences::encountered_units().insert(ut->id());
 		help::help_manager help_manager(&game_config_manager::get()->game_config());
 		help::show_unit_description(*ut);
 	}

--- a/src/gui/dialogs/multiplayer/faction_select.cpp
+++ b/src/gui/dialogs/multiplayer/faction_select.cpp
@@ -26,11 +26,14 @@
 #include "gui/widgets/settings.hpp"
 #include "gui/widgets/image.hpp"
 #include "gui/widgets/label.hpp"
+#include "gui/widgets/button.hpp"
 #include "gui/widgets/menu_button.hpp"
 #include "gui/widgets/toggle_button.hpp"
 #include "gui/widgets/window.hpp"
 #include "formatter.hpp"
+#include "game_config_manager.hpp"
 #include "gettext.hpp"
+#include "help/help.hpp"
 #include "units/types.hpp"
 
 #include "utils/functional.hpp"
@@ -74,6 +77,10 @@ void faction_select::pre_show(window& window)
 	//
 	find_widget<menu_button>(&window, "leader_menu", false).connect_click_handler(
 		std::bind(&faction_select::on_leader_select, this, std::ref(window)));
+
+	// Leader's profile button
+	find_widget<button>(&window, "type_profile", false).connect_click_handler(
+		std::bind(&faction_select::profile_button_callback, this, std::ref(window)));
 
 	//
 	// Set up faction list
@@ -193,6 +200,21 @@ void faction_select::on_leader_select(window& window)
 	});
 
 	update_leader_image(window);
+
+	// Disable the profile button if leader_type is dash or "Random"
+	button& profile_button = find_widget<button>(&window, "type_profile", false);
+	const std::string& leader_type = find_widget<menu_button>(&window, "leader_menu", false).get_value_string();
+	profile_button.set_active(unit_types.find(leader_type) != nullptr);
+}
+
+void faction_select::profile_button_callback(window& window)
+{
+	const std::string& leader_type = find_widget<menu_button>(&window, "leader_menu", false).get_value_string();
+	const unit_type* ut = unit_types.find(leader_type);
+	if(ut != nullptr) {
+		help::help_manager help_manager(&game_config_manager::get()->game_config());
+		help::show_unit_description(*ut);
+	}
 }
 
 void faction_select::on_gender_select(window& window)

--- a/src/gui/dialogs/multiplayer/faction_select.hpp
+++ b/src/gui/dialogs/multiplayer/faction_select.hpp
@@ -50,6 +50,8 @@ private:
 
 	void on_leader_select(window& window);
 
+	void profile_button_callback(window& window);
+
 	void on_gender_select(window& window);
 
 	void update_leader_image(window& window);


### PR DESCRIPTION
If the leader hasn't been discovered, the "Unknown Unit" topic will be shown.

Fixes #1491.

This is for 1.14. I tried to rebase it to master but the help system in master doesn't work for me at all right now even without the patch.