### PR TITLE
Made Blitting more permissive

### DIFF
--- a/src/image_modifications.cpp
+++ b/src/image_modifications.cpp
@@ -1013,7 +1013,12 @@ REGISTER_MOD_PARSER(BLIT, args)
 		ERR_DP << "no arguments passed to the ~BLIT() function" << std::endl;
 		return nullptr;
 	}
-
+	
+	if(s > 3){
+		ERR_DP << "too many arguments passed to the ~BLIT() function" << std::endl;
+		return nullptr;
+	}
+	
 	int x = 0, y = 0;
 
 	if(s == 3) {

--- a/src/image_modifications.cpp
+++ b/src/image_modifications.cpp
@@ -407,20 +407,18 @@ surface blit_modification::operator()(const surface& src) const
 		throw imod_exception(sstr);
 	}
 
-	if(surf_->w + x_ > src->w) {
+	if(surf_->w + x_ < 0) {
 		std::stringstream sstr;
 		sstr << "~BLIT(): offset and width '"
-			<< x_ + surf_->w << "' larger than destination image's width '"
-			<< src->w << "' no blitting performed.\n";
+			<< x_ + surf_->w << "' less than zero no blitting performed.\n";
 
 		throw imod_exception(sstr);
 	}
 
-	if(surf_->h + y_ > src->h) {
+	if(surf_->h + y_ < 0) {
 		std::stringstream sstr;
 		sstr << "~BLIT(): offset and height '"
-			<< y_ + surf_->h << "' larger than destination image's height '"
-			<< src->h << "' no blitting performed.\n";
+			<< y_ + surf_->h << "' less than zero no blitting performed.\n";
 
 		throw imod_exception(sstr);
 	}
@@ -1021,11 +1019,6 @@ REGISTER_MOD_PARSER(BLIT, args)
 	if(s == 3) {
 		x = lexical_cast_default<int>(param[1]);
 		y = lexical_cast_default<int>(param[2]);
-	}
-
-	if(x < 0 || y < 0) {
-		ERR_DP << "negative position arguments in ~BLIT() function" << std::endl;
-		return nullptr;
 	}
 
 	const image::locator img(param[0]);

--- a/src/tests/test_image_modifications.cpp
+++ b/src/tests/test_image_modifications.cpp
@@ -499,9 +499,13 @@ BOOST_AUTO_TEST_CASE(test_blit_modification_decoding_invalid_args)
 	environment_setup env_setup;
 
 	modification_queue queue =
-		modification::decode("~BLIT()");
+		modification::decode("~BLIT()"
+				     "~BLIT(wesnoth-icon.png,1,-2)"
+				     "~BLIT(wesnoth-icon.png,-1,2)"
+				     "~BLIT(wesnoth-icon.png,-1,-2)"
+				     "~BLIT(wesnoth-icon.png,1,2,3)");
 
-	BOOST_CHECK_EQUAL(queue.size(), 0);
+	BOOST_CHECK_EQUAL(queue.size(), 3);
 }
 
 /** Tests if the MASK modification with one argument is correctly decoded

--- a/src/tests/test_image_modifications.cpp
+++ b/src/tests/test_image_modifications.cpp
@@ -499,10 +499,7 @@ BOOST_AUTO_TEST_CASE(test_blit_modification_decoding_invalid_args)
 	environment_setup env_setup;
 
 	modification_queue queue =
-		modification::decode("~BLIT()"
-				     "~BLIT(wesnoth-icon.png,1,-2)"
-				     "~BLIT(wesnoth-icon.png,-1,2)"
-				     "~BLIT(wesnoth-icon.png,-1,-2)");
+		modification::decode("~BLIT()");
 
 	BOOST_CHECK_EQUAL(queue.size(), 0);
 }


### PR DESCRIPTION
SDL_BlitSurface's documentation (https://wiki.libsdl.org/SDL_BlitSurface) notes that "Blits with negative dstrect coordinates will be clipped properly".

Looking at the source code for SDL_UpperBlit() made me think that dstrect coordinates that were too big would also be handled appropriately.

I also managed to build wesnoth and run it. 
```units/goblins/rouser-lead-2.png~TC(1,magenta)~BLIT(data/core/images/halo/misc/leadership-flare-5.png, 15, -20)```
worked, and had no errors. This path tests both the negative handling and the overflow handling, so I thought it was probably good enough.

My second attempt at fixing #2225. Hopefully this goes better than the first one.