### PR TITLE
MP: Use listbox to choose leader

### DIFF
--- a/data/gui/window/mp_faction_select.cfg
+++ b/data/gui/window/mp_faction_select.cfg
@@ -3,6 +3,8 @@
 ### Definition of the window to select faction, leader, and gender
 ###
 
+# TODO when changing faction, the dialog changes width; if that reduces the width, the older wider dialog doesn't get undrawn
+
 #define _GUI_FACTION_LIST
 	[listbox]
 		id = "faction_list"
@@ -106,10 +108,60 @@
 							border_size = 5
 							horizontal_grow = true
 
-							[menu_button]
-								id = "leader_menu"
+							{GUI_FORCE_WIDGET_MINIMUM_SIZE  0 288 (
+							[listbox]
+								id = "leader_list"
 								definition = "default"
-							[/menu_button]
+								[list_definition]
+									[row]
+										[column]
+											vertical_grow = true
+											horizontal_grow = true
+
+											[toggle_panel]
+												definition = "default"
+
+												return_value_id = "ok"
+												[grid]
+													[row]
+														[column]
+															grow_factor = 1
+															horizontal_grow = true
+
+															border = "all"
+															border_size = 1
+															[image]
+																id = "leader_image"
+																definition = "default"
+																linked_group = "image2"
+															[/image]
+														[/column]
+
+														[column]
+															border = "all"
+															border_size = 5
+															horizontal_grow = true
+															[label]
+																id = "leader_name"
+																definition = "default"
+																linked_group = "name2"
+															[/label]
+														[/column]
+
+														[column]
+															[spacer]
+																width = 25
+															[/spacer]
+														[/column]
+													[/row]
+												[/grid]
+											[/toggle_panel]
+										[/column]
+									[/row]
+								[/list_definition]
+							[/listbox]
+							)}
+
 
 						[/column]
 
@@ -239,6 +291,16 @@
 
 		[linked_group]
 			id = "name"
+			fixed_width = true
+		[/linked_group]
+
+		[linked_group]
+			id = "image2"
+			fixed_width = true
+		[/linked_group]
+
+		[linked_group]
+			id = "name2"
 			fixed_width = true
 		[/linked_group]
 

--- a/data/gui/window/mp_faction_select.cfg
+++ b/data/gui/window/mp_faction_select.cfg
@@ -3,8 +3,6 @@
 ### Definition of the window to select faction, leader, and gender
 ###
 
-# TODO when changing faction, the dialog changes width; if that reduces the width, the older wider dialog doesn't get undrawn
-
 #define _GUI_FACTION_LIST
 	[listbox]
 		id = "faction_list"
@@ -125,7 +123,7 @@
 												[grid]
 													[row]
 														[column]
-															grow_factor = 1
+															grow_factor = 0
 															horizontal_grow = true
 
 															border = "all"
@@ -138,6 +136,7 @@
 														[/column]
 
 														[column]
+															grow_factor = 0
 															border = "all"
 															border_size = 5
 															horizontal_grow = true
@@ -149,6 +148,8 @@
 														[/column]
 
 														[column]
+															grow_factor = 1
+															horizontal_grow = true
 															[spacer]
 																width = 25
 															[/spacer]
@@ -278,11 +279,9 @@
 
 	[resolution]
 		definition = "default"
-		automatic_placement = true
 		vertical_placement = "center"
 		horizontal_placement = "center"
-
-		maximum_height = 700
+		{GUI_WINDOW_FIXED_SIZE_CENTERED 712 700}
 
 		[linked_group]
 			id = "image"

--- a/data/gui/window/mp_faction_select.cfg
+++ b/data/gui/window/mp_faction_select.cfg
@@ -80,25 +80,6 @@
 			grow_factor = 0
 
 			[column]
-				horizontal_alignment = "center"
-				border = "all"
-				border_size = 5
-
-				{GUI_FORCE_WIDGET_MINIMUM_SIZE 144 144 (
-					[image]
-						definition = "centered"
-						id = "leader_image"
-					[/image]
-				)}
-
-			[/column]
-
-		[/row]
-
-		[row]
-			grow_factor = 0
-
-			[column]
 				horizontal_grow = true
 
 				[grid]

--- a/src/game_initialization/flg_manager.hpp
+++ b/src/game_initialization/flg_manager.hpp
@@ -23,6 +23,7 @@ namespace randomness { class mt_rng; }
 namespace ng {
 
 const std::string random_enemy_picture("units/random-dice.png");
+const std::string blank_hex_picture("misc/blank-hex.png");
 
 /// FLG stands for faction, leader and gender.
 class flg_manager

--- a/src/gui/dialogs/multiplayer/faction_select.cpp
+++ b/src/gui/dialogs/multiplayer/faction_select.cpp
@@ -74,7 +74,7 @@ void faction_select::pre_show(window& window)
 	gender_toggle_.set_member_states("random");
 
 	gender_toggle_.set_callback_on_value_change(
-		std::bind(&faction_select::on_gender_select, this, std::ref(window)));
+		std::bind(&faction_select::on_gender_select, this));
 
 	//
 	// Set up leader menu button
@@ -202,8 +202,6 @@ void faction_select::on_leader_select(window& window)
 		return std::find(genders.begin(), genders.end(), gender) != genders.end();
 	});
 
-	update_leader_image(window);
-
 	// Disable the profile button if leader_type is dash or "Random"
 	button& profile_button = find_widget<button>(&window, "type_profile", false);
 	const std::string& leader_type = find_widget<menu_button>(&window, "leader_menu", false).get_value_string();
@@ -221,23 +219,9 @@ void faction_select::profile_button_callback(window& window)
 	}
 }
 
-void faction_select::on_gender_select(window& window)
+void faction_select::on_gender_select(void)
 {
 	flg_manager_.set_current_gender(gender_toggle_.get_active_member_value());
-
-	update_leader_image(window);
-}
-
-void faction_select::update_leader_image(window& window)
-{
-	std::string leader_image = ng::random_enemy_picture;
-
-	if(const unit_type* ut = unit_types.find(flg_manager_.current_leader())) {
-		const unit_type& utg = ut->get_gender_unit_type(flg_manager_.current_gender());
-		leader_image = formatter() << utg.image() << "~RC(" << utg.flag_rgb() << ">" << tc_color_ << ")" << "~SCALE_INTO_SHARP(144,144)";
-	}
-
-	find_widget<image>(&window, "leader_image", false).set_label(leader_image);
 }
 
 void faction_select::post_show(window& /*window*/)

--- a/src/gui/dialogs/multiplayer/faction_select.cpp
+++ b/src/gui/dialogs/multiplayer/faction_select.cpp
@@ -84,7 +84,7 @@ void faction_select::pre_show(window& window)
 
 	// Leader's profile button
 	find_widget<button>(&window, "type_profile", false).connect_click_handler(
-		std::bind(&faction_select::profile_button_callback, this, std::ref(window)));
+		std::bind(&faction_select::profile_button_callback, this));
 
 	//
 	// Set up faction list
@@ -204,13 +204,13 @@ void faction_select::on_leader_select(window& window)
 
 	// Disable the profile button if leader_type is dash or "Random"
 	button& profile_button = find_widget<button>(&window, "type_profile", false);
-	const std::string& leader_type = find_widget<menu_button>(&window, "leader_menu", false).get_value_string();
+	const std::string& leader_type = flg_manager_.current_leader();
 	profile_button.set_active(unit_types.find(leader_type) != nullptr);
 }
 
-void faction_select::profile_button_callback(window& window)
+void faction_select::profile_button_callback(void)
 {
-	const std::string& leader_type = find_widget<menu_button>(&window, "leader_menu", false).get_value_string();
+	const std::string& leader_type = flg_manager_.current_leader();
 	const unit_type* ut = unit_types.find(leader_type);
 	if(ut != nullptr) {
 		preferences::encountered_units().insert(ut->id());

--- a/src/gui/dialogs/multiplayer/faction_select.hpp
+++ b/src/gui/dialogs/multiplayer/faction_select.hpp
@@ -58,7 +58,7 @@ private:
 
 	void on_leader_select(window& window);
 
-	void profile_button_callback(window& window);
+	void profile_button_callback(void);
 
 	void on_gender_select(void);
 };

--- a/src/gui/dialogs/multiplayer/faction_select.hpp
+++ b/src/gui/dialogs/multiplayer/faction_select.hpp
@@ -60,9 +60,7 @@ private:
 
 	void profile_button_callback(window& window);
 
-	void on_gender_select(window& window);
-
-	void update_leader_image(window& window);
+	void on_gender_select(void);
 };
 
 } // namespace dialogs


### PR DESCRIPTION
Change the widget for choosing a leader in the MP "Choose Your Faction" dialog to a listbox.

![screenshot_2018-08-27_18-12-09](https://user-images.githubusercontent.com/24784687/44677219-eefe7c00-aa24-11e8-9ade-e611dfab6db9.png) ![screenshot_2018-08-27_18-12-59](https://user-images.githubusercontent.com/24784687/44677222-f2920300-aa24-11e8-85d8-3382de86deea.png)

With the _next-to-last_ commit there is a redrawing problem. You can reproduce it by starting an MP game with the AoH era. Open the CYF dialog, select the drakes faction then select the random faction. The dialog will become shorter and narrower but it will be drawn, not over the underlying screen but over the previous, longer and wider version of itself. The issue does not reproduce with the last commit, only with the one before it, but I am not sure the solution in the last commit is good.