### PR TITLE
Add a command-line interface to the WML diff functionality

### DIFF
--- a/diff.cfg
+++ b/diff.cfg
@@ -1,0 +1,36 @@
+[change_child]
+	index=0
+	[thing]
+		[insert]
+			this="The best!!!"
+			words="An essential tool..."
+		[/insert]
+		[delete]
+			that="x"
+		[/delete]
+		[insert_child]
+			index=0
+			[oops]
+				whoops="hey"
+			[/oops]
+		[/insert_child]
+		[delete_child]
+			index=0
+			[stuff]
+			[/stuff]
+		[/delete_child]
+		[change_child]
+			index=1
+			[stuff]
+				[insert]
+					what=42
+					who="Arthur Dent"
+				[/insert]
+				[delete]
+					nine="x"
+					ten="x"
+				[/delete]
+			[/stuff]
+		[/change_child]
+	[/thing]
+[/change_child]

--- a/doc/man/wesnoth.6
+++ b/doc/man/wesnoth.6
@@ -107,7 +107,8 @@ enables some Lua debugging mechanisms
 .BI -D,--diff \ left-file \  right-file
 diffs the two WML files; does not preprocess them first (to do that, run them through
 .B -p
-first). Outputs the diff as DiffWML on standard output.
+first). Outputs the diff as DiffWML on standard output or to the file indicated by
+.IR --output .
 .TP
 .BI -e[ file ],\ --editor[ =file ]
 start the in-game map editor directly. If
@@ -232,6 +233,9 @@ don't try to validate replay of unit test. Only relevant when used with
 .B --nosound
 runs the game without sounds and music.
 .TP
+.BI --output \ file
+output to the specified file. Applicable to diffing operations.
+.TP
 .BI --password \ password
 uses
 .I password
@@ -246,7 +250,8 @@ but Lua file should return a function which will be run as a coroutine and perio
 .TP
 .BI -P,--patch \ base-file \  patch-file
 applies a DiffWML patch to a WML file; does not preprocess either of the files.
-Outputs the patched WML to standard output.
+Outputs the patched WML to standard output or to the file indicated by
+.IR --output .
 .TP
 .BI -p,\ --preprocess \ source-file/folder \  target-directory
 preprocesses a specified file/folder. For each file(s) a plain .cfg file and a processed .cfg

--- a/doc/man/wesnoth.6
+++ b/doc/man/wesnoth.6
@@ -104,6 +104,11 @@ information about command mode).
 .B --debug-lua
 enables some Lua debugging mechanisms
 .TP
+.BI -D,--diff \ left-file \  right-file
+diffs the two WML files; does not preprocess them first (to do that, run them through
+.B -p
+first). Outputs the diff as DiffWML on standard output.
+.TP
 .BI -e[ file ],\ --editor[ =file ]
 start the in-game map editor directly. If
 .I file
@@ -238,6 +243,10 @@ when connecting to a server, ignoring other preferences. Unsafe.
 which defines a Wesnoth plugin. Similar to
 .BR --script ,
 but Lua file should return a function which will be run as a coroutine and periodically woken up with updates.
+.TP
+.BI -P,--patch \ base-file \  patch-file
+applies a DiffWML patch to a WML file; does not preprocess either of the files.
+Outputs the patched WML to standard output.
 .TP
 .BI -p,\ --preprocess \ source-file/folder \  target-directory
 preprocesses a specified file/folder. For each file(s) a plain .cfg file and a processed .cfg

--- a/src/commandline_options.cpp
+++ b/src/commandline_options.cpp
@@ -144,6 +144,10 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 	validate_schema(),
 	validate_wml(),
 	validate_with(),
+	do_diff(),
+	do_patch(),
+	diff_left(),
+	diff_right(),
 	version(false),
 	report(false),
 	windowed(false),
@@ -282,6 +286,8 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 		("validate-addon", po::value<std::string>(), "validate the specified addon's WML against the schema")
 		("validate-core", "validate the core WML against the schema")
 		("validate-schema", po::value<std::string>(), "validate a specified WML schema")
+		("diff,D", po::value<two_strings>()->multitoken(), "diff two preprocessed WML documents")
+		("patch,P", po::value<two_strings>()->multitoken(), "apply a patch to a preprocessed WML document")
 		;
 
 	po::options_description preprocessor_opts("Preprocessor mode options");
@@ -428,6 +434,18 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 		preprocess = true;
 		preprocess_path = vm["preprocess"].as<two_strings>().first;
 		preprocess_target = vm["preprocess"].as<two_strings>().second;
+	}
+	if (vm.count("diff"))
+	{
+		do_diff = true;
+		diff_left = vm["diff"].as<two_strings>().first;
+		diff_right = vm["diff"].as<two_strings>().second;
+	}
+	if (vm.count("patch"))
+	{
+		do_patch = true;
+		diff_left = vm["patch"].as<two_strings>().first;
+		diff_right = vm["patch"].as<two_strings>().second;
 	}
 	if (vm.count("preprocess-defines"))
 		preprocess_defines = utils::split(vm["preprocess-defines"].as<std::string>(), ',');

--- a/src/commandline_options.cpp
+++ b/src/commandline_options.cpp
@@ -281,17 +281,18 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 		("log-strict", po::value<std::string>(), "sets the strict level of the logger. any messages sent to log domains of this level or more severe will cause the unit test to fail regardless of the victory result.")
 		("noreplaycheck", "don't try to validate replay of unit test.")
 		("mp-test", "load the test mp scenarios.")
+		;
+
+	po::options_description parsing_opts("WML parsing options");
+	testing_opts.add_options()
 		("use-schema,S", po::value<std::string>(), "specify a schema to validate WML against (defaults to the core schema)")
 		("validate,V", po::value<std::string>(), "validate a specified WML file against a schema")
 		("validate-addon", po::value<std::string>(), "validate the specified addon's WML against the schema")
 		("validate-core", "validate the core WML against the schema")
 		("validate-schema", po::value<std::string>(), "validate a specified WML schema")
 		("diff,D", po::value<two_strings>()->multitoken(), "diff two preprocessed WML documents")
+		("output,o", po::value<std::string>(), "output to specified file")
 		("patch,P", po::value<two_strings>()->multitoken(), "apply a patch to a preprocessed WML document")
-		;
-
-	po::options_description preprocessor_opts("Preprocessor mode options");
-	preprocessor_opts.add_options()
 		("preprocess,p", po::value<two_strings>()->multitoken(), "requires two arguments: <file/folder> <target directory>. Preprocesses a specified file/folder. The preprocessed file(s) will be written in the specified target directory: a plain cfg file and a processed cfg file.")
 		("preprocess-defines", po::value<std::string>(), "comma separated list of defines to be used by '--preprocess' command. If 'SKIP_CORE' is in the define list the data/core won't be preprocessed. Example: --preprocess-defines=FOO,BAR")
 		("preprocess-input-macros", po::value<std::string>(), "used only by the '--preprocess' command. Specifies source file <arg> that contains [preproc_define]s to be included before preprocessing.")
@@ -310,7 +311,7 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 	//hidden_.add_options()
 	//	("example-hidden-option", "")
 	//	;
-	visible_.add(general_opts).add(campaign_opts).add(display_opts).add(logging_opts).add(multiplayer_opts).add(testing_opts).add(preprocessor_opts).add(proxy_opts);
+	visible_.add(general_opts).add(campaign_opts).add(display_opts).add(logging_opts).add(multiplayer_opts).add(testing_opts).add(parsing_opts).add(proxy_opts);
 
 	all_.add(visible_).add(hidden_);
 
@@ -446,6 +447,10 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 		do_patch = true;
 		diff_left = vm["patch"].as<two_strings>().first;
 		diff_right = vm["patch"].as<two_strings>().second;
+	}
+	if (vm.count("output"))
+	{
+		output_file = vm["output"].as<std::string>();
 	}
 	if (vm.count("preprocess-defines"))
 		preprocess_defines = utils::split(vm["preprocess-defines"].as<std::string>(), ',');

--- a/src/commandline_options.hpp
+++ b/src/commandline_options.hpp
@@ -215,6 +215,9 @@ public:
 	boost::optional<std::string> validate_wml;
 	/// Non-empty if --use-schema was given on the command line. Specifies the schema for use with --validate.
 	boost::optional<std::string> validate_with;
+	bool do_diff, do_patch;
+	/// Files for diffing or patching
+	std::string diff_left, diff_right;
 	/// True if --version was given on the command line. Prints version and exits.
 	bool version;
 	/// True if --report was given on the command line. Prints a bug report-style info dump and exits.

--- a/src/commandline_options.hpp
+++ b/src/commandline_options.hpp
@@ -215,6 +215,8 @@ public:
 	boost::optional<std::string> validate_wml;
 	/// Non-empty if --use-schema was given on the command line. Specifies the schema for use with --validate.
 	boost::optional<std::string> validate_with;
+	/// Output filename for WML diff or preprocessing
+	boost::optional<std::string> output_file;
 	bool do_diff, do_patch;
 	/// Files for diffing or patching
 	std::string diff_left, diff_right;

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -510,8 +510,13 @@ static int process_command_args(const commandline_options& cmdline_opts)
 		std::ifstream in_right(cmdline_opts.diff_right);
 		read(left, in_left);
 		read(right, in_right);
-		config_writer out(std::cout, compression::format::NONE);
+		std::ostream* os = &std::cout;
+		if(cmdline_opts.output_file) {
+			os = new std::ofstream(*cmdline_opts.output_file);
+		}
+		config_writer out(*os, compression::format::NONE);
 		out.write(right.get_diff(left));
+		if(os != &std::cout) delete os;
 		return 0;
 	}
 	
@@ -522,8 +527,13 @@ static int process_command_args(const commandline_options& cmdline_opts)
 		read(base, in_base);
 		read(diff, in_diff);
 		base.apply_diff(diff);
-		config_writer out(std::cout, compression::format::NONE);
+		std::ostream* os = &std::cout;
+		if(cmdline_opts.output_file) {
+			os = new std::ofstream(*cmdline_opts.output_file);
+		}
+		config_writer out(*os, compression::format::NONE);
 		out.write(base);
+		if(os != &std::cout) delete os;
 		return 0;
 	}
 

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -503,6 +503,29 @@ static int process_command_args(const commandline_options& cmdline_opts)
 		validator.set_create_exceptions(false); // Don't crash if there's an error, just go ahead anyway
 		return handle_validate_command(*cmdline_opts.validate_schema, validator, {});
 	}
+	
+	if(cmdline_opts.do_diff) {
+		config left, right;
+		std::ifstream in_left(cmdline_opts.diff_left);
+		std::ifstream in_right(cmdline_opts.diff_right);
+		read(left, in_left);
+		read(right, in_right);
+		config_writer out(std::cout, compression::format::NONE);
+		out.write(right.get_diff(left));
+		return 0;
+	}
+	
+	if(cmdline_opts.do_patch) {
+		config base, diff;
+		std::ifstream in_base(cmdline_opts.diff_left);
+		std::ifstream in_diff(cmdline_opts.diff_right);
+		read(base, in_base);
+		read(diff, in_diff);
+		base.apply_diff(diff);
+		config_writer out(std::cout, compression::format::NONE);
+		out.write(base);
+		return 0;
+	}
 
 	// Options changing their behavior dependent on some others should be checked below.
 
@@ -1036,6 +1059,8 @@ int main(int argc, char** argv)
 		   args[k] == "-R" ||
 		   args[k] == "--screenshot" ||
 		   args[k] == "--data-path" ||
+		   args[k] == "--diff" ||
+		   args[k] == "--patch" ||
 		   args[k] == "--userdata-path" ||
 		   args[k] == "--userconfig-path" ||
 		   args[k].compare(0, 11, "--validate=") == 0  ||


### PR DESCRIPTION
The diff functionality is there, so I figured it could be useful to expose it.

I would've just pushed straight to master instead of making a pull request, but I noticed output redirection doesn't seem to be working, so I decided to see if anyone had any idea why.

To be precise, the following command:

```
wesnoth.exe --diff test1.cfg test2.cfg > diff.cfg
```

outputs the diff to the console and not to diff.cfg. I tried both in VSCode's integrated terminal and in a standard Windows command prompt. I imagine it'll probably work as expected on Linux, but I'd like it to work on Windows too.