### PR TITLE
MP load game: do not overwrite saved AI

### DIFF
--- a/src/game_initialization/connect_engine.cpp
+++ b/src/game_initialization/connect_engine.cpp
@@ -1066,8 +1066,17 @@ config side_engine::new_config() const
 	}
 
 	if(controller_ == CNTR_COMPUTER && allow_player_) {
-		// Do not import default ai cfg otherwise - all is set by scenario config.
-		res.add_child_at("ai", config {"ai_algorithm", ai_algorithm_}, 0);
+		// If this is a saved game and "use_saved" (the default) was chosen for the
+		// AI algorithm, we do nothing. Otherwise we add the chosen AI and if this
+		// is a saved game, we also remove the old stages from the AI config.
+		if(ai_algorithm_ != "use_saved") {
+			if(parent_.params_.saved_game) {
+				for (config &ai_config : res.child_range("ai")) {
+					ai_config.clear_children("stage");
+				}
+			}
+			res.add_child_at("ai", config {"ai_algorithm", ai_algorithm_}, 0);
+		}
 	}
 
 	// A side's "current_player" is the player which has currently taken that side or the one for which it is reserved.

--- a/src/gui/dialogs/multiplayer/mp_staging.cpp
+++ b/src/gui/dialogs/multiplayer/mp_staging.cpp
@@ -198,6 +198,12 @@ void mp_staging::add_side_node(window& window, ng::side_engine_ptr side)
 
 	// We use an index-based loop in order to get the index of the selected option
 	std::vector<config> ai_options;
+	// If this is loading a saved game, we add an option at the beginning of the menu.
+	// This results in a mismatch between the indices of ai_options and ai_algorithms_
+	// that we need to account for later.
+	if(saved_game) {
+		ai_options.emplace_back("label", "Keep saved AI");
+	}
 	for(unsigned i = 0; i < ai_algorithms_.size(); ++i) {
 		ai_options.emplace_back("label", ai_algorithms_[i]->text);
 
@@ -211,10 +217,9 @@ void mp_staging::add_side_node(window& window, ng::side_engine_ptr side)
 	ai_selection.set_values(ai_options, selection);
 
 	connect_signal_notify_modified(ai_selection,
-		std::bind(&mp_staging::on_ai_select, this, side, std::ref(ai_selection)));
+		std::bind(&mp_staging::on_ai_select, this, side, std::ref(ai_selection), saved_game));
 
-	on_ai_select(side, ai_selection);
-
+	on_ai_select(side, ai_selection, saved_game);
 	//
 	// Controller
 	//
@@ -359,9 +364,20 @@ void mp_staging::on_controller_select(ng::side_engine_ptr side, grid& row_grid)
 	}
 }
 
-void mp_staging::on_ai_select(ng::side_engine_ptr side, menu_button& ai_menu)
+void mp_staging::on_ai_select(ng::side_engine_ptr side, menu_button& ai_menu, const bool saved_game)
 {
-	side->set_ai_algorithm(ai_algorithms_[ai_menu.get_value()]->id);
+	// If this is a saved game, we need to reduce the index by one, to account for
+	// the "Keep saved AI" option having been added to the computer player menu
+	int i = ai_menu.get_value();
+	if(saved_game) {
+		i--;
+	}
+
+	if(i < 0) {
+		side->set_ai_algorithm("use_saved");
+	} else {
+		side->set_ai_algorithm(ai_algorithms_[i]->id);
+	}
 
 	set_state_changed();
 }

--- a/src/gui/dialogs/multiplayer/mp_staging.hpp
+++ b/src/gui/dialogs/multiplayer/mp_staging.hpp
@@ -62,7 +62,7 @@ private:
 	int get_side_node_position(ng::side_engine_ptr side) const;
 
 	void on_controller_select(ng::side_engine_ptr side, grid& row_grid);
-	void on_ai_select(ng::side_engine_ptr side, menu_button& ai_menu);
+	void on_ai_select(ng::side_engine_ptr side, menu_button& ai_menu, const bool saved_game);
 	void on_color_select(ng::side_engine_ptr side, grid& row_grid);
 	void on_team_select(window& window, ng::side_engine_ptr side, menu_button& team_menu);
 


### PR DESCRIPTION
When an MP game is saved and then reloaded from the MP Create Game screen, one goes through the Game Lobby screen which gives the option of changing controllers and AIs for the different sides. Previously, this added an AI stage in front of the already existing AI for all computer player sides. This effectively replaced the existing AI.

This commit adds an option "Keep saved AI" to the Computer Player selection menu (when loading games only) and makes it the default. It does nothing to the AI config if this is chosen, otherwise it uses the new AI and also removes the old AI stages from the config.

This fixes #3791.