### PR TITLE
Minor pedantic fixes for 1.14

### DIFF
--- a/src/color.hpp
+++ b/src/color.hpp
@@ -250,7 +250,7 @@ namespace std
 	template<>
 	struct hash<color_t>
 	{
-		size_t operator()(const color_t& c) const
+		size_t operator()(const color_t& c) const noexcept
 		{
 			return c.to_rgba_bytes();
 		}

--- a/src/map/location.hpp
+++ b/src/map/location.hpp
@@ -210,7 +210,7 @@ std::ostream &operator<<(std::ostream &s, const std::vector<map_location>& v);
 namespace std {
 template<>
 struct hash<map_location> {
-	size_t operator()(const map_location& l) const {
+	size_t operator()(const map_location& l) const noexcept {
 		// The 2000 bias supposedly ensures that the correct x is recovered for negative y
 		// This implementation copied from the Lua location_set
 		return (l.wml_x()) * 16384 + (l.wml_y()) + 2000;

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -1871,7 +1871,7 @@ void server::handle_player_in_game(socket_ptr socket, std::shared_ptr<simple_wml
 using SendQueue = std::map<socket_ptr, std::deque<std::shared_ptr<simple_wml::document>>>;
 SendQueue send_queue;
 
-void handle_send_to_player(socket_ptr socket)
+static void handle_send_to_player(socket_ptr socket)
 {
 	if(send_queue[socket].empty()) {
 		send_queue.erase(socket);


### PR DESCRIPTION
I decided 1000 commits was enough lag and brought my repo up-to-date. CMake, using GCC 8.2.0, with strict and pedantic options, flagged a few warnings. I'm not looking at Master until someone claims it's working and playable. If these need to be there, too, someone else will have to do it.