### PR TITLE
Help: Hide abilities with empty names.

### DIFF
--- a/src/help/help_impl.cpp
+++ b/src/help/help_impl.cpp
@@ -547,6 +547,9 @@ std::vector<topic> generate_ability_topics(const bool sort_generated)
 	}
 
 	for(const auto& a : ability_topic_data) {
+		if (a.second->name.empty()) {
+			continue;
+		}
 		std::ostringstream text;
 		text << a.second->description;
 		text << "\n\n" << _("<header>text='Units with this ability'</header>") << "\n";


### PR DESCRIPTION
Fixes empty name abilities in help in Liberty S1.

I thought of adding support for `hide_help` for custom abilities but that might be overkill.