### PR TITLE
Healing: Display healing animation if the healer is visible but the patient is not (due to fog, shroud, nightstalk...)

### DIFF
--- a/src/actions/heal.cpp
+++ b/src/actions/heal.cpp
@@ -343,10 +343,7 @@ void calculate_healing(int side, bool update_display)
 			DBG_NG << "Just before healing animations, unit has " << healers.size() << " potential healers.\n";
 		}
 
-		const team & viewing_team =
-			resources::gameboard->teams()[display::get_singleton()->viewing_team()];
-		if (!resources::controller->is_skipping_replay() && update_display &&
-		    patient.is_visible_to_team(viewing_team, false) )
+		if (!resources::controller->is_skipping_replay() && update_display)
 		{
 			unit_list.emplace_front(patient, healers, healing, curing == POISON_CURE);
 		}

--- a/src/units/udisplay.cpp
+++ b/src/units/udisplay.cpp
@@ -778,8 +778,11 @@ void unit_healing(unit &healed, const std::vector<unit *> &healers, int healing,
 {
 	game_display* disp = game_display::get_singleton();
 	const map_location& healed_loc = healed.get_location();
+	const bool some_healer_is_unfogged =
+		(healers.end() != std::find_if_not(healers.begin(), healers.end(),
+			[&](unit* h) { return disp->fogged(h->get_location()); }));
 
-	if(do_not_show_anims(disp) || disp->fogged(healed_loc)) {
+	if(do_not_show_anims(disp) || (disp->fogged(healed_loc) && !some_healer_is_unfogged)) {
 		return;
 	}
 


### PR DESCRIPTION
<details><summary>Diff for testing</summary>

```
diff --git a/data/campaigns/Heir_To_The_Throne/scenarios/01_The_Elves_Besieged.cfg b/data/campaigns/Heir_To_The_Throne/scenarios/01_The_Elves_Besieged.cfg
index a2b5cfc3093..1c4587f63fa 100644
--- a/data/campaigns/Heir_To_The_Throne/scenarios/01_The_Elves_Besieged.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/01_The_Elves_Besieged.cfg
@@ -6,7 +6,7 @@
     victory_when_enemies_defeated=no
     map_data="{campaigns/Heir_To_The_Throne/maps/01_The_Elves_Besieged.map}"
     {TURNS 16 14 12}
-    {DEFAULT_SCHEDULE}
+    {SECOND_WATCH_HOUR1}
 
     {SCENARIO_MUSIC "battle.ogg"}
     {EXTRA_SCENARIO_MUSIC "casualties_of_war.ogg"}
@@ -23,8 +23,14 @@
     [/avoid]
 #enddef
 
+    turn_at=2
     [event]
         name=prestart
+        {UNIT 2 (White Mage) 18 19 (max_moves=0)}
+        {UNIT 2 (Skeleton) 17 18 (max_moves,hitpoints=0,1)}
+        {UNIT 2 (Shadow) 17 19 (max_moves,hitpoints=0,1)} # invisible patient
+        {UNIT 2 (White Mage) 17 17 (max_moves=0)}
+
         {VARIABLE besieged_enemies_killed 0}
         {NEED_DELFADOR (x,y=19,23)}
         [objectives]
@@ -72,6 +78,8 @@
         unrenamable=yes
         profile=portraits/konrad-elvish.png
         side=1
+        fog=yes
+        {UNIT 1 Gryphon 18 21 (vision=2)}
         canrecruit=yes
         controller=human
         recruit=Elvish Scout,Elvish Fighter,Elvish Archer,Elvish Shaman
```

</details>
