### PR TITLE
Game Load: Restore the ability to select 1.12.6 savegames in the list

### DIFF
--- a/src/save_index.cpp
+++ b/src/save_index.cpp
@@ -373,7 +373,11 @@ void extract_summary_from_config(config& cfg_save, config& cfg_summary)
 	cfg_summary["difficulty"] = cfg_save["difficulty"];
 	cfg_summary["random_mode"] = cfg_save["random_mode"];
 
-	cfg_summary["active_mods"] = cfg_save.child("multiplayer")["active_mods"];
+	if(cfg_save.has_child("multiplayer")) {
+		cfg_summary["active_mods"] = cfg_save.child("multiplayer")["active_mods"];
+	} else {
+		cfg_summary["active_mods"] = "";
+	}
 	cfg_summary["campaign"] = cfg_save["campaign"];
 	cfg_summary["version"] = cfg_save["version"];
 	cfg_summary["corrupt"] = "";

--- a/src/save_index.cpp
+++ b/src/save_index.cpp
@@ -373,11 +373,7 @@ void extract_summary_from_config(config& cfg_save, config& cfg_summary)
 	cfg_summary["difficulty"] = cfg_save["difficulty"];
 	cfg_summary["random_mode"] = cfg_save["random_mode"];
 
-	if(cfg_save.has_child("multiplayer")) {
-		cfg_summary["active_mods"] = cfg_save.child("multiplayer")["active_mods"];
-	} else {
-		cfg_summary["active_mods"] = "";
-	}
+	cfg_summary["active_mods"] = cfg_save.child_or_empty("multiplayer")["active_mods"];
 	cfg_summary["campaign"] = cfg_save["campaign"];
 	cfg_summary["version"] = cfg_save["version"];
 	cfg_summary["corrupt"] = "";


### PR DESCRIPTION
In 1.14 since 14abecb2df9f94b4a4438156f9808596d223864b (#3495), selecting a 1.12.6 savegame in Game Load results in

> The file you have tried to load is corrupt: 'Mandatory WML child missing yet untested for. Please report.'

This PR fixes that.