### PR TITLE
fix value={CTH_NUMBER} forget in force CTH macro

### DIFF
--- a/data/core/macros/utils.cfg
+++ b/data/core/macros/utils.cfg
@@ -544,6 +544,7 @@
                 [abilities]
                     [chance_to_hit]
                         id=forced_cth
+                        value={CTH_NUMBER}
                         cumulative=no
                         affect_self=yes
                         [filter_opponent]
@@ -595,6 +596,7 @@
                 [abilities]
                     [chance_to_hit]
                         id=forced_cth
+                        value={CTH_NUMBER}
                         cumulative=no
                         affect_self=yes
                         [filter_opponent]


### PR DESCRIPTION
i don't see before what value was forget, sorry about that.