### PR TITLE
Note dependencies on OpenGL and GLEW in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -38,6 +38,8 @@ order to build Wesnoth:
  * libbz2
  * libz
  * libcrypto (from OpenSSL)
+ * OpenGL
+ * GLEW
 
 The following libraries are optional dependencies that enable additional
 features:

--- a/data/core/about.cfg
+++ b/data/core/about.cfg
@@ -1178,6 +1178,9 @@
         name = "Ely Levy (Nakee)"
     [/entry]
     [entry]
+        name = "equal-l2"
+    [/entry]
+    [entry]
         name = "Étienne Simon (ejls)"
     [/entry]
     [entry]


### PR DESCRIPTION
They are required to build wesnoth client but not noted.