### PR TITLE
Fix bug in CHANCE_TO_HIT macro "Invalid WML found: [unstore_unit]: variable 'second_unit' doesn't exist"

### DIFF
--- a/data/core/macros/utils.cfg
+++ b/data/core/macros/utils.cfg
@@ -578,10 +578,6 @@
             name=attack end
             delayed_variable_substitution=yes
 
-            [filter]
-                {FILTER}
-            [/filter]
-
             [foreach]
                 array=unit.attack
                 [do]
@@ -595,11 +591,18 @@
                     {CLEAR_VARIABLE this_item.specials.original_chance_to_hit}
                 [/do]
             [/foreach]
-
-            [unstore_unit]
-                variable=unit
-                find_vacant=no
-            [/unstore_unit]
+            
+            [if]
+              [have_unit]
+               id=$unit.id
+              [/have_unit]
+                [then]
+                  [unstore_unit]
+                      variable=unit
+                      find_vacant=no
+                  [/unstore_unit]
+                [/then]
+            [/if]
         [/event]
     [/event]
 
@@ -669,10 +672,6 @@
             name=attack end
             delayed_variable_substitution=yes
 
-            [filter_second]
-                {FILTER}
-            [/filter_second]
-
             [foreach]
                 array=second_unit.attack
                 [do]
@@ -686,11 +685,18 @@
                     {CLEAR_VARIABLE this_item.specials.original_chance_to_hit}
                 [/do]
             [/foreach]
-
-            [unstore_unit]
-                variable=second_unit
-                find_vacant=no
-            [/unstore_unit]
+            
+            [if]
+              [have_unit]
+               id=$second_unit.id
+              [/have_unit]
+                [then]
+                  [unstore_unit]
+                      variable=second_unit
+                      find_vacant=no
+                  [/unstore_unit]
+                [/then]
+            [/if]
         [/event]
     [/event]
 #enddef

--- a/data/core/macros/utils.cfg
+++ b/data/core/macros/utils.cfg
@@ -577,6 +577,10 @@
         [event]
             name=attack end
             delayed_variable_substitution=yes
+            
+        [filter]
+            {FILTER}
+        [/filter]
 
             [foreach]
                 array=unit.attack
@@ -664,6 +668,10 @@
         [event]
             name=attack end
             delayed_variable_substitution=yes
+            
+        [filter_second]
+            {FILTER}
+        [/filter_second]
 
             [foreach]
                 array=second_unit.attack

--- a/data/core/macros/utils.cfg
+++ b/data/core/macros/utils.cfg
@@ -578,9 +578,9 @@
             name=attack end
             delayed_variable_substitution=yes
 
-        [filter]
-            {FILTER}
-        [/filter]
+            [filter]
+                {FILTER}
+            [/filter]
 
             [foreach]
                 array=unit.attack
@@ -669,9 +669,9 @@
             name=attack end
             delayed_variable_substitution=yes
 
-        [filter_second]
-            {FILTER}
-        [/filter_second]
+            [filter_second]
+                {FILTER}
+            [/filter_second]
 
             [foreach]
                 array=second_unit.attack

--- a/data/core/macros/utils.cfg
+++ b/data/core/macros/utils.cfg
@@ -579,10 +579,10 @@
             delayed_variable_substitution=yes
 
             [filter_condition]  
-              [have_unit]
-                 id=$unit.id
-              [/have_unit]
-           [/filter_condition]
+                [have_unit]
+                   id=$unit.id
+                [/have_unit]
+            [/filter_condition]
 
             [foreach]
                 array=unit.attack
@@ -672,10 +672,10 @@
             delayed_variable_substitution=yes
 
             [filter_condition]  
-              [have_unit]
-                 id=$second_unit.id
-              [/have_unit]
-           [/filter_condition]
+                [have_unit]
+                   id=$second_unit.id
+                [/have_unit]
+            [/filter_condition]
  
             [foreach]
                 array=second_unit.attack

--- a/data/core/macros/utils.cfg
+++ b/data/core/macros/utils.cfg
@@ -597,7 +597,7 @@
                     {CLEAR_VARIABLE this_item.specials.original_chance_to_hit}
                 [/do]
             [/foreach]
- 
+
             [unstore_unit]
                 variable=unit
                 find_vacant=no
@@ -690,7 +690,7 @@
                     {CLEAR_VARIABLE this_item.specials.original_chance_to_hit}
                 [/do]
             [/foreach]
- 
+
             [unstore_unit]
                 variable=second_unit
                 find_vacant=no

--- a/data/core/macros/utils.cfg
+++ b/data/core/macros/utils.cfg
@@ -580,7 +580,7 @@
 
             [filter_condition]  
                 [have_unit]
-                   id=$unit.id
+                    id=$unit.id
                 [/have_unit]
             [/filter_condition]
 
@@ -673,7 +673,7 @@
 
             [filter_condition]  
                 [have_unit]
-                   id=$second_unit.id
+                    id=$second_unit.id
                 [/have_unit]
             [/filter_condition]
  

--- a/data/core/macros/utils.cfg
+++ b/data/core/macros/utils.cfg
@@ -577,7 +577,7 @@
         [event]
             name=attack end
             delayed_variable_substitution=yes
-            
+
         [filter]
             {FILTER}
         [/filter]
@@ -668,7 +668,7 @@
         [event]
             name=attack end
             delayed_variable_substitution=yes
-            
+
         [filter_second]
             {FILTER}
         [/filter_second]

--- a/data/core/macros/utils.cfg
+++ b/data/core/macros/utils.cfg
@@ -578,6 +578,12 @@
             name=attack end
             delayed_variable_substitution=yes
 
+            [filter_condition]  
+              [have_unit]
+                 id=$unit.id
+              [/have_unit]
+           [/filter_condition]
+
             [foreach]
                 array=unit.attack
                 [do]
@@ -591,18 +597,11 @@
                     {CLEAR_VARIABLE this_item.specials.original_chance_to_hit}
                 [/do]
             [/foreach]
-            
-            [if]
-              [have_unit]
-               id=$unit.id
-              [/have_unit]
-                [then]
-                  [unstore_unit]
-                      variable=unit
-                      find_vacant=no
-                  [/unstore_unit]
-                [/then]
-            [/if]
+ 
+            [unstore_unit]
+                variable=unit
+                find_vacant=no
+            [/unstore_unit]
         [/event]
     [/event]
 
@@ -672,6 +671,12 @@
             name=attack end
             delayed_variable_substitution=yes
 
+            [filter_condition]  
+              [have_unit]
+                 id=$second_unit.id
+              [/have_unit]
+           [/filter_condition]
+ 
             [foreach]
                 array=second_unit.attack
                 [do]
@@ -685,18 +690,11 @@
                     {CLEAR_VARIABLE this_item.specials.original_chance_to_hit}
                 [/do]
             [/foreach]
-            
-            [if]
-              [have_unit]
-               id=$second_unit.id
-              [/have_unit]
-                [then]
-                  [unstore_unit]
-                      variable=second_unit
-                      find_vacant=no
-                  [/unstore_unit]
-                [/then]
-            [/if]
+ 
+            [unstore_unit]
+                variable=second_unit
+                find_vacant=no
+            [/unstore_unit]
         [/event]
     [/event]
 #enddef


### PR DESCRIPTION
If in attack end in FORCE_CHANCE_TO_HIT macro, unit or second unit doesn't exist anymore then we have an error message like "Invalid WML found: [unstore_unit]: variable 'second_unit' doesn't exist" because presence of unit not condition of execution of attack end event.