### PR TITLE
Game Load: Show list of enabled modification.

### DIFF
--- a/data/gui/window/game_load.cfg
+++ b/data/gui/window/game_load.cfg
@@ -369,7 +369,6 @@
 												id = "slblSummary"
 												definition = "default_small"
 												use_markup = true
-												horizontal_scrollbar_mode = "auto"
 												vertical_scrollbar_mode = "auto"
 												wrap = false
 											[/scroll_label]

--- a/data/gui/window/game_load.cfg
+++ b/data/gui/window/game_load.cfg
@@ -365,11 +365,14 @@
 											border_size = 5
 											horizontal_grow = true
 
-											[label]
-												id = "lblSummary"
+											[scroll_label]
+												id = "slblSummary"
 												definition = "default_small"
 												use_markup = true
-											[/label]
+												horizontal_scrollbar_mode = "auto"
+												vertical_scrollbar_mode = "auto"
+												wrap = false
+											[/scroll_label]
 
 										[/column]
 

--- a/src/gui/dialogs/game_load.cpp
+++ b/src/gui/dialogs/game_load.cpp
@@ -369,6 +369,22 @@ void game_load::evaluate_summary_string(std::stringstream& str, const config& cf
 	if(!cfg_summary["version"].empty()) {
 		str << "\n" << _("Version: ") << cfg_summary["version"];
 	}
+
+	const std::vector<std::string>& active_mods = utils::split(cfg_summary["active_mods"]);
+	if(!active_mods.empty()) {
+		str << "\n" << _("Modifications: ");
+		for(const auto& mod_id : active_mods) {
+			std::string mod_name;
+			try {
+				mod_name = cache_config_.find_child("modification", "id", mod_id)["name"].str();
+			} catch(const config::error&) {
+				// Fallback to nontranslatable mod id.
+				mod_name = "(" + mod_id + ")";
+			}
+
+			str << "\n" << font::unicode_bullet << " " << mod_name;
+		}
+	}
 }
 
 void game_load::delete_button_callback(window& window)

--- a/src/gui/dialogs/game_load.cpp
+++ b/src/gui/dialogs/game_load.cpp
@@ -30,6 +30,7 @@
 #include "gui/widgets/button.hpp"
 #include "gui/widgets/image.hpp"
 #include "gui/widgets/label.hpp"
+#include "gui/widgets/scroll_label.hpp"
 #ifdef GUI2_EXPERIMENTAL_LISTBOX
 #include "gui/widgets/list.hpp"
 #else
@@ -229,7 +230,7 @@ void game_load::display_savegame(window& window)
 	evaluate_summary_string(str, summary_);
 
 	// The new label value may have more or less lines than the previous value, so invalidate the layout.
-	find_widget<label>(&window, "lblSummary", false).set_label(str.str());
+	find_widget<scroll_label>(&window, "slblSummary", false).set_label(str.str());
 	window.invalidate_layout();
 
 	toggle_button& replay_toggle            = dynamic_cast<toggle_button&>(*show_replay_->get_widget());

--- a/src/gui/dialogs/game_load.cpp
+++ b/src/gui/dialogs/game_load.cpp
@@ -228,7 +228,9 @@ void game_load::display_savegame(window& window)
 	str << game.format_time_local() << "\n";
 	evaluate_summary_string(str, summary_);
 
+	// The new label value may have more or less lines than the previous value, so invalidate the layout.
 	find_widget<label>(&window, "lblSummary", false).set_label(str.str());
+	window.invalidate_layout();
 
 	toggle_button& replay_toggle            = dynamic_cast<toggle_button&>(*show_replay_->get_widget());
 	toggle_button& cancel_orders_toggle     = dynamic_cast<toggle_button&>(*cancel_orders_->get_widget());

--- a/src/save_index.cpp
+++ b/src/save_index.cpp
@@ -373,6 +373,7 @@ void extract_summary_from_config(config& cfg_save, config& cfg_summary)
 	cfg_summary["difficulty"] = cfg_save["difficulty"];
 	cfg_summary["random_mode"] = cfg_save["random_mode"];
 
+	cfg_summary["active_mods"] = cfg_save.child("multiplayer")["active_mods"];
 	cfg_summary["campaign"] = cfg_save["campaign"];
 	cfg_summary["version"] = cfg_save["version"];
 	cfg_summary["corrupt"] = "";


### PR DESCRIPTION
![screenshot_2018-08-24_18-33-20](https://user-images.githubusercontent.com/24784687/44601673-c11efa80-a7cc-11e8-9d79-817c0bec86f8.png)

This PR adds the "Modifications:" header and bulleted list. It shows the mod name if the mod is installed, else mod id, as done for campaigns.

Similar to #3478.