### PR TITLE
Fix halo remain while event don't finish

### DIFF
--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -2247,6 +2247,7 @@ int game_lua_kernel::intf_erase_unit(lua_State *L)
 			if (!map().on_board(loc)) {
 				return luaL_argerror(L, 1, "invalid location");
 			}
+			u->anim_comp().clear_haloes();
 		} else if (int side = u.on_recall_list()) {
 			team &t = board().get_team(side);
 			// Should it use underlying ID instead?


### PR DESCRIPTION
When an unit with halo is killed by kill function them halo don't clear before end of event.