### PR TITLE
Fix sorting of units by level in Recall List and Unit List.

### DIFF
--- a/src/gui/dialogs/unit_list.cpp
+++ b/src/gui/dialogs/unit_list.cpp
@@ -166,7 +166,7 @@ void unit_list::pre_show(window& window)
 	list.register_sorting_option(3, [this](const int i) { return unit_list_[i]->hitpoints(); });
 	list.register_sorting_option(4, [this](const int i) {
 		const unit& u = *unit_list_[i];
-		return std::make_tuple(u.level(), u.experience_to_advance());
+		return std::make_tuple(u.level(), -u.experience_to_advance());
 	});
 	list.register_sorting_option(5, [this](const int i) { return unit_list_[i]->experience(); });
 	list.register_translatable_sorting_option(6, [this](const int i) {

--- a/src/gui/dialogs/unit_list.cpp
+++ b/src/gui/dialogs/unit_list.cpp
@@ -166,7 +166,7 @@ void unit_list::pre_show(window& window)
 	list.register_sorting_option(3, [this](const int i) { return unit_list_[i]->hitpoints(); });
 	list.register_sorting_option(4, [this](const int i) {
 		const unit& u = *unit_list_[i];
-		return std::make_tuple(-u.level(), u.experience_to_advance());
+		return std::make_tuple(u.level(), u.experience_to_advance());
 	});
 	list.register_sorting_option(5, [this](const int i) { return unit_list_[i]->experience(); });
 	list.register_translatable_sorting_option(6, [this](const int i) {

--- a/src/gui/dialogs/unit_recall.cpp
+++ b/src/gui/dialogs/unit_recall.cpp
@@ -235,7 +235,7 @@ void unit_recall::pre_show(window& window)
 	list.register_translatable_sorting_option(1, [this](const int i) { return recall_list_[i]->name().str(); });
 	list.register_sorting_option(2, [this](const int i) {
 		const unit& u = *recall_list_[i];
-		return std::make_tuple(-u.level(), u.experience_to_advance());
+		return std::make_tuple(u.level(), u.experience_to_advance());
 	});
 	list.register_sorting_option(3, [this](const int i) { return recall_list_[i]->experience(); });
 	list.register_translatable_sorting_option(4, [this](const int i) {

--- a/src/gui/dialogs/unit_recall.cpp
+++ b/src/gui/dialogs/unit_recall.cpp
@@ -235,7 +235,7 @@ void unit_recall::pre_show(window& window)
 	list.register_translatable_sorting_option(1, [this](const int i) { return recall_list_[i]->name().str(); });
 	list.register_sorting_option(2, [this](const int i) {
 		const unit& u = *recall_list_[i];
-		return std::make_tuple(u.level(), u.experience_to_advance());
+		return std::make_tuple(u.level(), -u.experience_to_advance());
 	});
 	list.register_sorting_option(3, [this](const int i) { return recall_list_[i]->experience(); });
 	list.register_translatable_sorting_option(4, [this](const int i) {


### PR DESCRIPTION
Now the triangle points down when the list is sorted by level descending.