### PR TITLE
Liberty: Modified map and ai gold in S2 Civil Disobedience 

### DIFF
--- a/data/campaigns/Liberty/maps/02_Civil_Disobedience.map
+++ b/data/campaigns/Liberty/maps/02_Civil_Disobedience.map
@@ -4,12 +4,12 @@ Hh, Hh, Ss, Ww, Ww, Ss, Ss, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gg, Hh, Gg, Gg, G
 Ss, Ss, Ss, Ss, Ww, Ww, Ww, Gg, Ww, Ss, Gg, Gg^Fp, Gg^Fp, Hh, Gg, Gg, Ww, Gs^Fds, Ce, Ce, Re^Gvs, Ce, Re^Vl, Rr, Re, Re^Vh, Rr, Gs, Gs^Fds, Gs, Gs^Fds, Rr, Rr, Re^Vl, Rr, Gs^Fds, Rr, Ce, Ce, Gg, Gg, Gg
 Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Gg^Fp, Ww, Ww, Gg, Gg, Ce, Re^Gvs, Re^Gvs, Re^Gvs, Gs, Rr, Gs, Gs, Rr, Rr, Rr, Re^Vh, Rr, Rr, Gs, Rr, Gs, Rr, Re^Vh, Gs^Fds, Re^Gvs, Re^Gvs, Gg, Gg
 Ww, Ww, Ss, Ww, Ww, Ss, Ss, Ww, Ww, Ww, Ww^Bw\, Ww, Ss, Ww, Gg, Gg, Gs^Fms, Gs^Fds, Ce, Re^Gvs, Gs, Gs, Rr, Rr, Gs, Gs, Rr, Gs, Gs, Rr, Gs, Gs, Rr, Rr, Gd, Re, Rr, Re^Gvs, Re^Gvs, Re^Gvs, Gs^Fds, Gs^Fds
-Ww, Ww, Ww, Ss, Gg, Ss, Ss, Ss, Ww, Ww, Ss, Gg, Ww^Bw\, Ss, Gg, Re^Vh, Gg, Gg, Rr, Ce, Rr, Gs, Rr, Gs, Re, Re^Vl, Rr, Gs, Gs, Gd, Gs, Rr, Gs, Gs, Chr, Gs, Rr, Gs, Gs^Fds, Ce, Ce, Gs^Fds
+Ww, Ww, Ww, Ss, Gg, Ss, Ss, Ss, Ww, Ww, Gs^Fp, Gg, Ww^Bw\, Ss, Gg, Re^Vh, Gg, Gg, Rr, Ce, Rr, Gs, Rr, Gs, Re, Re^Vl, Rr, Gs, Gs, Gd, Gs, Rr, Gs, Gs, Chr, Gs, Rr, Gs, Gs^Fds, Ce, Ce, Gs^Fds
 Ss, Ss, Gg, Gg, Gg, Gg, Gs, Gg, Ww, Ss, Gs^Fp, Gs^Fp, Gs^Fp, Gg, Gg, Ww, Re, Re, Rr, Rr, Rr, Rr, Rr, Rr, Rr, Rr, Gg^Fet, Rr, Rr, Gs, Rr, Rr, Gs, Ch, 1 Kh, Rr, Re, Re^Vl, Re, Gg, Gg^Fds, Gg^Fds
-Gg, Gg, Gg, Gg, Gs^Fp, Gg, Re^Vh, Ce, Ss, Ww, Ss, Gs^Fp, Gg, Gg, Re, Re, Gg, Re, Gs^Fds, Ce, Gd, Gs, Rr, Gs, Gs, Rr, Rr, Rr, Re, Rr, Gs, Rr, Rr, Rr, Chr, Chr, Gs, Gs, Gg, Ce, Gg, Gs^Fds
-Gg, Gg, Gs, Gs^Fp, Gg, Gs, Gs, Ke, Re, Ww, Ww^Bw/, Re, Re, Re, Gg, Gg, Gg, Gg, Gs^Fds, Ce, Gs, Gs, Rr, Gs, Gs^Fds, Gs, Rr, Gs, Gs, Gs, Gs, Gs, Rr, Gs, Gs, Gd, Gs, Gs, Gg, Ce, Gg, Gg^Fds
-Gg, Gg, Gs^Fp, Gg, Gs^Fp, Gs, Re, Re, Ce, Re, Ww, Ww, Gg, Gg, Gs^Fp, Gs^Fms, Gs^Fms, Gs^Fds, Gs^Fds, Gs, Gs^Fds, Gs, Re^Gvs, Rr, Rr, Gd, Rr, Re^Vl, Re, Gs^Fds, Gs, Rr, Gs, Rr, Re^Vh, Gs, Gs^Fds, Gg, Ce, Ce, Gg, Gg
-Gs^Fp, Gs^Fp, Gg, Gg, Gs^Fp, Re, Gs^Fms, Ce, Gs, Gg^Fms, Gg^Vh, Ww, Ww, Gg^Fp, Gg^Fp, Gg, Gg, Gg, Ce, Gg, Gs, Re^Gvs, Re^Gvs, Re^Vh, Rr, Gs, Gs, Rr, Rr, Rr, Rr, Rr, Re^Vl, Re, Re^Gvs, Gs, Re^Gvs, Gs, Gs, Gg, Gg, Gg
+Gg, Gg, Gg, Gg, Gs^Fp, Gg, Re^Vh, Ce, Ss, Ww, Ss, Ss, Ce, Gg, Re, Re, Gg, Re, Gs^Fds, Ce, Gd, Gs, Rr, Gs, Gs, Rr, Rr, Rr, Re, Rr, Gs, Rr, Rr, Rr, Chr, Chr, Gs, Gs, Gg, Ce, Gg, Gs^Fds
+Gg, Gg, Gs, Gs^Fp, Gg, Gs, Gs, Ce, Re, Ww, Ww^Bw/, Re, Re, Re, Gg, Gg, Gg, Gg, Gs^Fds, Ce, Gs, Gs, Rr, Gs, Gs^Fds, Gs, Rr, Gs, Gs, Gs, Gs, Gs, Rr, Gs, Gs, Gd, Gs, Gs, Gg, Ce, Gg, Gg^Fds
+Gg, Gg, Gs^Fp, Gg, Gs^Fp, Gs, Re, Re, Ce, Re, Ww, Ww, Ce, Gg, Gs^Fp, Gs^Fms, Gs^Fms, Gs^Fds, Gs^Fds, Gs, Gs^Fds, Gs, Re^Gvs, Rr, Rr, Gd, Rr, Re^Vl, Re, Gs^Fds, Gs, Rr, Gs, Rr, Re^Vh, Gs, Gs^Fds, Gg, Ce, Ce, Gg, Gg
+Gs^Fp, Gs^Fp, Gg, Gg, Gs^Fp, Re, Gs^Fms, Gs, Gs, Ce, Gg^Vh, Ww, Ww, Gg^Fp, Gg^Fp, Gg, Gg, Gg, Ce, Gg, Gs, Re^Gvs, Re^Gvs, Re^Vh, Rr, Gs, Gs, Rr, Rr, Rr, Rr, Rr, Re^Vl, Re, Re^Gvs, Gs, Re^Gvs, Gs, Gs, Gg, Gg, Gg
 Gs^Fp, Gs^Fp, Gg, Gs^Fp, 2 Re, Re, Gs, Gs^Fms, Gs^Fds, Gs^Fds, Gg, Gg^Fms, Gg, Ww, Gg, Re^Vl, Gs^Fp, Gg, Ce, Gg, Gs, Re^Gvs, Re^Gvs, Gs, Ce, Re^Vl, Gs, Rr, Re^Vh, Gs^Fds, Gs, Rr, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Ce, Gs, Re^Gvs, Re^Gvs, Gs^Fms, Gs^Fms
 Gg, Gg, Gg, Gg, Re, Gg, Gg, Gs^Fds, Gs^Fds, Gg, Gg, Gs^Fds, Gg, Ww, Ww, Gg^Fp, Gg, Gg, Gs^Fp, Ce, Ce, Re^Gvs, Gs, Gs, Ce, Re, Gs, Rr, Gs, Gs, Gs, Rr, Re^Gvs, Re^Gvs, Re^Gvs, Re^Vh, Ce, Re^Gvs, Re^Gvs, Gs^Fms, Hh, Hh
 Gs^Fp, Gs^Fp, Gs^Fp, Gg, Re, Gg, Gs^Fms, Gs^Fds, Gs^Fms, Gg, Gs^Fds, Gg, Gs^Fds, Gg, Gg^Fms, Ww, Ww, Gg, Gg^Fp, Gg^Fp, Gg^Fp, Gg, Ss, Gg, Gg, Ce, Ce, Gs, Ce, Gs, Ce, Rr, Gs, Re^Gvs, Ce, Ce, Gs, Re^Gvs, Hh^Fms, Hh^Fms, Ww, Ww

--- a/data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg
+++ b/data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg
@@ -36,6 +36,7 @@
         side=2
         canrecruit=yes
         controller=ai
+        gold=0
         team_name=bad_guys
         user_team_name=_"Asheviere"
         [ai]
@@ -184,6 +185,8 @@
 
         {GENERIC_UNIT 2 Spearman 18 7}
         {MOVE_UNIT x,y=18,7 20 7}
+
+        {MOVE_UNIT id=Tarwen 12 8}
 
         [message]
             speaker=Baldras


### PR DESCRIPTION
This PR addresses #3376 by setting the ai gold to zero and changing the enemy captain's starting location to a non keep-hex (actually there are no more enemy keeps, since I modified the map very slightly). I left the ai leader with the attribute canrecruit=yes since the gold bar will make it clearer to the player that Tarwen is in fact the enemy leader (if it wasn't clear enough from the fact that he's a level 3, but anyway the gold bar is nice to have). 