### PR TITLE
Recruit Unit: Add search functionality

### DIFF
--- a/data/gui/window/unit_recruit.cfg
+++ b/data/gui/window/unit_recruit.cfg
@@ -132,23 +132,6 @@
 		[/helptip]
 
 		[grid]
-			[row]
-				grow_factor = 0
-
-				[column]
-					grow_factor = 1
-					border = "all"
-					border_size = 5
-					horizontal_alignment = "left"
-
-					[label]
-						definition = "title"
-						label = _ "Recruit Unit"
-					[/label]
-
-				[/column]
-
-			[/row]
 
 			[row]
 				grow_factor = 1
@@ -158,6 +141,35 @@
 					vertical_grow = true
 
 					[grid]
+
+						[row]
+
+							[column]
+								grow_factor = 1
+								border = "all"
+								border_size = 5
+								horizontal_alignment = "left"
+
+								[label]
+									definition = "title"
+									label = _ "Recruit Unit"
+								[/label]
+
+							[/column]
+
+							[column]
+								border = "all"
+								border_size = 5
+								horizontal_alignment = "left"
+
+								[text_box]
+									id = "filter_box"
+									definition = "default"
+									{FITER_TEXT_BOX_HINT}
+								[/text_box]
+
+							[/column]
+						[/row]
 
 						[row]
 							[column]

--- a/src/gui/dialogs/unit_recruit.cpp
+++ b/src/gui/dialogs/unit_recruit.cpp
@@ -95,7 +95,7 @@ void unit_recruit::filter_text_changed(text_box_base* textbox, const std::string
 			for(const auto & word : words)
 			{
 				// Search for the name in the local language.
-				// In debug mode, also search for the English name.
+				// In debug mode, also search for the type id.
 				found =
 				        (game_config::debug && ci_search(type->id(), word)) ||
 					ci_search(type->type_name(), word);

--- a/src/gui/dialogs/unit_recruit.hpp
+++ b/src/gui/dialogs/unit_recruit.hpp
@@ -14,6 +14,7 @@
 #pragma once
 
 #include "gui/dialogs/modal_dialog.hpp"
+#include "gui/widgets/text_box_base.hpp"
 
 class unit_type;
 class team;
@@ -42,6 +43,7 @@ private:
 	virtual void post_show(window& window) override;
 
 	void list_item_clicked(window& window);
+	void filter_text_changed(text_box_base* textbox, const std::string& text);
 
 	void show_help();
 
@@ -50,6 +52,8 @@ private:
 	team& team_;
 
 	int selected_index_;
+
+	std::vector<std::string> last_words_;
 };
 
 } // namespace dialogs


### PR DESCRIPTION
Will be useful, particularly for [certain](https://github.com/ProditorMagnus/Ageless-for-1-14/commit/a016fc9058afeeba05e148a7116a6c4116d4875b) large factions, but also for quickly searching the recruit list for a particular unit type.

In the test scenario (which allows you to recruit several dozen unit types) it looks like this:
![screenshot_2018-12-16_14-40-28](https://user-images.githubusercontent.com/24784687/50055702-156a3380-014a-11e9-870a-1f72438abb1c.png)

The search uses the localized name.