### PR TITLE
[DiD] Small fixes to address #3710

### DIFF
--- a/data/campaigns/Descent_Into_Darkness/scenarios/06_Return_to_Parthyn.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/06_Return_to_Parthyn.cfg
@@ -346,11 +346,7 @@
                 [show_objectives][/show_objectives]
             [/then]
             [else]
-                [endlevel]
-                    result=victory
-                    bonus=no
-                    {NEW_GOLD_CARRYOVER 40}
-                [/endlevel]
+                [show_objectives][/show_objectives]
             [/else]
         [/if]
     [/event]
@@ -380,35 +376,27 @@
         [/kill]
     [/event]
 
-    # Defeat Conditions
     [event]
         name=die
         [filter]
             side=3,4
+            [not]
+                id=Drogan
+            [/not]
         [/filter]
         [filter_second]
             side=1
         [/filter_second]
+        [filter_condition]
+            [not]
+                {DID_RTP_HAS_DROGAN}
+            [/not]
+        [/filter_condition]
 
-        [if]
-            {DID_RTP_HAS_DROGAN}
-            [then]
-                [message]
-                    speaker=Malin Keshar
-                    message= _ "Now the people of Parthyn will never accept me back!"
-                [/message]
-
-                [endlevel]
-                    result=defeat
-                [/endlevel]
-            [/then]
-            [else]
-                [message]
-                    speaker=Malin Keshar
-                    message= _ "See how you die when you spurn the help of Malin Keshar!"
-                [/message]
-            [/else]
-        [/if]
+        [message]
+            speaker=Malin Keshar
+            message= _ "See how you die when you spurn the help of Malin Keshar!"
+        [/message]
     [/event]
 
     # Victory Conditions


### PR DESCRIPTION
Like the title says, two small fixes to address issue #3710. Killing a unit on side 3/4 no longer causes you to instantly lose if Drogan is still alive. Killing the orc leader also does not result in victory; you still need to move to the signpost after. However, the objectives do state that as a bonus objective, you can kill the orc leader, but you don't actually get anything for doing so. Perhaps I could add a small gold reward?