### PR TITLE
SoF S9: Rephrase the intro text (fixes #3405)

### DIFF
--- a/data/campaigns/Sceptre_of_Fire/scenarios/9_Caverns_of_Flame.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/9_Caverns_of_Flame.cfg
@@ -157,7 +157,8 @@
 
     [story]
         [part]
-            story= _ "There was no exit from the caverns of Knalga. They had reached the realms of the orcs, with the elves hot on their trail. And there was no exit from those caves."
+            # po: The text in 1.14.4 mentioned Knalga. Geographically, these caves are in Knalga, but the text was confusing if the reader thought of the Knalgan Alliance.
+            story= _ "There was no exit for the dwarves. They had reached the realms of the orcs, with the elves hot on their trail. There was truly no exit from these caves."
         [/part]
         [part]
             story= _ "So the dwarves had no way out. They could not leave the caverns that they had entered."


### PR DESCRIPTION
The original text that referred to Knalga was confusing if the
player thought of Knalga as "dwarvish territory", and most of
the campaign's scenarios have been somewhere in Knalga.