### PR TITLE
Bugfix for issue 3119

### DIFF
--- a/src/replay.cpp
+++ b/src/replay.cpp
@@ -860,7 +860,7 @@ bool do_replay_handle(game_display& disp, const gamemap& map, const game_data& g
 			//do nothing
 
 		} else if((child = cfg->child("speak")) != NULL) {
-			const std::string& team_name = (*child)["team_name"];
+			const std::string& team_name = (*child)["to_sides"];
 			if (team_name == "" || (!is_observer()
 					&& teams[disp.viewing_team()].team_name() == team_name)
 					|| (is_observer() && team_name == "observer"))


### PR DESCRIPTION
Fixing the lack of stars on the remote client when sending a team/observer message.
This commit didn't modify the necessary lines in replay.cpp:
https://github.com/wesnoth/wesnoth/commit/6aa3b3bc9a920638b68e6ceebd96a23822767c8d
(of which the chat_msg::chat_msg one has already been fixed)