### PR TITLE
fix problems of negatives values for heals, leadership and resistance abilities

### DIFF
--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1567,7 +1567,8 @@ void attack_unit_and_advance(const map_location& attacker,
 int under_leadership(const unit &u, const map_location& loc, const_attack_ptr weapon, const_attack_ptr opp_weapon)
 {
 	unit_ability_list abil = u.get_abilities("leadership", loc, weapon, opp_weapon);
-	return abil.highest("value").first;
+	unit_abilities::effect leadership_effect(abil, 0, true);
+	return leadership_effect.get_composite_value();
 }
 
 //begin of weapon emulates function.

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1173,8 +1173,14 @@ effect::effect(const unit_ability_list& list, int def, bool backstab) :
 				set_effect.set(SET, value, ability.first, ability.second);
 			} else {
 				if (cumulative) value_set = std::max<int>(value_set, def);
-				if (value > value_set) {
+				if (value >= 0 && value_set >=0 && value > value_set) {
 					value_set = value;
+					set_effect.set(SET, value, ability.first, ability.second);
+				} else if (value < 0 && value_set < 0 && value < value_set) {
+					value_set = value;
+					set_effect.set(SET, value, ability.first, ability.second);
+				} else if ((value < 0 && value_set >= 0) || (value >= 0 && value_set <0)) {
+					value_set = value_set + value;
 					set_effect.set(SET, value, ability.first, ability.second);
 				}
 			}

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1174,7 +1174,7 @@ effect::effect(const unit_ability_list& list, int def, bool backstab) :
 			} else {
 				if (cumulative) value_set = std::max<int>(value_set, def);
 				if ((value < 0 && value_set >= 0) || (value >= 0 && value_set < 0)) {
-				value_set = value_set + value;
+					value_set = value_set + value;
 					set_effect.set(SET, value, ability.first, ability.second);
 				}
 				else if (value >=0) {

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1173,14 +1173,16 @@ effect::effect(const unit_ability_list& list, int def, bool backstab) :
 				set_effect.set(SET, value, ability.first, ability.second);
 			} else {
 				if (cumulative) value_set = std::max<int>(value_set, def);
-				if (value >= 0 && value_set >=0 && value > value_set) {
-					value_set = value;
+				if ((value < 0 && value_set >= 0) || (value >= 0 && value_set < 0)) {
+				value_set = value_set + value;
 					set_effect.set(SET, value, ability.first, ability.second);
-				} else if (value < 0 && value_set < 0 && value < value_set) {
-					value_set = value;
+				}
+				else if (value >=0) {
+					value_set = std::max<int>(value_set, value);
 					set_effect.set(SET, value, ability.first, ability.second);
-				} else if ((value < 0 && value_set >= 0) || (value >= 0 && value_set <0)) {
-					value_set = value_set + value;
+				}
+				else if (value < 0) {
+					value_set = std::min<int>(value_set, value);
 					set_effect.set(SET, value, ability.first, ability.second);
 				}
 			}


### PR DESCRIPTION
@CelticMinstrel  had suggest what i modifie the rules of calculation for resolve problem of negative values in heals. if value of heals adjacent to patient are negative, the lowest value is used, if an value is positive and another negative, the difference is applied. PR pulled in place of https://github.com/wesnoth/wesnoth/pull/3725