### PR TITLE
Don't scroll to an enemy leader that has an effective [hides] ability.

### DIFF
--- a/src/game_display.cpp
+++ b/src/game_display.cpp
@@ -200,7 +200,7 @@ void game_display::scroll_to_leader(int side, SCROLL_TYPE scroll_type,bool force
 {
 	unit_map::const_iterator leader = dc_->units().find_leader(side);
 
-	if(leader.valid() && leader->is_visible_to_team(dc_->teams()[viewing_team()], *dc_, false)) {
+	if(leader.valid() && leader->is_visible_to_team(dc_->get_team(viewing_side()), *dc_, false)) {
 		scroll_to_tile(leader->get_location(), scroll_type, true, force);
 	}
 }

--- a/src/game_display.cpp
+++ b/src/game_display.cpp
@@ -200,7 +200,7 @@ void game_display::scroll_to_leader(int side, SCROLL_TYPE scroll_type,bool force
 {
 	unit_map::const_iterator leader = dc_->units().find_leader(side);
 
-	if(leader.valid()) {
+	if(leader.valid() && leader->is_visible_to_team(dc_->teams()[viewing_team()], *dc_, false)) {
 		scroll_to_tile(leader->get_location(), scroll_type, true, force);
 	}
 }

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -592,7 +592,7 @@ void menu_handler::goto_leader(int side_num)
 {
 	unit_map::const_iterator i = units().find_leader(side_num);
 	if(i != units().end()
-			&& i->is_visible_to_team(gui_->get_disp_context().teams()[gui_->viewing_team()], gui_->get_disp_context(), false)) {
+			&& i->is_visible_to_team(gui_->get_disp_context().get_team(gui_->viewing_side()), gui_->get_disp_context(), false)) {
 		gui_->scroll_to_tile(i->get_location(), game_display::WARP);
 	}
 }

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -591,8 +591,8 @@ bool menu_handler::end_turn(int side_num)
 void menu_handler::goto_leader(int side_num)
 {
 	unit_map::const_iterator i = units().find_leader(side_num);
-	if(i != units().end()
-			&& i->is_visible_to_team(gui_->get_disp_context().get_team(gui_->viewing_side()), gui_->get_disp_context(), false)) {
+	const display_context& dc = gui_->get_disp_context();
+	if(i != units().end() && i->is_visible_to_team(dc.get_team(gui_->viewing_side()), dc, false)) {
 		gui_->scroll_to_tile(i->get_location(), game_display::WARP);
 	}
 }

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -591,7 +591,8 @@ bool menu_handler::end_turn(int side_num)
 void menu_handler::goto_leader(int side_num)
 {
 	unit_map::const_iterator i = units().find_leader(side_num);
-	if(i != units().end()) {
+	if(i != units().end()
+			&& i->is_visible_to_team(gui_->get_disp_context().teams()[gui_->viewing_team()], gui_->get_disp_context(), false)) {
 		gui_->scroll_to_tile(i->get_location(), game_display::WARP);
 	}
 }

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -926,7 +926,7 @@ private:
 	/**
 	 * @}
 	 * @defgroup unit_trait Trait and upkeep functions
-	 * @}
+	 * @{
 	 */
 public:
 	/**


### PR DESCRIPTION
Two cases are handled:

1. At start of side turn of the enemy
2. When the player presses 'l' during the enemy's turn

One case is not handled:

3. When loading a save that starts at a side turn of the enemy