### PR TITLE
Slightly rewrite dialogue (fixes #3386)

### DIFF
--- a/data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg
@@ -408,7 +408,7 @@
                 [/message]
                 [message]
                     speaker=narrator
-                    message= _ "On Father Morvin’s advice, the Council approached all the different orcish tribes and made treaties with them. If a chieftain refused to cooperate with the Alliance, he was forcibly removed from his post and another more favorably disposed put in his place."
+                    message= _ "On Father Morvin’s advice, the Council approached all the different orcish tribes and made treaties with them. If a chieftain refused to cooperate with the Alliance, he was forcibly removed from his post and a more favorably-disposed leader put in his place."
                     image=wesnoth-icon.png
                 [/message]
                 [message]
@@ -429,7 +429,7 @@
                 [/message]
                 [message]
                     speaker=narrator
-                    message= _ "On Father Morvin’s advice, the Council approached all the different orcish tribes and made treaties with them. If a chieftain refused to cooperate with the Alliance, he was forcibly removed from his post and another more favorably disposed put in his place."
+                    message= _ "On Father Morvin’s advice, the Council approached all the different orcish tribes and made treaties with them. If a chieftain refused to cooperate with the Alliance, he was forcibly removed from his post and a more favorably-disposed leader put in his place."
                     image=wesnoth-icon.png
                 [/message]
             [/else]


### PR DESCRIPTION
Some non-native English readers may find use of the word 'disposed' confusing.

(Using PR because I'm not sure of the process surrounding string freezes.)