### PR TITLE
Several sidebar changes

### DIFF
--- a/data/themes/default.cfg
+++ b/data/themes/default.cfg
@@ -414,7 +414,7 @@
                 ref=unit-type
                 id=unit-alignment
                 font_size={DEFAULT_FONT_SMALL}
-                rect="=,+0,=,+18"
+                rect="=,+0,=+50,+18"
                 xanchor=right
                 yanchor=fixed
             [/unit_alignment]

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -1100,7 +1100,7 @@ static config tod_stats_at(reports::context & rc, const map_location& hex)
 	std::ostringstream tooltip;
 	std::ostringstream text;
 
-	const map_location& tod_schedule_hex = display::get_singleton()->shrouded(hex) ? map_location::null_location() : hex;
+	const map_location& tod_schedule_hex = (hex.valid() && !display::get_singleton()->shrouded(hex)) ? hex : map_location::null_location();
 	const std::vector<time_of_day>& schedule = rc.tod().times(tod_schedule_hex);
 
 	int current = rc.tod().get_current_time(tod_schedule_hex);
@@ -1117,12 +1117,20 @@ static config tod_stats_at(reports::context & rc, const map_location& hex)
 
 	return text_report(text.str(), tooltip.str(), "..schedule");
 }
-
 REPORT_GENERATOR(tod_stats, rc)
 {
 	map_location mouseover_hex = rc.screen().mouseover_hex();
 	if (mouseover_hex.valid()) return tod_stats_at(rc, mouseover_hex);
 	return tod_stats_at(rc, rc.screen().selected_hex());
+}
+REPORT_GENERATOR(selected_tod_stats, rc)
+{
+	const unit *u = get_selected_unit(rc);
+	if(!u) return tod_stats_at(rc, map_location::null_location());
+	const map_location& attack_indicator_src = game_display::get_singleton()->get_attack_indicator_src();
+	const map_location& hex =
+		attack_indicator_src.valid() ? attack_indicator_src : u->get_location();
+	return tod_stats_at(rc, hex);
 }
 
 static config time_of_day_at(reports::context & rc, const map_location& mouseover_hex)
@@ -1166,6 +1174,15 @@ REPORT_GENERATOR(time_of_day, rc)
 	map_location mouseover_hex = rc.screen().mouseover_hex();
 	if (mouseover_hex.valid()) return time_of_day_at(rc, mouseover_hex);
 	return time_of_day_at(rc, rc.screen().selected_hex());
+}
+REPORT_GENERATOR(selected_time_of_day, rc)
+{
+	const unit *u = get_selected_unit(rc);
+	if(!u) return time_of_day_at(rc, map_location::null_location());
+	const map_location& attack_indicator_src = game_display::get_singleton()->get_attack_indicator_src();
+	const map_location& hex =
+		attack_indicator_src.valid() ? attack_indicator_src : u->get_location();
+	return time_of_day_at(rc, hex);
 }
 
 static config unit_box_at(reports::context & rc, const map_location& mouseover_hex)

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -1037,7 +1037,7 @@ REPORT_GENERATOR(highlighted_unit_weapons, rc)
 	const unit *u = get_selected_unit(rc);
 	const unit *sec_u = get_visible_unit(rc);
 
-	if (!u) return config();
+	if (!u) return report_unit_weapons(rc);
 	if (!sec_u || u == sec_u) return unit_weapons(rc, sec_u, rc.screen().mouseover_hex());
 
 	map_location highlighted_hex = rc.screen().displayed_unit_hex();

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -574,14 +574,25 @@ static config unit_defense(reports::context & rc, const unit* u, const map_locat
 REPORT_GENERATOR(unit_defense,rc)
 {
 	const unit *u = get_visible_unit(rc);
+	const team &viewing_team = rc.teams()[rc.screen().viewing_team()];
+	const map_location& mouseover_hex = rc.screen().mouseover_hex();
 	const map_location& displayed_unit_hex = rc.screen().displayed_unit_hex();
-	return unit_defense(rc, u, displayed_unit_hex);
+	const map_location& hex = (mouseover_hex.valid() && !viewing_team.shrouded(mouseover_hex)) ? mouseover_hex : displayed_unit_hex; 
+	return unit_defense(rc, u, hex);
 }
 REPORT_GENERATOR(selected_unit_defense, rc)
 {
 	const unit *u = get_selected_unit(rc);
-	const map_location& selected_hex = rc.screen().selected_hex();
-	return unit_defense(rc, u, selected_hex);
+	const map_location& attack_indicator_src = game_display::get_singleton()->get_attack_indicator_src();
+	if(attack_indicator_src.valid())
+		return unit_defense(rc, u, attack_indicator_src);
+
+	const map_location& mouseover_hex = rc.screen().mouseover_hex();
+	const unit *visible_unit = get_visible_unit(rc);
+	if(visible_unit && u && visible_unit->id() != u->id() && mouseover_hex.valid())
+		return unit_defense(rc, u, mouseover_hex);
+	else
+		return unit_defense(rc, u, u->get_location());
 }
 
 static config unit_vision(const unit* u)

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -1095,15 +1095,10 @@ REPORT_GENERATOR(unit_profile, rc)
 	return image_report(u->small_profile());
 }
 
-REPORT_GENERATOR(tod_stats, rc)
+static config tod_stats_at(reports::context & rc, const map_location& hex)
 {
 	std::ostringstream tooltip;
 	std::ostringstream text;
-
-	const map_location& selected_hex = rc.screen().selected_hex();
-	const map_location& mouseover_hex = rc.screen().mouseover_hex();
-
-	const map_location& hex = mouseover_hex.valid() ? mouseover_hex : selected_hex;
 
 	const map_location& tod_schedule_hex = display::get_singleton()->shrouded(hex) ? map_location::null_location() : hex;
 	const std::vector<time_of_day>& schedule = rc.tod().times(tod_schedule_hex);
@@ -1121,6 +1116,13 @@ REPORT_GENERATOR(tod_stats, rc)
 	text << current + 1 << "/" << times;
 
 	return text_report(text.str(), tooltip.str(), "..schedule");
+}
+
+REPORT_GENERATOR(tod_stats, rc)
+{
+	map_location mouseover_hex = rc.screen().mouseover_hex();
+	if (mouseover_hex.valid()) return tod_stats_at(rc, mouseover_hex);
+	return tod_stats_at(rc, rc.screen().selected_hex());
 }
 
 static config time_of_day_at(reports::context & rc, const map_location& mouseover_hex)

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -2326,7 +2326,9 @@ void unit::add_modification(const std::string& mod_type, const config& mod, bool
 			description += "\n";
 		}
 
-		description += utils::format_conjunct_list("", effects_description);
+		for(const auto& desc_line : effects_description) {
+			description += desc_line + "\n";
+		}
 	}
 
 	// store trait info


### PR DESCRIPTION
A bunch of small changes. The ones that affect the default theme are:

1. Don't truncate the abilities and traits lines before the "lvl" label
2. Make terrain defense follow mouseover, like the rest of the sidebar does.
3. Change the trait tooltip format