### PR TITLE
UI: Prefix tooltips with what kind of information they show

### DIFF
--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -212,8 +212,12 @@ static config unit_side(reports::context & rc, const unit* u)
 	std::stringstream text;
 	text << " " << u->side();
 
-	add_image(report, flag_icon + mods, u_team.side_name(), "");
-	add_text(report, text.str(), "", "");
+	std::ostringstream tooltip;
+	if (!u_team.side_name().empty()) {
+		tooltip << _("Side:") << " <b>" <<  u_team.side_name() << "</b>";
+	}
+	add_image(report, flag_icon + mods, tooltip.str(), "");
+	add_text(report, text.str(), tooltip.str(), "");
 	return report;
 }
 REPORT_GENERATOR(unit_side, rc)
@@ -562,10 +566,12 @@ static config unit_vision(const unit* u)
 	if (!u) return config();
 
 	// TODO
-	std::ostringstream str;
+	std::ostringstream str, tooltip;
 	if (u->vision() != u->total_movement()) {
-		str << _("vision: ") << u->vision(); }
-	return text_report(str.str());
+		str << _("vision:") << ' ' << u->vision();
+		tooltip << _("Vision:") << ' ' << u->vision();
+	}
+	return text_report(str.str(), tooltip.str());
 }
 REPORT_GENERATOR(unit_vision, rc)
 {
@@ -702,7 +708,7 @@ static int attack_info(reports::context & rc, const attack_type &at, config &res
 				tooltip << '\t' << _("With specials: ") << specials_damage << '\n';
 			}
 			if (tod_bonus) {
-				tooltip << '\t' << _("Time of day: ")
+				tooltip << '\t' << _("Time of day:") << ' '
 					<< utils::signed_percent(tod_bonus) << '\n';
 			}
 			if (leader_bonus) {
@@ -1077,6 +1083,7 @@ REPORT_GENERATOR(tod_stats, rc)
 
 	const std::vector<time_of_day>& schedule = rc.tod().times(hex);
 
+	tooltip << _("Time of day schedule:") << " \n";
 	int current = rc.tod().get_current_time(hex);
 	int i = 0;
 	for (const time_of_day& tod : schedule) {
@@ -1118,7 +1125,7 @@ static config time_of_day_at(reports::context & rc, const map_location& mouseove
 		chaotic_color = (b < 0) ? "green" : "red";
 		liminal_color = "red";
 	}
-	tooltip << tod.name << '\n'
+	tooltip << _("Time of day:") << " <b>" << tod.name << "</b>\n"
 		<< _("Lawful units: ") << "<span foreground=\"" << lawful_color  << "\">"
 		<< utils::signed_percent(b)  << "</span>\n"
 		<< _("Neutral units: ") << utils::signed_percent(0)  << '\n'

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -569,7 +569,12 @@ static config unit_vision(const unit* u)
 	std::ostringstream str, tooltip;
 	if (u->vision() != u->total_movement()) {
 		str << _("vision:") << ' ' << u->vision();
-		tooltip << _("Vision:") << ' ' << u->vision();
+		tooltip << _("Vision:") << ' ' << u->vision() << '\n';
+	}
+	if (u->jamming() != 0) {
+		if (str.tellp() == 0)
+			str << _("jamming:") << ' ' << u->jamming();
+		tooltip << _("Jamming:") << ' ' << u->jamming() << '\n';
 	}
 	return text_report(str.str(), tooltip.str());
 }


### PR DESCRIPTION
Having these prefixes is consistent with all other tooltips in the sidebar.

Also add a tooltip to vision because the label is truncated and there is no other way for the player to get the vision value.