### PR TITLE
wmllint: don't analyze WML within [filter_wml] blocks (most checks are not applicable to its contents)

### DIFF
--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -2261,11 +2261,17 @@ def hack_syntax(filename, lines):
                 print('"%s", line %d: %s -> %s -- DO NOT PREFIX PATHS WITH "userdata/"' \
                       % (filename, i+1, userdata.group(), userdata.group(1)))
         lines[i] = precomment + comment
+
     # Ensure that every attack has a translatable description.
+    in_filter_wml = False
     for i in range(len(lines)):
         if "no-syntax-rewrite" in lines[i]:
 
             break
+        elif "[filter_wml]" in lines[i]:
+            in_filter_wml = True
+        elif "[/filter_wml]" in lines[i]:
+            in_filter_wml = False
         elif "[attack]" in lines[i]:
             j = i;
             have_description = False
@@ -2287,7 +2293,7 @@ def hack_syntax(filename, lines):
                             description = '"' + description + '"\n'
                         # Skip the insertion if this is a dummy declaration
                         # or one modifying an attack inherited from a base unit.
-                        if "no-icon" not in comment:
+                        if "no-icon" not in comment and not in_filter_wml:
                             new_line = leader(syntactic) + "description=_"+description
                             if verbose:
                                 print('"%s", line %d: inserting %s' % (filename, i+1, repr(new_line)))


### PR DESCRIPTION
This fixes situation when wmllint tried to add `description=_"fireball"`
to the following WML code:

```
[filter]
    [filter_wml]
        [not]
            [attack]
                name=fireball
            [/attack]
        [/not]
    [/filter_wml]
[/filter]
```

Tags within `[filter_wml]` don't need to have all mandatory arguments
(like "description"), because:
1) they are temporary constructs and this description is never used,
2) such WML code expects that results will be filtered ONLY by name.
Adding description will remove results that have the same attack name
but different description.