### PR TITLE
Fix compile error for hardening a debug build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,9 +401,15 @@ set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${CMAKE_SOURCE_
 
 # replace the default Debug flag of -g with -O0 -DDEBUG -ggdb3
 # this matches the flags of scons' debug build
-MESSAGE("Replacing flags used for Debug build ${OPT} -DDEBUG -ggdb3 ${EXTRA_FLAGS_CONFIG} ${EXTRA_FLAGS_DEBUG}")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG -ggdb3 ${EXTRA_FLAGS_CONFIG} ${EXTRA_FLAGS_DEBUG}" CACHE STRING "change cmake's Debug flags to match scons' flags" FORCE)
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DDEBUG -ggdb3 ${EXTRA_FLAGS_CONFIG} ${EXTRA_FLAGS_DEBUG}" CACHE STRING "change cmake's Debug flags to match scons' flags" FORCE)
+if(HARDEN AND NOT WIN32)
+    MESSAGE("Replacing flags used for Debug build ${OPT} -Og -DDEBUG -ggdb3 ${EXTRA_FLAGS_CONFIG} ${EXTRA_FLAGS_DEBUG}")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Og -DDEBUG -ggdb3 ${EXTRA_FLAGS_CONFIG} ${EXTRA_FLAGS_DEBUG}" CACHE STRING "change cmake's Debug flags to match scons' flags" FORCE)
+    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Og -DDEBUG -ggdb3 ${EXTRA_FLAGS_CONFIG} ${EXTRA_FLAGS_DEBUG}" CACHE STRING "change cmake's Debug flags to match scons' flags" FORCE)
+else(HARDEN AND NOT WIN32)
+    MESSAGE("Replacing flags used for Debug build ${OPT} -DDEBUG -ggdb3 ${EXTRA_FLAGS_CONFIG} ${EXTRA_FLAGS_DEBUG}")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG -ggdb3 ${EXTRA_FLAGS_CONFIG} ${EXTRA_FLAGS_DEBUG}" CACHE STRING "change cmake's Debug flags to match scons' flags" FORCE)
+    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DDEBUG -ggdb3 ${EXTRA_FLAGS_CONFIG} ${EXTRA_FLAGS_DEBUG}" CACHE STRING "change cmake's Debug flags to match scons' flags" FORCE)
+endif(HARDEN AND NOT WIN32)
 set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${LINK_EXTRA_FLAGS_CONFIG} ${LINK_EXTRA_FLAGS_DEBUG}" CACHE STRING "" FORCE)
 
 # adds GLIBCXX_DEBUG definitions

--- a/SConstruct
+++ b/SConstruct
@@ -518,7 +518,10 @@ for env in [test_env, client_env, env]:
 # Start determining options for debug build
 # #
 
-        debug_flags = env["opt"]+"-DDEBUG -ggdb3"
+        if env['harden'] and env["PLATFORM"] != 'win32':
+            debug_flags = env["opt"]+"-Og -DDEBUG -ggdb3"
+        else:
+            debug_flags = env["opt"]+"-DDEBUG -ggdb3"
 
         if env["glibcxx_debug"] == True:
             glibcxx_debug_flags = "_GLIBCXX_DEBUG _GLIBCXX_DEBUG_PEDANTIC"


### PR DESCRIPTION
One cannot use _FORTIFTY_SOURCE without also using an optimization (-O).

When compiling a hardened Debug build, we'll use -Og. This provides only debug-safe optimizations.