### PR TITLE
Sort the movement costs in the tooltip in ascending order

### DIFF
--- a/data/advanced_preferences.cfg
+++ b/data/advanced_preferences.cfg
@@ -182,14 +182,6 @@
 [/advanced_preference]
 
 [advanced_preference]
-    field=sort_move_tooltip_alphabetically
-    name= _ "Sort movement costs in the tooltip alphabetically"
-    description= _ "Sort movement costs in the tooltip alphabetically. If set to no, tooltip movement costs will be by movement cost (ascending)."
-    type=boolean
-    default=yes
-[/advanced_preference]
-
-[advanced_preference]
     field=use_prng
     name= _ "Use experimental PRNG combat"
     description= _ "Enables more determinstic chance-to-hit calculations. This is an experimental feature designed to bring the observed hit/miss rate more in line with the displayed percentages.

--- a/data/advanced_preferences.cfg
+++ b/data/advanced_preferences.cfg
@@ -182,6 +182,14 @@
 [/advanced_preference]
 
 [advanced_preference]
+    field=sort_move_tooltip_alphabetically
+    name= _ "Sort movement costs in the tooltip alphabetically"
+    description= _ "Sort movement costs in the tooltip alphabetically. If set to no, tooltip movement costs will be by movement cost (ascending)."
+    type=boolean
+    default=yes
+[/advanced_preference]
+
+[advanced_preference]
     field=use_prng
     name= _ "Use experimental PRNG combat"
     description= _ "Enables more determinstic chance-to-hit calculations. This is an experimental feature designed to bring the observed hit/miss rate more in line with the displayed percentages.

--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -147,7 +147,7 @@ static inline std::string get_mp_tooltip(int total_movement, std::function<int (
 {
 	auto movement_compare = [](std::pair<t_string, int> a, std::pair<t_string, int> b)
 	{
-		return a.first < b.first;
+		return translation::icompare(a.first, b.first) < 0;
 	};
 
 	// terrain_moves pair: first: name, second: movement_cost

--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -145,6 +145,13 @@ static inline std::string get_hp_tooltip(const utils::string_map& res, const std
 
 static inline std::string get_mp_tooltip(int total_movement, std::function<int (t_translation::terrain_code)> get)
 {
+	auto movement_compare = [](std::pair<t_string, int> a, std::pair<t_string, int> b)
+	{
+		return a.first < b.first;
+	};
+
+	// terrain_moves pair: first: name, second: movement_cost
+	std::set<std::pair<t_string, int>, decltype(movement_compare)> terrain_moves(movement_compare);
 	std::ostringstream tooltip;
 	tooltip << "<big>" << _("Movement Costs:") << "</big>";
 
@@ -161,35 +168,42 @@ static inline std::string get_mp_tooltip(int total_movement, std::function<int (
 
 		const terrain_type& info = tdata->get_terrain_info(terrain);
 		if(info.union_type().size() == 1 && info.union_type()[0] == info.number() && info.is_nonnull()) {
-			const std::string& name = info.name();
-			const int moves = get(terrain);
-
-			tooltip << '\n' << font::unicode_bullet << " " << name << ": ";
-
-			// movement  -  range: 1 .. 5, movetype::UNREACHABLE=impassable
-			const bool cannot_move = moves > total_movement;
-
-			std::string color;
-			if(cannot_move) {
-				// cannot move in this terrain
-				color = "red";
-			} else if(moves > 1) {
-				color = "yellow";
-			} else {
-				color = "white";
-			}
-
-			tooltip << "<span color='" << color << "'>";
-
-			// A 5 MP margin; if the movement costs go above the unit's max moves + 5, we replace it with dashes.
-			if(cannot_move && (moves > total_movement + 5)) {
-				tooltip << font::unicode_figure_dash;
-			} else {
-				tooltip << moves;
-			}
-
-			tooltip << "</span>";
+			terrain_moves.emplace(info.name(), get(terrain));
 		}
+	}
+
+	
+
+	for(const std::pair<t_string, int> tm: terrain_moves)
+	{
+		const std::string name = tm.first;
+		const int moves = tm.second;
+
+		tooltip << '\n' << font::unicode_bullet << " " << name << ": ";
+
+		// movement  -  range: 1 .. 5, movetype::UNREACHABLE=impassable
+		const bool cannot_move = moves > total_movement;
+
+		std::string color;
+		if(cannot_move) {
+			// cannot move in this terrain
+			color = "red";
+		} else if(moves > 1) {
+			color = "yellow";
+		} else {
+			color = "white";
+		}
+
+		tooltip << "<span color='" << color << "'>";
+
+		// A 5 MP margin; if the movement costs go above the unit's max moves + 5, we replace it with dashes.
+		if(cannot_move && (moves > total_movement + 5)) {
+			tooltip << font::unicode_figure_dash;
+		} else {
+			tooltip << moves;
+		}
+
+		tooltip << "</span>";
 	}
 
 	return tooltip.str();

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -245,7 +245,7 @@ std::string unit_topic_generator::operator()() const {
 	// Used for sorting terrain_movement_info terrain_moves. Needs to be declared before terrain_moves.
 	auto movement_compare = [](terrain_movement_info a, terrain_movement_info b)
 	{
-		return a.name < b.name;
+		return translation::icompare(a.name, b.name) < 0;
 	};
 
 

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -42,6 +42,17 @@ static lg::log_domain log_help("help");
 
 namespace help {
 
+struct terrain_movement_info
+{
+	const t_string name;
+	const t_string id;
+	const int defense;
+	const int movement_cost;
+	const int vision_cost;
+	const int jamming_cost;
+	const bool defense_cap;
+};
+
 static std::string best_str(bool best) {
 	std::string lang_policy = (best ? _("Best of") : _("Worst of"));
 	std::string color_policy = (best ? "green": "red");
@@ -230,6 +241,14 @@ static void print_trait_list(std::stringstream & ss, const std::vector<trait_dat
 }
 
 std::string unit_topic_generator::operator()() const {
+	
+	// Used for sorting terrain_movement_info terrain_moves. Needs to be declared before terrain_moves.
+	auto movement_compare = [](terrain_movement_info a, terrain_movement_info b)
+	{
+		return a.name < b.name;
+	};
+
+
 	// Force the lazy loading to build this unit.
 	unit_types.build_unit_type(type_, unit_type::FULL);
 
@@ -632,6 +651,8 @@ std::string unit_topic_generator::operator()() const {
 		std::set<t_translation::terrain_code>::const_iterator terrain_it =
 			preferences::encountered_terrains().begin();
 
+		std::set<terrain_movement_info, decltype(movement_compare)> terrain_moves(movement_compare);
+
 		for (; terrain_it != preferences::encountered_terrains().end();
 				++terrain_it) {
 			const t_translation::terrain_code terrain = *terrain_it;
@@ -646,148 +667,169 @@ std::string unit_topic_generator::operator()() const {
 			}
 
 			if (info.union_type().size() == 1 && info.union_type()[0] == info.number() && info.is_nonnull()) {
-				std::vector<item> row;
-				const std::string& name = info.name();
-				const std::string& id = info.id();
-				const int views = movement_type.vision_cost(terrain);
-				const int jams  = movement_type.jamming_cost(terrain);
+				terrain_movement_info movement_info = 
+				{
+					info.name(),
+					info.id(),
+					100 - movement_type.defense_modifier(terrain),
+					moves,
+					movement_type.vision_cost(terrain),
+					movement_type.jamming_cost(terrain),
+					movement_type.get_defense().capped(terrain)
+				};
 
-				bool high_res = false;
-				const std::string tc_base = high_res ? "images/buttons/icon-base-32.png" : "images/buttons/icon-base-16.png";
-				const std::string terrain_image = "icons/terrain/terrain_type_" + id + (high_res ? "_30.png" : ".png");
+				terrain_moves.insert(movement_info);
+			}
+		}
 
-				const std::string final_image = tc_base + "~RC(magenta>" + id + ")~BLIT(" + terrain_image + ")";
+		for(const terrain_movement_info &terr_move : terrain_moves)
+		{
+			std::vector<item> row;
+			const std::string& name = terr_move.name;
+			const std::string& id = terr_move.id;
+			const int defense = terr_move.defense;
+			const int moves = terr_move.movement_cost;
+			const int views = terr_move.vision_cost;
+			const int jams  = terr_move.jamming_cost;
+			const bool has_cap = terr_move.defense_cap;
+			const bool cannot_move = moves > type_.movement();
 
-				row.emplace_back("<img>src='" + final_image + "'</img> " +
-						make_link(name, "..terrain_" + id),
-					font::line_width(name, normal_font_size) + (high_res ? 32 : 16) );
 
-				//defense  -  range: +10 % .. +70 %
-				const int defense = 100 - movement_type.defense_modifier(terrain);
-				std::string color;
-				if (defense <= 10) {
+			bool high_res = false;
+			const std::string tc_base = high_res ? "images/buttons/icon-base-32.png" : "images/buttons/icon-base-16.png";
+			const std::string terrain_image = "icons/terrain/terrain_type_" + id + (high_res ? "_30.png" : ".png");
+
+			const std::string final_image = tc_base + "~RC(magenta>" + id + ")~BLIT(" + terrain_image + ")";
+
+			row.emplace_back("<img>src='" + final_image + "'</img> " +
+					make_link(name, "..terrain_" + id),
+				font::line_width(name, normal_font_size) + (high_res ? 32 : 16) );
+
+			//defense  -  range: +10 % .. +70 %
+			std::string color;
+			if (defense <= 10) {
+				color = "red";
+			} else if (defense <= 30) {
+				color = "yellow";
+			} else if (defense <= 50) {
+				color = "white";
+			} else {
+				color = "green";
+			}
+
+			std::stringstream str;
+			str << "<format>color=" << color << " text='"<< defense << "%'</format>";
+			std::string markup = str.str();
+			str.str(clear_stringstream);
+			str << defense << "%";
+			row.emplace_back(markup, font::line_width(str.str(), normal_font_size));
+
+			//movement  -  range: 1 .. 5, movetype::UNREACHABLE=impassable
+			str.str(clear_stringstream);
+			if (cannot_move) {		// cannot move in this terrain
+				color = "red";
+			} else if (moves > 1) {
+				color = "yellow";
+			} else {
+				color = "white";
+			}
+			str << "<format>color=" << color << " text='";
+			// A 5 MP margin; if the movement costs go above
+			// the unit's max moves + 5, we replace it with dashes.
+			if(cannot_move && (moves > type_.movement() + 5)) {
+				str << font::unicode_figure_dash;
+			} else {
+				str << moves;
+			}
+			str << "'</format>";
+			markup = str.str();
+			str.str(clear_stringstream);
+			str << moves;
+			row.emplace_back(markup, font::line_width(str.str(), normal_font_size));
+
+			//defense cap
+			if (has_terrain_defense_caps) {
+				str.str(clear_stringstream);
+				if (has_cap) {
+					str << "<format>color='"<< color <<"' text='" << defense << "%'</format>";
+				} else {
+					str << "<format>color=white text='" << font::unicode_figure_dash << "'</format>";
+				}
+				markup = str.str();
+				str.str(clear_stringstream);
+				if (has_cap) {
+					str << defense << '%';
+				} else {
+					str << font::unicode_figure_dash;
+				}
+				row.emplace_back(markup, font::line_width(str.str(), normal_font_size));
+			}
+
+			//vision
+			if (has_vision) {
+				str.str(clear_stringstream);
+				const bool cannot_view = views > type_.vision();
+				if (cannot_view) {		// cannot view in this terrain
 					color = "red";
-				} else if (defense <= 30) {
+				} else if (views > moves) {
 					color = "yellow";
-				} else if (defense <= 50) {
+				} else if (views == moves) {
 					color = "white";
 				} else {
 					color = "green";
 				}
-
-				std::stringstream str;
-				str << "<format>color=" << color << " text='"<< defense << "%'</format>";
-				std::string markup = str.str();
-				str.str(clear_stringstream);
-				str << defense << "%";
-				row.emplace_back(markup, font::line_width(str.str(), normal_font_size));
-
-				//movement  -  range: 1 .. 5, movetype::UNREACHABLE=impassable
-				str.str(clear_stringstream);
-				if (cannot_move) {		// cannot move in this terrain
-					color = "red";
-				} else if (moves > 1) {
-					color = "yellow";
-				} else {
-					color = "white";
-				}
 				str << "<format>color=" << color << " text='";
-				// A 5 MP margin; if the movement costs go above
-				// the unit's max moves + 5, we replace it with dashes.
-				if(cannot_move && (moves > type_.movement() + 5)) {
+				// A 5 MP margin; if the vision costs go above
+				// the unit's vision + 5, we replace it with dashes.
+				if(cannot_view && (views > type_.vision() + 5)) {
 					str << font::unicode_figure_dash;
 				} else {
-					str << moves;
+					str << views;
 				}
 				str << "'</format>";
 				markup = str.str();
 				str.str(clear_stringstream);
-				str << moves;
+				str << views;
 				row.emplace_back(markup, font::line_width(str.str(), normal_font_size));
-
-				//defense cap
-				if (has_terrain_defense_caps) {
-					str.str(clear_stringstream);
-					const bool has_cap = movement_type.get_defense().capped(terrain);
-					if (has_cap) {
-						str << "<format>color='"<< color <<"' text='" << defense << "%'</format>";
-					} else {
-						str << "<format>color=white text='" << font::unicode_figure_dash << "'</format>";
-					}
-					markup = str.str();
-					str.str(clear_stringstream);
-					if (has_cap) {
-						str << defense << '%';
-					} else {
-						str << font::unicode_figure_dash;
-					}
-					row.emplace_back(markup, font::line_width(str.str(), normal_font_size));
-				}
-
-				//vision
-					if (has_vision) {
-						str.str(clear_stringstream);
-						const bool cannot_view = views > type_.vision();
-						if (cannot_view) {		// cannot view in this terrain
-							color = "red";
-						} else if (views > moves) {
-							color = "yellow";
-						} else if (views == moves) {
-							color = "white";
-						} else {
-							color = "green";
-						}
-						str << "<format>color=" << color << " text='";
-						// A 5 MP margin; if the vision costs go above
-						// the unit's vision + 5, we replace it with dashes.
-						if(cannot_view && (views > type_.vision() + 5)) {
-							str << font::unicode_figure_dash;
-						} else {
-							str << views;
-						}
-						str << "'</format>";
-						markup = str.str();
-						str.str(clear_stringstream);
-						str << views;
-						row.emplace_back(markup, font::line_width(str.str(), normal_font_size));
-					}
-
-				//jamming
-				if (has_jamming) {
-					str.str(clear_stringstream);
-					const bool cannot_jam = jams > type_.jamming();
-					if (cannot_jam) {		// cannot jamm in this terrain
-						color = "red";
-					} else if (jams > views) {
-						color = "yellow";
-					} else if (jams == views) {
-						color = "white";
-					} else {
-						color = "green";
-					}
-					str << "<format>color=" << color << " text='";
-					// A 5 MP margin; if the jamming costs go above
-					// the unit's jamming + 5, we replace it with dashes.
-					if ( cannot_jam  &&  jams > type_.jamming() + 5 ) {
-						str << font::unicode_figure_dash;
-					} else {
-						str << jams;
-					}
-					str << "'</format>";
-
-					push_tab_pair(row, str.str());
-				}
-
-				table.push_back(row);
 			}
-		}
 
+			//jamming
+			if (has_jamming) {
+				str.str(clear_stringstream);
+				const bool cannot_jam = jams > type_.jamming();
+				if (cannot_jam) {		// cannot jamm in this terrain
+					color = "red";
+				} else if (jams > views) {
+					color = "yellow";
+				} else if (jams == views) {
+					color = "white";
+				} else {
+					color = "green";
+				}
+				str << "<format>color=" << color << " text='";
+				// A 5 MP margin; if the jamming costs go above
+				// the unit's jamming + 5, we replace it with dashes.
+				if ( cannot_jam  &&  jams > type_.jamming() + 5 ) {
+					str << font::unicode_figure_dash;
+				} else {
+					str << jams;
+				}
+				str << "'</format>";
+
+				push_tab_pair(row, str.str());
+			}
+
+			table.push_back(row);
+		}
+		
 		ss << generate_table(table);
 	} else {
 		WRN_HP << "When building unit help topics, the display object was null and we couldn't get the terrain info we need.\n";
 	}
 	return ss.str();
 }
+
+
 
 void unit_topic_generator::push_header(std::vector< item > &row,  const std::string& name) const {
 	row.emplace_back(bold(name), font::line_width(name, normal_font_size, TTF_STYLE_BOLD));

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -583,6 +583,15 @@ static config unit_moves(reports::context & rc, const unit* u)
 	if (!u) return config();
 	std::ostringstream str, tooltip;
 	double movement_frac = 1.0;
+
+	auto movement_compare = [](std::pair<t_string, int> a, std::pair<t_string, int> b)
+	{
+		return a.first < b.first;
+	};
+
+	// terrain_moves pair: first: name, second: movement_cost
+	std::set<std::pair<t_string, int>, decltype(movement_compare)> terrain_moves(movement_compare);
+
 	if (u->side() == rc.screen().playing_side()) {
 		movement_frac = double(u->movement_left()) / std::max<int>(1, u->total_movement());
 		if (movement_frac > 1.0)
@@ -602,31 +611,34 @@ static config unit_moves(reports::context & rc, const unit* u)
 		const terrain_type& info = rc.map().get_terrain_info(terrain);
 
 		if (info.union_type().size() == 1 && info.union_type()[0] == info.number() && info.is_nonnull()) {
-
-			const std::string& name = info.name();
-			const int moves = u->movement_cost(terrain);
-
-			tooltip << name << ": ";
-
-			std::string color;
-			//movement  -  range: 1 .. 5, movetype::UNREACHABLE=impassable
-			const bool cannot_move = moves > u->total_movement();
-			if (cannot_move)		// cannot move in this terrain
-				color = "red";
-			else if (moves > 1)
-				color = "yellow";
-			else
-				color = "white";
-			tooltip << "<span foreground=\"" << color << "\">";
-			// A 5 MP margin; if the movement costs go above
-			// the unit's max moves + 5, we replace it with dashes.
-			if(cannot_move && (moves > u->total_movement() + 5)) {
-				tooltip << font::unicode_figure_dash;
-			} else {
-				tooltip << moves;
-			}
-			tooltip << naps << '\n';
+			terrain_moves.emplace(info.name(), u->movement_cost(terrain));
 		}
+	}
+
+	for(const std::pair<t_string, int> tm : terrain_moves)
+	{
+		const std::string name = tm.first;
+		const int moves = tm.second;
+		tooltip << name << ": ";
+		
+		std::string color;
+		//movement  -  range: 1 .. 5, movetype::UNREACHABLE=impassable
+		const bool cannot_move = moves > u->total_movement();
+		if (cannot_move)		// cannot move in this terrain
+			color = "red";
+		else if (moves > 1)
+			color = "yellow";
+		else
+			color = "white";
+		tooltip << "<span foreground=\"" << color << "\">";
+		// A 5 MP margin; if the movement costs go above
+		// the unit's max moves + 5, we replace it with dashes.
+		if(cannot_move && (moves > u->total_movement() + 5)) {
+			tooltip << font::unicode_figure_dash;
+		} else {
+			tooltip << moves;
+		}
+		tooltip << naps << '\n';
 	}
 
 	int grey = 128 + int((255 - 128) * movement_frac);

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -586,7 +586,7 @@ static config unit_moves(reports::context & rc, const unit* u)
 
 	auto movement_compare = [](std::pair<t_string, int> a, std::pair<t_string, int> b)
 	{
-		return a.first < b.first;
+		return translation::icompare(a.first, b.first) < 0;
 	};
 
 	// terrain_moves pair: first: name, second: movement_cost


### PR DESCRIPTION
Sort the movement costs in the tooltip in ascending order costs. First bases on movement costs, then alphabetically. Addresses https://github.com/wesnoth/wesnoth/issues/2673.