### PR TITLE
Help: Use `female_name` and `name` as fallback when `male_name` is empty and don't list hidden traits.

### DIFF
--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -395,10 +395,17 @@ std::string unit_topic_generator::operator()() const {
 		int must_have_nameless_traits = 0;
 
 		for (const config & trait : traits) {
-			std::string trait_name = trait["male_name"].str();
-			if (trait_name.empty()) trait_name = trait["female_name"].str();
-			if (trait_name.empty()) trait_name = trait["name"].str();
-			if (trait_name.empty()) continue; // Hidden trait
+			const std::string& male_name = trait["male_name"].str();
+			const std::string& female_name = trait["female_name"].str();
+			std::string trait_name;
+			if (type_.has_gender_variation(unit_race::MALE) && ! male_name.empty())
+				trait_name = male_name;
+			else if (type_.has_gender_variation(unit_race::FEMALE) && ! female_name.empty())
+				trait_name = female_name;
+			else if (! trait["name"].str().empty())
+				trait_name = trait["name"].str();
+			else
+				continue; // Hidden trait
 
 			std::string lang_trait_name = translation::gettext(trait_name.c_str());
 			if (lang_trait_name.empty() && trait["availability"].str() == "musthave") {

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -215,6 +215,7 @@ std::string terrain_topic_generator::operator()() const {
 
 
 //Typedef to help with formatting list of traits
+//Maps localized trait name to trait help topic ID
 typedef std::pair<std::string, std::string> trait_data;
 
 //Helper function for printing a list of trait data
@@ -394,7 +395,11 @@ std::string unit_topic_generator::operator()() const {
 		int must_have_nameless_traits = 0;
 
 		for (const config & trait : traits) {
-			const std::string trait_name = trait["male_name"];
+			std::string trait_name = trait["male_name"].str();
+			if (trait_name.empty()) trait_name = trait["female_name"].str();
+			if (trait_name.empty()) trait_name = trait["name"].str();
+			if (trait_name.empty()) continue; // Hidden trait
+
 			std::string lang_trait_name = translation::gettext(trait_name.c_str());
 			if (lang_trait_name.empty() && trait["availability"].str() == "musthave") {
 				++must_have_nameless_traits;


### PR DESCRIPTION
This algorithm was lifted from help::generate_trait_topics().

Fixes #3284