### PR TITLE
don't write unchanged unit attributes to savefiles

### DIFF
--- a/src/game_board.cpp
+++ b/src/game_board.cpp
@@ -341,7 +341,7 @@ void game_board::write_config(config & cfg) const
 			if(i.side() == side_num) {
 				config& u = side.add_child("unit");
 				i.get_location().write(u);
-				i.write(u);
+				i.write(u, false);
 			}
 		}
 		//recall list

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -60,7 +60,8 @@ attack_type::attack_type(const config& cfg) :
 	accuracy_(cfg["accuracy"]),
 	movement_used_(cfg["movement_used"].to_int(100000)),
 	parry_(cfg["parry"]),
-	specials_(cfg.child_or_empty("specials"))
+	specials_(cfg.child_or_empty("specials")),
+	changed_(true)
 {
 	if (description_.empty())
 		description_ = translation::egettext(id_.c_str());
@@ -213,6 +214,7 @@ bool attack_type::apply_modification(const config& cfg)
 	if( !matches_filter(cfg) )
 		return false;
 
+	set_changed(true);
 	const std::string& set_name = cfg["set_name"];
 	const t_string& set_desc = cfg["set_description"];
 	const std::string& set_type = cfg["set_type"];

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -53,18 +53,18 @@ public:
 	double defense_weight() const { return defense_weight_; }
 	const config &specials() const { return specials_; }
 
-	void set_name(const t_string& value) { description_  = value; }
-	void set_id(const std::string& value) { id_ = value; }
-	void set_type(const std::string& value) { type_ = value; }
-	void set_icon(const std::string& value) { icon_ = value; }
-	void set_range(const std::string& value) { range_ = value; }
-	void set_accuracy(int value) { accuracy_ = value; }
-	void set_parry(int value) { parry_ = value; }
-	void set_damage(int value) { damage_ = value; }
-	void set_num_attacks(int value) { num_attacks_ = value; }
-	void set_attack_weight(double value) { attack_weight_ = value; }
-	void set_defense_weight(double value) { defense_weight_ = value; }
-	void set_specials(config value) { specials_ = value; }
+	void set_name(const t_string& value) { description_  = value; set_changed(true); }
+	void set_id(const std::string& value) { id_ = value; set_changed(true); }
+	void set_type(const std::string& value) { type_ = value; set_changed(true); }
+	void set_icon(const std::string& value) { icon_ = value; set_changed(true); }
+	void set_range(const std::string& value) { range_ = value; set_changed(true); }
+	void set_accuracy(int value) { accuracy_ = value; set_changed(true); }
+	void set_parry(int value) { parry_ = value; set_changed(true); }
+	void set_damage(int value) { damage_ = value; set_changed(true); }
+	void set_num_attacks(int value) { num_attacks_ = value; set_changed(true); }
+	void set_attack_weight(double value) { attack_weight_ = value; set_changed(true); }
+	void set_defense_weight(double value) { defense_weight_ = value; set_changed(true); }
+	void set_specials(config value) { specials_ = value; set_changed(true); }
 
 	// In action/attack.cpp
 	std::pair<int, bool> combat_ability(const std::string& ability, int abil_value = 0, bool backstab_pos = false) const;
@@ -151,6 +151,14 @@ public:
 	specials_context_t specials_context_for_listing(bool attacking = true) const {
 		return specials_context_t(*this, attacking);
 	}
+	void set_changed(bool value)
+	{
+		changed_ = value;
+	}
+	bool get_changed() const
+	{
+		return changed_;
+	}
 private:
 
 	t_string description_;
@@ -168,6 +176,7 @@ private:
 	int movement_used_;
 	int parry_;
 	config specials_;
+	bool changed_;
 };
 
 using attack_list = std::vector<attack_ptr>;

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1203,6 +1203,7 @@ void unit::expire_modifications(const std::string& duration)
 	// If any modifications expire, then we will need to rebuild the unit.
 	const unit_type* rebuild_from = nullptr;
 	int hp = hit_points_;
+	int mp = movement_;
 	// Loop through all types of modifications.
 	for(const auto& mod_name : ModificationTypes) {
 		// Loop through all modifications of this type.
@@ -1230,6 +1231,7 @@ void unit::expire_modifications(const std::string& duration)
 		anim_comp_->clear_haloes();
 		advance_to(*rebuild_from);
 		hit_points_ = hp;
+		movement_ = std::min(mp, max_movement_);
 	}
 }
 


### PR DESCRIPTION
Unit attribues that unchanged
(except with object/advancement/trait) are no longer written
to savefiles, this not only greatly reduce savefile size on
some cases it also makes savefiles more comptible with newer
versions because it reduced the chance that old/incompatible
code is stored in savefiles.

Note that changes via [object] (`wesnoth.add_modification()`) also
count as changes but changes done via object in advance_to does not.
This is intentional as at add_modification an objects might have
an effect dependent on a filter that depends on directly changed
arrtibutes which would then be lost on rebuild if we wouldn't mark
them as 'changed'.