### PR TITLE
Fix #3744: Changing theme twice

### DIFF
--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -592,7 +592,6 @@ theme::theme(const config& cfg, const SDL_Rect& screen)
 theme& theme::operator=(theme&& other)
 {
 	theme_reset_event_ = other.theme_reset_event_;
-	known_themes = other.known_themes;
 	cur_theme = std::move(other.cur_theme);
 	cfg_ = std::move(other.cfg_);
 	panels_ = std::move(other.panels_);


### PR DESCRIPTION
After std::move, source (known_themes) can't be used.
Because it is a static variable, i removed std::move.