### PR TITLE
1.14: Enable MP lobby to play sounds and display desktop notifications when a new game is created

### DIFF
--- a/data/gui/window/mp_alerts_options.cfg
+++ b/data/gui/window/mp_alerts_options.cfg
@@ -197,7 +197,7 @@
 						{_GUI_LOBBY_SOUNDS_ENTRY "ready_for_start" _"Ready to start:"      _"When the game you are hosting is ready to start"}
 						{_GUI_LOBBY_SOUNDS_ENTRY "game_has_begun"  _"Game has begun:"      _"When the host (not you) has started the game"}
 						{_GUI_LOBBY_SOUNDS_ENTRY "turn_changed"    _"Turn changed:"        _"When a new turn has begun"}
-
+						{_GUI_LOBBY_SOUNDS_ENTRY "game_created"    _"Game created:"        _"When a new game has been created"}
 					[/grid]
 
 				[/column]

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -259,7 +259,8 @@ std::string
 	game_user_arrive = "join.wav",
 	game_user_leave  = "leave.wav",
 	ready_for_start  = "bell.wav",
-	game_has_begun   = "gamestart.ogg";
+	game_has_begun   = "gamestart.ogg",
+	game_created	 = "chat-highlight.ogg";
 
 const std::string
 	button_press     = "button.wav",
@@ -434,6 +435,7 @@ void load_config(const config &v)
 		load_attribute(s, "server_message",   server_message);
 		load_attribute(s, "player_joins",     player_joins);
 		load_attribute(s, "player_leaves",    player_leaves);
+		load_attribute(s, "game_created",     game_created);
 		load_attribute(s, "game_user_arrive", game_user_arrive);
 		load_attribute(s, "game_user_leave",  game_user_leave);
 		load_attribute(s, "ready_for_start",  ready_for_start);

--- a/src/game_config.hpp
+++ b/src/game_config.hpp
@@ -164,7 +164,7 @@ namespace game_config
 				private_message, friend_message,
 				server_message, player_joins, player_leaves,
 				game_user_arrive, game_user_leave, ready_for_start,
-				game_has_begun;
+				game_has_begun, game_created;
 		extern const std::string button_press, checkbox_release, slider_adjust,
 				menu_expand, menu_contract, menu_select;
 		namespace status {

--- a/src/game_initialization/lobby_info.cpp
+++ b/src/game_initialization/lobby_info.cpp
@@ -74,6 +74,9 @@ void do_notify(notify_mode mode, const std::string& sender, const std::string& m
 	case NOTIFY_MESSAGE:
 		mp_ui_alerts::public_message(true, sender, message);
 		break;
+	case NOTIFY_GAME_CREATED:
+		mp_ui_alerts::game_created(true, sender, message);
+		break;
 	default:
 		break;
 	}

--- a/src/game_initialization/lobby_info.hpp
+++ b/src/game_initialization/lobby_info.hpp
@@ -179,7 +179,8 @@ enum notify_mode {
 	NOTIFY_WHISPER_OTHER_WINDOW,
 	NOTIFY_LOBBY_JOIN,
 	NOTIFY_LOBBY_QUIT,
-	NOTIFY_COUNT
+	NOTIFY_COUNT,
+	NOTIFY_GAME_CREATED
 };
 
 void do_notify(notify_mode mode, const std::string& sender = "", const std::string& message = "");

--- a/src/gui/dialogs/multiplayer/lobby.cpp
+++ b/src/gui/dialogs/multiplayer/lobby.cpp
@@ -303,6 +303,10 @@ void mp_lobby::update_gamelist_diff()
 		const mp::game_info& game = *lobby_info_.games()[i];
 
 		if(game.display_status == mp::game_info::NEW) {
+			// call void do_notify(notify_mode mode, const std::string& sender, const std::string& message)
+			// sender will be the game_info.scenario (std::string) and message will be game_info.name (std::string) 
+			do_notify(mp::NOTIFY_GAME_CREATED, game.scenario, game.name);
+
 			LOG_LB << "Adding game to listbox " << game.id << "\n";
 
 			if(list_i != gamelistbox_->get_item_count()) {

--- a/src/mp_ui_alerts.cpp
+++ b/src/mp_ui_alerts.cpp
@@ -51,7 +51,26 @@ bool notif_pref(const std::string& id)
 } // end anonymous namespace
 
 // Note: This list must agree with data/gui/.../lobby_sound_options.cfg
-const std::vector<std::string> items {"player_joins", "player_leaves", "private_message", "friend_message", "public_message", "server_message", "ready_for_start", "game_has_begun", "turn_changed"};
+// @lilinitsy: As of 1.14, it seems the above comment is not true, but someone could check.
+const std::vector<std::string> items {"player_joins", "player_leaves", "private_message", "friend_message", "public_message", "server_message", "ready_for_start", "game_has_begun", "turn_changed", "game_created"};
+
+void game_created(bool is_lobby, const std::string & scenario, const std::string & name)
+{
+	std::string id = "game_created";
+	if (is_lobby && !lobby_pref(id)) {
+		return ;
+	}
+
+	if (sound_pref(id)) {
+		sound::play_UI_sound(game_config::sounds::game_created);
+	}
+
+	if (notif_pref(id)) {
+		const std::string message = VGETTEXT("A game ($name|, $scenario|) has been created", {{"name", name}, {"scenario", scenario}});
+		desktop::notifications::send(_("Wesnoth"), message, desktop::notifications::OTHER);
+	}
+	
+}
 
 void player_joins(bool is_lobby)
 {
@@ -176,11 +195,11 @@ bool get_def_pref_sound(const std::string & id) {
 }
 
 bool get_def_pref_notif(const std::string & id) {
-	return (desktop::notifications::available() && (id == "private_message" || id == "ready_for_start" || id == "game_has_begun" || id == "turn_changed"));
+	return (desktop::notifications::available() && (id == "private_message" || id == "ready_for_start" || id == "game_has_begun" || id == "turn_changed" || id == "game_created"));
 }
 
 bool get_def_pref_lobby(const std::string & id) {
-	return (id == "private_message" || id == "server_message");
+	return (id == "private_message" || id == "server_message" || id == "game_created");
 }
 
 

--- a/src/mp_ui_alerts.hpp
+++ b/src/mp_ui_alerts.hpp
@@ -27,6 +27,7 @@ namespace mp_ui_alerts {
 	// Functions called when such an event occurs
 	void player_joins(bool is_lobby);
 	void player_leaves(bool is_lobby);
+	void game_created(bool is_lobby, const std::string & scenario, const std::string & name);
 	void public_message(bool is_lobby, const std::string & sender, const std::string & message);
 	void friend_message(bool is_lobby, const std::string & sender, const std::string & message);
 	void private_message(bool is_lobby, const std::string & sender, const std::string & message);


### PR DESCRIPTION
Addresses the enhancement described at issue 2016 #2016.
The lobby will play a sound and display desktop notifications when a new game is played.

I couldn't figure out how to add it as a menu preference, so it currently can't be disabled.

Reopening because I'd screwed up my branches on my fork earlier.