### PR TITLE
Clear animation in heal_unit for fix halo remain

### DIFF
--- a/data/lua/wml/heal_unit.lua
+++ b/data/lua/wml/heal_unit.lua
@@ -44,6 +44,7 @@ function wesnoth.wml_actions.heal_unit(cfg)
 				animator:add(healers[1], 'healing', 'hit', {value = heal_amount})
 			end
 			animator:run()
+			animator:clear()
 		end
 
 		u.hitpoints = new_hitpoints


### PR DESCRIPTION
@jyrkive same problem og halo. This time if i modify an unit afyer heal_unit animated, the halo remain.