### PR TITLE
Run WML schema validation in travis. Fixes #3709

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
       env: CXXSTD=14 NLS=true LTS=1604 BRANCH=master
 
     - compiler: gcc
-      env: TOOL=scons CXXSTD=17 NLS=false LTS=1804 BRANCH=master
+      env: TOOL=scons CXXSTD=17 NLS=false LTS=1804 BRANCH=master VALIDATE=true
 
     - compiler: gcc
       env: TOOL=scons CXXSTD=14 NLS=false LTS=1604 BRANCH=master OPT=-O0

--- a/data/campaigns/Legend_of_Wesmere/lua/wml_tags.lua
+++ b/data/campaigns/Legend_of_Wesmere/lua/wml_tags.lua
@@ -2,7 +2,6 @@
 
 local labels = {}
 local wml_label = wesnoth.wml_actions.label
-local replace_map = wesnoth.wml_actions.replace_map
 
 local wml_actions = wesnoth.wml_actions
 local T = wml.tag
@@ -28,9 +27,9 @@ function wesnoth.wml_actions.label(cfg)
 	wml_label(cfg)
 end
 
-function wesnoth.wml_actions.replace_map(cfg)
+function wesnoth.wml_actions.replace_map_section(cfg)
 	if not cfg.x and not cfg.y then
-		return replace_map(cfg)
+		return wesnoth.wml_actions.replace_map(cfg)
 	end
 	local x1,x2 = string.match(cfg.x, "(%d+)-(%d+)")
 	local y1,y2 = string.match(cfg.y, "(%d+)-(%d+)")
@@ -54,7 +53,7 @@ function wesnoth.wml_actions.replace_map(cfg)
 		y = y + 1
 	end
 	local new_map = table.concat(t, '\n')
-	replace_map { map = new_map, expand = true, shrink = true }
+	wesnoth.wml_actions.replace_map { map = new_map, expand = true, shrink = true }
 end
 
 

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg
@@ -28,11 +28,11 @@
 
         {campaigns/Legend_of_Wesmere/maps/Kalian_map.cfg}
 
-        [replace_map]
+        [replace_map_section]
             x=9-53
             y=9-53
             {LOW_MAP  Kalian.map}
-        [/replace_map]
+        [/replace_map_section]
         [shift_labels]
             x=-8
             y=-9

--- a/data/campaigns/Legend_of_Wesmere/utils/map-utils.cfg
+++ b/data/campaigns/Legend_of_Wesmere/utils/map-utils.cfg
@@ -56,11 +56,11 @@
         [/do]
     [/foreach]
 
-    [replace_map]
+    [replace_map_section]
         x={X_SPAN}
         y={Y_SPAN}
         {LOW_MAP {MAP}}
-    [/replace_map]
+    [/replace_map_section]
     [shift_labels]
         x={OFFSET_X}
         y={OFFSET_Y}

--- a/data/campaigns/Liberty/scenarios/01_The_Raid.cfg
+++ b/data/campaigns/Liberty/scenarios/01_The_Raid.cfg
@@ -59,7 +59,6 @@
         [modifications]
             [object]
                 duration=forever
-                silent=yes
                 [effect]
                     apply_to=attack
                     name=mace-spiked
@@ -230,7 +229,6 @@
             [modifications]
                 [object]
                     duration=forever
-                    silent=yes
                     [effect]
                         apply_to=attack
                         name=mace-spiked

--- a/data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg
@@ -125,7 +125,7 @@
         # The second one suplements him, he hinders units to overcome his ZoC.
         # The Steelwart can't move; the Fighter is controlled by an Micro AI.
         {NOTRAIT_UNIT 4 "Dwarvish Steelclad" 31 28} {GUARDIAN} {NO_UPKEEP} {FACING se}
-        {NAMED_NOTRAIT_UNIT () "Dwarvish Fighter" 27 28 (dwarvish_return_guard) ()} {NO_UPKEEP}
+        {NAMED_NOTRAIT_UNIT 4 "Dwarvish Fighter" 27 28 (dwarvish_return_guard) ()} {NO_UPKEEP}
 
         {NOTRAIT_UNIT 4 "Dwarvish Stalwart" 28 21} {GUARDIAN} {NO_UPKEEP}
         {NOTRAIT_UNIT 4 "Dwarvish Stalwart" 32 21} {GUARDIAN} {NO_UPKEEP}
@@ -172,8 +172,8 @@
             [/avoid]
         [/ai]
 
-        {NOTRAIT_UNIT () "Troll Rocklobber" 39 5} {GUARDIAN} {NO_UPKEEP}
-        {NOTRAIT_UNIT () "Troll Rocklobber" 39 11} {GUARDIAN} {NO_UPKEEP}
+        {NOTRAIT_UNIT 6 "Troll Rocklobber" 39 5} {GUARDIAN} {NO_UPKEEP}
+        {NOTRAIT_UNIT 6 "Troll Rocklobber" 39 11} {GUARDIAN} {NO_UPKEEP}
     [/side]
 
     [side]
@@ -209,7 +209,7 @@
         canrecruit=yes
 
         # controlled by Micro AI, more meatshield than guard
-        {NAMED_NOTRAIT_UNIT () "Skeleton Archer" 24 2 (skeleton_return_guard) ()} {NO_UPKEEP}
+        {NAMED_NOTRAIT_UNIT 8 "Skeleton Archer" 24 2 (skeleton_return_guard) ()} {NO_UPKEEP}
     [/side]
 
     # And an empty side for the bat used in flavor event

--- a/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
@@ -2342,7 +2342,7 @@
 
         [message]
             speaker=Tallin
-            0message= _ "Get those doors open!"
+            message= _ "Get those doors open!"
         [/message]
 
         [sound]

--- a/data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg
@@ -293,7 +293,7 @@
                 [/terrain]
 
                 [modify_side]
-                    sie=4
+                    side=4
                     hidden=yes
                 [/modify_side]
             [/then]
@@ -358,7 +358,7 @@
             [/then]
             [else]
                 [modify_side]
-                    sie=5
+                    side=5
                     hidden=yes
                 [/modify_side]
             [/else]

--- a/data/campaigns/Sceptre_of_Fire/scenarios/Epilogue.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/Epilogue.cfg
@@ -14,7 +14,6 @@
         defeat_condition=no_units_left
         save_id=Rugnur
         side=1
-        canrecruit=yes
         controller=human
         team_name=alanin
         user_team_name= _ "Alanin"

--- a/data/schema/core/actionwml.cfg
+++ b/data/schema/core/actionwml.cfg
@@ -1175,6 +1175,8 @@
 			{DEFAULT_KEY fire_event s_bool no}
 			{DEFAULT_KEY check_passability s_bool yes}
 			{SIMPLE_KEY facing dir}
+			{SIMPLE_KEY x s_coordinates}
+			{SIMPLE_KEY y s_coordinates}
 		[/tag]
 	[/tag]
 	[tag]

--- a/data/schema/core/addons.cfg
+++ b/data/schema/core/addons.cfg
@@ -313,6 +313,8 @@
 	{SIMPLE_KEY force_lock_settings bool}
 	[tag]
 		name="story"
+		max=infinite
+		{SIMPLE_KEY title string}
 		{INSERT_TAG}
 		# TODO: Is this really recognized at story toplevel? Wiki claims it is.
 		[tag]
@@ -428,8 +430,8 @@
 	[tag]
 		name="label"
 		max=infinite
-		{SIMPLE_KEY x s_int}
-		{SIMPLE_KEY y s_int}
+		{SIMPLE_KEY x s_range_list}
+		{SIMPLE_KEY y s_range_list}
 		{SIMPLE_KEY text t_string}
 		{SIMPLE_KEY tooltip t_string} # Is this documented?
 		{SIMPLE_KEY immutable s_bool}

--- a/data/schema/filters/weapon.cfg
+++ b/data/schema/filters/weapon.cfg
@@ -15,3 +15,4 @@
 	{SIMPLE_KEY movement_used s_range_list}
 	{FILTER_BOOLEAN_OPS weapon}
 [/tag]
+

--- a/data/schema/units/abilities.cfg
+++ b/data/schema/units/abilities.cfg
@@ -106,6 +106,18 @@
 	[/tag]
 [/tag]
 [tag]
+	name="chance_to_hit"
+	max=infinite
+	super="units/unit_type/abilities/~value~"
+	{FILTER_TAG "filter_opponent" unit ()}
+[/tag]
+[tag]
+	name="firststrike"
+	max=infinite
+	super="units/unit_type/abilities/~generic~"
+	{FILTER_TAG "filter_second_weapon" weapon ()}
+[/tag]
+[tag]
 	name="*"
 	max=infinite
 	super="units/unit_type/abilities/~generic~"

--- a/data/schema/units/modifications.cfg
+++ b/data/schema/units/modifications.cfg
@@ -225,4 +225,6 @@
 	max=infinite
 	super="units/$modifications/base"
 	{SIMPLE_KEY duration object_duration}
+	{FILTER_TAG "filter" unit ()}
+	{ANY_KEY string}
 [/tag]

--- a/data/schema/units/specials.cfg
+++ b/data/schema/units/specials.cfg
@@ -15,7 +15,7 @@
 	{FILTER_TAG "filter_adjacent_loation" adjacent_location ()}
 	{FILTER_TAG "filter_self" unit {FILTER_TAG "filter_weapon" weapon ()}}
 	{FILTER_TAG "filter_opponent" unit {FILTER_TAG "filter_weapon" weapon ()}}
-	{FILTER_TAG "filter_atacker" unit {FILTER_TAG "filter_weapon" weapon ()}}
+	{FILTER_TAG "filter_attacker" unit {FILTER_TAG "filter_weapon" weapon ()}}
 	{FILTER_TAG "filter_defender" unit {FILTER_TAG "filter_weapon" weapon ()}}
 	{WML_MERGE_KEYS}
 [/tag]

--- a/data/schema/units/types.cfg
+++ b/data/schema/units/types.cfg
@@ -37,6 +37,8 @@
 	{SIMPLE_KEY usage ai_usage}
 	{SIMPLE_KEY vision int}
 	{SIMPLE_KEY xp_bar_scaling real}
+	{SIMPLE_KEY bar_offset_x int}
+	{SIMPLE_KEY bar_offset_y int}
 	{SIMPLE_KEY zoc bool}
 	{SIMPLE_KEY flying bool}
 	{LINK_TAG "units/$modifications/trait"}

--- a/data/test/scenarios/test_move.cfg
+++ b/data/test/scenarios/test_move.cfg
@@ -65,5 +65,7 @@
 {MOVE_MALFORMED_SCEN test_move_fail_2 (16,15,14,13,12,11) (3,3,3,3,3,3,3)}
 {MOVE_MALFORMED_SCEN test_move_fail_3 (16,15,14,13,12,11) (3,3,3,3,3)}
 {MOVE_MALFORMED_SCEN test_move_fail_4 (16,15,14,13,12) (3,3,3,3,3,3)}
+#ifndef SCHEMA_SHOULD_SKIP_THIS
 {MOVE_MALFORMED_SCEN test_move_fail_5 (16,15,chicken,13,12,11) (3,3,3,3,3,3)}
 {MOVE_MALFORMED_SCEN test_move_fail_6 (16,15,14,13,12,11) (3,3,3,3,3,bock)}
+#endif

--- a/utils/travis/docker_run.sh
+++ b/utils/travis/docker_run.sh
@@ -18,6 +18,7 @@ MP_TEST="${10}"
 BOOST_TEST="${11}"
 LTO="${12}"
 SAN="${13}"
+VALIDATE="${14}"
 
 if [ "$OPT" == "-O0" ]; then
     STRICT="true"
@@ -92,6 +93,18 @@ else
 
 # needed since docker returns the exit code of the final command executed, so a failure needs to be returned if any unit tests fail
     EXIT_VAL=0
+    
+    if [ "$VALIDATE" == "true" ]; then
+        echo "Executing schema_validation.sh"
+        
+        ./utils/travis/schema_validation.sh
+        RET=$?
+        
+        if [ $RET != 0 ]; then
+            echo "WML validation failed!"
+            EXIT_VAL=$RET
+        fi
+    fi
 
     if [ "$WML_TESTS" == "true" ]; then
         echo "Executing run_wml_tests"

--- a/utils/travis/schema_validation.sh
+++ b/utils/travis/schema_validation.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+function validate_core()
+{
+    SUCCESS="Yes"
+    NAME="$1"
+    
+    echo "------"
+    echo "Validating $NAME..."
+    
+    ./wesnoth --validate data/_main.cfg &> temp.log || SUCCESS="No"
+    if [ "$SUCCESS" == "No" ]; then
+        echo "$NAME failed validation!"
+        cat temp.log
+        rm temp.log
+    fi
+    
+    echo "$NAME validation complete!  Success: $SUCCESS"
+    echo "------"
+    
+    [ "$SUCCESS" == "Yes" ]
+}
+
+function validate_misc()
+{
+    SUCCESS="Yes"
+    NAME="$1"
+    DEFINE="$2"
+    
+    echo "------"
+    echo "Validating $NAME..."
+    
+    ./wesnoth --data-dir=. --validate=data/_main.cfg --preprocess-defines=$DEFINE &> temp.log || SUCCESS="No"
+    if [ "$SUCCESS" == "No" ]; then
+        echo "$NAME failed validation!"
+        cat temp.log
+        rm temp.log
+    fi
+    
+    echo "$NAME validation complete!  Success: $SUCCESS"
+    echo "------"
+    
+    [ "$SUCCESS" == "Yes" ]
+}
+
+function validate_campaign()
+{
+    SUCCESS="Yes"
+    NAME="$1"
+    DEFINE="$2"
+    shift
+    shift
+    DIFFICULTIES=("$@")
+    
+    echo "------"
+    echo "Validating $NAME..."
+    
+    for DIFFICULTY in ${DIFFICULTIES[@]}; do
+        if [ "$SUCCESS" == "Yes" ]; then
+            echo "Validating $DIFFICULTY..."
+            ./wesnoth --data-dir=. --validate=data/_main.cfg --preprocess-defines=$DEFINE,$DIFFICULTY &> temp.log || SUCCESS="No"
+            
+            if [ "$SUCCESS" == "No" ]; then
+                echo "$NAME failed $DIFFICULTY validation!"
+                cat temp.log
+            fi
+            
+            rm temp.log
+        else
+            echo "Skipping $DIFFICULTY validation"
+        fi
+    done
+    
+    echo "$NAME validation complete!  Success: $SUCCESS"
+    echo "------"
+    
+    [ "$SUCCESS" == "Yes" ]
+}
+
+RET=0
+
+validate_core "Core" || RET=1
+validate_misc "Editor"      "EDITOR" || RET=1
+validate_misc "Multiplayer" "MULTIPLAYER,MULTIPLAYER_A_NEW_LAND_LOAD" || RET=1
+validate_misc "Test"        "TEST,SCHEMA_SHOULD_SKIP_THIS"            || RET=1
+validate_campaign "An_Orcish_Incursion"     "CAMPAIGN_AN_ORCISH_INCURSION"     "EASY" "NORMAL" "HARD"             || RET=1
+validate_campaign "Dead_Water"              "CAMPAIGN_DEAD_WATER"              "EASY" "NORMAL" "HARD" "NIGHTMARE" || RET=1
+validate_campaign "Delfadors_Memoirs"       "CAMPAIGN_DELFADORS_MEMOIRS"       "EASY" "NORMAL" "HARD"             || RET=1
+validate_campaign "Descent_Into_Darkness"   "CAMPAIGN_DESCENT"                 "EASY" "NORMAL" "HARD"             || RET=1
+validate_campaign "Eastern_Invasion"        "CAMPAIGN_EASTERN_INVASION"        "EASY" "NORMAL" "HARD"             || RET=1
+validate_campaign "Heir_To_The_Throne"      "CAMPAIGN_HEIR_TO_THE_THRONE"      "EASY" "NORMAL" "HARD"             || RET=1
+validate_campaign "Legend_of_Wesmere"       "CAMPAIGN_LOW"                     "EASY" "NORMAL" "HARD"             || RET=1
+validate_campaign "Liberty"                 "CAMPAIGN_LIBERTY"                 "EASY" "NORMAL" "HARD"             || RET=1
+validate_campaign "Northern_Rebirth"        "CAMPAIGN_NORTHERN_REBIRTH"        "EASY" "NORMAL" "HARD"             || RET=1
+validate_campaign "Sceptre_of_Fire"         "CAMPAIGN_SCEPTRE_FIRE"            "EASY" "NORMAL" "HARD"             || RET=1
+validate_campaign "Secrets_of_the_Ancients" "CAMPAIGN_SECRETS_OF_THE_ANCIENTS" "EASY" "NORMAL" "HARD"             || RET=1
+validate_campaign "Son_Of_The_Black_Eye"    "CAMPAIGN_SON_OF_THE_BLACK_EYE"    "EASY" "NORMAL" "HARD"             || RET=1
+validate_campaign "The_Hammer_of_Thursagan" "CAMPAIGN_THE_HAMMER_OF_THURSAGAN" "EASY" "NORMAL" "HARD"             || RET=1
+validate_campaign "The_Rise_Of_Wesnoth"     "CAMPAIGN_THE_RISE_OF_WESNOTH"     "EASY" "NORMAL" "HARD"             || RET=1
+validate_campaign "The_South_Guard"         "CAMPAIGN_THE_SOUTH_GUARD"         "EASY" "NORMAL" "HARD"             || RET=1
+validate_campaign "tutorial"                "TUTORIAL"                         "EASY" "NORMAL" "HARD"             || RET=1
+validate_campaign "Two_Brothers"            "CAMPAIGN_TWO_BROTHERS"            "EASY" "HARD"                      || RET=1
+validate_campaign "Under_the_Burning_Suns"  "CAMPAIGN_UNDER_THE_BURNING_SUNS"  "EASY" "NORMAL" "HARD"             || RET=1
+
+exit $RET

--- a/utils/travis/steps/script.sh
+++ b/utils/travis/steps/script.sh
@@ -43,5 +43,5 @@ else
                --volume "$HOME"/.ccache:/root/.ccache \
                wesnoth-repo:"$LTS"-"$BRANCH" \
                bash -c './utils/travis/docker_run.sh "$@"' \
-               bash "$NLS" "$TOOL" "$CC" "$CXX" "$CXXSTD" "$OPT" "$WML_TESTS" "$WML_TEST_TIME" "$PLAY_TEST" "$MP_TEST" "$BOOST_TEST" "$LTO" "$SAN"
+               bash "$NLS" "$TOOL" "$CC" "$CXX" "$CXXSTD" "$OPT" "$WML_TESTS" "$WML_TEST_TIME" "$PLAY_TEST" "$MP_TEST" "$BOOST_TEST" "$LTO" "$SAN" "$VALIDATE"
 fi


### PR DESCRIPTION
This adds running the WML schema validation in travis.  It also updates the schema itself and fixes a few WML errors so that core and all campaigns under all difficulties pass the schema validation.