### PR TITLE
DiD S02: Stop when ambushed

### DIFF
--- a/data/campaigns/Descent_Into_Darkness/scenarios/02_Peaceful_Valley.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/02_Peaceful_Valley.cfg
@@ -255,6 +255,19 @@
             [/then]
         [/if]
 
+        # If there was a goblin next to the village before the guards spawned, the player may have
+        # already commanded their unit to attack. But as there are now more enemies, give the
+        # player a chance to choose a different opponent.
+        [if]
+            [variable]
+                name=number_of_guards
+                greater_than=0
+            [/variable]
+            [then]
+                [cancel_action][/cancel_action]
+            [/then]
+        [/if]
+
         {CLEAR_VARIABLE number_of_guards,guard_location}
     [/event]
 


### PR DESCRIPTION
This happens in a village-capture event, so the unit has finished
moving for this turn in any case.