### PR TITLE
Add harming option to heals abilities

### DIFF
--- a/src/actions/heal.cpp
+++ b/src/actions/heal.cpp
@@ -183,9 +183,11 @@ namespace {
 
 		int healing = 0;
 		int harming = 0;
+		int heal_value = 0;
+		bool inverse_value = false;
 
 
-		if ( patient.side() == side )
+	if ( patient.side() == side )
 		{
 			// Village healing?
 			update_healing(healing, harming,
@@ -207,13 +209,19 @@ namespace {
 
 			if ( healer->side() != side )
 				heal_it = heal_list.erase(heal_it);
-			else
-				++heal_it;
+			else {
+                 inverse_value= (*heal_it->first)["harming"].to_bool();
+                 ++heal_it;
+			}
 		}
 
 		// Now we can get the aggregate healing amount.
 		unit_abilities::effect heal_effect(heal_list, 0, false);
-		if ( update_healing(healing, harming, heal_effect.get_composite_value()) )
+		if (inverse_value)
+            heal_value = -heal_effect.get_composite_value();
+        else
+            heal_value = heal_effect.get_composite_value();
+		if ( update_healing(healing, harming, heal_value) )
 		{
 			// Collect the healers involved.
 			for (const unit_abilities::individual_effect & heal : heal_effect)


### PR DESCRIPTION
Some wml develloper said they can't use heals abilities for harm enemies because theu use of negative value doinf what the low harm wpuld inflited if two 'harmers' with negative heals value different are adjacent to same unit to harm. If one value is -4 and the other -8 then the unit would have -4 hp. This option permit to harm with heals abilities with positive value. 