### PR TITLE
Fix team chat not being marked as such on remote clients

### DIFF
--- a/src/replay.cpp
+++ b/src/replay.cpp
@@ -725,7 +725,7 @@ REPLAY_RETURN do_replay_handle(bool one_move)
 		}
 		else if (const config &speak = cfg->child("speak"))
 		{
-			const std::string &team_name = speak["team_name"];
+			const std::string &team_name = speak["to_sides"];
 			const std::string &speaker_name = speak["id"];
 			const std::string &message = speak["message"];
 			//if (!preferences::parse_should_show_lobby_join(speaker_name, message)) return;


### PR DESCRIPTION
https://github.com/wesnoth/wesnoth/issues/3119
Fixing the lack of stars on the remote client when sending a team/observer message.
This commit didn't modify the necessary lines in replay.cpp:
6aa3b3b
(of which the chat_msg::chat_msg one has already been fixed)