### PR TITLE
Fix Animations immediately following a message get truncated (issue #1617)

### DIFF
--- a/data/lua/wml/animate_unit.lua
+++ b/data/lua/wml/animate_unit.lua
@@ -109,5 +109,6 @@ end
 function wesnoth.wml_actions.animate_unit(cfg)
 	local anim = wesnoth.create_animator()
 	add_animation(anim, cfg)
+	wesnoth.delay(0)
 	anim:run()
 end

--- a/data/lua/wml/animate_unit.lua
+++ b/data/lua/wml/animate_unit.lua
@@ -109,6 +109,5 @@ end
 function wesnoth.wml_actions.animate_unit(cfg)
 	local anim = wesnoth.create_animator()
 	add_animation(anim, cfg)
-	wesnoth.delay(0)
 	anim:run()
 end

--- a/data/lua/wml/message.lua
+++ b/data/lua/wml/message.lua
@@ -475,5 +475,4 @@ function wesnoth.wml_actions.message(cfg)
 			if action ~= "none" then break end
 		end
 	end
-	wesnoth.delay(0)
 end

--- a/data/lua/wml/message.lua
+++ b/data/lua/wml/message.lua
@@ -475,4 +475,5 @@ function wesnoth.wml_actions.message(cfg)
 			if action ~= "none" then break end
 		end
 	end
+	wesnoth.delay(0)
 end


### PR DESCRIPTION
When unit with staff of tighteous die in s9 forbidden forest the animatiom is'nt played. The same problem with Dacyn disapear in S1 of EI. Insert wesnoth.delay fix this.