### PR TITLE
help: Prevent line breaks within the "Required XP: 80" block by using non-breaking spaces

### DIFF
--- a/src/font/constants.cpp
+++ b/src/font/constants.cpp
@@ -33,6 +33,7 @@ const size_t max_text_line_width = 4096;
 
 const std::string
 	ellipsis = "...",
+	nbsp = " ", // non-breaking space; unicode u00a0
 
 	unicode_minus = "-",
 	unicode_en_dash = "–", // unicode u2013

--- a/src/font/constants.hpp
+++ b/src/font/constants.hpp
@@ -37,6 +37,7 @@ extern const size_t max_text_line_width;
 // String constants
 extern const std::string
 	ellipsis,
+	nbsp,
 
 	unicode_minus,
 	unicode_en_dash,

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -477,15 +477,34 @@ std::string unit_topic_generator::operator()() const {
 
 	// Print some basic information such as HP and movement points.
 	// TODO: Make this info update according to musthave traits, similar to movetype below.
+
+	// TRANSLATORS: This string is used in the help page of a single unit.  If the translation
+	// uses spaces, use non-breaking spaces as appropriate for the target language to prevent
+	// unpleasant line breaks (issue #3256).
 	ss << _("HP:") << font::nbsp << type_.hitpoints() << jump(30)
+		// TRANSLATORS: This string is used in the help page of a single unit.  If the translation
+		// uses spaces, use non-breaking spaces as appropriate for the target language to prevent
+		// unpleasant line breaks (issue #3256).
 		<< _("Moves:") << font::nbsp << type_.movement() << jump(30);
 	if (type_.vision() != type_.movement()) {
+		// TRANSLATORS: This string is used in the help page of a single unit.  If the translation
+		// uses spaces, use non-breaking spaces as appropriate for the target language to prevent
+		// unpleasant line breaks (issue #3256).
 		ss << _("Vision:") << font::nbsp << type_.vision() << jump(30);
 	}
 	if (type_.jamming() > 0) {
+		// TRANSLATORS: This string is used in the help page of a single unit.  If the translation
+		// uses spaces, use non-breaking spaces as appropriate for the target language to prevent
+		// unpleasant line breaks (issue #3256).
 		ss << _("Jamming:") << font::nbsp << type_.jamming() << jump(30);
 	}
+	// TRANSLATORS: This string is used in the help page of a single unit.  If the translation
+	// uses spaces, use non-breaking spaces as appropriate for the target language to prevent
+	// unpleasant line breaks (issue #3256).
 	ss << _("Cost:") << font::nbsp << type_.cost() << jump(30)
+		// TRANSLATORS: This string is used in the help page of a single unit.  If the translation
+		// uses spaces, use non-breaking spaces as appropriate for the target language to prevent
+		// unpleasant line breaks (issue #3256).
 		<< _("Alignment:") << font::nbsp
 		<< make_link(type_.alignment_description(type_.alignment(), type_.genders().front()), "time_of_day")
 		<< jump(30);

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -477,20 +477,23 @@ std::string unit_topic_generator::operator()() const {
 
 	// Print some basic information such as HP and movement points.
 	// TODO: Make this info update according to musthave traits, similar to movetype below.
-	ss << _("HP: ") << type_.hitpoints() << jump(30)
-		<< _("Moves: ") << type_.movement() << jump(30);
+	ss << _("HP:") << font::nbsp << type_.hitpoints() << jump(30)
+		<< _("Moves:") << font::nbsp << type_.movement() << jump(30);
 	if (type_.vision() != type_.movement()) {
-		ss << _("Vision: ") << type_.vision() << jump(30);
+		ss << _("Vision:") << font::nbsp << type_.vision() << jump(30);
 	}
 	if (type_.jamming() > 0) {
-		ss << _("Jamming: ") << type_.jamming() << jump(30);
+		ss << _("Jamming:") << font::nbsp << type_.jamming() << jump(30);
 	}
-	ss << _("Cost: ") << type_.cost() << jump(30)
-		<< _("Alignment: ")
+	ss << _("Cost:") << font::nbsp << type_.cost() << jump(30)
+		<< _("Alignment:") << font::nbsp
 		<< make_link(type_.alignment_description(type_.alignment(), type_.genders().front()), "time_of_day")
 		<< jump(30);
 	if (type_.can_advance()) {
-		ss << _("Required XP: ") << type_.experience_needed();
+		// TRANSLATORS: This string is used in the help page of a single unit.  It uses
+		// non-breaking spaces to prevent unpleasant line breaks (issue #3256).  In the
+		// translation use non-breaking spaces as appropriate for the target language.
+		ss << _("Required\u00a0XP:") << font::nbsp << type_.experience_needed();
 	}
 
 	// Print the detailed description about the unit.


### PR DESCRIPTION
On 1.14, the help page for Shadow has a a line break between "Required XP" and the value:

![shadow](https://user-images.githubusercontent.com/24784687/41482948-c7ddf8f4-70c6-11e8-8442-90abe767ee1f.png)

This patch makes sure the "Required XP: 100" block is never split across a linebreak.