### PR TITLE
[EI] Modified some player shroud and fog settings for #3782

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg
@@ -29,6 +29,7 @@
         {CHARACTER_STATS_GWEDDRY}
 
         shroud=yes
+        fog=yes
     [/side]
     # wmllint: validate-on
 
@@ -45,7 +46,6 @@
         id=Kabak
         name= _ "Kabak"
         canrecruit=yes
-        hidden=yes
 
         [ai]
             aggression=1.0
@@ -68,6 +68,9 @@
         id=Knutan
         name= _ "Knutan"
         canrecruit=yes
+        shroud=yes
+        fog=yes
+        share_vision=none
 
         [ai]
             grouping=no
@@ -179,9 +182,6 @@
     [event]
         name=start
 
-        {VARIABLE undead no}
-        {VARIABLE monsters no}
-
         [message]
             speaker=Gweddry
             message= _ "Where are we? I can’t see where we are going."
@@ -189,7 +189,60 @@
 
         [message]
             speaker=Dacyn
-            message= _ "This is an old escape tunnel for the outpost; unfortunately these caves are currently inhabited by trolls. Now hurry, we have to move quickly; the undead will surely follow us down here."
+            message= _ "This is an old escape route for the outpost. Unfortunately these caves are currently inhabited by trolls, who are blocking our path through the tunnel."
+        [/message]
+
+        [scroll_to]
+            x,y=15,7
+        [/scroll_to]
+        [remove_shroud]
+            side=1
+            x,y=15,7
+            radius=1
+        [/remove_shroud]
+        [delay]
+            time=750
+        [/delay]
+
+        [scroll_to]
+            x,y=22,5
+        [/scroll_to]
+        [remove_shroud]
+            side=1
+            x,y=22,5
+            radius=1
+        [/remove_shroud]
+        [delay]
+            time=750
+        [/delay]
+
+        [scroll_to]
+            x,y=28,6
+        [/scroll_to]
+        [remove_shroud]
+            side=1
+            x,y=28,6
+            radius=1
+        [/remove_shroud]
+        [delay]
+            time=750
+        [/delay]
+
+        [scroll_to]
+            x,y=34,5
+        [/scroll_to]
+        [remove_shroud]
+            side=1
+            x,y=34,5
+            radius=1
+        [/remove_shroud]
+        [delay]
+            time=750
+        [/delay]
+
+        [message]
+            speaker=Dacyn
+            message= _ "We must make haste to escape before the undead catch up."
         [/message]
 
         [message]
@@ -201,25 +254,6 @@
             speaker=Dacyn
             message= _ "I will explain later. For now, suffice to say they are much too powerful for us; our only hope is to head north."
         [/message]
-    [/event]
-
-    # Find the trolls
-    [event]
-        name=sighted
-
-        {VARIABLE monsters yes}
-
-        [filter]
-            side=2
-        [/filter]
-        [filter_second]
-            side=1
-        [/filter_second]
-
-        [modify_side]
-            side=2
-            hidden=no
-        [/modify_side]
     [/event]
 
     [event]
@@ -253,21 +287,10 @@
             message= _ "Who goes there?"
         [/message]
 
-        [if]
-            {VARIABLE_CONDITIONAL monsters boolean_equals yes}
-            [then]
-                [message]
-                speaker=Gweddry
-                message= _ "We are soldiers of the king of Wesnoth. Will you help us fight these trolls?"
-                [/message]
-            [/then]
-            [else]
-                [message]
-                speaker=Gweddry
-                message= _ "We are soldiers of the king of Wesnoth. We know trolls dwell in these caves. Will you help us fight them?"
-                [/message]
-            [/else]
-        [/if]
+        [message]
+            speaker=Gweddry
+            message= _ "We are soldiers of the king of Wesnoth. Will you help us fight these trolls?"
+        [/message]
 
         [message]
             speaker=unit
@@ -297,8 +320,25 @@
 
         [message]
             speaker=Dacyn
-            message= _ "Very well. The best of luck in your battle."
+            message= _ "Very well. The best of luck in your battle. Gweddry, we may be able to avoid the bulk of the trolls by going through the dwarves' base."
         [/message]
+
+        [remove_shroud]
+            side=1
+            x,y=8-30,2-10
+        [/remove_shroud]
+        [remove_shroud]
+            side=1
+            x,y=31-36,4-10
+        [/remove_shroud]
+        [remove_shroud]
+            side=1
+            x,y=37-38,4-5
+        [/remove_shroud]
+        [modify_side]
+            side=3
+            share_vision=all
+        [/modify_side]
     [/event]
 
     {HOLY_AMULET 12 2}
@@ -355,8 +395,12 @@
 
         [remove_shroud]
             side=1
-            x,y=2-4,3
+            x,y=2-4,2-3
         [/remove_shroud]
+        [lift_fog]
+            side=1
+            x,y=2-4,2-3
+        [/lift_fog]
 
         [modify_side]
             side=4
@@ -423,7 +467,6 @@
         [/message]
 
         {CLEAR_VARIABLE undead}
-        {CLEAR_VARIABLE monsters}
 
         [endlevel]
             result=victory

--- a/data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg
@@ -282,6 +282,23 @@
             side=1
         [/filter_second]
 
+        [remove_shroud]
+            side=1
+            x,y=8-30,2-10
+        [/remove_shroud]
+        [remove_shroud]
+            side=1
+            x,y=31-36,4-10
+        [/remove_shroud]
+        [remove_shroud]
+            side=1
+            x,y=37-38,4-5
+        [/remove_shroud]
+        [modify_side]
+            side=3
+            share_vision=all
+        [/modify_side]
+
         [message]
             speaker=unit
             message= _ "Who goes there?"
@@ -320,25 +337,8 @@
 
         [message]
             speaker=Dacyn
-            message= _ "Very well. The best of luck in your battle. Gweddry, we may be able to avoid the bulk of the trolls by going through the dwarves' base."
+            message= _ "Very well. The best of luck in your battle. Gweddry, we may be able to avoid the bulk of the trolls by going through the dwarves’ tunnel."
         [/message]
-
-        [remove_shroud]
-            side=1
-            x,y=8-30,2-10
-        [/remove_shroud]
-        [remove_shroud]
-            side=1
-            x,y=31-36,4-10
-        [/remove_shroud]
-        [remove_shroud]
-            side=1
-            x,y=37-38,4-5
-        [/remove_shroud]
-        [modify_side]
-            side=3
-            share_vision=all
-        [/modify_side]
     [/event]
 
     {HOLY_AMULET 12 2}


### PR DESCRIPTION
This PR addresses #3782; I've changed the player side to have fog at all times now. On the first turn, the player can see the path where the trolls are (parts of the path are unshrouded, but fogged). Upon seeing the dwarves (turn 2 or 3 ish, typically), the map becomes unshrouded including the amulet and treasure rooms. This should keep the player from going the wrong way due to lack of information.