### PR TITLE
Liberty S6: Give the cave underground time of day.

### DIFF
--- a/data/campaigns/Liberty/scenarios/06_The_Grey_Woods.cfg
+++ b/data/campaigns/Liberty/scenarios/06_The_Grey_Woods.cfg
@@ -8,6 +8,16 @@
     {TURNS 50 44 42}
     {DEFAULT_SCHEDULE_SECOND_WATCH}
 
+    # terrain=* only works inside an event.
+    [event]
+        name=prestart
+        [time_area]
+            terrain=U*,U*^*,Ce,Cud,Kud,Ql,Xu
+            x,y=27-34,4-9
+            {UNDERGROUND}
+        [/time_area]
+    [/event]
+
     {INTRO_AND_SCENARIO_MUSIC "underground.ogg" "the_deep_path.ogg"}
     {EXTRA_SCENARIO_MUSIC "elvish-theme.ogg"}
     {EXTRA_SCENARIO_MUSIC "suspense.ogg"}


### PR DESCRIPTION
Added underground time_area because the terrain suggests it's a cave. Needs playtesting.