### PR TITLE
Tutorial S1: prevent getting stuck next to Delfador, unable to end turn

### DIFF
--- a/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
+++ b/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
@@ -74,12 +74,13 @@
             name= _ "Delfador"
             type=Elder Mage
             profile=portraits/delfador.png~RIGHT()
-            x,y=13,6
+            x,y=13,5
             random_traits=no
             facing=nw
             {IS_HERO}
             [modifications]
                 {TRAIT_INTELLIGENT}
+                {TRAIT_QUICK}
                 [object]
                     [effect]
                         apply_to=new_animation
@@ -265,6 +266,18 @@
             message= _ "Quiet! I will summon an enemy for you..."
         [/message]
 
+        # Delfador steps 2 hexes northeast to a new summoning position
+        {MOVE_UNIT (id=Delfador) 15 4}
+        {MODIFY_UNIT (id=Delfador) facing sw}
+
+        # Adjust Delfador's MP as if he really moved
+        [lua]
+            code= <<
+                local unit = wesnoth.get_units({id = "Delfador"})[1]
+                unit.moves = 5
+            >>
+        [/lua]
+
         [scroll_to_unit]
             id=Delfador
         [/scroll_to_unit]
@@ -394,6 +407,14 @@
         )}
 
         {MOVE_UNIT (id=Delfador) 14 8}
+
+        # Adjust Delfador's MP as if he really moved
+        [lua]
+            code= <<
+                local unit = wesnoth.get_units({id = "Delfador"})[1]
+                unit.moves = 0
+            >>
+        [/lua]
 
         {MODIFY_UNIT (id=Delfador) facing nw}
 
@@ -924,7 +945,7 @@
             blue=0
         [/color_adjust]
 
-        {MOVE_UNIT (id=Delfador) (12,8,8) (7,9,11)}
+        {MOVE_UNIT (id=Delfador) (12,8,8,8) (7,9,10,11)}
 
         [scroll_to_unit]
             type=Quintain


### PR DESCRIPTION
Fixes #1584 1c - Delfador summons the puppet, you have 0 MP left but the
                 puppet is not adjacent to you, and can't attack or undo

Changed Delfador's initial position to match the quintain's, and made him
step away to summon in the original place next to us, so we don't need to
move again to attack after we reach him.
The movement points of the mage are now updated and he gained quick trait
to fit for the more movements he does.
Final movement also touched, so he does not seem to sidestep the new
enemies when leaving the map.