### PR TITLE
THoT S6: Now that the player is told which hut to look at, don't trigger Ratheln if the player ignores the hint.

### DIFF
--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/06_High_Pass.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/06_High_Pass.cfg
@@ -275,9 +275,9 @@
         [filter]
             side=1
             [filter_location]
-                # Should be triggered regardless of how the Dwarves move through.
-                x=18-21
-                y=0-21
+                # The player was given a hint to check this particular hut out
+                x,y=19,10
+                {QUANTITY radius 4 3 2}
             [/filter_location]
         [/filter]
 


### PR DESCRIPTION
From https://github.com/wesnoth/wesnoth/pull/3395#issuecomment-408688252

The radius values may need balancing.