### PR TITLE
A cleaner fix for "iOS interfering with Mac: Mac touchpad generates touch events"

### DIFF
--- a/src/gui/core/event/handler.cpp
+++ b/src/gui/core/event/handler.cpp
@@ -380,9 +380,8 @@ void sdl_event_handler::handle_event(const SDL_Event& event)
 	}
 
 	Uint8 button = event.button.button;
-#if defined(__IPHONEOS__) || !defined(__APPLE__)
 	CVideo& video = dynamic_cast<window&>(*dispatchers_.back()).video();
-#endif
+
 	switch(event.type) {
 		case SDL_MOUSEMOTION:
 #ifdef MOUSE_TOUCH_EMULATION
@@ -478,7 +477,6 @@ void sdl_event_handler::handle_event(const SDL_Event& event)
 			text_editing(event.edit.text, event.edit.start, event.edit.length);
 			break;
 
-#if defined(__IPHONEOS__) || !defined(__APPLE__) 
 		case SDL_FINGERMOTION:
 			{
 				SDL_Rect r = video.screen_area();
@@ -508,7 +506,6 @@ void sdl_event_handler::handle_event(const SDL_Event& event)
 									event.mgesture.dTheta, event.mgesture.dDist, event.mgesture.numFingers);
 			}
 			break;
-#endif
 
 #if(defined(_X11) && !defined(__APPLE__)) || defined(_WIN32)
 		case SDL_SYSWMEVENT:

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -1103,6 +1103,14 @@ int main(int argc, char** argv)
 	sigaction(SIGINT, &terminate_handler, nullptr);
 #endif
 
+	// Mac's touchpad generates touch events too.
+	// Ignore them until Macs have a touchscreen: https://forums.libsdl.org/viewtopic.php?p=45758
+#if defined(__APPLE__) && !defined(__IPHONEOS__) 
+	SDL_EventState(SDL_FINGERMOTION, SDL_DISABLE);
+	SDL_EventState(SDL_FINGERDOWN, SDL_DISABLE);
+	SDL_EventState(SDL_FINGERUP, SDL_DISABLE);
+#endif	
+
 	// declare this here so that it will always be at the front of the event queue.
 	events::event_context global_context;
 


### PR DESCRIPTION
Compatible with MacOS 10.14.
Rollback of previous one.
Subtask of #3455