### PR TITLE
Fix: add redraw to narrator's message so village count is refreshed

### DIFF
--- a/data/lua/wml/message.lua
+++ b/data/lua/wml/message.lua
@@ -374,6 +374,7 @@ function wesnoth.wml_actions.message(cfg)
 		wesnoth.deselect_hex()
 		-- The speaker is expected to be either nil or a unit later
 		speaker = nil
+		wesnoth.fire("redraw")
 	else
 		-- Check ~= false, because the default if omitted should be true
 		if cfg.scroll ~= false then


### PR DESCRIPTION
Fixes: https://forums.wesnoth.org/viewtopic.php?f=21&t=48370

In the tutorial when we occupy the first village the message tells us the
village count got incremented, but in the old version it was incremented
only afterwards. Non-narrator messages were updated properly. By adding the
redraw, narrator messages triggered by capture event produce the same
result as other speakers.