### PR TITLE
Tutorial S1: display an undo message if impossible to reach next target

### DIFF
--- a/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
+++ b/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
@@ -173,6 +173,19 @@
         ) (
             {PRINT ( _ "Click on Li’sar")}
         )}
+
+        # For undo warning always keep a list of target hexes in target_loc
+        # First find Delfador and let "check_undo" event use the hexes around him
+        [store_locations]
+            [filter]
+                side=3
+            [/filter]
+            variable=target_loc
+            radius=1          # hexes next to Delfador
+        [/store_locations]
+
+        # Set to 'no' if undo message is to be disabled temporarily
+        {VARIABLE enable_undo_messages yes}
     [/event]
 
     # HP stat tracking
@@ -192,6 +205,142 @@
                 wml.variables.student_hp_heal_amount = hp_diff
             >>
         [/lua]
+    [/event]
+
+    # Give a warning to undo last step if target is out of reach
+    # Check whether at least one of our units can reach any of the target_loc locations
+    [event]
+        name=moveto
+        id=check_undo
+        first_time_only=no
+        [filter]
+            side=1
+        [/filter]
+        [allow_undo][/allow_undo]
+
+        # Store all our units
+        [store_unit]
+            [filter]
+                side=1
+            [/filter]
+            variable=student_team
+        [/store_unit]
+
+        {VARIABLE within_reach no}
+        #{VARIABLE mindist 100} # kept for debugging
+
+        [store_locations]
+            [filter]
+                side=2
+            [/filter]
+            radius=1    # hexes around the quintain(s)
+            variable=target_enemies
+        [/store_locations]
+
+        # Combine the quintains' neighbourhood as targets with the actual quest targets so we don't alert for undo if the player
+        # wants to attack instead of following the narrative
+        # Resulting array of locations is all_targets
+        [lua]
+            code= <<
+                if wml.variables.target_enemies == nil then
+                    wml.variables.all_targets = wml.variables.target_loc
+                else
+                    local target_loc = wml.array_access.get('target_loc')
+                    local targets = wml.array_access.get('target_enemies')
+                    for k, v in pairs(target_loc) do
+                        table.insert(targets, v)
+                    end
+                    wml.array_access.set('all_targets', targets)
+                end
+            >>
+        [/lua]
+
+        [if]
+            {VARIABLE_CONDITIONAL enable_undo_messages boolean_equals yes}
+            [then]
+                [foreach]   # Check each unit
+                    array=student_team
+                    [do]
+                        {VARIABLE moves_left $this_item.moves}
+                        {VARIABLE student_team_member $this_item.id}
+
+                        # compare their movement points with the movement costs of the valid target locations
+                        [foreach]
+                            array=all_targets
+                            [do]
+                                [find_path]
+                                    [traveler]
+                                        id=$student_team_member
+                                    [/traveler]
+                                    [destination]
+                                        x=$this_item.x
+                                        y=$this_item.y
+                                    [/destination]
+                                    variable=curr_distance
+                                    allow_multiple_turns=yes
+                                    check_zoc=no
+                                [/find_path]
+
+                                # debug: unit distance calculations
+                                #[if]
+                                #    {VARIABLE_CONDITIONAL curr_distance.movement_cost less_than $mindist}
+                                #    [then]
+                                #        {VARIABLE mindist $curr_distance.movement_cost}
+                                #    [/then]
+                                #[/if]
+
+                                [if]
+                                    {VARIABLE_CONDITIONAL curr_distance.movement_cost less_than_equal_to $moves_left}
+                                    [then]
+                                        {VARIABLE within_reach yes}
+                                    [/then]
+                                [/if]
+                            [/do]
+                        [/foreach]
+                    [/do]
+                [/foreach]
+            [/then]
+        [/if]
+
+        # debug: display resulting shortest path between all units of side 1 and all target_loc hexes
+        #[lua]
+        #    code= <<
+        #        print("Min dist: " .. wml.variables.mindist)
+        #    >>
+        #[/lua]
+
+        [if]
+            {VARIABLE_CONDITIONAL within_reach boolean_equals no}
+            {VARIABLE_CONDITIONAL enable_undo_messages boolean_equals yes}
+            [then]
+                {PRINT (_ "To undo your last move, press <b>u</b> or use the right-click menu.")}
+                {VARIABLE undo_displayed yes}
+            [/then]
+        [/if]
+
+        # Clear undo message only if it is currently displayed and player performs undo
+        #  - so normal quest PRINTs are not cleared when the player does an undo on his own
+        # (Original message not restored yet after undo.)
+        [on_undo]
+            [if]
+                {VARIABLE_CONDITIONAL undo_displayed boolean_equals yes}
+                [then]
+                    {CLEAR_PRINT}
+                    {VARIABLE undo_displayed no}
+                [/then]
+            [/if]
+        [/on_undo]
+    [/event]
+
+    [event]
+        name=remove_check_undo
+        first_time_only=yes
+        [remove_event]
+            id=check_undo
+        [/remove_event]
+
+        {CLEAR_VARIABLE student_team,moves_left,student_team_member,curr_distance,target_loc,target_unit,all_targets}
+        {CLEAR_VARIABLE within_reach,undo_displayed,enable_undo_messages}
     [/event]
 
     [event]
@@ -499,6 +648,11 @@
             y=3,7
         [/label]
 
+        # Update targets for undo message: villages
+        [store_villages]
+            variable=target_loc
+        [/store_villages]
+
         {GENDER (
             {PRINT ( _ "Move Konrad to a nearby village")}
         ) (
@@ -567,6 +721,12 @@
             y=6
         [/label]
 
+        # Update targets for undo message: keep
+        [store_locations]
+            variable=target_loc
+            x,y=9,6
+        [/store_locations]
+
         {GENDER (
             {PRINT ( _ "Move Konrad to the keep")}
         ) (
@@ -617,6 +777,9 @@
                 message= _"Be sure to examine the <i>traits</i> of your new recruits. They are listed under its race in the sidebar. Traits can subtly affect how you use your troops. For example, units with the <i>quick</i> trait can move a extra hex each turn, and units with the <i>intelligent</i> trait require 20% less experience to level up."
             [/message]
 
+            # Allow our hero to move freely until next turn without undo messages now that the recruiting is done
+            {VARIABLE enable_undo_messages no}
+
             [allow_end_turn][/allow_end_turn]
 
             {PRINT ( _ "End your turn")}
@@ -641,6 +804,16 @@
                 id=Quintain
             [/have_unit]
         [/filter_condition]
+
+        # Update undo target: quintain and its surrounding hexes
+        {VARIABLE enable_undo_messages yes}
+        [store_locations]
+            [filter]
+                side=2
+            [/filter]
+            variable=target_loc
+            radius=1    # hexes next to the first quintain
+        [/store_locations]
 
         [disallow_end_turn][/disallow_end_turn]
 
@@ -704,6 +877,11 @@
 
             # After this, we no longer need to restrict turn endings
             [allow_end_turn][/allow_end_turn]
+
+            # Now our hero is free to wander around without undo warnings - clean up
+            [fire_event]
+                name=remove_check_undo
+            [/fire_event]
         [/event]
 
         [event]
@@ -870,6 +1048,12 @@
         # This is for debug purposes, so anyone using console commands doesn't get stuck
         # and unable to end their turn. It should have no affect on normal gameplay.
         [allow_end_turn][/allow_end_turn]
+
+        # Debug or not, from now on our hero is free to wander - don't warn about undo
+        # (there is one corner case when it would still be useful)
+        [fire_event]
+            name=remove_check_undo
+        [/fire_event]
 
         [message]
             speaker=second_unit


### PR DESCRIPTION
Fixes #3039

Until the elves attack the quintain it is not allowed to end turns before
completing the given tasks. Display a message how to undo if there is
not enough MP remaining to reach the current destination by either unit.