### PR TITLE
After and #3634, #3557, this switch is excess.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -361,7 +361,6 @@ if env["prereqs"]:
 
     have_server_prereqs = (\
         conf.CheckCPlusPlus(gcc_version = "4.8") & \
-        conf.CheckLib("libcrypto") & \
         conf.CheckBoost("iostreams", require_version = boost_version) & \
         conf.CheckBoostIostreamsGZip() & \
         conf.CheckBoostIostreamsBZip2() & \


### PR DESCRIPTION
Another libcrypto reference can be skipped on Mac.