### PR TITLE
Tutorial S2: Don't allow the orc to recruit wolves on turn 1

### DIFF
--- a/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
+++ b/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
@@ -64,6 +64,31 @@
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression    1.00}
             {AI_SIMPLE_ALWAYS_ASPECT village_value 0.30}
+            # Galdrad's hints about getting to the island village before the wolf riders assume that some will be recruited by the end of turn 2, but won't be able to get to that village until turn 4.
+            [aspect]
+                id=recruitment_instructions
+                [facet]
+                    turns=1
+                    [value]
+                        [recruit]
+                            type=Orcish Grunt,Orcish Archer
+                        [/recruit]
+                    [/value]
+                [/facet]
+                [facet]
+                    turns=2
+                    [value]
+                        [recruit]
+                            type=Wolf Rider
+                            number=2
+                            importance=1
+                        [/recruit]
+                        [recruit]
+                            importance=0
+                        [/recruit]
+                    [/value]
+                [/facet]
+            [/aspect]
         [/ai]
     [/side]
 


### PR DESCRIPTION
If the wolves are recruited on the first turn then Galdrad's turn 3 hint about
getting to the island before them is too difficult for a tutorial, and his hint
about holding the village on turn 4 hint may be a turn too late.

Some have to be recruited on turn 2 to fit the turn 3 hint about them, so rig
the AI's recruitment to do that.