### PR TITLE
wmllint: fix "local variable 'unit_id' referenced before assignment"

### DIFF
--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -1347,6 +1347,8 @@ def global_sanity_check(filename, lines):
     notecheck = True
     trait_note = dict(notepairs)
     note_trait = {p[1]:p[0] for p in notepairs}
+    unit_id = ""
+    base_unit = ""
     for nav in WmllintIterator(lines, filename):
         if "wmllint: notecheck off" in nav.text:
             notecheck = False


### PR DESCRIPTION
In global_sanity_check(), variables "unit_id" and "base_unit" can be
used before assignment. This happens, for example, in this WML file:
https://github.com/Dugy/Legend_of_the_Invincibles/blob/master/utils/amla.cfg#L65
... where there is a [/unit_type] tag without the matching [unit_type].

(these variables are normally initialized when [unit_type] is found)