### PR TITLE
Menu: re-order and re-rank campaigns (including new ranks) (fixes #1222)

### DIFF
--- a/data/campaigns/An_Orcish_Incursion/_main.cfg
+++ b/data/campaigns/An_Orcish_Incursion/_main.cfg
@@ -10,14 +10,14 @@
     image="data/campaigns/An_Orcish_Incursion/images/campaign_image.png"
     name= _ "An Orcish Incursion"
     abbrev= _ "AOI"
-    rank=10
+    rank=15
     start_year="8 YW"
     end_year="9 YW"
     first_scenario=01_Defend_the_Forest
     define="CAMPAIGN_AN_ORCISH_INCURSION"
     description=_ "Defend the forests of the elves against the first orcs to reach the Great Continent, learning valuable tactics as you do so.
 
-" + _"(Novice level, 7 scenarios.)"
+" + _"(Rookie level, 7 scenarios.)"
 
     {CAMPAIGN_DIFFICULTY EASY   "units/elves-wood/fighter.png~RC(magenta>red)" ( _ "Fighter") ( _ "Beginner")}
     {CAMPAIGN_DIFFICULTY NORMAL "units/elves-wood/lord.png~RC(magenta>red)" ( _ "Lord") ( _ "Normal")} {DEFAULT_DIFFICULTY}

--- a/data/campaigns/Dead_Water/_main.cfg
+++ b/data/campaigns/Dead_Water/_main.cfg
@@ -6,7 +6,7 @@
 # wmlscope: set export=no
 [campaign]
     id=Dead_Water
-    rank=170
+    rank=110
     start_year="626 YW"
     end_year="627 YW"
     icon="units/undead/soulless-swimmer.png~RC(magenta>blue)"

--- a/data/campaigns/Delfadors_Memoirs/_main.cfg
+++ b/data/campaigns/Delfadors_Memoirs/_main.cfg
@@ -21,7 +21,7 @@
     define=CAMPAIGN_DELFADORS_MEMOIRS
     name= _ "Delfador’s Memoirs"
     abbrev=_ "DM"
-    rank=160
+    rank=115
     start_year="468 YW"
     end_year="470 YW"
     icon="units/human-magi/elder-mage.png~RC(magenta>red)"

--- a/data/campaigns/Descent_Into_Darkness/_main.cfg
+++ b/data/campaigns/Descent_Into_Darkness/_main.cfg
@@ -6,7 +6,7 @@
 # wmlscope: set export=no
 [campaign]
     id=Descent_into_Darkness
-    rank=150
+    rank=100
     start_year="389 YW"
     end_year="390 YW"
     icon="data/campaigns/Descent_Into_Darkness/images/units/dark-mage.png~RC(magenta>red)"

--- a/data/campaigns/Eastern_Invasion/_main.cfg
+++ b/data/campaigns/Eastern_Invasion/_main.cfg
@@ -6,7 +6,7 @@
 # wmlscope: set export=no
 [campaign]
     id=Eastern_Invasion
-    rank=130
+    rank=60
     start_year="625 YW"
     end_year="627 YW"
     icon="units/human-loyalists/general.png~RC(magenta>red)"
@@ -21,7 +21,7 @@
 
     description= _ "There are rumors of undead attacks on the eastern border of Wesnoth. You, an officer in the Royal Army, have been sent to the eastern front to protect the villagers and find out what is happening.
 
-" + _"(Intermediate level, 16 scenarios.)"
+" + _"(Novice level, 16 scenarios.)"
     image="data/campaigns/Eastern_Invasion/images/campaign_image.png"
 
     [about]

--- a/data/campaigns/Heir_To_The_Throne/_main.cfg
+++ b/data/campaigns/Heir_To_The_Throne/_main.cfg
@@ -10,7 +10,7 @@
     icon="data/campaigns/Heir_To_The_Throne/images/units/konrad-lord-leading.png"
     image="data/campaigns/Heir_To_The_Throne/images/campaign_image.png"
     abbrev= _ "HttT"
-    rank=20
+    rank=50
     start_year="517 YW"
     end_year="518 YW"
     define=CAMPAIGN_HEIR_TO_THE_THRONE

--- a/data/campaigns/Legend_of_Wesmere/_main.cfg
+++ b/data/campaigns/Legend_of_Wesmere/_main.cfg
@@ -31,7 +31,7 @@
     extra_defines=ENABLE_DWARVISH_RUNESMITH
     id=LOW
     define=CAMPAIGN_LOW
-    rank=150
+    rank=160
     start_year="20 YW"
     end_year="93 YW"
 

--- a/data/campaigns/Legend_of_Wesmere/_main.cfg
+++ b/data/campaigns/Legend_of_Wesmere/_main.cfg
@@ -31,7 +31,7 @@
     extra_defines=ENABLE_DWARVISH_RUNESMITH
     id=LOW
     define=CAMPAIGN_LOW
-    rank=125
+    rank=150
     start_year="20 YW"
     end_year="93 YW"
 
@@ -50,7 +50,7 @@
     name=_ "Legend of Wesmere"
     description=_ "The tale of Kalenz, the High Lord who rallied his people after the second orcish invasion of the Great Continent and became the most renowned hero in the recorded history of the Elves.
 
-" + _"(Intermediate level, 18 scenarios.)"
+" + _"(Hard level, 18 scenarios.)"
 
     {CAMPAIGN_DIFFICULTY EASY   "units/elves-wood/fighter.png~RC(magenta>brown)" ( _ "Soldier") ( _ "Easy")}
     {CAMPAIGN_DIFFICULTY NORMAL "units/elves-wood/lord.png~RC(magenta>brown)" ( _ "Lord") ( _ "Normal")} {DEFAULT_DIFFICULTY}

--- a/data/campaigns/Liberty/_main.cfg
+++ b/data/campaigns/Liberty/_main.cfg
@@ -9,7 +9,7 @@
     id=Liberty
     name= _ "Liberty"
     abbrev= _ "Liberty"
-    rank=110
+    rank=55
     year="501 YW"
     first_scenario=01_The_Raid
     define=CAMPAIGN_LIBERTY
@@ -25,7 +25,7 @@
     # wmllint: local spelling marchlanders
     description= _ "As the shadow of civil war lengthens across Wesnoth, a band of hardy marchlanders revolts against the tyranny of Queen Asheviere. To win their way to freedom, they must defeat not just the trained blades of Wesnothian troops but darker foes including orcs and undead.
 
-" + _"(Intermediate level, 8 scenarios.)"
+" + _"(Novice level, 8 scenarios.)"
 
     [about]
         title = _ "Campaign Design"

--- a/data/campaigns/Northern_Rebirth/_main.cfg
+++ b/data/campaigns/Northern_Rebirth/_main.cfg
@@ -8,7 +8,7 @@
     id=Northern_Rebirth
     name= _ "Northern Rebirth"
     abbrev= _ "NR"
-    rank=215
+    rank=210
     start_year="534 YW"
     end_year="535 YW"
     first_scenario=01_Breaking_the_Chains

--- a/data/campaigns/Northern_Rebirth/_main.cfg
+++ b/data/campaigns/Northern_Rebirth/_main.cfg
@@ -8,7 +8,7 @@
     id=Northern_Rebirth
     name= _ "Northern Rebirth"
     abbrev= _ "NR"
-    rank=240
+    rank=215
     start_year="534 YW"
     end_year="535 YW"
     first_scenario=01_Breaking_the_Chains

--- a/data/campaigns/Sceptre_of_Fire/_main.cfg
+++ b/data/campaigns/Sceptre_of_Fire/_main.cfg
@@ -10,7 +10,7 @@
     image="data/campaigns/Sceptre_of_Fire/images/campaign_image.png"
     name= _ "The Sceptre of Fire"
     abbrev= _ "SoF"
-    rank=215
+    rank=155
     start_year="25 YW"
     end_year="40 YW"
     define="CAMPAIGN_SCEPTRE_FIRE"
@@ -31,7 +31,7 @@ The Fire-sceptre great —
 And of the makers of the same,
 Their tale I now relate...</i>
 
-" + _"(Expert level, 9 scenarios.)"
+" + _"(Hard level, 9 scenarios.)"
 
     description_alignment = "center"
 

--- a/data/campaigns/Secrets_of_the_Ancients/_main.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/_main.cfg
@@ -9,7 +9,7 @@
     icon="data/campaigns/Secrets_of_the_Ancients/images/units/ancient-lich/ancient-lich.png~RC(magenta>red)"
     name= _ "Secrets of the Ancients"
     abbrev= _ "SotA"
-    rank=160
+    rank=165
     start_year="22 YW"
     end_year="23 YW"
     first_scenario=01_Slipping_Away

--- a/data/campaigns/Secrets_of_the_Ancients/_main.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/_main.cfg
@@ -9,7 +9,7 @@
     icon="data/campaigns/Secrets_of_the_Ancients/images/units/ancient-lich/ancient-lich.png~RC(magenta>red)"
     name= _ "Secrets of the Ancients"
     abbrev= _ "SotA"
-    rank=180
+    rank=160
     start_year="22 YW"
     end_year="23 YW"
     first_scenario=01_Slipping_Away
@@ -20,7 +20,7 @@
     define=CAMPAIGN_SECRETS_OF_THE_ANCIENTS
     description= _ "Rediscover the secrets known by the lich lords of the Green Isle. They knew how to live forever, so why can't you?
 
-(Intermediate level, 21 scenarios.)
+(Hard level, 21 scenarios.)
 "
     image="data/campaigns/Secrets_of_the_Ancients/images/portraits/campaign-image.png"
 

--- a/data/campaigns/Son_Of_The_Black_Eye/_main.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/_main.cfg
@@ -8,7 +8,7 @@
     id=Son_of_the_Black-Eye
     name= _ "Son of the Black-Eye"
     abbrev= _ "SotBE"
-    rank=220
+    rank=200
     start_year="842 YW"
     end_year="858 YW"
     first_scenario=01_End_of_Peace

--- a/data/campaigns/The_Hammer_of_Thursagan/_main.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/_main.cfg
@@ -10,7 +10,7 @@
     name= _ "The Hammer of Thursagan"
     image="data/campaigns/The_Hammer_of_Thursagan/images/campaign_image.png"
     abbrev= _ "THoT"
-    rank=140
+    rank=105
     start_year="550 YW"
     end_year="551 YW"
     define=CAMPAIGN_THE_HAMMER_OF_THURSAGAN

--- a/data/campaigns/The_Rise_Of_Wesnoth/_main.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/_main.cfg
@@ -6,7 +6,7 @@
 # wmlscope: set export=no
 [campaign]
     id=The_Rise_of_Wesnoth
-    rank=230
+    rank=205
     start_year="2 BW"
     end_year="1 YW"
     name= _ "The Rise of Wesnoth"

--- a/data/campaigns/The_Rise_Of_Wesnoth/_main.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/_main.cfg
@@ -6,7 +6,7 @@
 # wmlscope: set export=no
 [campaign]
     id=The_Rise_of_Wesnoth
-    rank=205
+    rank=150
     start_year="2 BW"
     end_year="1 YW"
     name= _ "The Rise of Wesnoth"
@@ -23,7 +23,7 @@
 
     description= _ "Lead Prince Haldric through the destruction of the Green Isle and across the Ocean to establish the very kingdom of Wesnoth itself. The confrontation with Lich-Lord Jevyan awaits...
 
-" + _"(Expert level, 24 scenarios.)"
+" + _"(Hard level, 24 scenarios.)"
 
     [about]
         title = _ "Campaign Design"

--- a/data/campaigns/The_South_Guard/_main.cfg
+++ b/data/campaigns/The_South_Guard/_main.cfg
@@ -10,7 +10,7 @@
     abbrev= _ "TSG"
 
     define=CAMPAIGN_THE_SOUTH_GUARD
-    rank=15
+    rank=10
     start_year="607 YW"
     end_year="608 YW"
 
@@ -20,7 +20,7 @@
 
 Note: This campaign is designed as an introduction to Wesnoth. The ‘Civilian’ difficulty level is aimed at first-time players.
 
-" + _"(Novice level, 9 scenarios.)"
+" + _"(Rookie level, 9 scenarios.)"
 
     {CAMPAIGN_DIFFICULTY EASY   "units/human-peasants/peasant.png~RC(magenta>red)" ( _ "Civilian") ( _ "Beginner")}
     {CAMPAIGN_DIFFICULTY NORMAL "units/human-loyalists/spearman.png~RC(magenta>red)" ( _ "Recruit") ( _ "Easy")} {DEFAULT_DIFFICULTY}

--- a/data/campaigns/Two_Brothers/_main.cfg
+++ b/data/campaigns/Two_Brothers/_main.cfg
@@ -20,7 +20,7 @@
 
     description= _ "An evil mage is threatening the small village of Maghre and its inhabitants. The village’s mage sends to his warrior brother for help, but not all goes as planned. Can you help?
 
-" + _"(Novice level, 4 scenarios.)"
+" + _"(Rookie level, 4 scenarios.)"
 
     [about]
         images = "story/Two_Brothers_M1P1.png,story/Two_Brothers_M1P2.png,story/Two_Brothers_M2P1.png,story/Two_Brothers_M4P1_the_end.png"

--- a/data/campaigns/Under_the_Burning_Suns/_main.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/_main.cfg
@@ -12,7 +12,7 @@
     icon="data/campaigns/Under_the_Burning_Suns/images/units/quenoth/kaleh.png~RC(magenta>red)"
     image="data/campaigns/Under_the_Burning_Suns/images/campaign_image.png"
     abbrev= _ "UtBS"
-    rank=250
+    rank=210
     year="300 AF"
     define=CAMPAIGN_UNDER_THE_BURNING_SUNS
     first_scenario=01_The_Morning_After

--- a/data/campaigns/Under_the_Burning_Suns/_main.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/_main.cfg
@@ -12,7 +12,7 @@
     icon="data/campaigns/Under_the_Burning_Suns/images/units/quenoth/kaleh.png~RC(magenta>red)"
     image="data/campaigns/Under_the_Burning_Suns/images/campaign_image.png"
     abbrev= _ "UtBS"
-    rank=210
+    rank=205
     year="300 AF"
     define=CAMPAIGN_UNDER_THE_BURNING_SUNS
     first_scenario=01_The_Morning_After


### PR DESCRIPTION
Fixes #1222.

Note that the wiki's description of "rank" on the CampaignWML page will need to be updated, though I don't have a wiki account or the knowledge of how that's supposed to go (I suppose it'd be the addition of one of those "if version XYZ or later:" blocks?).

For ease of comparison, here's a before and after summary of each campaign's rank and category, along with the wiki text:

BEFORE
```
Novice:
    5 A Tale of Two Brothers
   10 An Orcish Incursion
   15 The South Guard
   20 Heir to the Throne
Intermediate:
  110 Liberty
  125 Legend of Wesmere
  130 Eastern Invasion
  140 The Hammer of Thursagan
  150 Descent into Darkness
  160 Delfador's Memoirs
  170 Dead Water
  180 Secrets of the Ancients
Expert:
  215 The Sceptre of Fire
  220 Son of the Black-Eye
  230 The Rise of Wesnoth
  240 Northern Rebirth
  250 Under the Burning Suns
```

CampaignWML:
  rank: a number that determines the order of campaigns in the campaign selection menu. Lower rank campaigns appear earlier, with unranked campaigns at the end. Currently the mainline campaigns use multiples of 10 from 0 to 399, with 0-99 for Novice campaigns, 100-199 for Intermediate campaigns, and 200-399 for Expert campaigns; if you specify this, it should not be less than 400. (Note: This replaces an older convention that topped out at 50.)

AFTER
```
Rookie:
    5 A Tale of Two Brothers
   10 The South Guard
   15 An Orcish Incursion
Novice:
   50 Heir to the Throne
   55 Liberty
   60 Eastern Invasion
Intermediate:
  100 Descent into Darkness
  105 The Hammer of Thursagan
  110 Dead Water
  115 Delfador's Memoirs
Hard:
  150 Legend of Wesmere
  155 The Sceptre of Fire
  160 Secrets of the Ancients
Expert:
  200 Son of the Black-Eye
  205 The Rise of Wesnoth
  210 Under the Burning Suns
  215 Northern Rebirth
```

CampaignWML:
  rank: a number that determines the order of campaigns in the campaign selection menu. Lower rank campaigns appear earlier, with unranked campaigns at the end. Currently the mainline campaigns use multiples of 5 from 0 to 249, with 0-49 for Rookie campaigns, 50-99 for Novice campaigns, 100-149 for Intermediate campaigns, 150-199 for Hard campaigns, and 200-249 for Expert campaigns; if you specify this, it should not be less than 300.
