### PR TITLE
Attack Enemy: Don't show "poison" in the attacks list if the enemy is unpoisonable

### DIFF
--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -22,6 +22,7 @@
 #include "game_board.hpp"
 #include "lexical_cast.hpp"
 #include "log.hpp"
+#include "map/map.hpp"
 #include "resources.hpp"
 #include "team.hpp"
 #include "terrain/filter.hpp"
@@ -1027,10 +1028,20 @@ bool attack_type::special_active(const config& special, AFFECTS whom,
 	temporary_facing self_facing(self, self_loc_.get_relative_dir(other_loc_));
 	temporary_facing other_facing(other, other_loc_.get_relative_dir(self_loc_));
 
-	// Filter poison
-	if (special["id"] == "poison" && other && other->get_state("unpoisonable")) {
+	// Filter poison, plague, drain
+	if (special["id"] == "drains" && other && other->get_state("undrainable")) {
 		return false;
 	}
+	if (special["id"] == "plague" && other &&
+		(other->get_state("unplagueable") ||
+		 resources::gameboard->map().is_village(other_loc_))) {
+		return false;
+	}
+	if (special["id"] == "poison" && other &&
+		(other->get_state("unpoisonable") || other->get_state(unit::STATE_POISONED))) {
+		return false;
+	}
+
 
 	// Translate our context into terms of "attacker" and "defender".
 	unit_const_ptr & att = is_attacker_ ? self : other;

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1027,6 +1027,11 @@ bool attack_type::special_active(const config& special, AFFECTS whom,
 	temporary_facing self_facing(self, self_loc_.get_relative_dir(other_loc_));
 	temporary_facing other_facing(other, other_loc_.get_relative_dir(self_loc_));
 
+	// Filter poison
+	if (special["id"] == "poison" && other && other->get_state("unpoisonable")) {
+		return false;
+	}
+
 	// Translate our context into terms of "attacker" and "defender".
 	unit_const_ptr & att = is_attacker_ ? self : other;
 	unit_const_ptr & def = is_attacker_ ? other : self;

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -19,6 +19,7 @@
 
 #include "display.hpp"
 #include "display_context.hpp"
+#include "font/text_formatting.hpp"
 #include "game_board.hpp"
 #include "lexical_cast.hpp"
 #include "log.hpp"
@@ -705,13 +706,14 @@ std::string attack_type::weapon_specials(bool only_active, bool is_backstab) con
 	std::string res;
 	for (const config::any_child &sp : specials_.all_children_range())
 	{
-		if ( only_active  &&  !special_active(sp.cfg, AFFECT_EITHER, is_backstab) )
-			continue;
+		const bool active = special_active(sp.cfg, AFFECT_EITHER, is_backstab);
 
 		const std::string& name = sp.cfg["name"].str();
 		if (!name.empty()) {
 			if (!res.empty()) res += ", ";
+			if (only_active && !active) res += font::span_color(font::inactive_details_color);
 			res += name;
+			if (only_active && !active) res += "</span>";
 		}
 	}
 


### PR DESCRIPTION
This PR removes the ellipsed word.

![screenshot_2018-11-03_19-16-14](https://user-images.githubusercontent.com/24784687/47956546-d61ec380-df9d-11e8-8f17-ecec9c9cafb8.png)

Is this right? It tested okay but I am not completely sure.