### PR TITLE
Fixes track titles not being set from WML.

### DIFF
--- a/src/scripting/lua_audio.cpp
+++ b/src/scripting/lua_audio.cpp
@@ -274,6 +274,7 @@ static int impl_track_set(lua_State* L) {
 	modify_bool_attrib("once", (*track)->set_play_once(value));
 	modify_int_attrib("ms_before", (*track)->set_ms_before(value));
 	modify_int_attrib("ms_after", (*track)->set_ms_after(value));
+	modify_string_attrib("title", (*track)->set_title(value));
 	return 0;
 }
 

--- a/src/sound_music_track.hpp
+++ b/src/sound_music_track.hpp
@@ -50,6 +50,7 @@ public:
 	void set_shuffle(bool v) { shuffle_ = v; }
 	void set_ms_before(int v) { ms_before_ = v; }
 	void set_ms_after(int v) { ms_after_ = v; }
+	void set_title(const std::string& v) { title_ = v; }
 
 private:
 	void resolve();


### PR DESCRIPTION
The current implementation of the [music] tag [sets the title](https://github.com/wesnoth/wesnoth/blob/master/data/lua/wml-tags.lua#L297) after adding the track, however the title field was read only.  This makes the field writeable.

---

Fixes #3461 

I can merge and cherry-pick this if there are no concerns.