### PR TITLE
GUI2 Schema: Add missing parentheses to regexps.

### DIFF
--- a/data/gui/schema.cfg
+++ b/data/gui/schema.cfg
@@ -1,7 +1,7 @@
 [wml_schema]
     [type]
         name=bool
-        value="^true|false|yes|no$"
+        value="^(true|false|yes|no)$"
     [/type]
     [type]
         name=border
@@ -49,11 +49,11 @@
     [/type]
     [type]
         name=grow_direction
-        value="^horizontal|vertical$"
+        value="^(horizontal|vertical)$"
     [/type]
     [type]
         name=h_align
-        value="^left|right|center$"
+        value="^(left|right|center)$"
     [/type]
     [type]
         name=int
@@ -61,11 +61,11 @@
     [/type]
     [type]
         name=resize_mode
-        value="^scale|stretch|tile|tile_center$"
+        value="^(scale|stretch|tile|tile_center)$"
     [/type]
     [type]
         name=scrollbar_mode
-        value="^always|never|auto|initial_auto$"
+        value="^(always|never|auto|initial_auto)$"
     [/type]
     [type]
         name=string
@@ -81,7 +81,7 @@
     [/type]
     [type]
         name=v_align
-        value="^top|bottom|center$"
+        value="^(top|bottom|center)$"
     [/type]
     [tag]
         name="root"


### PR DESCRIPTION
The '|' operator has lower precedence than ^ and $.