### PR TITLE
Add attack icons to unit_preview_pane

### DIFF
--- a/data/gui/widget/unit_preview_pane.cfg
+++ b/data/gui/widget/unit_preview_pane.cfg
@@ -194,8 +194,8 @@
 										vertical_grow = false
 										horizontal_alignment = "left"
 										vertical_alignment = "top"
-										border = "top,right"
-										border_size = 3
+										border = "top"
+										border_size = 2
 										[image]
 											definition = "default"
 											id = "image_range"
@@ -207,8 +207,8 @@
 										vertical_grow = false
 										horizontal_alignment = "left"
 										vertical_alignment = "top"
-										border = "top,right"
-										border_size = 3
+										border = "top"
+										border_size = 2
 										[image]
 											definition = "default"
 											id = "image_type"
@@ -220,8 +220,8 @@
 										vertical_grow = false
 										horizontal_alignment = "left"
 										vertical_alignment = "top"
-										border = "top,bottom"
-										border_size = 1
+										border = "left"
+										border_size = 5
 										[label]
 											wrap = true
 											definition = "default_small"

--- a/data/gui/widget/unit_preview_pane.cfg
+++ b/data/gui/widget/unit_preview_pane.cfg
@@ -184,6 +184,55 @@
 						[/node]
 
 						[node]
+							id = "item_image"
+							unfolded = true
+							[node_definition]
+								[row]
+									[column]
+										grow_factor = 0
+										horizontal_grow = false
+										vertical_grow = false
+										horizontal_alignment = "left"
+										vertical_alignment = "top"
+										border = "top,right"
+										border_size = 3
+										[image]
+											definition = "default"
+											id = "image_range"
+										[/image]
+									[/column]
+									[column]
+										grow_factor = 0
+										horizontal_grow = false
+										vertical_grow = false
+										horizontal_alignment = "left"
+										vertical_alignment = "top"
+										border = "top,right"
+										border_size = 3
+										[image]
+											definition = "default"
+											id = "image_type"
+										[/image]
+									[/column]
+									[column]
+										grow_factor = 1
+										horizontal_grow = false
+										vertical_grow = false
+										horizontal_alignment = "left"
+										vertical_alignment = "top"
+										border = "top,bottom"
+										border_size = 1
+										[label]
+											wrap = true
+											definition = "default_small"
+											id = "name"
+										[/label]
+									[/column]
+								[/row]
+							[/node_definition]
+						[/node]
+
+						[node]
 							id = "hp_xp_mp"
 							unfolded = true
 							[node_definition]

--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -222,19 +222,16 @@ void unit_preview_pane::print_attack_details(T attacks, tree_view_node& parent_n
 		const bool range_png_exists = ::image::locator(range_png).file_exists();
 		const bool type_png_exists = ::image::locator(type_png).file_exists();
 
-		auto& subsection = add_name_tree_node(
-			header_node,
-			"item",
-			(formatter()
+		const std::string label = (formatter()
 			 << font::span_color(font::unit_type_color)
 			 << a.damage() << font::weapon_numbers_sep << a.num_attacks()
-			 << " " << a.name() << "</span>").str()
-		);
-
-		subsection.add_child("item_image",
+			 << " " << a.name() << "</span>").str();
+		auto& subsection = header_node.add_child(
+			"item_image",
 			{
-				{ "image_range", { { "label", range_png }, { "use_markup", "true" } } },
-				{ "image_type", { { "label", type_png }, { "use_markup", "true" } } },
+				{ "image_range", { { "label", range_png } } },
+				{ "image_type", { { "label", type_png } } },
+				{ "name", { { "label", label }, { "use_markup", "true" } } },
 			}
 		);
 

--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -222,10 +222,14 @@ void unit_preview_pane::print_attack_details(T attacks, tree_view_node& parent_n
 		const bool range_png_exists = ::image::locator(range_png).file_exists();
 		const bool type_png_exists = ::image::locator(type_png).file_exists();
 
+		const t_string& range = string_table["range_" + a.range()];
+		const t_string& type = string_table["type_" + a.type()];
+
 		const std::string label = (formatter()
 			 << font::span_color(font::unit_type_color)
 			 << a.damage() << font::weapon_numbers_sep << a.num_attacks()
 			 << " " << a.name() << "</span>").str();
+
 		auto& subsection = header_node.add_child(
 			"item_image",
 			{
@@ -235,14 +239,17 @@ void unit_preview_pane::print_attack_details(T attacks, tree_view_node& parent_n
 			}
 		);
 
+		find_widget<styled_widget>(&subsection, "image_range", true).set_tooltip(range);
+		find_widget<styled_widget>(&subsection, "image_type", true).set_tooltip(type);
+
 		if(!range_png_exists || !type_png_exists) {
 			add_name_tree_node(
 				subsection,
 				"item",
 				(formatter()
 				 << font::span_color(font::weapon_details_color)
-				 << string_table["range_" + a.range()] << font::weapon_details_sep
-				 << string_table["type_" + a.type()] << "</span>"
+				 << range << font::weapon_details_sep
+				 << type << "</span>"
 				 ).str()
 			);
 		}

--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -217,6 +217,10 @@ void unit_preview_pane::print_attack_details(T attacks, tree_view_node& parent_n
 	);
 
 	for(const auto& a : attacks) {
+		const std::string range_png = std::string("icons/profiles/") + a.range() + "_attack.png~SCALE_INTO_SHARP(16,16)";
+		const std::string type_png = std::string("icons/profiles/") + a.type() + ".png~SCALE_INTO_SHARP(16,16)";
+		const bool range_png_exists = ::image::locator(range_png).file_exists();
+		const bool type_png_exists = ::image::locator(type_png).file_exists();
 
 		auto& subsection = add_name_tree_node(
 			header_node,
@@ -224,11 +228,20 @@ void unit_preview_pane::print_attack_details(T attacks, tree_view_node& parent_n
 			(formatter() << font::span_color(font::unit_type_color) << a.damage() << font::weapon_numbers_sep << a.num_attacks() << " " << a.name() << "</span>").str()
 		);
 
-		add_name_tree_node(
-			subsection,
-			"item",
-			(formatter() << font::span_color(font::weapon_details_color) << string_table["range_" + a.range()] << font::weapon_details_sep << string_table["type_" + a.type()] << "</span>").str()
+		subsection.add_child("item_image",
+			{
+				{ "image_range", { { "label", range_png }, { "use_markup", "true" } } },
+				{ "image_type", { { "label", type_png }, { "use_markup", "true" } } },
+			}
 		);
+
+		if(!range_png_exists || !type_png_exists) {
+			add_name_tree_node(
+				subsection,
+				"item",
+				(formatter() << font::span_color(font::weapon_details_color) << string_table["range_" + a.range()] << font::weapon_details_sep << string_table["type_" + a.type()] << "</span>").str()
+			);
+		}
 
 		for(const auto& pair : a.special_tooltips()) {
 			add_name_tree_node(

--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -225,7 +225,10 @@ void unit_preview_pane::print_attack_details(T attacks, tree_view_node& parent_n
 		auto& subsection = add_name_tree_node(
 			header_node,
 			"item",
-			(formatter() << font::span_color(font::unit_type_color) << a.damage() << font::weapon_numbers_sep << a.num_attacks() << " " << a.name() << "</span>").str()
+			(formatter()
+			 << font::span_color(font::unit_type_color)
+			 << a.damage() << font::weapon_numbers_sep << a.num_attacks()
+			 << " " << a.name() << "</span>").str()
 		);
 
 		subsection.add_child("item_image",
@@ -239,7 +242,11 @@ void unit_preview_pane::print_attack_details(T attacks, tree_view_node& parent_n
 			add_name_tree_node(
 				subsection,
 				"item",
-				(formatter() << font::span_color(font::weapon_details_color) << string_table["range_" + a.range()] << font::weapon_details_sep << string_table["type_" + a.type()] << "</span>").str()
+				(formatter()
+				 << font::span_color(font::weapon_details_color)
+				 << string_table["range_" + a.range()] << font::weapon_details_sep
+				 << string_table["type_" + a.type()] << "</span>"
+				 ).str()
 			);
 		}
 


### PR DESCRIPTION
This adds range and damage type icons to the unit preview pane, like #3732 did to the sidebar.

Depends on #3732 for finding the the `blade` icon (#3732 renamed blades.png to blade.png).

Currently this is a work in progress, not ready to be merged yet. This is how far I got, does anyone know how to stop that line from stretching to fill the width of the pane?

![screenshot_2018-11-23_04-53-40](https://user-images.githubusercontent.com/24784687/48928954-f88c6880-eedb-11e8-8c9d-3210d3b18d3e.png)

cc @CelticMinstrel 