### PR TITLE
WML: Support [filter_side] in [item].

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -45,6 +45,7 @@
    * Support male_voice and female_voice in [message]
    * Support [break], [continue], and [return] in [random_placement]
    * [remove_sound_source] now accepts a comma-separated ID list
+   * Support [filter_team] in [side] in addition to team_name=
 
 ## Version 1.14.4+dev
  ### Campaigns

--- a/data/lua/wml/items.lua
+++ b/data/lua/wml/items.lua
@@ -16,6 +16,7 @@ local function add_overlay(x, y, cfg)
 			image = cfg.image,
 			halo = cfg.halo,
 			team_name = cfg.team_name,
+			filter_side = cfg.filter_side,
 			visible_in_fog = cfg.visible_in_fog,
 			redraw = cfg.redraw,
 			name = cfg.name

--- a/data/lua/wml/items.lua
+++ b/data/lua/wml/items.lua
@@ -16,7 +16,7 @@ local function add_overlay(x, y, cfg)
 			image = cfg.image,
 			halo = cfg.halo,
 			team_name = cfg.team_name,
-			filter_side = cfg.filter_side,
+			filter_team = cfg.filter_team,
 			visible_in_fog = cfg.visible_in_fog,
 			redraw = cfg.redraw,
 			name = cfg.name

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1691,8 +1691,12 @@ void display::draw_gamemap()
 
 		const overlay& item = overlay_record.second;
 		const std::string& current_team_name = get_teams()[viewing_team()].team_name();
+		const std::vector<std::string>& current_team_names = utils::split(current_team_name);
+		const std::vector<std::string>& team_names = utils::split(item.team_name);
 
-		if((item.team_name.empty() || item.team_name.find(current_team_name) != std::string::npos) &&
+		if((item.team_name.empty() ||
+			std::find_first_of(team_names.begin(), team_names.end(),
+				current_team_names.begin(), current_team_names.end()) != team_names.end()) &&
 			(!fogged(o_loc) || item.visible_in_fog))
 		{
 			const texture tex = item.image.find("~NO_TOD_SHIFT()") == std::string::npos

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -3323,11 +3323,23 @@ static int intf_add_known_unit(lua_State *L)
 int game_lua_kernel::intf_add_tile_overlay(lua_State *L)
 {
 	map_location loc = luaW_checklocation(L, 1);
-	config cfg = luaW_checkconfig(L, 2);
+	vconfig cfg = luaW_checkvconfig(L, 2);
+	const vconfig &ssf = cfg.child("filter_side");
+
+	std::string team_name;
+	if (!ssf.null()) {
+		const std::vector<int>& teams = side_filter(ssf, &game_state_).get_teams();
+		std::vector<std::string> team_names;
+		std::transform(teams.begin(), teams.end(), std::back_inserter(team_names),
+			[&](int team) { return game_state_.get_disp_context().get_team(team).team_name(); });
+		team_name = utils::join(team_names);
+	} else {
+		team_name = cfg["team_name"].str();
+	}
 
 	if (game_display_) {
 		game_display_->add_overlay(loc, cfg["image"], cfg["halo"],
-			cfg["team_name"], cfg["name"], cfg["visible_in_fog"].to_bool(true));
+			team_name, cfg["name"], cfg["visible_in_fog"].to_bool(true));
 	}
 	return 0;
 }

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -3324,7 +3324,7 @@ int game_lua_kernel::intf_add_tile_overlay(lua_State *L)
 {
 	map_location loc = luaW_checklocation(L, 1);
 	vconfig cfg = luaW_checkvconfig(L, 2);
-	const vconfig &ssf = cfg.child("filter_side");
+	const vconfig &ssf = cfg.child("filter_team");
 
 	std::string team_name;
 	if (!ssf.null()) {


### PR DESCRIPTION
If [filter_side] is present then "team_name" is ignored.

Fixes #1477.

Constructing a comma-separated set of team names is ugly but I didn't want to change `add_overlay` and the `overlay` struct. https://github.com/wesnoth/wesnoth/blob/cc98bcd9d015a852dbec2053f300ce4682c4765d/src/overlay.hpp#L23-L26