### PR TITLE
Don't show time of day under shroud

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,8 @@
      Japanese, Polish, Scottish Gaelic, Slovak, Spanish, Ukrainian.
  ### Lua API
    * Allow specifying custom flags (in particular teleport) when using a custom cost function in wesnoth.find_path
+ ### User Interface
+   * Don't show in the sidebar the time of day schedule of a shrouded hex. (issue #3638)
  ### Packaging
    * OpenMP support has been removed. It is no longer an optional build-time dependency.
  ### Units

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -1077,9 +1077,10 @@ REPORT_GENERATOR(tod_stats, rc)
 
 	const map_location& hex = mouseover_hex.valid() ? mouseover_hex : selected_hex;
 
-	const std::vector<time_of_day>& schedule = rc.tod().times(hex);
+	const map_location& tod_schedule_hex = display::get_singleton()->shrouded(hex) ? map_location::null_location() : hex;
+	const std::vector<time_of_day>& schedule = rc.tod().times(tod_schedule_hex);
 
-	int current = rc.tod().get_current_time(hex);
+	int current = rc.tod().get_current_time(tod_schedule_hex);
 	int i = 0;
 	for (const time_of_day& tod : schedule) {
 		if (i == current) tooltip << "<big><b>";


### PR DESCRIPTION
In the test scenario mouseover (4,19) to see the difference.

In master, the tod image and tod schedule indication in the sidebar show:

- "dusk 4/6" outside the cave
- "dusk 1/1" on (4,19) in master - leaking the fact that the tod schedule under the shroud consists of one timezone
- "dusk 4/6" on (4,19) with this patch - on a shrouded hex it shows what it shows on a non-shrouded hex, regardless of the time area of the shrouded hex. Is that good or would it be better to show, say, a black image and "?/?" instead, when mouseover'ing a shrouded hex?

(tagging "bug" because showing dusk and 1/1 is _definitely_ incorrect)