### PR TITLE
DW S05: Add a po hint about the orc saying "mermen" (part of #2940)

### DIFF
--- a/data/campaigns/Dead_Water/scenarios/05_Tirigaz.cfg
+++ b/data/campaigns/Dead_Water/scenarios/05_Tirigaz.cfg
@@ -713,7 +713,7 @@
                     x,y=$x1,$y1
                     image=misc/blank-hex.png~BLIT(items/chest-open.png~CROP(0,10,72,62),0,0)
                 [/item]
-        
+
                 [if]
                     [have_unit]
                         x,y=$x2,$y2
@@ -782,6 +782,7 @@
 
         [message]
             speaker=Marg-Tonz
+            # po: orc's boss' last breath, deliberately gendered instead of changing to "merfolk"
             message= _ "I hate mermen!"
         [/message]
     [/event]


### PR DESCRIPTION
The orc calls them fish-men several times, so changing it to "merfolk"
wouldn't fit.

Also a whitespace fix from wmlindent.