### PR TITLE
[WIP] add wesnoth_min_version

### DIFF
--- a/src/addon/client.cpp
+++ b/src/addon/client.cpp
@@ -20,6 +20,7 @@
 #include "cursor.hpp"
 #include "font/pango/escape.hpp"
 #include "formula/string_utils.hpp"
+#include "game_config.hpp"
 #include "gettext.hpp"
 #include "gui/dialogs/addon/install_dependencies.hpp"
 #include "gui/dialogs/message.hpp"
@@ -85,7 +86,7 @@ bool addons_client::request_addons_list(config& cfg)
 	/** @todo FIXME: get rid of this legacy "campaign"/"campaigns" silliness
 	 */
 
-	this->send_simple_request("request_campaign_list", response_buf);
+	this->send_request(config("request_campaign_list", config("client_version", game_config::version)), response_buf);
 	this->wait_for_transfer_done(_("Downloading list of add-ons..."));
 
 	std::swap(cfg, response_buf.child("campaigns"));
@@ -234,6 +235,7 @@ bool addons_client::download_addon(config& archive_cfg, const std::string& id, c
 
 	request_body["name"] = id;
 	request_body["increase_downloads"] = increase_downloads;
+	request_body["client_version"] = game_config::version;
 
 	utils::string_map i18n_symbols;
 	i18n_symbols["addon_title"] = font::escape_text(title);

--- a/src/addon/info.cpp
+++ b/src/addon/info.cpp
@@ -65,7 +65,7 @@ void addon_info::read(const config& cfg)
 	this->description = cfg["description"].str();
 	this->icon = cfg["icon"].str();
 	this->version = cfg["version"].str();
-	this->wesnoth_min_version = cfg["wesnoth_min_version"].str();
+	this->req_w_version = cfg["required_wesnoth_version"].str();
 	this->author = cfg["author"].str();
 	this->size = cfg["size"];
 	this->downloads = cfg["downloads"];
@@ -96,7 +96,7 @@ void addon_info::write(config& cfg) const
 	cfg["description"] = this->description;
 	cfg["icon"] = this->icon;
 	cfg["version"] = this->version.str();
-	cfg["wesnoth_min_version"] = this->wesnoth_min_version.str();
+	cfg["required_wesnoth_version"] = this->req_w_version.str();
 	cfg["author"] = this->author;
 	cfg["size"] = this->size;
 	cfg["downloads"] = this->downloads;
@@ -119,7 +119,7 @@ void addon_info::write(config& cfg) const
 void addon_info::write_minimal(config& cfg) const
 {
 	cfg["version"] = this->version.str();
-	cfg["wesnoth_min_version"] = this->wesnoth_min_version.str();
+	cfg["required_wesnoth_version"] = this->req_w_version.str();
 	cfg["uploads"] = this->uploads;
 	cfg["type"] = get_addon_type_string(this->type);
 	cfg["title"] = this->title;

--- a/src/addon/info.cpp
+++ b/src/addon/info.cpp
@@ -65,6 +65,7 @@ void addon_info::read(const config& cfg)
 	this->description = cfg["description"].str();
 	this->icon = cfg["icon"].str();
 	this->version = cfg["version"].str();
+	this->wesnoth_min_version = cfg["wesnoth_min_version"].str();
 	this->author = cfg["author"].str();
 	this->size = cfg["size"];
 	this->downloads = cfg["downloads"];
@@ -95,6 +96,7 @@ void addon_info::write(config& cfg) const
 	cfg["description"] = this->description;
 	cfg["icon"] = this->icon;
 	cfg["version"] = this->version.str();
+	cfg["wesnoth_min_version"] = this->wesnoth_min_version.str();
 	cfg["author"] = this->author;
 	cfg["size"] = this->size;
 	cfg["downloads"] = this->downloads;
@@ -117,6 +119,7 @@ void addon_info::write(config& cfg) const
 void addon_info::write_minimal(config& cfg) const
 {
 	cfg["version"] = this->version.str();
+	cfg["wesnoth_min_version"] = this->wesnoth_min_version.str();
 	cfg["uploads"] = this->uploads;
 	cfg["type"] = get_addon_type_string(this->type);
 	cfg["title"] = this->title;

--- a/src/addon/info.hpp
+++ b/src/addon/info.hpp
@@ -36,7 +36,7 @@ struct addon_info
 
 	version_info version;
 
-	version_info wesnoth_min_version;
+	version_info req_w_version;
 
 	std::string author;
 
@@ -70,7 +70,7 @@ struct addon_info
 
 	addon_info()
 		: id(), title(), description(), icon()
-		, version(), wesnoth_min_version(), author(), size(), downloads()
+		, version(), req_w_version(), author(), size(), downloads()
 		, uploads(), type(), tags(), locales()
 		, core()
 		, depends()
@@ -83,7 +83,7 @@ struct addon_info
 
 	explicit addon_info(const config& cfg)
 		: id(), title(), description(), icon()
-		, version(), wesnoth_min_version(), author(), size(), downloads()
+		, version(), req_w_version(), author(), size(), downloads()
 		, uploads(), type(), tags(), locales()
 		, core()
 		, depends()
@@ -117,7 +117,7 @@ struct addon_info
 			this->created = o.created;
 			this->order = o.order;
 			this->local_only = o.local_only;
-			this->wesnoth_min_version = o.wesnoth_min_version;
+			this->req_w_version = o.req_w_version;
 		}
 		return *this;
 	}

--- a/src/addon/info.hpp
+++ b/src/addon/info.hpp
@@ -36,6 +36,8 @@ struct addon_info
 
 	version_info version;
 
+	version_info wesnoth_min_version;
+
 	std::string author;
 
 	int size;
@@ -68,7 +70,7 @@ struct addon_info
 
 	addon_info()
 		: id(), title(), description(), icon()
-		, version(), author(), size(), downloads()
+		, version(), wesnoth_min_version(), author(), size(), downloads()
 		, uploads(), type(), tags(), locales()
 		, core()
 		, depends()
@@ -81,7 +83,7 @@ struct addon_info
 
 	explicit addon_info(const config& cfg)
 		: id(), title(), description(), icon()
-		, version(), author(), size(), downloads()
+		, version(), wesnoth_min_version(), author(), size(), downloads()
 		, uploads(), type(), tags(), locales()
 		, core()
 		, depends()
@@ -115,6 +117,7 @@ struct addon_info
 			this->created = o.created;
 			this->order = o.order;
 			this->local_only = o.local_only;
+			this->wesnoth_min_version = o.wesnoth_min_version;
 		}
 		return *this;
 	}

--- a/src/campaign_server/campaign_server.cpp
+++ b/src/campaign_server/campaign_server.cpp
@@ -689,8 +689,33 @@ void server::handle_request_campaign_list(const server::request& req)
 				continue;
 			}
 		}
-
+#ifdef __UNUSED__
+		// todo: when we change the campaigns format internally it might be easier 
+		//       to do it this way than to explicitly remove attributes in the
+		//       row below.
+		config& j = campaign_list.add_child("campaign", config(
+			"author", i["author"],
+			"dependencies", i["dependencies"],
+			"description", i["description"],
+			"downloads", i["downloads"],
+			"icon", i["icon"],
+			"name", i["name"],
+			"required_wesnoth_version", i["required_wesnoth_version"],
+			"timestamp", i["timestamp"],
+			"title", i["title"],
+			"translate", i["translate"],
+			"type", i["type"],
+			"uploads", i["uploads"],
+			"version", i["version"],
+		));
+		
+		const config& url_params = i.child_or_empty("feedback");
+		if(!url_params.empty() && !feedback_url_format_.empty()) {
+			j["feedback_url"] = format_addon_feedback_url(feedback_url_format_, url_params);
+		}
+#else
 		campaign_list.add_child("campaign", i);
+#endif
 	}
 
 	for(config& j : campaign_list.child_range("campaign"))

--- a/src/campaign_server/campaign_server.cpp
+++ b/src/campaign_server/campaign_server.cpp
@@ -1009,12 +1009,6 @@ void server::handle_upload(const server::request& req)
 		}
 
 		(*campaign)["size"] = filesystem::file_size(filename);
-
-		write_config();
-
-		send_message(message, req.sock);
-
-		fire("hook_post_upload", upload["name"]);
 		if(w_version_diff == OLDER) {
 			// remove all versions of the campaign that can be replaced by this.			
 			campaigns().remove_children("campaign", [&](const config& cfg){
@@ -1039,6 +1033,12 @@ void server::handle_upload(const server::request& req)
 				req_w_version = c["required_wesnoth_version"].str();
 			}
 		}
+
+		write_config();
+
+		send_message(message, req.sock);
+
+		fire("hook_post_upload", upload["name"]);
 	}
 }
 

--- a/src/campaign_server/campaign_server.hpp
+++ b/src/campaign_server/campaign_server.hpp
@@ -24,6 +24,8 @@
 
 #include <chrono>
 
+class version_info;
+
 namespace campaignd {
 
 /**
@@ -142,6 +144,9 @@ private:
 
 	/** Retrieves a campaign by id if found, or a null config otherwise. */
 	config& get_campaign(const std::string& id) { return campaigns().find_child("campaign", "name", id); }
+
+	/** Retrieves a campaign by id if found, or a null config otherwise. */
+	config* get_campaign(const std::string& id, const version_info& wesnoth_version);
 
 	void delete_campaign(const std::string& id);
 

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -158,6 +158,7 @@ public:
 		typedef config &reference;
 		typedef child_list::iterator Itor;
 		typedef child_iterator this_type;
+		child_iterator(): i_() {}
 		explicit child_iterator(const Itor &i): i_(i) {}
 
 		child_iterator &operator++() { ++i_; return *this; }
@@ -201,6 +202,7 @@ public:
 		typedef child_list::const_iterator Itor;
 		typedef const_child_iterator this_type;
 		explicit const_child_iterator(const Itor &i): i_(i) {}
+		const_child_iterator(): i_() {}
 		const_child_iterator(const child_iterator &i): i_(i.i_) {}
 
 		const_child_iterator &operator++() { ++i_; return *this; }
@@ -571,6 +573,7 @@ public:
 		typedef any_child reference;
 		typedef std::vector<child_pos>::iterator Itor;
 		typedef all_children_iterator this_type;
+		all_children_iterator(): i_() {}
 		explicit all_children_iterator(const Itor &i): i_(i) {}
 
 		all_children_iterator &operator++() { ++i_; return *this; }
@@ -624,6 +627,7 @@ public:
 		typedef std::vector<child_pos>::const_iterator Itor;
 		typedef const_all_children_iterator this_type;
 		explicit const_all_children_iterator(const Itor &i): i_(i) {}
+		const_all_children_iterator(): i_() {}
 		const_all_children_iterator(all_children_iterator& i): i_(i.i_) {}
 
 		const_all_children_iterator &operator++() { ++i_; return *this; }

--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -424,6 +424,7 @@ void game_config_manager::load_addons_cfg()
 		}
 
 		version_info addon_version(metadata["version"]);
+		version_info min_wesnoth_version(metadata["min_wesnoth_version"]);
 
 		try {
 			// Load this addon from the cache to a config.
@@ -447,6 +448,7 @@ void game_config_manager::load_addons_cfg()
 					cfg["addon_title"] = addon_title;
 					// Note that this may reformat the string in a canonical form.
 					cfg["addon_version"] = addon_version.str();
+					cfg["min_wesnoth_version"] = min_wesnoth_version.str();
 				}
 			}
 

--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -424,7 +424,7 @@ void game_config_manager::load_addons_cfg()
 		}
 
 		version_info addon_version(metadata["version"]);
-		version_info min_wesnoth_version(metadata["min_wesnoth_version"]);
+		version_info req_w_version(metadata["required_wesnoth_version"]);
 
 		try {
 			// Load this addon from the cache to a config.
@@ -448,7 +448,7 @@ void game_config_manager::load_addons_cfg()
 					cfg["addon_title"] = addon_title;
 					// Note that this may reformat the string in a canonical form.
 					cfg["addon_version"] = addon_version.str();
-					cfg["min_wesnoth_version"] = min_wesnoth_version.str();
+					cfg["required_wesnoth_version"] = req_w_version.str();
 				}
 			}
 

--- a/src/game_initialization/mp_game_utils.cpp
+++ b/src/game_initialization/mp_game_utils.cpp
@@ -45,6 +45,8 @@ static void add_multiplayer_classification(config& multiplayer, saved_game& stat
 	multiplayer["difficulty_define"] = state.classification().difficulty;
 	multiplayer["mp_campaign"] = state.classification().campaign;
 	multiplayer["mp_campaign_name"] = state.classification().campaign_name;
+	multiplayer["min_wesnoth_version"] = state.min_wesnoth_version();
+	
 }
 
 config initial_level_config(saved_game& state)

--- a/src/game_initialization/mp_game_utils.cpp
+++ b/src/game_initialization/mp_game_utils.cpp
@@ -45,7 +45,7 @@ static void add_multiplayer_classification(config& multiplayer, saved_game& stat
 	multiplayer["difficulty_define"] = state.classification().difficulty;
 	multiplayer["mp_campaign"] = state.classification().campaign;
 	multiplayer["mp_campaign_name"] = state.classification().campaign_name;
-	multiplayer["min_wesnoth_version"] = state.min_wesnoth_version();
+	multiplayer["required_wesnoth_version"] = state.req_w_version();
 	
 }
 

--- a/src/saved_game.cpp
+++ b/src/saved_game.cpp
@@ -94,7 +94,7 @@ saved_game::saved_game()
 	, starting_point_type_(STARTING_POINT_NONE)
 	, starting_point_()
 	, replay_data_()
-	, min_wesnoth_version_()
+	, req_w_version_()
 	, skip_story_(false)
 {
 }
@@ -108,7 +108,7 @@ saved_game::saved_game(config cfg)
 	, starting_point_type_(STARTING_POINT_NONE)
 	, starting_point_()
 	, replay_data_()
-	, min_wesnoth_version_()
+	, req_w_version_()
 	, skip_story_(false)
 
 {
@@ -124,7 +124,7 @@ saved_game::saved_game(const saved_game& state)
 	, starting_point_type_(state.starting_point_type_)
 	, starting_point_(state.starting_point_)
 	, replay_data_(state.replay_data_)
-	, min_wesnoth_version_(state.min_wesnoth_version_)
+	, req_w_version_(state.req_w_version_)
 	, skip_story_(state.skip_story_)
 {
 }
@@ -242,7 +242,7 @@ void saved_game::expand_scenario()
 		if(scenario) {
 			this->starting_point_type_ = STARTING_POINT_SCENARIO;
 			this->starting_point_ = scenario;
-			min_wesnoth_version_ = std::max(min_wesnoth_version_, version_info(this->starting_pos_["min_wesnoth_version"]));
+			req_w_version_ = std::max(req_w_version_, version_info(this->starting_pos_["required_wesnoth_version"]));
 
 			// A hash has to be generated using an unmodified scenario data.
 			mp_settings_.hash = scenario.hash();
@@ -307,7 +307,7 @@ void saved_game::load_mod(const std::string& type, const std::string& id)
 		// Note the addon_id if this mod is required to play the game in mp.
 		std::string require_attr = "require_" + type;
 
-		min_wesnoth_version_ = std::max(min_wesnoth_version_, version_info(cfg["min_wesnoth_version"]));
+		req_w_version_ = std::max(req_w_version_, version_info(cfg["required_wesnoth_version"]));
 		// By default, eras have "require_era = true", and mods have "require_modification = false".
 		bool require_default = (type == "era");
 
@@ -682,7 +682,7 @@ void saved_game::swap(saved_game& other)
 	starting_point_.swap(other.starting_point_);
 
 	std::swap(starting_point_type_, other.starting_point_type_);
-	std::swap(min_wesnoth_version_, other.min_wesnoth_version_);
+	std::swap(req_w_version_, other.req_w_version_);
 }
 
 void saved_game::set_data(config& cfg)
@@ -735,7 +735,7 @@ void saved_game::set_data(config& cfg)
 
 	classification_ = game_classification(cfg);
 	mp_settings_ = mp_game_settings(cfg.child_or_empty("multiplayer"));
-	min_wesnoth_version_ = version_info(cfg["min_wesnoth_version"]);
+	req_w_version_ = version_info(cfg["required_wesnoth_version"]);
 	cfg.clear();
 }
 

--- a/src/saved_game.cpp
+++ b/src/saved_game.cpp
@@ -94,6 +94,7 @@ saved_game::saved_game()
 	, starting_point_type_(STARTING_POINT_NONE)
 	, starting_point_()
 	, replay_data_()
+	, min_wesnoth_version_()
 	, skip_story_(false)
 {
 }
@@ -107,6 +108,7 @@ saved_game::saved_game(config cfg)
 	, starting_point_type_(STARTING_POINT_NONE)
 	, starting_point_()
 	, replay_data_()
+	, min_wesnoth_version_()
 	, skip_story_(false)
 
 {
@@ -122,6 +124,7 @@ saved_game::saved_game(const saved_game& state)
 	, starting_point_type_(state.starting_point_type_)
 	, starting_point_(state.starting_point_)
 	, replay_data_(state.replay_data_)
+	, min_wesnoth_version_(state.min_wesnoth_version_)
 	, skip_story_(state.skip_story_)
 {
 }
@@ -239,6 +242,7 @@ void saved_game::expand_scenario()
 		if(scenario) {
 			this->starting_point_type_ = STARTING_POINT_SCENARIO;
 			this->starting_point_ = scenario;
+			min_wesnoth_version_ = std::max(min_wesnoth_version_, version_info(this->starting_pos_["min_wesnoth_version"]));
 
 			// A hash has to be generated using an unmodified scenario data.
 			mp_settings_.hash = scenario.hash();
@@ -303,6 +307,7 @@ void saved_game::load_mod(const std::string& type, const std::string& id)
 		// Note the addon_id if this mod is required to play the game in mp.
 		std::string require_attr = "require_" + type;
 
+		min_wesnoth_version_ = std::max(min_wesnoth_version_, version_info(cfg["min_wesnoth_version"]));
 		// By default, eras have "require_era = true", and mods have "require_modification = false".
 		bool require_default = (type == "era");
 
@@ -316,6 +321,7 @@ void saved_game::load_mod(const std::string& type, const std::string& id)
 
 			mp_settings_.update_addon_requirements(required_mod);
 		}
+
 
 		// Copy events
 		for(const config& modevent : cfg.child_range("event")) {
@@ -676,6 +682,7 @@ void saved_game::swap(saved_game& other)
 	starting_point_.swap(other.starting_point_);
 
 	std::swap(starting_point_type_, other.starting_point_type_);
+	std::swap(min_wesnoth_version_, other.min_wesnoth_version_);
 }
 
 void saved_game::set_data(config& cfg)
@@ -728,7 +735,7 @@ void saved_game::set_data(config& cfg)
 
 	classification_ = game_classification(cfg);
 	mp_settings_ = mp_game_settings(cfg.child_or_empty("multiplayer"));
-
+	min_wesnoth_version_ = version_info(cfg["min_wesnoth_version"]);
 	cfg.clear();
 }
 

--- a/src/saved_game.hpp
+++ b/src/saved_game.hpp
@@ -125,6 +125,7 @@ public:
 	bool skip_story() const { return skip_story_; }
 	void set_skip_story(bool skip_story) { skip_story_ = skip_story; }
 	version_info min_wesnoth_version() const { return min_wesnoth_version_; }
+	void set_min_wesnoth_version(const version_info& v) { min_wesnoth_version_ = v; }
 private:
 	bool has_carryover_expanded_;
 	/**

--- a/src/saved_game.hpp
+++ b/src/saved_game.hpp
@@ -124,8 +124,8 @@ public:
 	/// Whether to play [story] tags
 	bool skip_story() const { return skip_story_; }
 	void set_skip_story(bool skip_story) { skip_story_ = skip_story; }
-	version_info min_wesnoth_version() const { return min_wesnoth_version_; }
-	void set_min_wesnoth_version(const version_info& v) { min_wesnoth_version_ = v; }
+	version_info req_w_version() const { return req_w_version_; }
+	void set_req_w_version(const version_info& v) { req_w_version_ = v; }
 private:
 	bool has_carryover_expanded_;
 	/**
@@ -149,7 +149,7 @@ private:
 
 	replay_recorder_base replay_data_;
 
-	version_info min_wesnoth_version_;
+	version_info req_w_version_;
 
 	bool skip_story_;
 };

--- a/src/saved_game.hpp
+++ b/src/saved_game.hpp
@@ -124,7 +124,7 @@ public:
 	/// Whether to play [story] tags
 	bool skip_story() const { return skip_story_; }
 	void set_skip_story(bool skip_story) { skip_story_ = skip_story; }
-
+	version_info min_wesnoth_version() const { return min_wesnoth_version_; }
 private:
 	bool has_carryover_expanded_;
 	/**
@@ -147,6 +147,8 @@ private:
 	config starting_point_;
 
 	replay_recorder_base replay_data_;
+
+	version_info min_wesnoth_version_;
 
 	bool skip_story_;
 };

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -1258,6 +1258,10 @@ int game_lua_kernel::intf_get_starting_location(lua_State* L)
 	luaW_pushlocation(L, starting_pos);
 	return 1;
 }
+version_info game_lua_kernel::get_api_level() const
+{
+	return std::max(play_controller_.get_saved_game().min_wesnoth_version(), checked_api_level());
+}
 /**
  * - Arg 1: version number
  * - Arg 2: function to execute when this version number is given.
@@ -1268,7 +1272,7 @@ int game_lua_kernel::intf_switch_version(lua_State *L)
 	version_info required_version = version_info(luaL_checkstring(L, 1));
 	version_info api_level = play_controller_.get_saved_game().min_wesnoth_version();
 	version_info wesnoth_version = game_config::version;
-	if(api_level < version_info("1.14.6")) {
+	if(get_api_level() < version_info("1.14.6")) {
 		return luaL_error(L, "wesnoth.switch_version requires wesnoth api level 1.14.6 or higher.");
 	}
 	if(wesnoth_version >= required_version) {

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -1260,7 +1260,7 @@ int game_lua_kernel::intf_get_starting_location(lua_State* L)
 }
 version_info game_lua_kernel::get_api_level() const
 {
-	return std::max(play_controller_.get_saved_game().min_wesnoth_version(), checked_api_level());
+	return std::max(play_controller_.get_saved_game().req_w_version(), checked_api_level());
 }
 /**
  * - Arg 1: version number
@@ -1270,18 +1270,18 @@ version_info game_lua_kernel::get_api_level() const
 int game_lua_kernel::intf_switch_version(lua_State *L)
 {
 	version_info required_version = version_info(luaL_checkstring(L, 1));
-	version_info api_level = play_controller_.get_saved_game().min_wesnoth_version();
+	version_info api_level = play_controller_.get_saved_game().req_w_version();
 	version_info wesnoth_version = game_config::version;
 	if(get_api_level() < version_info("1.14.6")) {
 		return luaL_error(L, "wesnoth.switch_version requires wesnoth api level 1.14.6 or higher.");
 	}
 	if(wesnoth_version >= required_version) {
 		if(!lua_isnoneornil(L, 2)) {
-			play_controller_.get_saved_game().set_min_wesnoth_version(required_version);
+			play_controller_.get_saved_game().set_req_w_version(required_version);
 			int top = lua_gettop(L);
 			lua_pushvalue(L, 2);
 			luaW_pcall(L, 0, LUA_MULTRET , false);
-			play_controller_.get_saved_game().set_min_wesnoth_version(api_level);
+			play_controller_.get_saved_game().set_req_w_version(api_level);
 			return lua_gettop(L) - top;
 		}
 	}
@@ -1326,7 +1326,7 @@ int game_lua_kernel::impl_game_config_get(lua_State *L)
 	return_string_attrib("scenario_id", gamedata().get_id());
 	return_vector_string_attrib("defeat_music", gamedata().get_defeat_music());
 	return_vector_string_attrib("victory_music", gamedata().get_victory_music());
-	return_string_attrib("api_level", play_controller_.get_saved_game().min_wesnoth_version().str() );
+	return_string_attrib("api_level", play_controller_.get_saved_game().req_w_version().str() );
 
 	const mp_game_settings& mp_settings = play_controller_.get_mp_settings();
 	const game_classification & classification = play_controller_.get_classification();

--- a/src/scripting/game_lua_kernel.hpp
+++ b/src/scripting/game_lua_kernel.hpp
@@ -153,6 +153,7 @@ class game_lua_kernel : public lua_kernel_base
 	int intf_replace_schedule(lua_State *l);
 	int intf_set_time_of_day(lua_State *L);
 	int intf_scroll(lua_State *L);
+	int intf_switch_version(lua_State *L);
 	int intf_get_all_vars(lua_State *L);
 	int impl_theme_item(lua_State *L, std::string name);
 	int impl_theme_items_get(lua_State *L);

--- a/src/scripting/game_lua_kernel.hpp
+++ b/src/scripting/game_lua_kernel.hpp
@@ -60,6 +60,7 @@ class game_lua_kernel : public lua_kernel_base
 	std::stack<game_events::queued_event const * > queued_events_;
 
 	const game_events::queued_event & get_event_info();
+	version_info get_api_level() const;
 
 	static void extract_preload_scripts(const config& game_config);
 	static std::vector<config> preload_scripts;

--- a/src/scripting/lua_kernel_base.hpp
+++ b/src/scripting/lua_kernel_base.hpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 #include "utils/functional.hpp"
+#include "game_version.hpp"
 #include <cstdint>
 
 struct lua_State;
@@ -73,9 +74,12 @@ public:
 		return *static_cast<T*>(get_lua_kernel_base_ptr(L));
 	}
 
+	virtual void temporarily_raise_apilevel(const version_info& v);
+	virtual void reset_apilevel();
 	virtual uint32_t get_random_seed();
 	lua_State * get_state() { return mState; }
 	void add_widget_definition(const std::string& type, const std::string& id) { registered_widget_definitions_.emplace_back(type, id); }
+	const version_info& checked_api_level() const { return checked_api_level_; }
 protected:
 	lua_State *mState;
 
@@ -110,6 +114,7 @@ protected:
 	};
 
 	command_log cmd_log_;
+	version_info checked_api_level_;
 
 	// Print text to the command log for this lua kernel. Used as a replacement impl for lua print.
 	int intf_print(lua_State * L);
@@ -134,6 +139,8 @@ protected:
 	int intf_require(lua_State * L);
 
 	int intf_kernel_type(lua_State* L);
+
+	int intf_compare_versions(lua_State* L);
 
 	virtual int impl_game_config_get(lua_State* L);
 	virtual int impl_game_config_set(lua_State* L);

--- a/src/server/game.cpp
+++ b/src/server/game.cpp
@@ -162,9 +162,9 @@ static const simple_wml::node& get_multiplayer(const simple_wml::node& root)
 		return root;
 	}
 }
-version_info game::wesnoth_min_version() const
+version_info game::req_w_version() const
 {
-	return version_info(get_multiplayer(level_.root())["wesnoth_min_version"].to_string());
+	return version_info(get_multiplayer(level_.root())["required_wesnoth_version"].to_string());
 }
 
 bool game::allow_observers() const
@@ -1393,8 +1393,8 @@ bool game::add_player(const socket_ptr& player, bool observer)
 	bool became_observer = false;
 	
 	const auto& player_info = player_connections_.find(user)->info();
-	if(version_info(player_info.version()) < wesnoth_min_version()) {
-		send_server_message("This game used an add-on that requires wesnoth version " + wesnoth_min_version().str() + " to run.", player);
+	if(version_info(player_info.version()) < req_w_version()) {
+		send_server_message("This game used an add-on that requires wesnoth version " + req_w_version().str() + " to run.", player);
 		return false;
 	}
 	if(!started_ && !observer && take_side(user)) {

--- a/src/server/game.cpp
+++ b/src/server/game.cpp
@@ -162,6 +162,10 @@ static const simple_wml::node& get_multiplayer(const simple_wml::node& root)
 		return root;
 	}
 }
+version_info game::wesnoth_min_version() const
+{
+	return version_info(get_multiplayer(level_.root())["wesnoth_min_version"].to_string());
+}
 
 bool game::allow_observers() const
 {
@@ -1387,6 +1391,12 @@ bool game::add_player(const socket_ptr& player, bool observer)
 	DBG_GAME << debug_player_info();
 
 	bool became_observer = false;
+	
+	const auto& player_info = player_connections_.find(user)->info();
+	if(version_info(player_info.version()) < wesnoth_min_version()) {
+		send_server_message("This game used an add-on that requires wesnoth version " + wesnoth_min_version().str() + " to run.", player);
+		return false;
+	}
 	if(!started_ && !observer && take_side(user)) {
 		DBG_GAME << "adding player...\n";
 		players_.push_back(player);

--- a/src/server/game.hpp
+++ b/src/server/game.hpp
@@ -81,7 +81,7 @@ public:
 	/** when the host sends the new scenario of a mp campaign */
 	void new_scenario(const socket_ptr& player);
 
-	version_info wesnoth_min_version() const;
+	version_info req_w_version() const;
 	
 	bool level_init() const
 	{

--- a/src/server/game.hpp
+++ b/src/server/game.hpp
@@ -19,6 +19,7 @@
 #include "player_connection.hpp"
 #include "simple_wml.hpp"
 #include "utils/make_enum.hpp"
+#include "game_version.hpp"
 
 #include <boost/ptr_container/ptr_vector.hpp>
 
@@ -80,6 +81,8 @@ public:
 	/** when the host sends the new scenario of a mp campaign */
 	void new_scenario(const socket_ptr& player);
 
+	version_info wesnoth_min_version() const;
+	
 	bool level_init() const
 	{
 		return level_.child("snapshot") || level_.child("scenario");

--- a/src/synced_context.cpp
+++ b/src/synced_context.cpp
@@ -31,6 +31,7 @@
 #include "play_controller.hpp"
 #include "actions/undo.hpp"
 #include "game_end_exceptions.hpp"
+#include "scripting/game_lua_kernel.hpp"
 #include "seed_rng.hpp"
 #include "syncmp_handler.hpp"
 #include "units/id.hpp"
@@ -392,6 +393,11 @@ set_scontext_synced_base::set_scontext_synced_base()
 	synced_context::reset_undo_commands();
 	old_rng_ = randomness::generator;
 	randomness::generator = new_rng_.get();
+	
+	game_lua_kernel* lk = resources::controller->gamestate().get_lua_kernel();
+	if(lk) {
+		lk->reset_apilevel();
+	}
 }
 set_scontext_synced_base::~set_scontext_synced_base()
 {
@@ -399,6 +405,11 @@ set_scontext_synced_base::~set_scontext_synced_base()
 	assert(synced_context::get_synced_state() == synced_context::SYNCED);
 	randomness::generator = old_rng_;
 	synced_context::set_synced_state(synced_context::UNSYNCED);
+
+	game_lua_kernel* lk = resources::controller->gamestate().get_lua_kernel();
+	if(lk) {
+		lk->reset_apilevel();
+	}
 }
 
 set_scontext_synced::set_scontext_synced()


### PR DESCRIPTION
Addons can now specify a min_wesnoth_version attribute, addons with a
high min_wesnoth_version are hidden users with older wesnoth version in
the addon server, also users with older wesnoth wesnoth cannot join
addons with a high addon_min_version.

We need something like this if we want to add new apis to stable releases as we want to do, but also withotu new apis this can be useful if addons make heavily use of apis that are borken in older wesnoth version.


While this is a good starting step, it's not 100% clear how to continue: It wodul make sense to allow using new api only when the wesnoth_minversion attribute was specified accoringly, but that does no work in all cases, for example if a code woudl like to use wesnoth1.14.7 api but also has a fallback code for older api we shdoul allow that aswell.
