### PR TITLE
Show "failed to fit" message with single timestamp

### DIFF
--- a/src/gui/widgets/generator.cpp
+++ b/src/gui/widgets/generator.cpp
@@ -169,9 +169,9 @@ void horizontal_list::place(const point& origin, const point& size)
 	}
 
 	if(current_origin.x != origin.x + size.x) {
-		ERR_GUI_L << "Failed to fit horizontal list to requested rect; expected right edge was " << origin.x + size.x;
-		ERR_GUI_L << ", actual right edge was " << current_origin.x;
-		ERR_GUI_L << " (left edge is " << origin.x << ")\n";
+		ERR_GUI_L << "Failed to fit horizontal list to requested rect; expected right edge was " << origin.x + size.x
+		          << ", actual right edge was " << current_origin.x
+		          << " (left edge is " << origin.x << ")\n";
 	}
 }
 
@@ -380,9 +380,9 @@ void vertical_list::place(const point& origin, const point& size)
 	}
 
 	if(current_origin.y != origin.y + size.y) {
-		ERR_GUI_L << "Failed to fit vertical list to requested rect; expected bottom edge was " << origin.y + size.y;
-		ERR_GUI_L << ", actual bottom edge was " << current_origin.y;
-		ERR_GUI_L << " (top edge is " << origin.y << ")\n";
+		ERR_GUI_L << "Failed to fit vertical list to requested rect; expected bottom edge was " << origin.y + size.y
+		          << ", actual bottom edge was " << current_origin.y
+		          << " (top edge is " << origin.y << ")\n";
 	}
 }
 


### PR DESCRIPTION
Before 20180724 17:21:37 error gui/layout: Failed to fit vertical list to requested rect; expected bottom edge was 27720180724 17:21:37 error gui/layout: , actual bottom edge was 19520180724 17:21:37 error gui/layout:  (top edge is 113)
After 20180724 17:34:30 error gui/layout: Failed to fit vertical list to requested rect; expected bottom edge was 277, actual bottom edge was 195 (top edge is 113)