### PR TITLE
Partial fix of weapon special marked as inactive

### DIFF
--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -813,7 +813,7 @@ static int attack_info(reports::context & rc, const attack_type &at, config &res
 	}
 
 	{
-		auto ctx = at.specials_context_for_listing();
+		auto ctx = at.specials_context_for_listing(u.side() == rc.screen().playing_side());
 		boost::dynamic_bitset<> active;
 		const std::vector<std::pair<t_string, t_string>> &specials = at.special_tooltips(&active);
 		const std::size_t specials_size = specials.size();

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -561,10 +561,11 @@ attack_type::specials_context_t::specials_context_t(
 	weapon.is_for_listing_ = false;
 }
 
-attack_type::specials_context_t::specials_context_t(const attack_type& weapon)
+attack_type::specials_context_t::specials_context_t(const attack_type& weapon, bool attacking)
 	: parent(weapon.shared_from_this())
 {
 	weapon.is_for_listing_ = true;
+	weapon.is_attacker_ = attacking;
 }
 
 attack_type::specials_context_t::~specials_context_t()

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -114,7 +114,7 @@ public:
 		std::shared_ptr<const attack_type> parent;
 		friend class attack_type;
 		/// Initialize weapon specials context for listing
-		explicit specials_context_t(const attack_type& weapon);
+		explicit specials_context_t(const attack_type& weapon, bool attacking);
 		/// Initialize weapon specials context for a unit type
 		specials_context_t(const attack_type& weapon, const unit_type& self_type, const map_location& loc, bool attacking = true);
 		/// Initialize weapon specials context for a single unit
@@ -144,8 +144,8 @@ public:
 	specials_context_t specials_context(const unit_type& self_type, const map_location& loc, bool attacking = true) const {
 		return specials_context_t(*this, self_type, loc, attacking);
 	}
-	specials_context_t specials_context_for_listing() const {
-		return specials_context_t(*this);
+	specials_context_t specials_context_for_listing(bool attacking = true) const {
+		return specials_context_t(*this, attacking);
 	}
 private:
 


### PR DESCRIPTION
Related to #3178 

This should fix weapon specials with "active_on" and "[filter_self] formula=" marked as inactive in the tooltips. 

I couldn't fix backstab because i didn't know what to do :p let me explain why in this example:

![capture](https://user-images.githubusercontent.com/29802612/41206584-6b5bc7c8-6d06-11e8-942e-96e3c912a8de.PNG)

The Thief will have backstab enabled vs the Sergeant, but not vs the Troll Whelp. So what should the tooltip say in this case? That backstab is active because there is _at least_ one enemy who satisfies the skill's requirements? Or should it say something else?
Afaik such issue may occur with any weapon special having "[filter_opponent]" or "[filter_defender]" as filters.
 