### PR TITLE
#3634, #3557: Port from iOS: Compile with Apple crypto framework instead of OpenSSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,13 @@ option(ENABLE_HISTORY "Enable using GNU history for history in lua console" ON)
 if(ENABLE_GAME OR ENABLE_TESTS)
 	find_package(SDL2 2.0.4 REQUIRED)
 endif(ENABLE_GAME OR ENABLE_TESTS)
-find_package(Crypto 1.0 REQUIRED)
+
+if(NOT APPLE)
+	find_package(Crypto 1.0 REQUIRED)
+else()
+	set(CRYPTO_LIBRARY "-framework Security")
+endif()
+
 find_package(Boost 1.50 REQUIRED COMPONENTS iostreams program_options regex system thread random)
 
 # no, gettext executables are not required when NLS is deactivated

--- a/SConstruct
+++ b/SConstruct
@@ -377,6 +377,10 @@ if env["prereqs"]:
         conf.CheckBoostLocaleBackends(["icu", "winapi"]) \
             or Warning("Only icu and winapi backends of Boost Locale are supported. Bugs/crashes are very likely with other backends")
 
+    if(have_server_prereqs and env["PLATFORM"] != 'darwin'):
+        # Otherwise, use Security.framework
+        have_server_prereqs = have_server_prereqs & conf.CheckLib("libcrypto")
+
     if env['harden']:
         env["have_fortify"] = conf.CheckFortifySource()
 
@@ -617,6 +621,7 @@ for env in [test_env, client_env, env]:
     if env["PLATFORM"] == 'darwin':            # Mac OS X
         env.Append(FRAMEWORKS = "Cocoa")            # Cocoa GUI
         env.Append(FRAMEWORKS = "IOKit")            # IOKit
+        env.Append(FRAMEWORKS = "Security")         # commonCrypto (after OpenSSL replacement on Mac)
 
 if not env['static_test']:
     test_env.Append(CPPDEFINES = "BOOST_TEST_DYN_LINK")

--- a/projectfiles/Xcode/Wesnoth.xcodeproj/project.pbxproj
+++ b/projectfiles/Xcode/Wesnoth.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1C38BEB0217F92FD007326D9 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C38BEAF217F92FD007326D9 /* Security.framework */; };
 		1EF6CE8214D9846D00ECBE58 /* mp_host_game_prompt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1EF6CE8014D9846D00ECBE58 /* mp_host_game_prompt.cpp */; };
 		46181DCF2119F73A00908BC2 /* apple_battery_info.mm in Sources */ = {isa = PBXBuildFile; fileRef = 46181DCE2119F73A00908BC2 /* apple_battery_info.mm */; };
 		46181DD22119F74D00908BC2 /* battery_info.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46181DD12119F74C00908BC2 /* battery_info.cpp */; };
@@ -124,7 +125,6 @@
 		46F57087205FCF5D007031BF /* filesystem_sdl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 91FBBAD71CB6BC3F00470BFE /* filesystem_sdl.cpp */; };
 		46F57088205FCF7E007031BF /* config_attribute_value.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC0341DF1ECF46FE000F2E2B /* config_attribute_value.cpp */; };
 		46F57098205FD0B4007031BF /* SDL2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55998F70EC61EA5008DD061 /* SDL2.framework */; };
-		46F57099205FD0BF007031BF /* libcrypto.1.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 90BC845A1EDBD7B600A6630D /* libcrypto.1.1.dylib */; };
 		46F5709A205FE48C007031BF /* string_utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B55999AF0EC62181008DD061 /* string_utils.cpp */; };
 		46F570A6205FF856007031BF /* addon_utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46F5709E205FF856007031BF /* addon_utils.cpp */; };
 		46F570A7205FF856007031BF /* blacklist.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46F570A2205FF856007031BF /* blacklist.cpp */; };
@@ -191,11 +191,7 @@
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
 		903F959C1ED5489500F1BDD3 /* credentials.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 903F959B1ED5489500F1BDD3 /* credentials.cpp */; };
 		903F959F1ED5496700F1BDD3 /* hash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B52EE8AD121359A600CFBDAB /* hash.cpp */; };
-		905440871EE46ABC0091D1AE /* libcrypto.1.1.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 90BC845A1EDBD7B600A6630D /* libcrypto.1.1.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		90606A2B1D5599BA00719B40 /* libpcre.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 90606A2A1D5599BA00719B40 /* libpcre.1.dylib */; };
-		90BC845B1EDBD7B600A6630D /* libcrypto.1.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 90BC845A1EDBD7B600A6630D /* libcrypto.1.1.dylib */; };
-		90BC845C1EDBD7B600A6630D /* libcrypto.1.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 90BC845A1EDBD7B600A6630D /* libcrypto.1.1.dylib */; };
-		90BC845D1EDBD7B600A6630D /* libcrypto.1.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 90BC845A1EDBD7B600A6630D /* libcrypto.1.1.dylib */; };
 		9107AE181DB32899001927B0 /* lapi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC89A1061879D17D00A3B0B1 /* lapi.cpp */; };
 		9107AE191DB3289D001927B0 /* lauxlib.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC89A1071879D17D00A3B0B1 /* lauxlib.cpp */; };
 		9107AE1A1DB328A2001927B0 /* lbaselib.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC89A1081879D17D00A3B0B1 /* lbaselib.cpp */; };
@@ -1390,7 +1386,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				905440871EE46ABC0091D1AE /* libcrypto.1.1.dylib in Copy Frameworks */,
 				91B622011B76C0A600B00E0F /* libboost_filesystem-mt.dylib in Copy Frameworks */,
 				91B622021B76C0A600B00E0F /* libboost_iostreams-mt.dylib in Copy Frameworks */,
 				91B622031B76C0A600B00E0F /* libboost_locale-mt.dylib in Copy Frameworks */,
@@ -1440,6 +1435,7 @@
 
 /* Begin PBXFileReference section */
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
+		1C38BEAF217F92FD007326D9 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		1EF6CE8014D9846D00ECBE58 /* mp_host_game_prompt.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mp_host_game_prompt.cpp; sourceTree = "<group>"; };
 		1EF6CE8114D9846D00ECBE58 /* mp_host_game_prompt.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = mp_host_game_prompt.hpp; sourceTree = "<group>"; };
 		46181DCD2119F73A00908BC2 /* apple_battery_info.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = apple_battery_info.hpp; path = ../../src/desktop/apple_battery_info.hpp; sourceTree = "<group>"; };
@@ -1597,7 +1593,6 @@
 		903F959B1ED5489500F1BDD3 /* credentials.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = credentials.cpp; path = preferences/credentials.cpp; sourceTree = "<group>"; };
 		903F959D1ED5489D00F1BDD3 /* credentials.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = credentials.hpp; path = preferences/credentials.hpp; sourceTree = "<group>"; };
 		90606A2A1D5599BA00719B40 /* libpcre.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libpcre.1.dylib; path = lib/libpcre.1.dylib; sourceTree = "<group>"; };
-		90BC845A1EDBD7B600A6630D /* libcrypto.1.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libcrypto.1.1.dylib; path = lib/libcrypto.1.1.dylib; sourceTree = "<group>"; };
 		9107AE141DB32862001927B0 /* liblua.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = liblua.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		9107AE471DB3D8FE001927B0 /* standard_colors.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = standard_colors.cpp; path = font/standard_colors.cpp; sourceTree = "<group>"; };
 		9107AE481DB3D8FE001927B0 /* standard_colors.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = standard_colors.hpp; path = font/standard_colors.hpp; sourceTree = "<group>"; };
@@ -2773,6 +2768,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1C38BEB0217F92FD007326D9 /* Security.framework in Frameworks */,
 				46BCC905211A1E68003BDB8C /* IOKit.framework in Frameworks */,
 				ECA9E7471CA20AA800A947D6 /* libreadline.7.0.dylib in Frameworks */,
 				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
@@ -2785,7 +2781,6 @@
 				91B622221B76C0F400B00E0F /* libboost_regex-mt.dylib in Frameworks */,
 				91B622231B76C0F400B00E0F /* libboost_system-mt.dylib in Frameworks */,
 				91B622241B76C0F400B00E0F /* libboost_thread-mt.dylib in Frameworks */,
-				90BC845B1EDBD7B600A6630D /* libcrypto.1.1.dylib in Frameworks */,
 				EC5C243B18EF07B4001FA499 /* libbz2.1.0.dylib in Frameworks */,
 				B513B2290ED36BFB0006E551 /* libcairo.2.dylib in Frameworks */,
 				EC5C243C18EF07B4001FA499 /* libexpat.1.dylib in Frameworks */,
@@ -2827,7 +2822,6 @@
 			files = (
 				91C548C31D8866ED00FE6A7B /* CoreFoundation.framework in Frameworks */,
 				91C548E21D886E9000FE6A7B /* libboost_system-mt.dylib in Frameworks */,
-				46F57099205FD0BF007031BF /* libcrypto.1.1.dylib in Frameworks */,
 				91C548E81D886F1E00FE6A7B /* libboost_locale-mt.dylib in Frameworks */,
 				46F57098205FD0B4007031BF /* SDL2.framework in Frameworks */,
 				91C548ED1D886FC500FE6A7B /* libboost_filesystem-mt.dylib in Frameworks */,
@@ -2858,7 +2852,6 @@
 				91A215DF1CAD99E000927AEA /* libboost_iostreams-mt.dylib in Frameworks */,
 				91A215E01CAD99E000927AEA /* libboost_system-mt.dylib in Frameworks */,
 				91A215E11CAD99E000927AEA /* libboost_thread-mt.dylib in Frameworks */,
-				90BC845D1EDBD7B600A6630D /* libcrypto.1.1.dylib in Frameworks */,
 				91A215E21CAD9B9000927AEA /* libpango-1.0.0.dylib in Frameworks */,
 				91A215E31CAD9B9000927AEA /* libpangocairo-1.0.0.dylib in Frameworks */,
 				916718EB1CADA88800B055A9 /* libgobject-2.0.0.dylib in Frameworks */,
@@ -2873,7 +2866,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				90BC845C1EDBD7B600A6630D /* libcrypto.1.1.dylib in Frameworks */,
 				F4D2A9D514DAED4200CAFF31 /* CoreFoundation.framework in Frameworks */,
 				ECF9D44119F4042700E6C9D9 /* libboost_filesystem-mt.dylib in Frameworks */,
 				F4EF0D4D13AD4D53003C701D /* libboost_iostreams-mt.dylib in Frameworks */,
@@ -3243,6 +3235,7 @@
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				1C38BEAF217F92FD007326D9 /* Security.framework */,
 				46BCC904211A1E68003BDB8C /* IOKit.framework */,
 				1058C7A2FEA54F0111CA2CBB /* Included Frameworks */,
 				ECF9D43F19F4026D00E6C9D9 /* libboost_filesystem-mt.dylib */,
@@ -3257,7 +3250,6 @@
 				91E355621CACA1CE00774252 /* libboost_unit_test_framework-mt.dylib */,
 				EC5C242218EF07B4001FA499 /* libbz2.1.0.dylib */,
 				B513B2270ED36BFB0006E551 /* libcairo.2.dylib */,
-				90BC845A1EDBD7B600A6630D /* libcrypto.1.1.dylib */,
 				EC5C242318EF07B4001FA499 /* libexpat.1.dylib */,
 				EC5C242418EF07B4001FA499 /* libffi.6.dylib */,
 				EC5C242518EF07B4001FA499 /* libfontconfig.1.dylib */,

--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -32,8 +32,10 @@
 
 #include <boost/version.hpp>
 
+#ifndef __APPLE__
 #include <openssl/crypto.h>
 #include <openssl/opensslv.h>
+#endif
 
 #include <pango/pangocairo.h>
 
@@ -71,6 +73,8 @@ std::string format_version(const SDL_version& v)
 						<< static_cast<unsigned>(v.minor) << '.'
 						<< static_cast<unsigned>(v.patch);
 }
+
+#ifndef __APPLE__
 
 std::string format_openssl_patch_level(uint8_t p)
 {
@@ -158,6 +162,8 @@ std::string format_openssl_version(long v)
 
 }
 
+#endif
+
 version_table_manager::version_table_manager()
 	: compiled(LIB_COUNT, "")
 	, linked(LIB_COUNT, "")
@@ -233,9 +239,11 @@ version_table_manager::version_table_manager()
 	// OpenSSL/libcrypto
 	//
 
+#ifndef __APPLE__
 	compiled[LIB_CRYPTO] = format_openssl_version(OPENSSL_VERSION_NUMBER);
 	linked[LIB_CRYPTO] = format_openssl_version(SSLeay());
 	names[LIB_CRYPTO] = "OpenSSL/libcrypto";
+#endif
 
 	//
 	// Cairo

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -22,15 +22,26 @@
 #include <string.h>
 #include <assert.h>
 
+#ifndef __APPLE__
+
 #include <openssl/sha.h>
 #include <openssl/md5.h>
+
+static_assert(utils::md5::DIGEST_SIZE == MD5_DIGEST_LENGTH, "Constants mismatch");
+static_assert(utils::sha1::DIGEST_SIZE == SHA_DIGEST_LENGTH, "Constants mismatch");
+
+#else
+
+#include <CommonCrypto/CommonDigest.h>
+
+static_assert(utils::md5::DIGEST_SIZE == CC_MD5_DIGEST_LENGTH, "Constants mismatch");
+static_assert(utils::sha1::DIGEST_SIZE == CC_SHA1_DIGEST_LENGTH, "Constants mismatch");
+
+#endif
 
 extern "C" {
 #include "crypt_blowfish/crypt_blowfish.h"
 }
-
-static_assert(utils::md5::DIGEST_SIZE == MD5_DIGEST_LENGTH, "Constants mismatch");
-static_assert(utils::sha1::DIGEST_SIZE == SHA_DIGEST_LENGTH, "Constants mismatch");
 
 namespace {
 
@@ -57,10 +68,16 @@ std::string hexencode_hash(const std::array<uint8_t, len>& input) {
 namespace utils {
 
 md5::md5(const std::string& input) {
+
+#ifndef __APPLE__
 	MD5_CTX md5_worker;
 	MD5_Init(&md5_worker);
 	MD5_Update(&md5_worker, input.data(), input.size());
 	MD5_Final(hash.data(), &md5_worker);
+#else
+	CC_MD5(input.data(), static_cast<CC_LONG>(input.size()), hash.data());
+#endif
+
 }
 
 int md5::get_iteration_count(const std::string& hash) {
@@ -108,10 +125,14 @@ std::string md5::base64_digest() const
 
 sha1::sha1(const std::string& str)
 {
+#ifndef __APPLE__
 	SHA_CTX hasher;
 	SHA1_Init(&hasher);
 	SHA1_Update(&hasher, str.data(), str.size());
 	SHA1_Final(hash.data(), &hasher);
+#else
+	CC_MD5(str.data(), static_cast<CC_LONG>(str.size()), hash.data());
+#endif
 }
 
 std::string sha1::hex_digest() const

--- a/src/preferences/credentials.cpp
+++ b/src/preferences/credentials.cpp
@@ -21,7 +21,12 @@ See the COPYING file for more details.
 
 #include <algorithm>
 #include <memory>
+
+#ifndef __APPLE__
 #include <openssl/rc4.h>
+#else
+#include <CommonCrypto/CommonCryptor.h>
+#endif
 
 #ifdef _WIN32
 #include <boost/range/iterator_range.hpp>
@@ -254,12 +259,13 @@ secure_buffer build_key(const std::string& server, const std::string& login)
 
 static secure_buffer rc4_crypt(const secure_buffer& text, const secure_buffer& key)
 {
+	secure_buffer result(text.size(), '\0');
+#ifndef __APPLE__
 	RC4_KEY cipher_key;
 	RC4_set_key(&cipher_key, key.size(), key.data());
 	const size_t block_size = key.size();
 	const size_t blocks = text.size() / block_size;
 	const size_t extra = text.size() % block_size;
-	secure_buffer result(text.size(), '\0');
 	for(size_t i = 0; i < blocks * block_size; i += block_size) {
 		RC4(&cipher_key, block_size, text.data() + i, result.data() + i);
 	}
@@ -267,6 +273,23 @@ static secure_buffer rc4_crypt(const secure_buffer& text, const secure_buffer& k
 		size_t i = blocks * block_size;
 		RC4(&cipher_key, extra, text.data() + i, result.data() + i);
 	}
+#else
+	size_t outWritten = 0;
+	CCCryptorStatus ccStatus = CCCrypt(kCCDecrypt,
+		kCCAlgorithmRC4,
+		kCCOptionPKCS7Padding,
+		key.data(),
+		key.size(),
+		nullptr,
+		text.data(),
+		text.size(),
+		result.data(),
+		result.size(),
+		&outWritten);
+	
+	assert(ccStatus == kCCSuccess);
+	assert(outWritten == text.size());
+#endif
 	return result;
 }
 

--- a/utils/travis/install_deps.sh
+++ b/utils/travis/install_deps.sh
@@ -5,7 +5,7 @@ set -ev
 if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
 
 	brew update
-	brew install scons cairo pango moreutils sdl2_image sdl2_ttf sdl2_mixer openssl
+	brew install scons cairo pango moreutils sdl2_image sdl2_ttf sdl2_mixer
 
 else
 

--- a/utils/travis/steps/install.sh
+++ b/utils/travis/steps/install.sh
@@ -26,8 +26,6 @@ if [ "$TRAVIS_OS_NAME" = "osx" ]; then
         travis_wait ./projectfiles/Xcode/Fix_Xcode_Dependencies
     else
         travis_wait ./utils/travis/install_deps.sh
-        export CXXFLAGS="-I/usr/local/opt/openssl/include $CFLAGS"
-        export LDFLAGS="-L/usr/local/opt/openssl/lib $LDFLAGS"
     fi
 else
     docker build -t wesnoth-repo:"$LTS"-"$BRANCH" -f docker/Dockerfile-travis-"$LTS"-"$BRANCH" .


### PR DESCRIPTION
Didn't test scons, so let's wait for Travis. The changes are pretty straightforward though.

I don't use MacCompileStuff project, but use MacPorts, so my environment is quite different.

Should fix both #3634 and #3557.