### PR TITLE
HttT S6: Cancel attacks, support alt cave entrance

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/06_The_Siege_of_Elensefar.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/06_The_Siege_of_Elensefar.cfg
@@ -702,7 +702,7 @@
     # Konrad's troops reach Muff Jaanal's citadel.
 
     [event]
-        name=moveto
+        name=enter_hex
         [filter]
             side=1
             x=16-17

--- a/data/campaigns/Heir_To_The_Throne/scenarios/06_The_Siege_of_Elensefar.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/06_The_Siege_of_Elensefar.cfg
@@ -454,6 +454,9 @@
                             speaker=Reglok
                             message= _ "Let’s expel these invaders! Today, the city is ours again!"
                         [/message]
+
+                        # Allow the player to cancel attack orders
+                        [cancel_action][/cancel_action]
                     [/event]
                 [/command]
             [/option]
@@ -758,6 +761,9 @@
             x=22
             y=2
         [/scroll_to_unit]
+
+        # Allow the player to cancel attack orders
+        [cancel_action][/cancel_action]
     [/event]
 
     {campaigns/Heir_To_The_Throne/utils/deaths.cfg}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/06_The_Siege_of_Elensefar.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/06_The_Siege_of_Elensefar.cfg
@@ -705,8 +705,8 @@
         name=enter_hex
         [filter]
             side=1
-            x=16-17
-            y=5-6
+            x=12-13,16-17
+            y=  3-4,  5-6
         [/filter]
 
         [message]


### PR DESCRIPTION
If the player ordered a unit to move and attack, allow the attack to be canceled, as done in #3227 for DiD. And change the undead reinforcements triggering.