### PR TITLE
Create a harms ability to resolve negative value of heals ability

### DIFF
--- a/src/actions/heal.cpp
+++ b/src/actions/heal.cpp
@@ -223,6 +223,32 @@ namespace {
 				DBG_NG << "Unit has " << healers.size() << " healers.\n";
 			}
 		}
+		
+		unit_ability_list harm_list = patient.get_abilities("harms");
+		// Remove all healers not on this side (since they do not heal now).
+		unit_ability_list::iterator harm_it = harm_list.begin();
+		while ( harm_it != harm_list.end() ) {
+			unit_map::iterator healer = units.find(harm_it->second);
+			assert(healer != units.end());
+
+			if ( healer->side() != side )
+				harm_it = harm_list.erase(harm_it);
+			else
+				++harm_it;
+		}
+
+		// Now we can get the aggregate harming amount.
+		unit_abilities::effect harm_effect(harm_list, 0, false);
+		if ( update_healing(healing, harming, -harm_effect.get_composite_value()) )
+		{
+			// Collect the healers involved.
+			for (const unit_abilities::individual_effect & heal : harm_effect)
+				healers.push_back(&*units.find(heal.loc));
+
+			if ( !healers.empty() ) {
+				DBG_NG << "Unit has " << healers.size() << " healers.\n";
+			}
+		}
 
 		return healing + harming;
 	}


### PR DESCRIPTION
I hope what this soluce is best what harming option. Alas the same healing_anim is used by the two abilities. But the unit with harms use that on ennemies ( diffetent side what allied). An same unit both adajacent to healer and harmer will be healed in healer turn and harmed in harmer turn.