### PR TITLE
Don't scroll to a teleporting unit that's invisible at the source or destination

### DIFF
--- a/src/units/udisplay.cpp
+++ b/src/units/udisplay.cpp
@@ -74,13 +74,8 @@ static void teleport_unit_between(const map_location& a, const map_location& b,
 	const display_context& dc = disp.get_disp_context();
 	const team& viewing_team = dc.get_team(disp.viewing_side());
 
-	// Temporarily change the unit's location to check if it's visible
-	// before and after the teleport.
-	assert(temp_unit.get_location() == a);
-	const bool a_visible = temp_unit.is_visible_to_team(viewing_team, dc, false);
-	temp_unit.set_location(b);
-	const bool b_visible = temp_unit.is_visible_to_team(viewing_team, dc, false);
-	temp_unit.set_location(a);
+	const bool a_visible = temp_unit.is_visible_to_team(a, viewing_team, dc, false);
+	const bool b_visible = temp_unit.is_visible_to_team(b, viewing_team, dc, false);
 
 	if ( a_visible ) { // teleport
 		disp.invalidate(a);
@@ -331,8 +326,8 @@ void unit_mover::proceed_to(unit_ptr u, size_t path_index, bool update, bool wai
 	path_index = std::min(path_index, path_.size()-1);
 
 	for ( ; current_ < path_index; ++current_ ) {
-		// It is possible for paths_[current_] and paths_[current_+1] not to be adjacent.
-		// When that is the case, and the unit is invisible at paths_[current_], we shouldn't
+		// It is possible for path_[current_] and path_[current_+1] not to be adjacent.
+		// When that is the case, and the unit is invisible at path_[current_], we shouldn't
 		// scroll to that hex.
 		std::vector<map_location> locs;
 		if (!temp_unit_ptr_->invisible(path_[current_], disp_->get_disp_context()))

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -2358,6 +2358,11 @@ bool unit::invisible(const map_location& loc, const display_context& dc, bool se
 bool unit::is_visible_to_team(const team& team,const  display_context& dc, bool const see_all) const
 {
 	const map_location& loc = get_location();
+	return is_visible_to_team(loc, team, dc, see_all);
+}
+
+bool unit::is_visible_to_team(const map_location& loc, const team& team, const  display_context& dc, bool const see_all) const
+{
 	if(!dc.map().on_board(loc)) {
 		return false;
 	}

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1571,6 +1571,8 @@ public:
 	bool invisible(const map_location& loc, const display_context& dc, bool see_all = true) const;
 
 	bool is_visible_to_team(const team& team, const display_context& dc, bool const see_all = true) const;
+	/// Return true if the unit would be visible to team if its location were loc.
+	bool is_visible_to_team(const map_location& loc, const team& team, const display_context& dc, bool const see_all = true) const;
 
 	/**
 	 * Serializes the current unit metadata values.


### PR DESCRIPTION
Like #3559, but for teleporting.

<details><summary>Diff for testing</summary>

```
diff --git a/data/campaigns/An_Orcish_Incursion/scenarios/01_Defend_the_Forest.cfg b/data/campaigns/An_Orcish_Incursion/scenarios/01_Defend_the_Forest.cfg
index f4d83db542..93a4dc3426 100644
--- a/data/campaigns/An_Orcish_Incursion/scenarios/01_Defend_the_Forest.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/01_Defend_the_Forest.cfg
@@ -12,6 +12,7 @@
     turns=24
     next_scenario=02_Assassins
 
+    {SECOND_WATCH}
     {DEFAULT_SCHEDULE}
 
     {SCENARIO_MUSIC       knolls.ogg}
@@ -82,13 +83,13 @@
         side=2
         controller=ai
         recruit="Orcish Archer,Orcish Grunt,Wolf Rider"
-        {GOLD 100 125 150}
+        {GOLD 0 0 0}
         income=0
         team_name=Orcs
         user_team_name= _ "Orcs"
         {FLAG_VARIANT6 ragged}
 
-        type=Orcish Warrior
+        type=Shadow
         id=Urugha
         name=_ "Urugha"
         canrecruit=yes
@@ -101,8 +102,6 @@
         [/ai]
     [/side]
 
-    {STARTING_VILLAGES 1 6}
-
     [event]
         name=prestart
 
@@ -159,6 +158,21 @@
             message= _ "Yes, my lord!"
         [/message]
 
+        {UNIT 1 (Elvish Lady) 5 17 (hitpoints=1)}
+        {UNIT 2 (Silver Mage) 12 2 ()}
+        [+unit]
+            [modifications]
+                [object]
+                    [effect]
+                        apply_to=new_ability
+                        [abilities]
+                            {ABILITY_NIGHTSTALK}
+                        [/abilities]
+                    [/effect]
+                [/object]
+            [/modifications]
+        [/unit]
+
         [kill]
             id=Lomarfel
         [/kill]
@@ -170,6 +184,13 @@
         [/move_unit_fake]
     [/event]
 
+    [time_area]
+        {QUANTITY x,y 5-15,1-5 1-10,10-20 1,1}
+        {AFTERNOON}
+    [/time_area]
+
+    {STARTING_VILLAGES 2 999}
+
     [event]
         name=turn 2
 
```

The three cases in the `[time_area]` are when only the teleporting unit is visible at the source hex only, at the destination hex only, or at neither.

</details>