### PR TITLE
Add left padding to messages with right portrait

### DIFF
--- a/data/gui/window/wml_message.cfg
+++ b/data/gui/window/wml_message.cfg
@@ -774,6 +774,19 @@ where left_padding = if(gamemap_width - ({__GUI_IMAGE_WIDTH} + ({__GUI_IMAGE_WID
 											[column]
 
 												[spacer]
+													width = "(
+if(gamemap_width - ({__GUI_IMAGE_WIDTH} + ({__GUI_IMAGE_WIDTH})) > {MAX_TEXT_WIDTH}
+, gamemap_width - ({__GUI_IMAGE_WIDTH} + ({__GUI_IMAGE_WIDTH}) + {MAX_TEXT_WIDTH})
+, 0
+))"
+													height = 75
+												[/spacer]
+
+											[/column]
+
+											[column]
+
+												[spacer]
 													# reserve place for the image and set a minimum height for the text
 													id = "image_place_holder"
 

--- a/data/gui/window/wml_message.cfg
+++ b/data/gui/window/wml_message.cfg
@@ -633,7 +633,9 @@ if(gamemap_width - ({__GUI_IMAGE_WIDTH}) > {MAX_TEXT_WIDTH}
 											[column]
 
 												[spacer]
-													width = 10
+													width = "(
+if(gamemap_width - ({__GUI_IMAGE_WIDTH} + ({__GUI_IMAGE_WIDTH})) > {MAX_TEXT_WIDTH} , {__GUI_IMAGE_WIDTH} , 10)
+)"
 													height = 75
 												[/spacer]
 
@@ -645,10 +647,12 @@ if(gamemap_width - ({__GUI_IMAGE_WIDTH}) > {MAX_TEXT_WIDTH}
 
 												[spacer]
 													width = "(
-if(gamemap_width - (10 + ({__GUI_IMAGE_WIDTH})) > {MAX_TEXT_WIDTH}
-, gamemap_width - (10 + ({__GUI_IMAGE_WIDTH}) + {MAX_TEXT_WIDTH})
+if(gamemap_width - (left_padding + ({__GUI_IMAGE_WIDTH})) > {MAX_TEXT_WIDTH}
+, gamemap_width - (left_padding + ({__GUI_IMAGE_WIDTH}) + {MAX_TEXT_WIDTH})
 , 0
-))"
+)
+where left_padding = if(gamemap_width - ({__GUI_IMAGE_WIDTH} + ({__GUI_IMAGE_WIDTH})) > {MAX_TEXT_WIDTH} , {__GUI_IMAGE_WIDTH} , 10)
+)"
 													height = 75
 												[/spacer]
 


### PR DESCRIPTION
Fixes #1938. Tested on 800x600 and 1920x1080. This brings the left edge of the message (title and text) away from the left edge of the map. When the screen is wide enough, the text is placed at the same position regardless of whether the portrait is on the left, on the right, or on both sides. To test this start AToTB and read the dialog.