### PR TITLE
Fix the unit name and unit side flag tooltips (Thanks, Landiss!)

### DIFF
--- a/data/themes/default.cfg
+++ b/data/themes/default.cfg
@@ -463,7 +463,7 @@
                 ref=label-mp
                 id=unit-moves
                 font_size={DEFAULT_FONT_TINY}
-                rect="=,+0,=-5,+16"
+                rect="=,+0,=-5,+14"
                 prefix_literal=" "
                 xanchor=right
                 yanchor=fixed


### PR DESCRIPTION
https://github.com/wesnoth/wesnoth/issues/3306
Fixes this rectangle box breaking the tooltips for the unit_side flag and the unit name.