### PR TITLE
Fix problem of negatives value in heals andleadership abilities

### DIFF
--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1569,12 +1569,8 @@ int under_leadership(const unit &u, const map_location& loc, const_attack_ptr we
 	int leader_up = 0;
 	int leader_down = 0;
 	unit_ability_list abil = u.get_abilities("leadership", loc, weapon, opp_weapon);
-	if (abil.highest("value").first >= 0){ 
-		leader_up = abil.highest("value").first;
-	}
-	if (abil.lowest("value").first < 0){ 
-		leader_down = abil.lowest("value").first;
-	}
+	leader_up = std::max(0, abil.highest("value").first);
+	leader_down= std::min(0, abil.lowest("value").first);
 	return leader_up + leader_down;
 }
 

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1566,7 +1566,7 @@ void attack_unit_and_advance(const map_location& attacker,
 
 int under_leadership(const unit &u, const map_location& loc, const_attack_ptr weapon, const_attack_ptr opp_weapon)
 {
-	int leader_up= 0;
+	int leader_up = 0;
 	int leader_down = 0;
 	unit_ability_list abil = u.get_abilities("leadership", loc, weapon, opp_weapon);
 	if (abil.highest("value").first >= 0) leader_up = abil.highest("value").first;

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -222,7 +222,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 			drain_percent = drain_percent_effects.get_composite_value();
 		}
 		if (weapon->combat_ability("drains", 50, backstab_pos).second) {
-                drain_percent = weapon->combat_ability("drains", 50, backstab_pos).first;
+			drain_percent = weapon->combat_ability("drains", 50, backstab_pos).first;
 		}
 	}
 

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1572,11 +1572,11 @@ void attack_unit_and_advance(const map_location& attacker,
 int under_leadership(const unit &u, const map_location& loc, const_attack_ptr weapon, const_attack_ptr opp_weapon)
 {
 	int leader_up=0;
-    int leader_down =0;
+	int leader_down =0;
 	unit_ability_list abil = u.get_abilities("leadership", loc, weapon, opp_weapon);
-    if (abil.highest("value").first>0) leader_up=abil.highest("value").first;
-    if (abil.lowest("value").first<0) leader_down=abil.lowest("value").first;
-    return leader_up + leader_down;
+	if (abil.highest("value").first>0) leader_up=abil.highest("value").first;
+	if (abil.lowest("value").first<0) leader_down=abil.lowest("value").first;
+	return leader_up + leader_down;
 }
 
 //begin of weapon emulates function.

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -222,12 +222,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 			drain_percent = drain_percent_effects.get_composite_value();
 		}
 		if (weapon->combat_ability("drains", 50, backstab_pos).second) {
-                int negative_drains = 0;
-                int positive_drains = 0;
-                unit_ability_list drains_abilities = u.get_abilities("drains", u_loc, weapon, opp_weapon);
-                if(!(drains_abilities.highest("value").first < 0)) positive_drains = weapon->combat_ability("drains", 50, backstab_pos).first;
-                if(drains_abilities.lowest("value").first < 0) negative_drains = drains_abilities.lowest("value").first;
-                drain_percent = positive_drains + negative_drains;
+                drain_percent = weapon->combat_ability("drains", 50, backstab_pos).first;
 		}
 	}
 

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -223,9 +223,11 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 		}
 		if (weapon->combat_ability("drains", 50, backstab_pos).second) {
                 int negative_drains = 0;
+                int positive_drains = 0;
                 unit_ability_list drains_abilities = u.get_abilities("drains", u_loc, weapon, opp_weapon);
+                if(!(drains_abilities.highest("value").first < 0)) positive_drains = weapon->combat_ability("drains", 50, backstab_pos).first;
                 if(drains_abilities.lowest("value").first < 0) negative_drains = drains_abilities.lowest("value").first;
-                drain_percent = weapon->combat_ability("drains", 50, backstab_pos).first + negative_drains;
+                drain_percent = positive_drains + negative_drains;
 		}
 	}
 
@@ -1570,11 +1572,11 @@ void attack_unit_and_advance(const map_location& attacker,
 int under_leadership(const unit &u, const map_location& loc, const_attack_ptr weapon, const_attack_ptr opp_weapon)
 {
 	int leader_up=0;
-	int leader_down =0;
+    int leader_down =0;
 	unit_ability_list abil = u.get_abilities("leadership", loc, weapon, opp_weapon);
-	if (abil.highest("value").first>0) leader_up = abil.highest("value").first;
-	if (abil.lowest("value").first<0) leader_down = abil.lowest("value").first;
-	return leader_up + leader_down;
+    if (abil.highest("value").first>0) leader_up=abil.highest("value").first;
+    if (abil.lowest("value").first<0) leader_down=abil.lowest("value").first;
+    return leader_up + leader_down;
 }
 
 //begin of weapon emulates function.

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1566,11 +1566,11 @@ void attack_unit_and_advance(const map_location& attacker,
 
 int under_leadership(const unit &u, const map_location& loc, const_attack_ptr weapon, const_attack_ptr opp_weapon)
 {
-	int leader_up=0;
-	int leader_down =0;
+	int leader_up= 0;
+	int leader_down = 0;
 	unit_ability_list abil = u.get_abilities("leadership", loc, weapon, opp_weapon);
-	if (abil.highest("value").first>0) leader_up=abil.highest("value").first;
-	if (abil.lowest("value").first<0) leader_down=abil.lowest("value").first;
+	if (abil.highest("value").first >= 0) leader_up = abil.highest("value").first;
+	if (abil.lowest("value").first < 0) leader_down = abil.lowest("value").first;
 	return leader_up + leader_down;
 }
 

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -222,7 +222,10 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 			drain_percent = drain_percent_effects.get_composite_value();
 		}
 		if (weapon->combat_ability("drains", 50, backstab_pos).second) {
-			drain_percent = weapon->combat_ability("drains", 50, backstab_pos).first;
+                int negative_drains = 0;
+                unit_ability_list drains_abilities = get_abilities("drains", u_loc, weapon, opp_weapon);
+                if(drains_abilities.lowest("value") < 0) negative_drains = drains_abilities.lowest("value");
+                drain_percent = weapon->combat_ability("drains", 50, backstab_pos).first + negative_drains;
 		}
 	}
 
@@ -1566,8 +1569,12 @@ void attack_unit_and_advance(const map_location& attacker,
 
 int under_leadership(const unit &u, const map_location& loc, const_attack_ptr weapon, const_attack_ptr opp_weapon)
 {
+	int leader_up=0;
+	int leader_down =0;
 	unit_ability_list abil = u.get_abilities("leadership", loc, weapon, opp_weapon);
-	return abil.highest("value").first;
+	if (abil.highest("value").first>0) leader_up = abil.highest("value").first;
+	if (abil.lowest("value").first<0) leader_down = abil.lowest("value").first;
+	return leader_up + leader_down;
 }
 
 //begin of weapon emulates function.

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -223,8 +223,8 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 		}
 		if (weapon->combat_ability("drains", 50, backstab_pos).second) {
                 int negative_drains = 0;
-                unit_ability_list drains_abilities = get_abilities("drains", u_loc, weapon, opp_weapon);
-                if(drains_abilities.lowest("value") < 0) negative_drains = drains_abilities.lowest("value");
+                unit_ability_list drains_abilities = u.get_abilities("drains", u_loc, weapon, opp_weapon);
+                if(drains_abilities.lowest("value").first < 0) negative_drains = drains_abilities.lowest("value").first;
                 drain_percent = weapon->combat_ability("drains", 50, backstab_pos).first + negative_drains;
 		}
 	}

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1569,8 +1569,12 @@ int under_leadership(const unit &u, const map_location& loc, const_attack_ptr we
 	int leader_up = 0;
 	int leader_down = 0;
 	unit_ability_list abil = u.get_abilities("leadership", loc, weapon, opp_weapon);
-	if (abil.highest("value").first >= 0) leader_up = abil.highest("value").first;
-	if (abil.lowest("value").first < 0) leader_down = abil.lowest("value").first;
+	if (abil.highest("value").first >= 0){ 
+		leader_up = abil.highest("value").first;
+	}
+	if (abil.lowest("value").first < 0){ 
+		leader_down = abil.lowest("value").first;
+	}
 	return leader_up + leader_down;
 }
 

--- a/src/actions/heal.cpp
+++ b/src/actions/heal.cpp
@@ -215,7 +215,7 @@ namespace {
 		// Now we can get the aggregate healing amount.
 		unit_abilities::effect heal_effect(heal_list, 0, false);
 		if (heal_list.lowest("value").first < 0) healer_down = heal_list.lowest("value").first;
-		if (!(heal_list.highest("value").first<0)) healer_up = heal_effect.get_composite_value();
+		if (heal_effect.get_composite_value() >= 0) healer_up = heal_effect.get_composite_value();
 		int heal_value = healer_up + healer_down;
 		if ( update_healing(healing, harming, heal_value) )
 		{

--- a/src/actions/heal.cpp
+++ b/src/actions/heal.cpp
@@ -214,8 +214,12 @@ namespace {
 
 		// Now we can get the aggregate healing amount.
 		unit_abilities::effect heal_effect(heal_list, 0, false);
-		if (heal_list.lowest("value").first < 0) healer_down = heal_list.lowest("value").first;
-		if (heal_list.highest("value").first >= 0) healer_up = heal_list.highest("value").first;
+		if (heal_list.lowest("value").first < 0) {
+			healer_down = heal_list.lowest("value").first;
+		}
+		if (heal_list.highest("value").first >= 0){
+			healer_up = heal_list.highest("value").first;
+		}
 		int heal_value = healer_up + healer_down;
 		if ( update_healing(healing, harming, heal_value) )
 		{

--- a/src/actions/heal.cpp
+++ b/src/actions/heal.cpp
@@ -215,7 +215,7 @@ namespace {
 		// Now we can get the aggregate healing amount.
 		unit_abilities::effect heal_effect(heal_list, 0, false);
 		if (heal_list.lowest("value").first < 0) healer_down = heal_list.lowest("value").first;
-		if (heal_effect.get_composite_value() >= 0) healer_up = heal_effect.get_composite_value();
+		if (heal_list.highest("value").first >= 0) healer_up = heal_list.highest("value").first;
 		int heal_value = healer_up + healer_down;
 		if ( update_healing(healing, harming, heal_value) )
 		{

--- a/src/actions/heal.cpp
+++ b/src/actions/heal.cpp
@@ -182,6 +182,7 @@ namespace {
 
 		int healing = 0;
 		int harming = 0;
+		int healer_down = 0;
 
 
 		if ( patient.side() == side )
@@ -212,7 +213,9 @@ namespace {
 
 		// Now we can get the aggregate healing amount.
 		unit_abilities::effect heal_effect(heal_list, 0, false);
-		if ( update_healing(healing, harming, heal_effect.get_composite_value()) )
+		if (heal_list.lowest("value").first < 0) healer_down = heal_list.lowest("value").first;
+		int heal_value = heal_effect.get_composite_value() + healer_down;
+		if ( update_healing(healing, harming, heal_value) )
 		{
 			// Collect the healers involved.
 			for (const unit_abilities::individual_effect & heal : heal_effect)

--- a/src/actions/heal.cpp
+++ b/src/actions/heal.cpp
@@ -214,12 +214,8 @@ namespace {
 
 		// Now we can get the aggregate healing amount.
 		unit_abilities::effect heal_effect(heal_list, 0, false);
-		if (heal_list.lowest("value").first < 0) {
-			healer_down = heal_list.lowest("value").first;
-		}
-		if (heal_list.highest("value").first >= 0){
-			healer_up = heal_list.highest("value").first;
-		}
+		healer_down = std::min(0, heal_list.lowest("value").first);
+		healer_up = std::max(0, heal_list.highest("value").first);
 		int heal_value = healer_up + healer_down;
 		if ( update_healing(healing, harming, heal_value) )
 		{

--- a/src/actions/heal.cpp
+++ b/src/actions/heal.cpp
@@ -183,6 +183,7 @@ namespace {
 		int healing = 0;
 		int harming = 0;
 		int healer_down = 0;
+		int healer_up = 0;
 
 
 		if ( patient.side() == side )
@@ -214,7 +215,8 @@ namespace {
 		// Now we can get the aggregate healing amount.
 		unit_abilities::effect heal_effect(heal_list, 0, false);
 		if (heal_list.lowest("value").first < 0) healer_down = heal_list.lowest("value").first;
-		int heal_value = heal_effect.get_composite_value() + healer_down;
+		if (!(heal_list.highest("value").first<0)) healer_up = heal_effect.get_composite_value();
+		int heal_value = healer_up + healer_down;
 		if ( update_healing(healing, harming, heal_value) )
 		{
 			// Collect the healers involved.

--- a/src/actions/heal.cpp
+++ b/src/actions/heal.cpp
@@ -217,6 +217,9 @@ namespace {
 		healer_down = std::min(0, heal_list.lowest("value").first);
 		healer_up = std::max(0, heal_list.highest("value").first);
 		int heal_value = healer_up + healer_down;
+		if(healer_down == 0){
+			heal_value = heal_effect.get_composite_value();
+		}
 		if ( update_healing(healing, harming, heal_value) )
 		{
 			// Collect the healers involved.


### PR DESCRIPTION
I prefer modify the abilities function for resolve this problems instead to alter effect constructor because i don't want what chance_to_hit, berserk damage or attacks abilities could be affected. This fix resolve problems of value= negative_value but add, sub multiply or divide don't concerned.  I eventually post an test case in this PR but i post the code immediately for what you're read this. replace https://github.com/wesnoth/wesnoth/pull/3725