### PR TITLE
wmlxgettext: fix #3469: lua plural strings not recognized in some context

### DIFF
--- a/utils/pywmlx/state/lua_states.py
+++ b/utils/pywmlx/state/lua_states.py
@@ -77,7 +77,8 @@ class LuaCommentState:
 
 class LuaStr00:
     def __init__(self):
-        self.regex = re.compile(r'((?:_)|(?:.*?\s+_))\s*\(')
+        # self.regex = re.compile(r'((?:_)|(?:.*?\s+_))\s*\(')
+        self.regex = re.compile(r'\b_\b\s*\(')
         self.iffail = 'lua_str01'
     
     def run(self, xline, lineno, match):

--- a/utils/pywmlx/state/lua_states.py
+++ b/utils/pywmlx/state/lua_states.py
@@ -77,7 +77,6 @@ class LuaCommentState:
 
 class LuaStr00:
     def __init__(self):
-        # self.regex = re.compile(r'((?:_)|(?:.*?\s+_))\s*\(')
         self.regex = re.compile(r'\b_\b\s*\(')
         self.iffail = 'lua_str01'
     


### PR DESCRIPTION
wmlxgettext couldn't recognize lua plural strings in some context. More in details the underscore marker ( _ ) originally required to be located at the beginning of the line or preceded by a space.
Now string maker is recognized without the requirement of an extra space, so syntax like: 
`local var = wesnoth.format(_("one thing","$count things",count), {count = count})`
now can be recognized as plural string, even if the underscore marker is not preceded by a space, but is preceded, for example, by a parenthesis