### PR TITLE
Unit Display: When an invisible enemy unit recruits another invisible unit, don't scroll to their location

### DIFF
--- a/src/units/udisplay.cpp
+++ b/src/units/udisplay.cpp
@@ -698,20 +698,34 @@ void reset_helpers(const unit *attacker,const unit *defender)
 void unit_recruited(const map_location& loc,const map_location& leader_loc)
 {
 	game_display* disp = game_display::get_singleton();
+	const display_context& dc = disp->get_disp_context();
+	const team& viewing_team = dc.get_team(disp->viewing_side());
 	if(!disp || disp->video().update_locked() || disp->video().faked() ||disp->fogged(loc)) return;
+
 	unit_map::const_iterator u = disp->get_units().find(loc);
 	if(u == disp->get_units().end()) return;
+	const bool unit_visible = u->is_visible_to_team(viewing_team, dc, false);
+
+	unit_map::const_iterator leader = disp->get_units().find(leader_loc); // may be null_location
+	const bool leader_visible = (leader != disp->get_units().end()) && leader->is_visible_to_team(viewing_team, dc, false);
+
 	u->set_hidden(true);
 
 	unit_animator animator;
-	if(leader_loc != map_location::null_location()) {
-		unit_map::const_iterator leader = disp->get_units().find(leader_loc);
-		if(leader == disp->get_units().end()) return;
+	if (leader_visible && unit_visible) {
 		disp->scroll_to_tiles(loc,leader_loc,game_display::ONSCREEN,true,0.0,false);
-		leader->set_facing(leader_loc.get_relative_dir(loc));
-		animator.add_animation(&*leader, "recruiting", leader_loc, loc, 0, true);
-	} else {
+	} else if (leader_visible) {
+		disp->scroll_to_tile(leader_loc,game_display::ONSCREEN,true,false);
+	} else if (unit_visible) {
 		disp->scroll_to_tile(loc,game_display::ONSCREEN,true,false);
+	} else {
+		return;
+	}
+	if (leader != disp->get_units().end()) {
+		leader->set_facing(leader_loc.get_relative_dir(loc));
+		if (leader_visible) {
+			animator.add_animation(&*leader, "recruiting", leader_loc, loc, 0, true);
+		}
 	}
 
 	disp->draw();


### PR DESCRIPTION
Scrolling to them would leak their location to the player.

edit: To test this:

```
diff --git a/data/campaigns/Heir_To_The_Throne/scenarios/01_The_Elves_Besieged.cfg b/data/campaigns/Heir_To_The_Throne/scenarios/01_The_Elves_Besieged.cfg
index 805f25cc67..4c9fb338bc 100644
--- a/data/campaigns/Heir_To_The_Throne/scenarios/01_The_Elves_Besieged.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/01_The_Elves_Besieged.cfg
@@ -6,7 +6,8 @@
     victory_when_enemies_defeated=no
     map_data="{campaigns/Heir_To_The_Throne/maps/01_The_Elves_Besieged.map}"
     {TURNS 16 14 12}
-    {DEFAULT_SCHEDULE}
+    {SECOND_WATCH}
+    {DAWN}
 
     {SCENARIO_MUSIC "battle.ogg"}
     {EXTRA_SCENARIO_MUSIC "casualties_of_war.ogg"}
@@ -160,13 +161,14 @@
 #enddef
 
     [side]
-        type=Orcish Warlord
+        {QUANTITY type Nightgaunt Nightgaunt Lich}
         id=Urug-Telfar
         name= _ "Urug-Telfar"
         side=2
+        x,y=31,3
         canrecruit=yes
         profile=portraits/orcs/grunt-2.png
-        recruit=Orcish Warrior,Goblin Knight,Goblin Pillager,Orcish Crossbowman,Orcish Assassin,Troll
+        {QUANTITY recruit Shadow Skeleton Shadow}
         gold=400
         [ai]
             recruitment_pattern=scout,fighter,mixed fighter,archer
@@ -187,6 +189,7 @@
         id=Knafa-Tan
         name= _ "Knafa-Tan"
         side=3
+        x,y=9,4
         canrecruit=yes
         recruit=Orcish Warrior,Wolf Rider,Orcish Crossbowman,Orcish Assassin,Troll
         {EBESIEGED_RECRUITMENT}
@@ -208,6 +211,7 @@
         id=Maga-Knafa
         name= _ "Maga-Knafa"
         side=4
+        x,y=9,5
         canrecruit=yes
         recruit=Orcish Warrior,Wolf Rider,Orcish Crossbowman,Troll Warrior,Orcish Slayer
         {EBESIEGED_RECRUITMENT}
```