### PR TITLE
Add WML unit test for unupgradable

### DIFF
--- a/data/test/scenarios/swarm_disables_upgrades.cfg
+++ b/data/test/scenarios/swarm_disables_upgrades.cfg
@@ -13,6 +13,7 @@
             [/filter]
             max_hitpoints=100
             hitpoints=100
+            attacks_left=1
         [/modify_unit]
         [object]
             silent=yes
@@ -73,11 +74,13 @@
                 increase_attacks=12
             [/effect]
         [/object]
+
         [store_unit]
             [filter]
                 id=alice
             [/filter]
             variable=a
+            kill=yes
         [/store_unit]
         [store_unit]
             [filter]
@@ -85,15 +88,27 @@
             [/filter]
             variable=b
         [/store_unit]
+        [unstore_unit]
+            variable=a
+            find_vacant=yes
+            x,y=$b.x,$b.y
+        [/unstore_unit]
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=a
+        [/store_unit]
+
         [do_command]
             [attack]
                 weapon=0
                 defender_weapon=0
                 [source]
-                    x,y=$b.x,$b.y
+                    x,y=$a.x,$a.y
                 [/source]
                 [destination]
-                    x,y=$a.x,$a.y
+                    x,y=$b.x,$b.y
                 [/destination]
             [/attack]
         [/do_command]

--- a/data/test/scenarios/swarm_disables_upgrades.cfg
+++ b/data/test/scenarios/swarm_disables_upgrades.cfg
@@ -1,0 +1,116 @@
+# This unit test defines a WML object based implementation of the "unupgradable" ability
+# https://github.com/ProditorMagnus/Ageless-for-1-14/blob/52c1eaf31722bb58046a1b459d4f29daa8d88487/data/general_data/weapon_specials/unupgradable.cfg
+# and checks that it works. What is being tested here is that
+# [swarm] with swarm_attacks_max=swarm_attacks_min prevents strike changes
+# - through [attacks]
+# - through [effect] increase_attacks
+
+{GENERIC_UNIT_TEST "swarm_disables_upgrades" (
+    [event]
+        name=start
+        [modify_unit]
+            [filter]
+            [/filter]
+            max_hitpoints=100
+            hitpoints=100
+        [/modify_unit]
+        [object]
+            silent=yes
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=append
+                    [swarm]
+                        swarm_attacks_max=1
+                        swarm_attacks_min=1
+                    [/swarm]
+                    [attacks]
+                        value=10
+                    [/attacks]
+                    [attacks]
+                        add=13
+                    [/attacks]
+                    [damage]
+                        value=1
+                    [/damage]
+                    [chance_to_hit]
+                        value=100
+                    [/chance_to_hit]
+                [/set_specials]
+            [/effect]
+            [filter]
+                id=bob
+            [/filter]
+        [/object]
+        [object]
+            silent=yes
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=append
+                    [attacks]
+                        value=10
+                    [/attacks]
+                    [damage]
+                        value=1
+                    [/damage]
+                    [chance_to_hit]
+                        value=100
+                    [/chance_to_hit]
+                [/set_specials]
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+        [object]
+            silent=yes
+            [filter]
+                id=bob
+            [/filter]
+            [effect]
+                apply_to=attack
+                increase_attacks=12
+            [/effect]
+        [/object]
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=a
+        [/store_unit]
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=b
+        [/store_unit]
+        [do_command]
+            [attack]
+                weapon=0
+                defender_weapon=0
+                [source]
+                    x,y=$b.x,$b.y
+                [/source]
+                [destination]
+                    x,y=$a.x,$a.y
+                [/destination]
+            [/attack]
+        [/do_command]
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=a
+        [/store_unit]
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=b
+        [/store_unit]
+        {ASSERT ({VARIABLE_CONDITIONAL a.hitpoints equals 99})}
+        {ASSERT ({VARIABLE_CONDITIONAL b.hitpoints equals 90})}
+        {SUCCEED}
+    [/event]
+)}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -127,6 +127,7 @@
 0 test_time_area_prestart
 0 test_berzerk_firststrike
 0 feeding
+0 swarm_disables_upgrades
 #
 # Deterministic unit facing tests
 0 recruit_facing_enemy_one


### PR DESCRIPTION
Current implementation of unupgradable relies on [swarm] overwriting all strike modifications. That is not documented behavior, so it makes sense to add a test for it.