### PR TITLE
Dead Water and core's Storm Trident: Change "mermen" to "merfolk"

### DIFF
--- a/data/campaigns/Dead_Water/scenarios/07_Bilheld.cfg
+++ b/data/campaigns/Dead_Water/scenarios/07_Bilheld.cfg
@@ -64,7 +64,7 @@
         [ai]
             villages_per_scout=1
         [/ai]
-        # The drakes need a lot of money. Mermen are pretty effective
+        # The drakes need a lot of money. Merfolk are pretty effective
         # against them in the water.
         {INCOME4 20 25 30 35}
         {GOLD4 250 290 330 380}
@@ -121,7 +121,7 @@
         name=start
         [message]
             speaker=Vlagnor
-            message= _ "What are you mermen doing here?"
+            message= _ "What are you merfolk doing here?"
         [/message]
         [message]
             speaker=Kai Krellis
@@ -141,7 +141,7 @@
         [/message]
         [message]
             speaker=Vlagnor
-            message= _ "She kill drakes. If you are her friend, we will kill you. We do not want MORE mermen blasting and stabbing."
+            message= _ "She kill drakes. If you are her friend, we will kill you. We do not want MORE merfolk blasting and stabbing."
         [/message]
         [message]
             speaker=Kai Krellis

--- a/data/campaigns/Dead_Water/scenarios/10_The_Flaming_Sword.cfg
+++ b/data/campaigns/Dead_Water/scenarios/10_The_Flaming_Sword.cfg
@@ -502,10 +502,10 @@
     # <empty>:   Caladon is not a leader. He is still a unit on side 1
     #
     # "passive": His side still has "controller=null" set. (He is
-    # giving the mermen time to leave before attacking them.)
+    # giving the merfolk time to leave before attacking them.)
     #
     # "impatient": Caladon’s side now has "controller=ai" set. (He's
-    # tired of waiting for the mermen to leave.) This is actually
+    # tired of waiting for the merfolk to leave.) This is actually
     # *set* on the players turn, because Caladon’s side doesn't *get*
     # a turn until it is set. On his first turn after "impatient" is
     # set, he will say something and summon fire guardians.
@@ -566,7 +566,7 @@
 
         [message]
             speaker=narrator
-            message= _ "The mermen clapped their hands over their ears as a terrible wail echoed off the castle walls."
+            message= _ "The merfolk clapped their hands over their ears as a terrible wail echoed off the castle walls."
             image=wesnoth-icon.png
         [/message]
 

--- a/data/campaigns/Dead_Water/scenarios/12_Revenge.cfg
+++ b/data/campaigns/Dead_Water/scenarios/12_Revenge.cfg
@@ -14,7 +14,7 @@
         [/part]
         [part]
             {DW_BIGMAP}
-            story= _ "The tribe that had fled Jotha unable to fight returned as an army stiffened by veteran fighters and led by a warrior king. Though they were tired from their journey, weariness fell from them as they neared home. The mermen arrived during the night, and found the mouth of their bay guarded, so they headed south along the coast to some outlying villages to gather news of the invaders."
+            story= _ "The tribe that had fled Jotha unable to fight returned as an army stiffened by veteran fighters and led by a warrior king. Though they were tired from their journey, weariness fell from them as they neared home. The merfolk arrived during the night, and found the mouth of their bay guarded, so they headed south along the coast to some outlying villages to gather news of the invaders."
         [/part]
     [/story]
 
@@ -149,7 +149,7 @@
 
     {RING_OF_STRENGTH_EVENTS}
 
-    #The mermen have no villages left when they return (but a few are
+    #The merfolk have no villages left when they return (but a few are
     #still unclaimed):
     {STARTING_VILLAGES 2 15}
     {STARTING_VILLAGES_AREA 2 28 24 4}
@@ -488,7 +488,7 @@
         name=turn 2
         [message]
             speaker=narrator
-            message= _ "At dawn, the mermen got a good look at their opponents."
+            message= _ "At dawn, the merfolk got a good look at their opponents."
             image=wesnoth-icon.png
         [/message]
 

--- a/data/campaigns/Dead_Water/scenarios/13_Epilogue.cfg
+++ b/data/campaigns/Dead_Water/scenarios/13_Epilogue.cfg
@@ -30,7 +30,7 @@
         name=start
         [message]
             speaker=narrator
-            message= _ "After destroying Mal-Ravanal’s henchmen, Kai Krellis awaited another attack. But it never came. Krellis sent some messengers south to discover what they could. The news that came back was better than good. Mal-Ravanal was dead! Soldiers of Wesnoth had defeated him at about the same time the mermen had defeated the undead at Jotha. With the evil wizard gone, the mermen relaxed and began rebuilding in earnest, and soon Jotha was restored."
+            message= _ "After destroying Mal-Ravanal’s henchmen, Kai Krellis awaited another attack. But it never came. Krellis sent some messengers south to discover what they could. The news that came back was better than good. Mal-Ravanal was dead! Soldiers of Wesnoth had defeated him at about the same time the merfolk had defeated the undead at Jotha. With the evil wizard gone, the merfolk relaxed and began rebuilding in earnest, and soon Jotha was restored."
             image=wesnoth-icon.png
         [/message]
 

--- a/data/campaigns/Dead_Water/units/Citizen.cfg
+++ b/data/campaigns/Dead_Water/units/Citizen.cfg
@@ -14,7 +14,7 @@
     advances_to=Merman Brawler,Merman Fighter,Merman Hunter
     cost=9
     usage=fighter
-    description= _ "Mermen are mostly peaceful, but will fight to defend their homes. In this situation, even mermen with no weapons or training can be dangerous."
+    description= _ "Merfolk are mostly peaceful, but will fight to defend their homes. In this situation, even merfolk with no weapons or training can be dangerous."
     die_sound=mermen-die.ogg
     {DEFENSE_ANIM "units/merfolk/citizen-defend.png" "units/merfolk/citizen-defend.png" mermen-hit.wav }
     [attack]

--- a/data/campaigns/Dead_Water/utils/dw-utils.cfg
+++ b/data/campaigns/Dead_Water/utils/dw-utils.cfg
@@ -69,7 +69,8 @@
     side=1
     controller=human
     team_name=good guys
-    user_team_name= _ "Merman Forces"
+    # po: shown in the status table
+    user_team_name= _ "user_team_name^Merfolk"
 
     type=Merman Child King
     id=Kai Krellis

--- a/data/campaigns/Dead_Water/utils/items.cfg
+++ b/data/campaigns/Dead_Water/utils/items.cfg
@@ -1,6 +1,6 @@
 #textdomain wesnoth-dw
 
-# This copy of OBJ_TRIDENT_STORM adds the new merman types to the allowed units, and is only the object. It doesn't include the event for picking it up. The trident in wolf_coast uses a more complicated event for picking it up.
+# This copy of OBJ_TRIDENT_STORM is only the object, it doesn't include the event for picking it up. This trident is used in the wolf_coast scenario, which uses a campaign-specific set of events for picking it up.
 
 #define STORM_TRIDENT X Y ID
     [object]
@@ -8,11 +8,11 @@
         name= _ "Storm Trident"
         image=items/storm-trident.png
         duration=forever
-        description= _ "This weapon shoots powerful lightning bolts at your enemies."
+        description= _ "This trident gives merfolk the power to throw lightning at their enemies."
         silent=yes
-        cannot_use_message= _ "Only a merman can use this item."
+        cannot_use_message= _ "Only the merfolk can use this item."
         [filter]
-            type=Merman Citizen,Merman Brawler,Merman Child King,Merman Young King,Merman Soldier King,Merman Warrior King,Mermaid Diviner,Mermaid Enchantress,Mermaid Initiate,Mermaid Priestess,Mermaid Siren,Merman Entangler,Merman Fighter,Merman Hoplite,Merman Hunter,Merman Javelineer,Merman Netcaster,Merman Spearman,Merman Triton,Merman Warrior
+            race=merman
             x={X}
             y={Y}
         [/filter]

--- a/data/core/macros/items.cfg
+++ b/data/core/macros/items.cfg
@@ -518,7 +518,7 @@
             name= _ "Storm Trident"
             image=items/storm-trident.png
             duration=forever
-            description= _ "This trident allows a merman to shoot electric bolts at his enemies!"
+            description= _ "This trident gives merfolk the power to throw lightning at their enemies."
             [effect]
                 apply_to=new_attack
                 name="storm trident"


### PR DESCRIPTION
* Dead Water: Change "mermen" to "merfolk" (part of #2940)
    This commit excludes changes to S05 Tirigaz, I think changing the dialogue
    there is going to be more complicated, and it's better for that to have a
    separate PR.

* Prose: the Storm Trident's description uses "merfolk" (issue #2936)
    Also update Dead Water's copy of it to use race= instead of a
    list of unit types (as done for the core object in 613dd431).