### PR TITLE
Add --skip-story option

### DIFF
--- a/doc/man/wesnoth.6
+++ b/doc/man/wesnoth.6
@@ -71,6 +71,11 @@ the campaign difficulty selection widget will appear.
 .BI --campaign-scenario \ id_scenario
 The id of the scenario from the specified campaign. The default is the first scenario.
 .TP
+.B --campaign-skip-story
+Skip story screens and dialog through the end of the
+.B start
+event.
+.TP
 .BI --core \ id_core
 overrides the loaded core with the one whose id is specified.
 .TP

--- a/src/commandline_options.cpp
+++ b/src/commandline_options.cpp
@@ -65,6 +65,7 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 	campaign(),
 	campaign_difficulty(),
 	campaign_scenario(),
+	campaign_skip_story(false),
 	clock(false),
 	data_path(false),
 	data_dir(),
@@ -215,6 +216,7 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 		("campaign,c", po::value<std::string>()->implicit_value(std::string()), "goes directly to the campaign with id <arg>. A selection menu will appear if no id was specified.")
 		("campaign-difficulty", po::value<int>(), "The difficulty of the specified campaign (1 to max). If none specified, the campaign difficulty selection widget will appear.")
 		("campaign-scenario", po::value<std::string>(),"The id of the scenario from the specified campaign. The default is the first scenario.")
+		("campaign-skip-story", "Skip [story] tags of the specified campaign.")
 		;
 
 	po::options_description display_opts("Display options");
@@ -312,6 +314,8 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 		campaign_difficulty = vm["campaign-difficulty"].as<int>();
 	if (vm.count("campaign-scenario"))
 		campaign_scenario = vm["campaign-scenario"].as<std::string>();
+	if (vm.count("campaign-skip-story"))
+		campaign_skip_story = true;
 	if (vm.count("clock"))
 		clock = true;
 	if (vm.count("core"))

--- a/src/commandline_options.hpp
+++ b/src/commandline_options.hpp
@@ -56,6 +56,8 @@ public:
 	boost::optional<int> campaign_difficulty;
 	/// Non-empty if --campaign-scenario was given on the command line. Chooses starting scenario in the campaign to be played. Dependent on --campaign.
 	boost::optional<std::string> campaign_scenario;
+	/// True if --skip-story was given on the command line. Skips [story] and [message]s through the end of the "start" event. Dependent on --campaign.
+	bool campaign_skip_story;
 	/// True if --clock was given on the command line. Enables
 	bool clock;
 	/// Non-empty if --core was given on the command line. Chooses the core to be loaded.

--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -118,7 +118,7 @@ game_launcher::game_launcher(const commandline_options& cmdline_opts, const char
 	play_replay_(false),
 	multiplayer_server_(),
 	jump_to_multiplayer_(false),
-	jump_to_campaign_(false, -1, "", ""),
+	jump_to_campaign_(false, false, -1, "", ""),
 	jump_to_editor_(false),
 	load_data_()
 {
@@ -163,6 +163,10 @@ game_launcher::game_launcher(const commandline_options& cmdline_opts, const char
 		if (cmdline_opts_.campaign_scenario) {
 			jump_to_campaign_.scenario_id_ = *cmdline_opts_.campaign_scenario;
 			std::cerr << "selected scenario id: [" << jump_to_campaign_.scenario_id_ << "]\n";
+		}
+
+		if (cmdline_opts_.campaign_skip_story) {
+			jump_to_campaign_.skip_story_ = true;
 		}
 	}
 	if (cmdline_opts_.clock)
@@ -729,6 +733,7 @@ bool game_launcher::goto_campaign()
 {
 	if(jump_to_campaign_.jump_){
 		if(new_campaign()) {
+			state_.set_skip_story(jump_to_campaign_.skip_story_);
 			jump_to_campaign_.jump_ = false;
 			launch_game(NO_RELOAD_DATA);
 		}else{

--- a/src/game_launcher.hpp
+++ b/src/game_launcher.hpp
@@ -33,14 +33,16 @@ namespace savegame { struct load_game_metadata; }
 struct jump_to_campaign_info
 {
 public:
-	jump_to_campaign_info(bool jump,int difficulty, const std::string& campaign_id,const std::string& scenario_id)
+	jump_to_campaign_info(bool jump, bool skip_story, int difficulty, const std::string& campaign_id,const std::string& scenario_id)
 		: jump_(jump)
+		, skip_story_(skip_story)
 		, difficulty_(difficulty)
 		, campaign_id_(campaign_id)
 		, scenario_id_(scenario_id)
 	{
 	}
 	bool jump_;
+	bool skip_story_;
 	int difficulty_;
 	std::string campaign_id_,scenario_id_;
 };
@@ -71,6 +73,7 @@ public:
 	void set_tutorial();
 	void set_test(const std::string& id);
 
+	/// Return the ID of the campaign to jump to (skipping the main menu).
 	std::string jump_to_campaign_id() const;
 	bool new_campaign();
 	bool goto_campaign();

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -374,6 +374,7 @@ void play_controller::fire_start()
 {
 	gamestate().gamedata_.set_phase(game_data::START);
 	pump().fire("start");
+	skip_story_ = false; // Show [message]s from now on even with --campaign-skip-story
 	// start event may modify start turn with WML, reflect any changes.
 	gamestate().gamedata_.get_variable("turn_number") = int(turn());
 	refresh_objectives();

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -153,6 +153,7 @@ play_controller::play_controller(const config& level, saved_game& state_of_game,
 	, statistics_context_(new statistics::scenario_context(level["name"]))
 	, replay_(new replay(state_of_game.get_replay()))
 	, skip_replay_(skip_replay)
+	, skip_story_(state_of_game.skip_story())
 	, linger_(false)
 	, init_side_done_now_(false)
 	, map_start_()

--- a/src/play_controller.hpp
+++ b/src/play_controller.hpp
@@ -189,6 +189,8 @@ public:
 	bool is_linger_mode() const { return linger_; }
 	void do_autosave();
 
+	bool is_skipping_story() const { return skip_story_; }
+
 	void do_consolesave(const std::string& filename);
 
 	events::mouse_handler& get_mouse_handler_base() override;
@@ -339,6 +341,7 @@ protected:
 	std::unique_ptr<replay> replay_;
 
 	bool skip_replay_;
+	bool skip_story_;
 	bool linger_;
 	/**
 	 * Whether we did init sides in this session

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -229,7 +229,7 @@ LEVEL_RESULT playsingle_controller::play_scenario(const config& level)
 	}
 	sound::commit_music_changes();
 
-	if(!this->is_skipping_replay()) {
+	if(!this->is_skipping_replay() && !saved_game_.skip_story()) {
 		// Combine all the [story] tags into a single config. Handle this here since
 		// storyscreen::controller doesn't have a default constructor.
 		config cfg;

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -229,7 +229,7 @@ LEVEL_RESULT playsingle_controller::play_scenario(const config& level)
 	}
 	sound::commit_music_changes();
 
-	if(!this->is_skipping_replay() && !saved_game_.skip_story()) {
+	if(!this->is_skipping_replay() && !this->is_skipping_story()) {
 		// Combine all the [story] tags into a single config. Handle this here since
 		// storyscreen::controller doesn't have a default constructor.
 		config cfg;

--- a/src/saved_game.cpp
+++ b/src/saved_game.cpp
@@ -94,6 +94,7 @@ saved_game::saved_game()
 	, starting_pos_type_(STARTINGPOS_NONE)
 	, starting_pos_()
 	, replay_data_()
+	, skip_story_(false)
 {
 }
 
@@ -106,6 +107,7 @@ saved_game::saved_game(config cfg)
 	, starting_pos_type_(STARTINGPOS_NONE)
 	, starting_pos_()
 	, replay_data_()
+	, skip_story_(false)
 
 {
 	set_data(cfg);
@@ -120,6 +122,7 @@ saved_game::saved_game(const saved_game& state)
 	, starting_pos_type_(state.starting_pos_type_)
 	, starting_pos_(state.starting_pos_)
 	, replay_data_(state.replay_data_)
+	, skip_story_(state.skip_story_)
 {
 }
 

--- a/src/saved_game.hpp
+++ b/src/saved_game.hpp
@@ -121,6 +121,10 @@ public:
 	replay_recorder_base& get_replay() { return replay_data_; }
 	const replay_recorder_base& get_replay() const { return replay_data_; }
 
+	/// Whether to play [story] tags
+	bool skip_story() const { return skip_story_; }
+	void set_skip_story(bool skip_story) { skip_story_ = skip_story; }
+
 private:
 	bool has_carryover_expanded_;
 	/**
@@ -143,6 +147,8 @@ private:
 	config starting_pos_;
 
 	replay_recorder_base replay_data_;
+
+	bool skip_story_;
 };
 
 /** Implement non-member swap function for std::swap (calls @ref saved_game::swap). */

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -2693,7 +2693,7 @@ int game_lua_kernel::intf_deselect_hex(lua_State*)
  */
 int game_lua_kernel::intf_is_skipping_messages(lua_State *L)
 {
-	bool skipping = play_controller_.is_skipping_replay();
+	bool skipping = play_controller_.is_skipping_replay() || play_controller_.is_skipping_story();
 	if (!skipping) {
 		skipping = game_state_.events_manager_->pump().context_skip_messages();
 	}

--- a/src/tests/test_commandline_options.cpp
+++ b/src/tests/test_commandline_options.cpp
@@ -29,6 +29,7 @@ BOOST_AUTO_TEST_CASE (test_empty_options)
 	BOOST_CHECK(!co.campaign);
 	BOOST_CHECK(!co.campaign_difficulty);
 	BOOST_CHECK(!co.campaign_scenario);
+	BOOST_CHECK(!co.campaign_skip_story);
 	BOOST_CHECK(!co.clock);
 	BOOST_CHECK(!co.data_dir);
 	BOOST_CHECK(!co.data_path);
@@ -104,6 +105,7 @@ BOOST_AUTO_TEST_CASE (test_default_options)
 	BOOST_CHECK(co.campaign && co.campaign->empty());
 	BOOST_CHECK(!co.campaign_difficulty);
 	BOOST_CHECK(!co.campaign_scenario);
+	BOOST_CHECK(!co.campaign_skip_story);
 	BOOST_CHECK(!co.clock);
 	BOOST_CHECK(!co.data_dir);
 	BOOST_CHECK(!co.data_path);
@@ -175,6 +177,7 @@ BOOST_AUTO_TEST_CASE (test_full_options)
 		"--campaign=campfoo",
 		"--campaign-difficulty=16",
 		"--campaign-scenario=scenfoo",
+		"--campaign-skip-story",
 		"--clock",
 		"--controller=5:confoo",
 		"--controller=6:conbar",
@@ -239,6 +242,7 @@ BOOST_AUTO_TEST_CASE (test_full_options)
 	BOOST_CHECK(co.campaign && *co.campaign == "campfoo");
 	BOOST_CHECK(co.campaign_difficulty && *co.campaign_difficulty == 16);
 	BOOST_CHECK(co.campaign_scenario && *co.campaign_scenario == "scenfoo");
+	BOOST_CHECK(co.campaign_skip_story);
 	BOOST_CHECK(co.clock);
 	BOOST_CHECK(co.data_dir && *co.data_dir == "datadirfoo");
 	BOOST_CHECK(co.data_path);
@@ -331,6 +335,7 @@ BOOST_AUTO_TEST_CASE (test_positional_options)
 	BOOST_CHECK(!co.campaign);
 	BOOST_CHECK(!co.campaign_difficulty);
 	BOOST_CHECK(!co.campaign_scenario);
+	BOOST_CHECK(!co.campaign_skip_story);
 	BOOST_CHECK(!co.clock);
 	BOOST_CHECK(co.data_dir && *co.data_dir == "datadirfoo");
 	BOOST_CHECK(!co.data_path);


### PR DESCRIPTION
Fixes #3472. [story] and [message] through the end of the `start` event will be skipped.

Try it: `./wesnoth -cThe_South_Guard --campaign-difficulty=1 --campaign-scenario=01_Born_to_the_Banner --campaign-skip-story`

