### PR TITLE
HttT S6: Point out exactly where the ford is.

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/06_The_Siege_of_Elensefar.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/06_The_Siege_of_Elensefar.cfg
@@ -502,7 +502,11 @@
                 [remove_item]
                     x,y=6,32
                 [/remove_item]
-                {REMOVE_LABEL 6 32}
+                [label]
+                    x,y=6,32
+                    text="" # wmllint: ignore
+                    team_name=elves
+                [/label]
                 [scroll_to]
                     x,y=6,32
                 [/scroll_to]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/06_The_Siege_of_Elensefar.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/06_The_Siege_of_Elensefar.cfg
@@ -346,6 +346,14 @@
                         name=thieves_ford
                         value=yes
                     [/set_variable]
+                    {HIGHLIGHT_IMAGE 6 32 items/gohere.png ()}
+                    [label]
+                        x,y=6,32
+                        # po: The party and an ally have agreed to meet at the location identified by this label.
+                        text=_ "Meeting point"
+                        team_name=elves
+                    [/label]
+                    # The image will be removed when the ford appears
                 [/command]
             [/option]
             [option]
@@ -491,6 +499,13 @@
                 equals=yes
             [/variable]
             [then]
+                [remove_item]
+                    x,y=6,32
+                [/remove_item]
+                {REMOVE_LABEL 6 32}
+                [scroll_to]
+                    x,y=6,32
+                [/scroll_to]
                 [message]
                     speaker=narrator
                     image="wesnoth-icon.png"


### PR DESCRIPTION
Also scroll to it, in case the viewport is elsewhere.

Suggested on the forums https://forums.wesnoth.org/viewtopic.php?p=634718#p634718

{REMOVE_LABEL} doesn't remove the label, from a brief look that seems to be a bug in that macro?