### PR TITLE
Sidebar alignment follows mouseover

### DIFF
--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -197,7 +197,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 			resources::gameboard->units(), resources::gameboard->map(), u_loc, u.alignment(), u.is_fearless());
 
 	// Leadership bonus.
-	int leader_bonus = under_leadership(units, u_loc, weapon, opp_weapon).first;
+	int leader_bonus = under_leadership(u, u_loc, weapon, opp_weapon);
 	if(leader_bonus != 0) {
 		damage_multiplier += leader_bonus;
 	}
@@ -1564,15 +1564,13 @@ void attack_unit_and_advance(const map_location& attacker,
 	}
 }
 
-std::pair<int, map_location> under_leadership(const unit_map& units, const map_location& loc, const_attack_ptr weapon, const_attack_ptr opp_weapon)
+int under_leadership(const unit &u, const map_location& loc, const_attack_ptr weapon, const_attack_ptr opp_weapon)
 {
-	const unit_map::const_iterator un = units.find(loc);
-	if(un == units.end()) {
-		return {0, map_location::null_location()};
-	}
+	unit_ptr new_unit = u.clone();
+	new_unit->set_location(loc);
 
-	unit_ability_list abil = un->get_abilities("leadership", weapon, opp_weapon);
-	return abil.highest("value");
+	unit_ability_list abil = new_unit->get_abilities("leadership", weapon, opp_weapon);
+	return abil.highest("value").first;
 }
 
 //begin of weapon emulates function.

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1735,7 +1735,15 @@ int combat_modifier(const unit_map& units,
 		bool is_fearless)
 {
 	const tod_manager& tod_m = *resources::tod_manager;
-	int lawful_bonus = tod_m.get_illuminated_time_of_day(units, map, loc).lawful_bonus;
+	const time_of_day& effective_tod = tod_m.get_illuminated_time_of_day(units, map, loc);
+	return combat_modifier(effective_tod, alignment, is_fearless);
+}
+
+int combat_modifier(const time_of_day& effective_tod,
+		unit_type::ALIGNMENT alignment,
+		bool is_fearless)
+{
+	const int lawful_bonus = effective_tod.lawful_bonus;
 	return generic_combat_modifier(lawful_bonus, alignment, is_fearless);
 }
 

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1566,10 +1566,7 @@ void attack_unit_and_advance(const map_location& attacker,
 
 int under_leadership(const unit &u, const map_location& loc, const_attack_ptr weapon, const_attack_ptr opp_weapon)
 {
-	unit_ptr new_unit = u.clone();
-	new_unit->set_location(loc);
-
-	unit_ability_list abil = new_unit->get_abilities("leadership", weapon, opp_weapon);
+	unit_ability_list abil = u.get_abilities("leadership", loc, weapon, opp_weapon);
 	return abil.highest("value").first;
 }
 

--- a/src/actions/attack.hpp
+++ b/src/actions/attack.hpp
@@ -29,6 +29,7 @@
 
 struct map_location;
 class team;
+struct time_of_day;
 class unit;
 class unit_map;
 class gamemap;
@@ -291,6 +292,14 @@ bool bool_leadership(const std::string& ability,const unit_map& units, const map
 int combat_modifier(const unit_map& units,
 		const gamemap& map,
 		const map_location& loc,
+		unit_type::ALIGNMENT alignment,
+		bool is_fearless);
+
+/**
+ * Returns the amount that a unit's damage should be multiplied by
+ * due to the current time of day.
+ */
+int combat_modifier(const time_of_day& effective_tod,
 		unit_type::ALIGNMENT alignment,
 		bool is_fearless);
 

--- a/src/actions/attack.hpp
+++ b/src/actions/attack.hpp
@@ -276,10 +276,9 @@ void attack_unit_and_advance(const map_location& attacker,
  * Tests if the unit at loc is currently affected by leadership.
  * (i.e. has a higher-level unit with the 'leadership' ability next to it).
  *
- * Returns a pair of bonus percentage and the leader's location if the unit is affected,
- * or 0 and map_location::null_location() otherwise.
+ * Returns the bonus percentage (possibly 0 if there's no leader adjacent).
  */
-std::pair<int, map_location> under_leadership(const unit_map& units, const map_location& loc, const_attack_ptr weapon, const_attack_ptr opp_weapon = nullptr);
+int under_leadership(const unit &u, const map_location& loc, const_attack_ptr weapon, const_attack_ptr opp_weapon = nullptr);
 bool leadership_affects_self(const std::string& ability,const unit_map& units, const map_location& loc, const_attack_ptr weapon=nullptr,const_attack_ptr opp_weapon=nullptr);
 bool leadership_affects_opponent(const std::string& ability,const unit_map& units, const map_location& loc, const_attack_ptr weapon=nullptr,const_attack_ptr opp_weapon=nullptr);
 std::pair<int, bool> ability_leadership(const std::string& ability, const unit_map& units, const map_location& loc, const map_location& opp_loc, bool attacker=true, int abil_value=0, bool backstab_pos=false, const_attack_ptr weapon=nullptr, const_attack_ptr opp_weapon=nullptr);

--- a/src/game_display.hpp
+++ b/src/game_display.hpp
@@ -149,6 +149,8 @@ public:
 	/** Set the attack direction indicator. */
 	void set_attack_indicator(const map_location& src, const map_location& dst);
 	void clear_attack_indicator();
+	// TODO: compare reports::context::mhb()->current_unit_attacks_from()
+	const map_location& get_attack_indicator_src() { return attack_indicator_src_; }
 
 	/** Function to get attack direction suffix. */
 	std::string attack_indicator_direction() const {

--- a/src/gui/dialogs/attack_predictions.cpp
+++ b/src/gui/dialogs/attack_predictions.cpp
@@ -222,7 +222,7 @@ void attack_predictions::set_data(window& window, const combatant_data& attacker
 	}
 
 	// Leadership bonus.
-	const int leadership_bonus = under_leadership(resources::gameboard->units(), attacker.unit_.get_location(), weapon, opp_weapon).first;
+	const int leadership_bonus = under_leadership(attacker.unit_, attacker.unit_.get_location(), weapon, opp_weapon);
 
 	if(leadership_bonus != 0) {
 		set_label_helper("leadership_modifier", utils::signed_percent(leadership_bonus));

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -675,20 +675,20 @@ static inline const color_t attack_info_percent_color(int resistance)
 	return font::YELLOW_COLOR;
 }
 
-static int attack_info(reports::context & rc, const attack_type &at, config &res, const unit &u, const map_location &displayed_unit_hex)
+static int attack_info(reports::context & rc, const attack_type &at, config &res, const unit &u, const map_location &hex)
 {
 	std::ostringstream str, tooltip;
 	int damage = 0;
 
 	{
-		auto ctx = at.specials_context(unit_const_ptr(&u), displayed_unit_hex, u.side() == rc.screen().playing_side());
+		auto ctx = at.specials_context(unit_const_ptr(&u), hex, u.side() == rc.screen().playing_side());
 		int base_damage = at.damage();
 		int specials_damage = at.modified_damage(false);
 		int damage_multiplier = 100;
 		const_attack_ptr weapon  = at.shared_from_this();
-		int tod_bonus = combat_modifier(get_visible_time_of_day_at(rc, displayed_unit_hex), u.alignment(), u.is_fearless());
+		int tod_bonus = combat_modifier(get_visible_time_of_day_at(rc, hex), u.alignment(), u.is_fearless());
 		damage_multiplier += tod_bonus;
-		int leader_bonus = under_leadership(u, displayed_unit_hex, weapon);
+		int leader_bonus = under_leadership(u, hex, weapon);
 		if (leader_bonus != 0)
 			damage_multiplier += leader_bonus;
 

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -341,14 +341,14 @@ REPORT_GENERATOR(selected_unit_status, rc)
 	return unit_status(rc, u);
 }
 
-static config unit_alignment(reports::context & rc, const unit* u)
+static config unit_alignment(reports::context & rc, const unit* u, const map_location& hex)
 {
 	if (!u) return config();
 	std::ostringstream str, tooltip;
 	const std::string align = unit_type::alignment_description(u->alignment(), u->gender());
 	const std::string align_id = u->alignment().to_string();
-	int cm = combat_modifier(rc.units(), rc.map(), rc.screen().displayed_unit_hex(), u->alignment(),
-			u->is_fearless());
+	const time_of_day effective_tod = get_visible_time_of_day_at(rc, hex);
+	int cm = combat_modifier(effective_tod, u->alignment(), u->is_fearless());
 
 	color_t color = font::weapon_color;
 	if (cm != 0)
@@ -365,12 +365,18 @@ static config unit_alignment(reports::context & rc, const unit* u)
 REPORT_GENERATOR(unit_alignment, rc)
 {
 	const unit *u = get_visible_unit(rc);
-	return unit_alignment(rc, u);
+	const map_location& mouseover_hex = rc.screen().mouseover_hex();
+	const map_location& displayed_unit_hex = rc.screen().displayed_unit_hex();
+	const map_location& hex = mouseover_hex.valid() ? mouseover_hex : displayed_unit_hex;
+	return unit_alignment(rc, u, hex);
 }
 REPORT_GENERATOR(selected_unit_alignment, rc)
 {
 	const unit *u = get_selected_unit(rc);
-	return unit_alignment(rc, u);
+	const map_location& attack_indicator_src = game_display::get_singleton()->get_attack_indicator_src();
+	const map_location& hex_to_show_alignment_at =
+		attack_indicator_src.valid() ? attack_indicator_src : u->get_location();
+	return unit_alignment(rc, u, hex_to_show_alignment_at);
 }
 
 

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -688,7 +688,7 @@ static int attack_info(reports::context & rc, const attack_type &at, config &res
 		const_attack_ptr weapon  = at.shared_from_this();
 		int tod_bonus = combat_modifier(get_visible_time_of_day_at(rc, displayed_unit_hex), u.alignment(), u.is_fearless());
 		damage_multiplier += tod_bonus;
-		int leader_bonus = under_leadership(rc.units(), displayed_unit_hex, weapon).first;
+		int leader_bonus = under_leadership(u, displayed_unit_hex, weapon);
 		if (leader_bonus != 0)
 			damage_multiplier += leader_bonus;
 

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -686,7 +686,7 @@ static int attack_info(reports::context & rc, const attack_type &at, config &res
 		int specials_damage = at.modified_damage(false);
 		int damage_multiplier = 100;
 		const_attack_ptr weapon  = at.shared_from_this();
-		int tod_bonus = combat_modifier(rc.units(), rc.map(), displayed_unit_hex, u.alignment(), u.is_fearless());
+		int tod_bonus = combat_modifier(get_visible_time_of_day_at(rc, displayed_unit_hex), u.alignment(), u.is_fearless());
 		damage_multiplier += tod_bonus;
 		int leader_bonus = under_leadership(rc.units(), displayed_unit_hex, weapon).first;
 		if (leader_bonus != 0)
@@ -999,12 +999,14 @@ static config unit_weapons(reports::context & rc, const unit *attacker, const ma
 	return res;
 }
 
-static config unit_weapons(reports::context & rc, const unit *u)
+/*
+ * Display the attacks of the displayed unit against the unit passed as argument.
+ * 'hex' is the location the attacker will be at during combat.
+ */
+static config unit_weapons(reports::context & rc, const unit *u, const map_location &hex)
 {
 	config res = config();
 	if ((u != nullptr) && (!u->attacks().empty())) {
-		map_location displayed_unit_hex = rc.screen().displayed_unit_hex();
-
 		const std::string attack_headline = _n("Attack", "Attacks", u->attacks().size());
 
 		add_text(res,  span_color(font::weapon_details_color)
@@ -1012,7 +1014,7 @@ static config unit_weapons(reports::context & rc, const unit *u)
 
 		for (const attack_type &at : u->attacks())
 		{
-			attack_info(rc, at, res, *u, displayed_unit_hex);
+			attack_info(rc, at, res, *u, hex);
 		}
 	}
 	return res;
@@ -1020,9 +1022,12 @@ static config unit_weapons(reports::context & rc, const unit *u)
 REPORT_GENERATOR(unit_weapons, rc)
 {
 	const unit *u = get_visible_unit(rc);
+	const map_location& mouseover_hex = rc.screen().mouseover_hex();
+	const map_location& displayed_unit_hex = rc.screen().displayed_unit_hex();
+	const map_location& hex = mouseover_hex.valid() ? mouseover_hex : displayed_unit_hex;
 	if (!u) return config();
 
-	return unit_weapons(rc, u);
+	return unit_weapons(rc, u, hex);
 }
 REPORT_GENERATOR(highlighted_unit_weapons, rc)
 {
@@ -1030,7 +1035,7 @@ REPORT_GENERATOR(highlighted_unit_weapons, rc)
 	const unit *sec_u = get_visible_unit(rc);
 
 	if (!u) return config();
-	if (!sec_u || u == sec_u) return unit_weapons(rc, sec_u);
+	if (!sec_u || u == sec_u) return unit_weapons(rc, sec_u, rc.screen().mouseover_hex());
 
 	map_location highlighted_hex = rc.screen().displayed_unit_hex();
 	map_location attack_loc;
@@ -1038,7 +1043,7 @@ REPORT_GENERATOR(highlighted_unit_weapons, rc)
 		attack_loc = rc.mhb()->current_unit_attacks_from(highlighted_hex);
 
 	if (!attack_loc.valid())
-		return unit_weapons(rc, sec_u);
+		return unit_weapons(rc, sec_u, rc.screen().mouseover_hex());
 
 	return unit_weapons(rc, u, attack_loc, sec_u, false);
 }
@@ -1048,7 +1053,7 @@ REPORT_GENERATOR(selected_unit_weapons, rc)
 	const unit *sec_u = get_visible_unit(rc);
 
 	if (!u) return config();
-	if (!sec_u || u == sec_u) return unit_weapons(rc, u);
+	if (!sec_u || u == sec_u) return unit_weapons(rc, u, u->get_location());
 
 	map_location highlighted_hex = rc.screen().displayed_unit_hex();
 	map_location attack_loc;
@@ -1056,7 +1061,7 @@ REPORT_GENERATOR(selected_unit_weapons, rc)
 		attack_loc = rc.mhb()->current_unit_attacks_from(highlighted_hex);
 
 	if (!attack_loc.valid())
-		return unit_weapons(rc, u);
+		return unit_weapons(rc, u, u->get_location());
 
 	return unit_weapons(rc, u, attack_loc, sec_u, true);
 }


### PR DESCRIPTION
This PR makes the alignment and weapon info in the sidebar show information for the mouseover hex, not for the unit's present position. For example, in the test scenario click the Footpad (14,6) and mouseover one of the empty hexes adjacent to the Dark Adept that has darkens; with the PR you'll see the sidebar show "chaotic (+25%)", compared to "chaotic (+0)%)" currently. Fog and shroud are honored.