### PR TITLE
Replay: Don't disable the "Point of view" button after reset

### DIFF
--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -209,7 +209,9 @@ void playsingle_controller::play_scenario_main_loop()
 				resources::gameboard->teams()[i].set_local(local_players[i]);
 			}
 			play_scenario_init();
-			replay_.reset(new replay_controller(*this, false, ex.level, [this](){ on_replay_end(false); } ));
+			if (replay_ == nullptr) {
+				replay_.reset(new replay_controller(*this, false, ex.level, [this](){ on_replay_end(false); } ));
+			}
 			if(ex.start_replay) {
 				replay_->play_replay();
 			}


### PR DESCRIPTION
Fixes #3107 

The PR is for 1.14 because I couldn't test it with master. It compiled after changing the new constructor overload but I couldn't even load the replay UI in master.