### PR TITLE
Saurian Race Description

### DIFF
--- a/data/core/units.cfg
+++ b/data/core/units.cfg
@@ -247,7 +247,24 @@ The Dunefolk’s inquisitive and explorative nature does not preclude military s
         male_name= _ "race^Saurian"
         female_name= _ "race+female^Saurian"
         plural_name= _ "race^Saurians"
-        description= "" # wmllint: ignore
+        description= "Saurians are lizard-like creatures. Smaller and more slender than humans, they rarely stand taller than a ten year old child, though from tip of snout to end of tail a Saurian can be as long as the average man is tall. Light and nimble, the warriors prefer to fight as they hunt — slipping through enemy lines to target the weak and the injured while evading their attackers.
+
+<header>text='Society'</header>
+Saurians are very mysterious creatures due to their tendency to live in areas inhospitable to others, such as swamps. Fatalistic in the extreme, Saurians believe all the events in a life can be predicted by the use of a complex form of astrology.
+
+Saurian culture is sharply segregated between the genders. Within each gender the members compete, and through skill, determination, and reputation establish a clear pecking order, with a chief at the top. On those occasions when the two genders interact they do not contest for dominance; instead, the situation determines the dominant gender. The chief of the males is alpha within the clan's village or encampment while the chief of females is dominant anywhere else. This continues down the rank structure with each male or female being dominant over any member of the opposite gender with lower rank and submitting to members of the opposite gender with higher rank.
+
+The segregation and alternating gender-dominance of Saurian society is an outgrowth of their clearly defined gender roles. It is the responsibility of the female to hunt and find food, skills which ultimately train them to be warriors: the skirmishers, flankers, and ambushers other races so fear. Males, meanwhile, are responsible for guarding the clutch — the eggs left by the females. While this leaves time for the males to develop and hone the arts of astrology, healing, and magic, it also exposes them to significant danger, as they are stationary targets for a Saurian clan's number one enemy — other Saurian clans.
+
+New Saurian clans are started when the proper astrological signs are read. Called a “hatching,” each female indicated by the conjunction selects a group of individuals with lower rank and leave their source clan. Frequently all females with a specific trait will be indicated, causing multiple clans to “hatch” at the same time. Selection is a simple process: no group leaving can be larger than any other, all the groups together cannot be larger than the group being left, and higher ranking allows a female to overrule another female's choice of who they take.
+
+Because of their rapid population growth, frequent splits in clans, and the fact that cannibalism is not taboo, violence is one of the defining features of Saurian life. This limits the growth of the Saurian culture to fits and starts, as much of their knowledge is passed by oral tradition and their possessions must be mobile.
+
+<header>text='Geography'</header>
+Saurians can live in many different areas, though swamps are by far their most common habitat.
+
+<header>text='Biology'</header>
+Saurians live spectacularly short lives by comparison to most of the other races of Wesnoth, reaching full adulthood within three years and often dying by the time they are 10 to 15 years old. By far, the most common cause of death is violence. Saurian females produce clutches of about 20 eggs roughly once a year, which creates constant population pressure and would stress most carnivores' food supply. Hunters and scavengers, Saurians have extremely strong jaws and have a very powerful digestive system with highly acidic fluids, making them capable of eating and digesting all of their prey including skin, teeth, horns and bones. Further, they have no aversion to eating carrion and even committing cannibalism, which are both regular occurrences."
         num_traits=2
         undead_variation=saurian
         #Tentative list of fricative heavy lizard names


### PR DESCRIPTION
Fixes #3372  (fix for #3392 to be later for master only)

Gives the Saurians a race description (taken from the wiki, with the minor change of comparing height against humans instead of drakes) The wiki description has been around for several years.

Has the Saurian warrior line be female, in accordance with the new race description, some lore in SotA and some UMC campaigns, which have likely gotten this from the wiki.