### PR TITLE
Better os version handling

### DIFF
--- a/projectfiles/Xcode/Wesnoth.xcodeproj/project.pbxproj
+++ b/projectfiles/Xcode/Wesnoth.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		46BED4DA2050711600842FA5 /* scenario-story.cfg in Copy Data Files */ = {isa = PBXBuildFile; fileRef = 46BED4D92050710800842FA5 /* scenario-story.cfg */; };
 		46EEFB7220872C5E00E1E75A /* chat_log.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46EEFB7020872C5D00E1E75A /* chat_log.cpp */; };
 		46EEFB7320872C5E00E1E75A /* chat_log.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46EEFB7020872C5D00E1E75A /* chat_log.cpp */; };
+		46F54C27211DFB7200374A1C /* apple_version.mm in Sources */ = {isa = PBXBuildFile; fileRef = 46F54C26211DFB7200374A1C /* apple_version.mm */; };
 		46F57084205FCE34007031BF /* base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 469BDB53205C357400DBF748 /* base64.cpp */; };
 		46F57085205FCE48007031BF /* crypt_blowfish.c in Sources */ = {isa = PBXBuildFile; fileRef = 46BED4D1205060EA00842FA5 /* crypt_blowfish.c */; };
 		46F57086205FCE79007031BF /* hash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B52EE8AD121359A600CFBDAB /* hash.cpp */; };
@@ -1455,6 +1456,8 @@
 		46DF5BCC1F46173700BE6D24 /* irdya_datetime.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = irdya_datetime.cpp; sourceTree = "<group>"; };
 		46EEFB7020872C5D00E1E75A /* chat_log.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = chat_log.cpp; sourceTree = "<group>"; };
 		46EEFB7120872C5D00E1E75A /* chat_log.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = chat_log.hpp; sourceTree = "<group>"; };
+		46F54C26211DFB7200374A1C /* apple_version.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = apple_version.mm; path = ../../src/desktop/apple_version.mm; sourceTree = "<group>"; };
+		46F54C28211DFB9100374A1C /* apple_version.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = apple_version.hpp; path = ../../src/desktop/apple_version.hpp; sourceTree = "<group>"; };
 		46F5709D205FF856007031BF /* fs_commit.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fs_commit.hpp; sourceTree = "<group>"; };
 		46F5709E205FF856007031BF /* addon_utils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = addon_utils.cpp; sourceTree = "<group>"; };
 		46F5709F205FF856007031BF /* blacklist.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blacklist.hpp; sourceTree = "<group>"; };
@@ -2880,6 +2883,8 @@
 			children = (
 				F40A13BD1A3AA56800C4D071 /* apple_notification.hpp */,
 				F40A13BB1A3A88BA00C4D071 /* apple_notification.mm */,
+				46F54C28211DFB9100374A1C /* apple_version.hpp */,
+				46F54C26211DFB7200374A1C /* apple_version.mm */,
 				B559986A0EC616B3008DD061 /* SDLMain.h */,
 				B559986B0EC616B3008DD061 /* SDLMain.mm */,
 			);
@@ -4996,6 +5001,7 @@
 				62D24F321519987400350848 /* context_manager.cpp in Sources */,
 				EC59F2611A4529D2001910CB /* context.cpp in Sources */,
 				B597EBEE0FC082AB00CE81F5 /* contexts.cpp in Sources */,
+				46F54C27211DFB7200374A1C /* apple_version.mm in Sources */,
 				B54AC6D90FEA9EB5006F6FBD /* contexts.cpp in Sources */,
 				B54AC6E00FEA9EB5006F6FBD /* contexts.cpp in Sources */,
 				B5A9BD5E0ECA805A002BE442 /* styled_widget.cpp in Sources */,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -267,6 +267,7 @@ if(APPLE)
 	set(libwesnoth-game_STAT_SRC
 		${libwesnoth-game_STAT_SRC}
 		desktop/apple_notification.mm
+		desktop/apple_version.mm
 	)
 endif(APPLE)
 

--- a/src/SConscript
+++ b/src/SConscript
@@ -90,6 +90,7 @@ if env["PLATFORM"] == "win32":
 
 if env["PLATFORM"] == 'darwin':
     wesnoth_client_sources.append("desktop/apple_notification.mm")
+    wesnoth_client_sources.append("desktop/apple_version.mm")
 
 if env["notifications"]:
     wesnoth_client_sources.append("desktop/dbus_notification.cpp")

--- a/src/desktop/apple_version.hpp
+++ b/src/desktop/apple_version.hpp
@@ -1,0 +1,27 @@
+/*
+ Copyright (C) 2018 by Martin Hrubý <hrubymar10@gmail.com>
+ Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+ 
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY.
+ 
+ See the COPYING file for more details.
+ */
+
+#pragma once
+
+#include "version.hpp"
+
+#include <string>
+
+namespace desktop {
+	namespace apple {
+		
+		std::string os_version();
+		
+	} // end namespace apple
+} // end namespace desktop

--- a/src/desktop/apple_version.mm
+++ b/src/desktop/apple_version.mm
@@ -1,0 +1,59 @@
+/*
+ Copyright (C) 2018 by Martin Hrubý <hrubymar10@gmail.com>
+ Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+ 
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY.
+ 
+ See the COPYING file for more details.
+ */
+
+#ifdef __APPLE__
+
+#include "apple_version.hpp"
+
+#import "../version.hpp"
+
+#if defined(__APPLE__) && defined(__MACH__) && defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__)
+#define __IPHONEOS__ (__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__*1000)
+#endif
+
+#if defined(__IPHONEOS__)
+//TODO: Implement iOS version detection
+#else
+#import <Foundation/Foundation.h>
+#endif
+
+namespace desktop {
+	namespace apple {
+		std::string os_version() {
+#if defined(__IPHONEOS__)
+			//TODO: Implement iOS version detection
+#else
+			std::string version_string = "Apple";
+			NSArray *version_array = [[[NSProcessInfo processInfo] operatingSystemVersionString] componentsSeparatedByString:@" "];
+			
+			const version_info version_info([[version_array objectAtIndex:1] UTF8String]);
+			
+			if (version_info.major_version() == 10 && version_info.minor_version() < 12) {
+				version_string += " OS X ";
+			} else {
+				version_string += " macOS ";
+			}
+			
+			version_string += [[version_array objectAtIndex:1] UTF8String];
+			version_string += " (";
+			version_string += [[version_array objectAtIndex:3] UTF8String];
+			
+			return version_string;
+#endif
+		}
+		
+	} // end namespace apple
+} // end namespace desktop
+
+#endif //end __APPLE__

--- a/src/desktop/version.cpp
+++ b/src/desktop/version.cpp
@@ -151,6 +151,22 @@ std::string os_version()
 		if(!ver.empty()) {
 			return ver;
 		}
+	} else {
+		
+	//
+	// POSIX uname version fallback.
+	//
+		
+		utsname u;
+		
+		if(uname(&u) != 0) {
+			ERR_DU << "os_version: uname error (" << strerror(errno) << ")\n";
+		}
+		
+		return formatter() 	<< u.sysname << ' '
+							<< u.release << ' '
+							<< u.version << ' '
+							<< u.machine;
 	}
 
 #elif defined(_WIN32)

--- a/src/desktop/version.cpp
+++ b/src/desktop/version.cpp
@@ -21,11 +21,14 @@
 #include "gettext.hpp"
 #include "log.hpp"
 #include "serialization/unicode.hpp"
-#include "../version.hpp"
 
 #include <cstring>
 
-#if defined(_X11) || defined(__APPLE__)
+#if defined(__APPLE__)
+
+#include "apple_version.hpp"
+
+#elif defined(_X11)
 
 #include <cerrno>
 #include <sys/utsname.h>
@@ -71,7 +74,7 @@ bool on_wine()
 }
 #endif
 
-#if defined(_X11) || defined(__APPLE__)
+#if defined(_X11)
 /**
  * Release policy for POSIX pipe streams opened with popen(3).
  */
@@ -117,49 +120,15 @@ std::string read_pipe_line(scoped_posix_pipe& p)
 
 std::string os_version()
 {
-#if defined(_X11) || defined(__APPLE__)
-
-#ifdef __APPLE__
+#if defined(__APPLE__)
 
 	//
 	// Standard Mac OS X version
 	//
 	
-	std::string version_string = "Apple";
+	return desktop::apple::os_version();
 
-	static const std::string version_plist = "/System/Library/CoreServices/SystemVersion.plist";
-	static const std::string defaults_bin = "/usr/bin/defaults";
-
-	if(filesystem::file_exists(defaults_bin) && filesystem::file_exists(version_plist)) {
-		static const std::string cmdline_version = defaults_bin + " read " + version_plist + " ProductUserVisibleVersion";
-		static const std::string cmdline_build = defaults_bin + " read " + version_plist + " ProductBuildVersion";
-
-		scoped_posix_pipe p_version(popen(cmdline_version.c_str(), "r"));
-		const std::string& version = read_pipe_line(p_version);
-		
-		scoped_posix_pipe p_build(popen(cmdline_build.c_str(), "r"));
-		const std::string& build = read_pipe_line(p_build);
-
-		if(!version.empty()) {
-			const version_info version_info(version);
-			
-			if (version_info.major_version() == 10 && version_info.minor_version() < 12) {
-				version_string += " OS X ";
-			} else {
-				 version_string += " macOS ";
-			}
-			
-			version_string += version;
-		}
-		
-		if(!build.empty()) {
-			version_string += " (" + build + ")";
-		}
-	}
-	
-	return version_string;
-
-#else
+#elif defined(_X11)
 
 	//
 	// Linux Standard Base version.
@@ -183,22 +152,6 @@ std::string os_version()
 			return ver;
 		}
 	}
-#endif
-
-	//
-	// POSIX uname version.
-	//
-
-	utsname u;
-
-	if(uname(&u) != 0) {
-		ERR_DU << "os_version: uname error (" << strerror(errno) << ")\n";
-	}
-
-	return formatter() << u.sysname << ' '
-						<< u.release << ' '
-						<< u.version << ' '
-						<< u.machine;
 
 #elif defined(_WIN32)
 

--- a/src/desktop/version.cpp
+++ b/src/desktop/version.cpp
@@ -151,23 +151,22 @@ std::string os_version()
 		if(!ver.empty()) {
 			return ver;
 		}
-	} else {
+	}
 		
 	//
 	// POSIX uname version fallback.
 	//
 		
-		utsname u;
+	utsname u;
 		
-		if(uname(&u) != 0) {
-			ERR_DU << "os_version: uname error (" << strerror(errno) << ")\n";
-		}
-		
-		return formatter() 	<< u.sysname << ' '
-							<< u.release << ' '
-							<< u.version << ' '
-							<< u.machine;
+	if(uname(&u) != 0) {
+		ERR_DU << "os_version: uname error (" << strerror(errno) << ")\n";
 	}
+		
+	return formatter() 	<< u.sysname << ' '
+						<< u.release << ' '
+						<< u.version << ' '
+						<< u.machine;
 
 #elif defined(_WIN32)
 

--- a/src/desktop/version.cpp
+++ b/src/desktop/version.cpp
@@ -152,18 +152,18 @@ std::string os_version()
 			return ver;
 		}
 	}
-		
+
 	//
 	// POSIX uname version fallback.
 	//
-		
+
 	utsname u;
-		
+
 	if(uname(&u) != 0) {
 		ERR_DU << "os_version: uname error (" << strerror(errno) << ")\n";
 	}
-		
-	return formatter() 	<< u.sysname << ' '
+
+	return formatter() << u.sysname << ' '
 						<< u.release << ' '
 						<< u.version << ' '
 						<< u.machine;


### PR DESCRIPTION
Old os version detection was in case of macOS buggy so I reworked it. It is faster now and native.

## TODO
- [x] Create new os version handler for macOS
- [x] Prepare apple specific code for iOS implementation

## Idea
I used `desktop::apple::os_version()` namespace. It may be nice to rework rest of platform specific code to use this namespace style (not only os_version, but also notifications, ...)