### PR TITLE
Fix typo in menu_button: active icon was used instead of pressed icon

### DIFF
--- a/data/core/about.cfg
+++ b/data/core/about.cfg
@@ -1169,6 +1169,9 @@
         name = "Duthlet"
     [/entry]
     [entry]
+        name = "Edward Chernenko"
+    [/entry]
+    [entry]
         name = "Ekdohibs"
     [/entry]
     [entry]

--- a/data/gui/widget/menu_button_default.cfg
+++ b/data/gui/widget/menu_button_default.cfg
@@ -112,7 +112,7 @@
 				[image]
 					x = "(width - 25)"
 					y = 2
-					name = "icons/arrows/short_arrow_left_25-active.png~ROTATE(-90)"
+					name = "icons/arrows/short_arrow_left_25-pressed.png~ROTATE(-90)"
 				[/image]
 			[/draw]
 

--- a/data/gui/widget/multimenu_button_default.cfg
+++ b/data/gui/widget/multimenu_button_default.cfg
@@ -112,7 +112,7 @@
 				[image]
 					x = "(width - 25)"
 					y = 2
-					name = "icons/arrows/short_arrow_left_25-active.png~ROTATE(-90)"
+					name = "icons/arrows/short_arrow_left_25-pressed.png~ROTATE(-90)"
 				[/image]
 			[/draw]
 


### PR DESCRIPTION
Icon `short_arrow_left_25-pressed.png` exists, but is not used anywhere.
Widgets in `menu_button_default.cfg` and `multimenu_button_default.cfg` were using active icon (`short_arrow_left_25-active.png`) for the "pressed" state.