### PR TITLE
 resolve problem of negative value without alterate illuminates 

### DIFF
--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -870,10 +870,60 @@ Xu, Xu, Qxu, Qxu, Ql, Ql, Ql, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Gg, Gg, Gg, Gg, Gg
             [/modifications]
         [/unit]
         [unit]
-            # Drain tester (for undead and default drain)
+            # Drain tester (for undead and default drain) and reverse heals tester
             x,y=21,7
             type="Lich"
             generate_name=yes
+	    [modifications]
+                [object]
+                    [effect]
+                        apply_to=new_ability
+                            [abilities]
+                                [heals]
+				    value=-4
+				    id=aura of death 4
+				    affect_enemies=yes
+				    name= _ "aura of death ("4")"
+				    female_name= _ "female^aura of death ("4")"
+				    affect_self=no
+				    affect_allies=no
+				    poison=slowed
+				    [affect_adjacent]
+				        adjacent=n,ne,se,s,sw,n
+				    [/affect_adjacent]
+                                [/heals]
+                            [/abilities]
+                    [/effect]
+                [/object]
+            [/modifications]
+        [/unit]
+	[unit]
+            # reverse heals tester
+            x,y=20,6
+            type="Ancient Lich"
+            generate_name=yes
+	    [modifications]
+                [object]
+                    [effect]
+                        apply_to=new_ability
+                            [abilities]
+                                [heals]
+				    value=-8
+				    id=aura of death 8
+				    affect_enemies=yes
+				    name= _ "aura of death ("8")"
+				    female_name= _ "female^aura of death ("8")"
+				    affect_self=no
+				    affect_allies=no
+				    poison=slowed
+				    [affect_adjacent]
+				        adjacent=n,ne,se,s,sw,n
+				    [/affect_adjacent]
+                                [/heals]
+                            [/abilities]
+                    [/effect]
+                [/object]
+            [/modifications]
         [/unit]
         [unit]
             # Drain tester

--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -324,7 +324,7 @@ Xu, Xu, Qxu, Qxu, Ql, Ql, Ql, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Gg, Gg, Gg, Gg, Gg
         [unit]
             # A unit whose portrait is only shown on the right side.
             x,y=18,11
-            type="White Mage"
+            type="Mage of Light"
             gender="female"
             generate_name=yes
         [/unit]
@@ -351,6 +351,8 @@ Xu, Xu, Qxu, Qxu, Ql, Ql, Ql, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Gg, Gg, Gg, Gg, Gg
                                 female_name= "female^darkens"
                                 description= "darkens and stuff"
                                 affect_self=yes
+				[affect_adjacent]
+				[/affect_adjacent]
                             [/illuminates]
                         [/abilities]
                     [/effect]

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1567,7 +1567,9 @@ void attack_unit_and_advance(const map_location& attacker,
 int under_leadership(const unit &u, const map_location& loc, const_attack_ptr weapon, const_attack_ptr opp_weapon)
 {
 	unit_ability_list abil = u.get_abilities("leadership", loc, weapon, opp_weapon);
-	return abil.highest("value").first;
+	int leader_up = std::max(0, abil.highest("value").first);
+	int leader_down = std::min(0, abil.lowest("value").first);
+	return leader_up + leader_down;
 }
 
 //begin of weapon emulates function.

--- a/src/tod_manager.cpp
+++ b/src/tod_manager.cpp
@@ -255,7 +255,7 @@ const time_of_day tod_manager::get_illuminated_time_of_day(const unit_map & unit
 			    !itor->incapacitated())
 			{
 				unit_ability_list illum = itor->get_abilities("illuminates");
-				unit_abilities::effect illum_effect(illum, terrain_light, false);
+				unit_abilities::effect illum_effect(illum, terrain_light, false, true);
 				const int unit_mod = illum_effect.get_composite_value();
 
 				// Record this value.

--- a/src/units/abilities.hpp
+++ b/src/units/abilities.hpp
@@ -40,7 +40,7 @@ struct individual_effect
 class effect
 {
 	public:
-		effect(const unit_ability_list& list, int def, bool backstab);
+		effect(const unit_ability_list& list, int def, bool backstab, bool old_calc = false);
 
 		// Provide read-only access to the effect list:
 		typedef std::vector<individual_effect>::const_iterator iterator;


### PR DESCRIPTION
i replace https://github.com/wesnoth/wesnoth/pull/3754 by this PR for more readibility. The new rule of calculation is used by default. illuminates abilities are an exception and old rule of calculation in the effect constructor must be used for not modify the final values when two units with illuminates but with opposites values are adjacent.