### PR TITLE
TSG win conditions

### DIFF
--- a/data/campaigns/The_South_Guard/scenarios/05_Choice_In_The_Fog.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/05_Choice_In_The_Fog.cfg
@@ -524,10 +524,20 @@
                         [objective]
                             description= _ "Find the source of the undead and destroy it"
                             condition=win
+                            [show_if]
+                                [have_unit]
+                                    id="Mal M'Brin"
+                                [/have_unit]
+                            [/show_if]
                         [/objective]
                         [objective]
                             description= _ "Defeat Urza Afalas"
                             condition=win
+                            [show_if]
+                                [have_unit]
+                                    id=Urza Afalas
+                                [/have_unit]
+                            [/show_if]
                         [/objective]
                         [objective]
                             description= _ "Death of Deoran"

--- a/data/campaigns/The_South_Guard/scenarios/05_Choice_In_The_Fog.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/05_Choice_In_The_Fog.cfg
@@ -257,6 +257,43 @@
             [objective]
                 description= _ "Investigate the areas to the south of the Black River"
                 condition=win
+                [show_if]
+                    [variable]
+                        name=found_urza_afalas
+                        boolean_not_equals=yes
+                    [/variable]
+                [/show_if]
+            [/objective]
+            [objective]
+                description= _ "Find the source of the undead and destroy it"
+                condition=win
+                [show_if]
+                    [variable]
+                        name=found_urza_afalas
+                        boolean_equals=yes
+                    [/variable]
+                    # Don't show this objective when the player sides with the elves and kills the lich before killing the bandit leader.
+                    [have_unit]
+                        id="Mal M'Brin"
+                    [/have_unit]
+                [/show_if]
+            [/objective]
+            [objective]
+                description= _ "Defeat Urza Afalas"
+                condition=win
+                [show_if]
+                    [variable]
+                        name=found_urza_afalas
+                        boolean_equals=yes
+                    [/variable]
+                    [variable]
+                        name=side_with_bandits
+                        boolean_equals=no
+                    [/variable]
+                    [have_unit]
+                        id=Urza Afalas
+                    [/have_unit]
+                [/show_if]
             [/objective]
             [objective]
                 description= _ "Death of Deoran"
@@ -273,6 +310,28 @@
             [objective]
                 description= _ "Death of Ethiliel"
                 condition=lose
+                [show_if]
+                    [variable]
+                        name=found_urza_afalas
+                        boolean_equals=no
+                    [/variable]
+                    [or]
+                        [variable]
+                            name=side_with_bandits
+                            boolean_equals=no
+                        [/variable]
+                    [/or]
+                [/show_if]
+            [/objective]
+            [objective]
+                description= _ "Death of Urza Afalas"
+                condition=lose
+                [show_if]
+                    [variable]
+                        name=side_with_bandits
+                        boolean_equals=yes
+                    [/variable]
+                [/show_if]
             [/objective]
 
             {TURNS_RUN_OUT}
@@ -519,50 +578,7 @@
                         value=no
                     [/set_variable]
 
-                    [objectives]
-                        side=1
-                        [objective]
-                            description= _ "Find the source of the undead and destroy it"
-                            condition=win
-                            [show_if]
-                                [have_unit]
-                                    id="Mal M'Brin"
-                                [/have_unit]
-                            [/show_if]
-                        [/objective]
-                        [objective]
-                            description= _ "Defeat Urza Afalas"
-                            condition=win
-                            [show_if]
-                                [have_unit]
-                                    id=Urza Afalas
-                                [/have_unit]
-                            [/show_if]
-                        [/objective]
-                        [objective]
-                            description= _ "Death of Deoran"
-                            condition=lose
-                        [/objective]
-                        [objective]
-                            description= _ "Death of Sir Gerrick"
-                            condition=lose
-                        [/objective]
-                        [objective]
-                            description= _ "Death of Minister Hylas"
-                            condition=lose
-                        [/objective]
-                        [objective]
-                            description= _ "Death of Ethiliel"
-                            condition=lose
-                        [/objective]
-
-                        {TURNS_RUN_OUT}
-
-                        [gold_carryover]
-                            bonus=yes
-                            carryover_percentage=40
-                        [/gold_carryover]
-                    [/objectives]
+                    [show_objectives][/show_objectives]
                 [/command]
             [/option]
 
@@ -669,36 +685,7 @@
                         shroud=no
                     [/modify_side]
 
-                    [objectives]
-                        side=1
-                        [objective]
-                            description= _ "Find the source of the undead and destroy it"
-                            condition=win
-                        [/objective]
-                        [objective]
-                            description= _ "Death of Deoran"
-                            condition=lose
-                        [/objective]
-                        [objective]
-                            description= _ "Death of Sir Gerrick"
-                            condition=lose
-                        [/objective]
-                        [objective]
-                            description= _ "Death of Minister Hylas"
-                            condition=lose
-                        [/objective]
-                        [objective]
-                            description= _ "Death of Urza Afalas"
-                            condition=lose
-                        [/objective]
-
-                        {TURNS_RUN_OUT}
-
-                        [gold_carryover]
-                            bonus=yes
-                            carryover_percentage=40
-                        [/gold_carryover]
-                    [/objectives]
+                    [show_objectives][/show_objectives]
                 [/command]
             [/option]
         [/message]


### PR DESCRIPTION
Fixes #3031.

The objectives look funny in linger mode after killing both Urza Afalas and the lich, there's no condition=win objective shown at all, I'm not sure what to do about that.
![screenshot_2018-07-01_17-25-37](https://user-images.githubusercontent.com/24784687/42136964-d981c5d8-7d53-11e8-8d36-b9d235cf1615.png)