### PR TITLE
Make defender's "first strike" inactive if the attacker also has "first strike", fixes #3784

### DIFF
--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -101,7 +101,7 @@ private:
 
 	// Configured as a bit field, in case that is useful.
 	enum AFFECTS { AFFECT_SELF=1, AFFECT_OTHER=2, AFFECT_EITHER=3 };
-	bool special_active(const config& special, AFFECTS whom,
+	bool special_active(const config& special, AFFECTS whom, const std::string& tag_name,
 	                    bool include_backstab=true) const;
 
 	// Used via specials_context() to control which specials are


### PR DESCRIPTION
Here is a commit to address issue #3784 . This will make a defender's "first strike" inactive if the attacker also has "first strike".