### PR TITLE
allow non hosts to change factions later.

### DIFF
--- a/data/gui/window/mp_join_game.cfg
+++ b/data/gui/window/mp_join_game.cfg
@@ -62,6 +62,18 @@
 					[/column]
 
 					[column]
+						grow_factor = 0
+						vertical_alignment = "center"
+
+						[button]
+							id = "select_leader"
+							definition = "settings_mp_staging"
+							tooltip = _"Select the faction and leader for this side"
+						[/button]
+
+					[/column]
+
+					[column]
 						grow_factor = 1
 						horizontal_grow = true
 

--- a/src/game_initialization/flg_manager.cpp
+++ b/src/game_initialization/flg_manager.cpp
@@ -33,11 +33,18 @@ namespace ng
 flg_manager::flg_manager(const std::vector<const config*>& era_factions,
 		const config& side, const bool lock_settings, const bool use_map_settings, const bool saved_game)
 	: era_factions_(era_factions)
-	, side_(side)
+	, side_num_(side["side"].to_int())
+	, faction_from_recruit_(side["faction_from_recruit"].to_bool())
+	, original_type_(get_default_faction(side)["type"].str())
+	, original_gender_(get_default_faction(side)["gender"].str())
+	, savegame_gender_()
+	, original_faction_(get_default_faction(side)["faction"].str())
+	, original_recruit_(utils::split(get_default_faction(side)["recruit"].str()))
+	, choose_faction_by_leader_(side["leader"].str())
 	, saved_game_(saved_game)
-	, has_no_recruits_(get_original_recruits(side_).empty() && side_["previous_recruits"].empty())
-	, faction_lock_(side_["faction_lock"].to_bool(lock_settings))
-	, leader_lock_(side_["leader_lock"].to_bool(lock_settings))
+	, has_no_recruits_(original_recruit_.empty() && side["previous_recruits"].empty())
+	, faction_lock_(side["faction_lock"].to_bool(lock_settings))
+	, leader_lock_(side["leader_lock"].to_bool(lock_settings))
 	, available_factions_()
 	, available_leaders_()
 	, available_genders_()
@@ -47,14 +54,14 @@ flg_manager::flg_manager(const std::vector<const config*>& era_factions,
 	, current_faction_(nullptr)
 	, current_leader_("null")
 	, current_gender_("null")
-	, default_leader_type_(side_["type"])
-	, default_leader_gender_(side_["gender"])
+	, default_leader_type_(side["type"])
+	, default_leader_gender_(side["gender"])
 	, default_leader_cfg_(nullptr)
 {
-	const std::string& leader_id = side_["id"];
+	const std::string& leader_id = side["id"];
 	if(!leader_id.empty()) {
 		// Check if leader was carried over and now is in [unit] tag.
-		default_leader_cfg_ = &side_.find_child("unit", "id", leader_id);
+		default_leader_cfg_ = &side.find_child("unit", "id", leader_id);
 		if(*default_leader_cfg_) {
 			default_leader_type_ = (*default_leader_cfg_)["type"].str();
 			default_leader_gender_ = (*default_leader_cfg_)["gender"].str();
@@ -63,7 +70,7 @@ flg_manager::flg_manager(const std::vector<const config*>& era_factions,
 		}
 	} else if(default_leader_type_.empty()) {
 		// Find a unit which can recruit.
-		for(const config& side_unit : side_.child_range("unit")) {
+		for(const config& side_unit : side.child_range("unit")) {
 			if(side_unit["canrecruit"].to_bool()) {
 				default_leader_type_ = side_unit["type"].str();
 				default_leader_gender_ = side_unit["gender"].str();
@@ -84,9 +91,18 @@ flg_manager::flg_manager(const std::vector<const config*>& era_factions,
 	leader_lock_ = leader_lock_ && (use_map_settings || lock_settings || default_leader_type_.empty());
 	faction_lock_ = faction_lock_ && (use_map_settings || lock_settings);
 
+	//TODO: this code looks wrong, we should probably just use default_leader_gender_ from above.
+	for(const config& side_unit : side.child_range("unit")) {
+		if(current_leader_ == side_unit["type"] && side_unit["canrecruit"].to_bool()) {
+			savegame_gender_ = side_unit["gender"].str();
+			break;
+		}
+	}
+
 	update_available_factions();
 
 	select_default_faction();
+	
 }
 
 void flg_manager::set_current_faction(const unsigned index)
@@ -109,7 +125,7 @@ void flg_manager::set_current_faction(const std::string& id)
 		index++;
 	}
 
-	ERR_MP << "Faction '" << id << "' is not available for side " << side_["side"] << " Ignoring";
+	ERR_MP << "Faction '" << id << "' is not available for side " << side_num_ << " Ignoring";
 }
 
 void flg_manager::set_current_leader(const unsigned index)
@@ -245,7 +261,7 @@ void flg_manager::resolve_random(randomness::mt_rng& rng, const std::vector<std:
 void flg_manager::update_available_factions()
 {
 	const config* custom_faction = nullptr;
-	const bool show_custom_faction = get_default_faction(side_)["faction"] == "Custom" || !has_no_recruits_ || faction_lock_;
+	const bool show_custom_faction = original_faction_ == "Custom" || !has_no_recruits_ || faction_lock_;
 
 	for(const config* faction : era_factions_) {
 		if((*faction)["id"] == "Custom" && !show_custom_faction) {
@@ -258,7 +274,7 @@ void flg_manager::update_available_factions()
 		}
 
 		// Add default faction to the top of the list.
-		if(get_default_faction(side_)["faction"] == (*faction)["id"]) {
+		if(original_faction_ == (*faction)["id"]) {
 			available_factions_.insert(available_factions_.begin(), faction);
 		} else {
 			available_factions_.push_back(faction);
@@ -327,17 +343,8 @@ void flg_manager::update_available_genders()
 	available_genders_.clear();
 
 	if(saved_game_) {
-		std::string gender;
-
-		for(const config& side_unit : side_.child_range("unit")) {
-			if(current_leader_ == side_unit["type"] && side_unit["canrecruit"].to_bool()) {
-				gender = side_unit["gender"].str();
-				break;
-			}
-		}
-
-		if(!gender.empty()) {
-			available_genders_.push_back(gender);
+		if(!savegame_gender_.empty()) {
+			available_genders_.push_back(savegame_gender_);
 		}
 	} else {
 		if(const unit_type* unit = unit_types.find(current_leader_)) {
@@ -421,7 +428,7 @@ void flg_manager::update_choosable_genders()
 
 void flg_manager::select_default_faction()
 {
-	const config::attribute_value& default_faction = get_default_faction(side_)["faction"];
+	const std::string& default_faction = original_faction_;
 	auto default_faction_it = std::find_if(choosable_factions_.begin(), choosable_factions_.end(),
 		[&default_faction](const config* faction) {
 			return (*faction)["id"] == default_faction;
@@ -439,17 +446,17 @@ int flg_manager::find_suitable_faction() const
 	std::vector<std::string> find;
 	std::string search_field;
 
-	if(const config::attribute_value* f = get_default_faction(side_).get("faction")) {
+	if(!original_faction_.empty()) {
 		// Choose based on faction.
-		find.push_back(f->str());
+		find.push_back(original_faction_);
 		search_field = "id";
-	} else if(side_["faction_from_recruit"].to_bool()) {
+	} else if(faction_from_recruit_) {
 		// Choose based on recruit.
-		find = get_original_recruits(side_);
+		find = original_recruit_;
 		search_field = "recruit";
-	} else if(const config::attribute_value *l = side_.get("leader")) {
+	} else if(!choose_faction_by_leader_.empty()) {
 		// Choose based on leader.
-		find.push_back(*l);
+		find.push_back(choose_faction_by_leader_);
 		search_field = "leader";
 	} else {
 		find.push_back("Custom");
@@ -520,7 +527,7 @@ void flg_manager::set_current_leader(const std::string& leader)
 {
 	int index = leader_index(leader);
 	if(index < 0) {
-		ERR_MP << "Leader '" << leader << "' is not available for side " << side_["side"] << " Ignoring";
+		ERR_MP << "Leader '" << leader << "' is not available for side " << side_num_ << " Ignoring";
 	} else {
 		set_current_leader(index);
 	}
@@ -530,15 +537,10 @@ void flg_manager::set_current_gender(const std::string& gender)
 {
 	int index = gender_index(gender);
 	if(index < 0) {
-		ERR_MP << "Gender '" << gender << "' is not available for side " << side_["side"] << " Ignoring";
+		ERR_MP << "Gender '" << gender << "' is not available for side " << side_num_ << " Ignoring";
 	} else {
 		set_current_gender(index);
 	}
-}
-
-std::vector<std::string> flg_manager::get_original_recruits(const config& cfg)
-{
-	return utils::split(get_default_faction(cfg)["recruit"].str());
 }
 
 const config& flg_manager::get_default_faction(const config& cfg)

--- a/src/game_initialization/flg_manager.hpp
+++ b/src/game_initialization/flg_manager.hpp
@@ -104,8 +104,16 @@ private:
 
 	const std::vector<const config*>& era_factions_;
 
-	const config& side_;
+	// not sure how reilable the content of this field is, it's currently only used for debugging info.
+	const int side_num_;
+	const bool faction_from_recruit_;
 
+	const std::string original_type_;
+	const std::string original_gender_;
+	std::string savegame_gender_;
+	const std::string original_faction_;
+	const std::vector<std::string> original_recruit_;
+	const std::string choose_faction_by_leader_;
 	const bool saved_game_;
 	const bool has_no_recruits_;
 
@@ -129,7 +137,6 @@ private:
 	std::string default_leader_gender_;
 	const config* default_leader_cfg_;
 
-	static std::vector<std::string> get_original_recruits(const config& cfg);
 	static const config& get_default_faction(const config& cfg);
 };
 

--- a/src/gui/core/timer.cpp
+++ b/src/gui/core/timer.cpp
@@ -44,7 +44,13 @@ static std::map<size_t, timer>& get_timers()
 	static std::map<size_t, timer>* ptimers = new std::map<size_t, timer>();
 	return *ptimers;
 }
-/** The id of the event being executed, 0 if none. */
+/** 
+	The id of the event being executed, 0 if none.
+	NOTE: it is possible that multiple timers are executed at the same time
+	      if one of the timer starts an event loop for example if its handler
+		  shows a dialog. In that case code that relies on this breaks. This
+		  could probably fixed my making this a list/stack of ids.
+*/
 static size_t executing_id = 0;
 
 /** Did somebody try to remove the timer during its execution? */

--- a/src/gui/dialogs/multiplayer/faction_select.cpp
+++ b/src/gui/dialogs/multiplayer/faction_select.cpp
@@ -53,11 +53,19 @@ faction_select::faction_select(ng::flg_manager& flg_manager, const std::string& 
 	, last_faction_(flg_manager.current_faction_index())
 	, last_leader_(flg_manager.current_leader_index())
 	, last_gender_(flg_manager.current_gender_index())
+	, w_(nullptr)
 {
 }
 
+void faction_select::cancel()
+{
+	if(w_) {
+		w_->set_retval(retval::CANCEL);
+	}
+}
 void faction_select::pre_show(window& window)
 {
+	w_ = &window;
 	find_widget<label>(&window, "starting_pos", false).set_label(std::to_string(side_));
 
 	//

--- a/src/gui/dialogs/multiplayer/faction_select.hpp
+++ b/src/gui/dialogs/multiplayer/faction_select.hpp
@@ -32,6 +32,9 @@ public:
 
 	DEFINE_SIMPLE_EXECUTE_WRAPPER(faction_select)
 
+	void cancel();
+	
+	int get_side_num() const { return side_; }
 private:
 	ng::flg_manager& flg_manager_;
 
@@ -43,6 +46,7 @@ private:
 
 	const int last_faction_, last_leader_, last_gender_;
 
+	gui2::window* w_;
 	/** Inherited from modal_dialog, implemented by REGISTER_DIALOG. */
 	virtual const std::string& window_id() const override;
 

--- a/src/gui/dialogs/multiplayer/mp_join_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_join_game.cpp
@@ -209,8 +209,12 @@ bool mp_join_game::fetch_game_config()
 		const std::string color = (*side_choice)["color"].str();
 
 		std::vector<const config*> era_factions;
+
+		//make this safe against changes to level_ that might make possible_sides invalid pointers.
+		config era_copy;
 		for(const config& side : possible_sides) {
-			era_factions.push_back(&side);
+			config& side_new = era_copy.add_child("multiplayer_side", side);
+			era_factions.push_back(&side_new);
 		}
 
 		const bool is_mp = state_.classification().is_normal_mp_game();
@@ -332,8 +336,11 @@ void mp_join_game::show_flg_select(int side_num)
 		const std::string color = side_choice["color"].str();
 
 		std::vector<const config*> era_factions;
+		//make this safe against changes to level_ that might make possible_sides invalid pointers.
+		config era_copy;
 		for(const config& side : possible_sides) {
-			era_factions.push_back(&side);
+			config& side_new = era_copy.add_child("multiplayer_side", side);
+			era_factions.push_back(&side_new);
 		}
 
 		const bool is_mp = state_.classification().is_normal_mp_game();

--- a/src/gui/dialogs/multiplayer/mp_join_game.hpp
+++ b/src/gui/dialogs/multiplayer/mp_join_game.hpp
@@ -52,6 +52,8 @@ private:
 	/** Inherited from modal_dialog. */
 	virtual void post_show(window& window) override;
 
+	void show_flg_select(int side_num);
+
 	void generate_side_list(window& window);
 
 	void network_handler(window& window);

--- a/src/gui/dialogs/multiplayer/mp_join_game.hpp
+++ b/src/gui/dialogs/multiplayer/mp_join_game.hpp
@@ -53,7 +53,8 @@ private:
 	/** Inherited from modal_dialog. */
 	virtual void post_show(window& window) override;
 
-	void show_flg_select(int side_num);
+	/** @returns false if an error ocurred. */
+	bool show_flg_select(int side_num);
 
 	void generate_side_list(window& window);
 

--- a/src/gui/dialogs/multiplayer/mp_join_game.hpp
+++ b/src/gui/dialogs/multiplayer/mp_join_game.hpp
@@ -81,6 +81,8 @@ private:
 	std::unique_ptr<player_list_helper> player_list_;
 
 	gui2::dialogs::faction_select* open_flg_dialog_;
+
+	std::size_t flg_button_callback_timer_id_;
 };
 
 } // namespace dialogs

--- a/src/gui/dialogs/multiplayer/mp_join_game.hpp
+++ b/src/gui/dialogs/multiplayer/mp_join_game.hpp
@@ -31,6 +31,7 @@ class tree_view_node;
 
 namespace dialogs
 {
+class faction_select;
 
 class mp_join_game : public modal_dialog, private plugin_executor
 {
@@ -78,6 +79,8 @@ private:
 	std::map<std::string, tree_view_node*> team_tree_map_;
 
 	std::unique_ptr<player_list_helper> player_list_;
+
+	gui2::dialogs::faction_select* open_flg_dialog_;
 };
 
 } // namespace dialogs

--- a/src/utils/scope_exit.hpp
+++ b/src/utils/scope_exit.hpp
@@ -1,0 +1,30 @@
+/*
+   Copyright (C) 2003 - 2018 the Battle for Wesnoth Project http://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#pragma once
+
+#include "global.hpp"
+
+#include <functional>
+
+namespace utils {
+
+class scope_exit {
+	//TODO: with c++17 we could make this a template class with 'F f_' instead of 'std::function<void ()> f_';
+	std::function<void ()> f_;
+public:
+	template<typename F>
+	explicit scope_exit(F&& f) : f_(f) {}
+	~scope_exit() { if(f_) { f_(); }}
+};
+} // namespace utils


### PR DESCRIPTION
previously players had to leave an rejoin the game to change their faction.
this was most annoying in coop games where you want might want to choose
your faction in consultation with the other players. Also you previously could
not even checkout the different available factions again after you joined
the game.