### PR TITLE
Fix rare bug in FORCE_CHANCE_TO_HIT

### DIFF
--- a/data/core/macros/utils.cfg
+++ b/data/core/macros/utils.cfg
@@ -578,6 +578,12 @@
             name=attack end
             delayed_variable_substitution=yes
 
+            [filter_condition]
+                [have_unit]
+                    id=$unit.id
+                [/have_unit]
+            [/filter_condition]
+
             [foreach]
                 array=unit.attack
                 [do]
@@ -664,6 +670,12 @@
         [event]
             name=attack end
             delayed_variable_substitution=yes
+
+            [filter_condition]
+                [have_unit]
+                    id=$second_unit.id
+                [/have_unit]
+            [/filter_condition]
 
             [foreach]
                 array=second_unit.attack

--- a/data/core/macros/utils.cfg
+++ b/data/core/macros/utils.cfg
@@ -514,6 +514,8 @@
     #!         greater_than=10
     #!     [/variable]
     #! )}
+    # WARNING : if an unit must disappear in mid-battle before attack end was fired, recrrate unit instead to unstore or cth modifications 
+    # persist. Or don't use this macro.
     [event]
         name=attack
         first_time_only=no
@@ -564,6 +566,9 @@
                         id=forced_cth
                         value={CTH_NUMBER}
                         cumulative=no
+                        [filter_opponent]
+                            {SECOND_FILTER}
+                        [/filter_opponent]
                     [/value]
                 [/set_variables]
             [/do]
@@ -657,6 +662,9 @@
                         id=forced_cth
                         value={CTH_NUMBER}
                         cumulative=no
+                        [filter_opponent]
+                            {SECOND_FILTER}
+                        [/filter_opponent]
                     [/value]
                 [/set_variables]
             [/do]

--- a/data/core/macros/utils.cfg
+++ b/data/core/macros/utils.cfg
@@ -697,6 +697,27 @@
             [/unstore_unit]
         [/event]
     [/event]
+    [event]
+            name=unit placed
+            delayed_variable_substitution=yes
+
+			[filter]
+				[filter_wml]
+					[attack]
+						[specials]
+							[chance_to_hit]
+								id=forced_cth
+							[/chance_to_hit]
+						[/specials]
+					[/attack]
+				[/filter_wml]
+			[/filter]
+
+			[transform_unit]
+				id=$unit.id
+				transform_to=$unit.type
+			[/transform_unit]
+	[/event]
 #enddef
 
 #define LOOT AMOUNT SIDE

--- a/data/core/macros/utils.cfg
+++ b/data/core/macros/utils.cfg
@@ -697,27 +697,6 @@
             [/unstore_unit]
         [/event]
     [/event]
-    [event]
-            name=unit placed
-            delayed_variable_substitution=yes
-
-			[filter]
-				[filter_wml]
-					[attack]
-						[specials]
-							[chance_to_hit]
-								id=forced_cth
-							[/chance_to_hit]
-						[/specials]
-					[/attack]
-				[/filter_wml]
-			[/filter]
-
-			[transform_unit]
-				id=$unit.id
-				transform_to=$unit.type
-			[/transform_unit]
-	[/event]
 #enddef
 
 #define LOOT AMOUNT SIDE

--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -4064,7 +4064,7 @@ unplagueable: $wml_unit.status.unplagueable"
         {CLEAR_VARIABLE xy_len}
     [/event]
     {FORCE_CHANCE_TO_HIT (type=Silver Mage) (type="Orcish Archer") 50 ()}
-  [event]
+    [event]
         name=attack end
         [filter]
             type=Silver Mage
@@ -4072,25 +4072,25 @@ unplagueable: $wml_unit.status.unplagueable"
 
        [store_unit]
 	    [filter]
-            id=$unit.id
-        [/filter]
+                id=$unit.id
+	    [/filter]
 		variable=blink_test
 		kill=yes
-		 [/store_unit]
+	[/store_unit]
     [/event]
-	[event]
+    [event]
 	name=turn 2
-    [unstore_unit]
+	[unstore_unit]
 		variable=blink_test
 		x,y=17,3
 	[/unstore_unit]
 	[unit]
 		side=2
-        x,y=18,3
+		x,y=18,3
 		type="Orcish Archer"
 		generate_name=yes
 		jamming=5
-    [/unit]
+	[/unit]
 	[/event]
 [/test]
 

--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -4091,7 +4091,7 @@ unplagueable: $wml_unit.status.unplagueable"
 		generate_name=yes
 		jamming=5
 	[/unit]
-	[/event]
+[/event]
 [/test]
 
 [units]

--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -4063,6 +4063,35 @@ unplagueable: $wml_unit.status.unplagueable"
         {CLEAR_VARIABLE x_len}
         {CLEAR_VARIABLE xy_len}
     [/event]
+    {FORCE_CHANCE_TO_HIT (type=Silver Mage) (type="Orcish Archer") 50 ()}
+  [event]
+        name=attack end
+        [filter]
+            type=Silver Mage
+        [/filter]
+
+       [store_unit]
+	    [filter]
+            id=$unit.id
+        [/filter]
+		variable=blink_test
+		kill=yes
+		 [/store_unit]
+    [/event]
+	[event]
+	name=turn 2
+    [unstore_unit]
+		variable=blink_test
+		x,y=17,3
+	[/unstore_unit]
+	[unit]
+		side=2
+        x,y=18,3
+		type="Orcish Archer"
+		generate_name=yes
+		jamming=5
+    [/unit]
+	[/event]
 [/test]
 
 [units]


### PR DESCRIPTION
If in attack end in FORCE_CHANCE_TO_HIT macro, unit or second unit doesn't exist anymore because rare case where unit disapear before attack end event was called then we have an error message like "Invalid WML found: [unstore_unit]: variable 'second_unit' doesn't exist" because presence of unit not condition of execution of event.