### PR TITLE
[AToTB] Added castle ToD to S3

### DIFF
--- a/data/campaigns/Two_Brothers/maps/03_Guarded_Castle.map
+++ b/data/campaigns/Two_Brothers/maps/03_Guarded_Castle.map
@@ -25,7 +25,7 @@ Ww, Gg, Gg, Gg, Gg, Gg, Gg, Gg^Vh, Gg, Gg, Gg, Hh, Gg, Gg, Gg^Es, Gg, Rd, Rd, Rd
 Ww, Ww, Ww^Bw/, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Rd, Rd, Rd, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gs^Fmw, Gg, Gg, Gs^Fmw, Gs^Fmw, Gg, Gs^Fmw
 Ww, Ww, Ww, Ww, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg^Es, Gg, Gg, Rd, Re, Rd, Gg, Gg^Es, Gg, Gg, Gg, Gg, Gg, Re^Gvs, Re^Vh, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gs^Fmw, Gg, Gs^Fmw, Gs^Fp
 Ww, Ww, Ww, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Re, Gg, Gg, Gg, Rd, Rd, Gg, Gg, Gg, Gg, Gg, Gg, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Gg, Gg, Gg, Gs^Fmw, Gg, Gg, Gs^Fmw, Gg, Gg, Gs^Fp, Gs^Vh, Gs^Fp
-Gs^Fp, Gs^Vh, Gs^Fp, Ww, Gg, Gg, Re, Gg, Re, Re, Gg, Re, Re, Re, Gg, Re, Gg, Gg, Gg, Gg, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Gg, Gg, Gg, Gg, Gs^Fmw, Gs^Fmw, Gs, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gg
+Gs^Fp, Gs^Fp, Gs^Fp, Ww, Gg, Gg, Re, Gg, Re, Re, Gg, Re, Re, Re, Gg, Re, Gg, Gg, Gg, Gg, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Gg, Gg, Gg, Gg, Gs^Fmw, Gs^Fmw, Gs, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gg
 Gs^Fp, Gs^Fp, Gs^Fp, Ww, Ww^Bw/, Re, Gg, Re, Gg, Gg, Re^Vh, Gg, Gg, Gg, Rd, Re, Gg, Gg, Gg, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Gg, Gg, Gg, Gg, Gs^Fdw, Gg, Gg, Gs, Gs^Vh, Gs^Fp, Chr, Chr, Gs^Fp, Gs, Gs^Fp
 Gs^Fp, Gs^Fp, Re, Re, Ww, Gg, Gg, Gg, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Gg, Rd, Gg, Gg, Gg, Gg, Gg, Gg, Re^Gvs, Gg, Gg, Gg, Gs^Fdw, Gs^Fdw, Gg, Gg, Gg, Gg, Gs^Fp, Chr, Gs^Fp, Chr, Chr, Chr, Gs^Fp, Gs^Fp
 Re, Re, Gs^Fp, Gs^Fp, Gs^Fp, Ww, Gg, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Gg, Gg, Rd, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gs^Fmw, Gg, Gg, Gg, Gg, Gg, Gg, Gs^Fp, Gs^Fp, Chr, Chr, Chr, 1 Khr, Chr, Gs^Fp, Gs^Fp, Gg

--- a/data/campaigns/Two_Brothers/maps/03_Guarded_Castle.map
+++ b/data/campaigns/Two_Brothers/maps/03_Guarded_Castle.map
@@ -1,19 +1,19 @@
 Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xu, Xu, Xu, Xu, Xu, Xu, Xu
 Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Xu, Xu, Xu, Xu, Xu, Xu, Xu
-Xu, Xu, Uu, Xu, Uu, Xu, Xu, Xu, Ql, Xu, Xu, Xos, Ior, Xos, Ior, Xos, Ior, Xol, Xol, Xos, Xol, Xol, Ior, Xos, Ior, Xos, Ior, Xos, Ior^Eb, Xos, Ior^Eb, Xos, Ql, Xu, Xu, Xu, Ql, Xu, Xu
+Xu, Xu, Uu, Xu, Uu, Xu, Xu, Xu, Ql, Xu, Xu, Xos, Ior, Xos, Ior, Xos^Efs, Ior, Xos, Xos^Efs, Xos, Xos^Efs, Xos, Ior, Xos^Efs, Ior, Xos, Ior, Xos, Ior^Eb, Xos, Ior^Eb, Xos, Ql, Xu, Xu, Xu, Ql, Xu, Xu
 Xu, Xu, Uu, Uu, Uu, Uu, Xu, Ql, Ql, Uu, Ql, Xos, Ior, Ior, Ior, Ior, Ior, Ior, Ior, Ior, Ior, Ior, Ior, Ior, Ior, Ior, Ior, Xos, Ior, Ior, Ior, Xos, Ql, Ql, Xu, Ql, Ql, Xu, Xu
 Xu, Xu, Xu, Uu, Uu, Uu, Xu, Rr, Rr, Ql, Uu, Xos, Ior^Es, Ior, Xos, Xos, Xos, Ior, Rr, Cud, Rr, Ior, Xos, Xos, Xos, Ior, Ior, Xos, Ior, Ior, Ior, Xos, Ql, Rr, Rr, Rr, Ql, Xu, Xu
 Xu, Xu, Ql, Xu, Xu, Uu, Rr, Rr, Xos, Xos, Xos, Xos, Ior, Ior, Xos, Ior, Ior, Ior, Cud, 2 Kud, Cud, Ior, Ior, Ior, Xos, Ior, Ior, Xos, Ior, Ior, Ior, Xos, Xos, Rr, Rr, Rr, Rr, Xu, Xos
-Xu, Xu, Uu, Ql, Rr, Rr, Rr, Xos, Uu, Uu, Uu, Xos, Ior, Ior, Ior, Ior, Ior, Ior, Ior, Rr, Ior, Ior, Ior, Ior, Ior, Ior, Ior, Xos, Xol, Ior, Ior, Ior, Ior, Xol, Xol, Rr, Rr, Xos, Xos
-Xu, Xu, Ql, Ql, Xos, Rr, Rr, Uu, Uu, Uu, Xol, Xos, Ior, Ior, Xos, Ior, Xos, Ior, Xos, Ior, Xos, Ior, Xos, Ior, Xos, Ior, Rr, Ior, Ior, Xol, Xos, Ior, Ior, Ior, Rr, Rr, Rr, Xos, Xos
-Xu, Xu, Xos, Xos, Xos, Rr, Rr, Xos, Xos, Xol, Ior, Ior, Rr, Rr, Rr, Xol, Xol, Xos, Xos, Xos, Xos, Xos, Xol, Xol, Rr, Rr, Rr, Ior, Ior, Ior, Ior, Xos, Xos, Ior, Ior, Ior, Rr, Xos, Xos
-Xos, Xos, Ior, Ior, Ior, Ior, Ior, Ior, Ior, Ior, Xos, Xos, Rr, Rr, Rr, Rr, Rr, Xos, Rr, Xos, Rr, Xos, Rr, Rr, Rr, Rr, Rr, Xos, Xos, Ior, Ior, Ior, Xos, Xos, Xol, Ior, Ior, Xos, Xos
-Xos, Xos, Ior^Ebn, Ior, Xos, Xos, Uu, Ior, Ior, Xos, Rr, Rr, Rr, Xos, Rr, Rr, Rr, Rr, Rr^Es, Rr, Rr, Rr, Rr, Rr, Rr, Xos, Rr, Rr, Rr^Eb, Xos, Ior, Ior, Ior, Xol, Ior, Ior, Ior, Xos, Xos
+Xu, Xu, Uu, Ql, Rr, Rr, Rr, Xos, Uu, Uu, Uu, Xos, Ior, Ior, Ior, Ior, Ior, Ior, Ior, Rr, Ior, Ior, Ior, Ior, Ior, Ior, Ior, Xos, Xol, Ior, Ior, Ior, Ior, Xos, Xos^Efs, Rr, Rr, Xos, Xos
+Xu, Xu, Ql, Ql, Xos, Rr, Rr, Uu, Uu, Uu, Xos^Efs, Xos, Ior, Ior, Xos, Ior, Xos, Ior, Xos, Ior, Xos, Ior, Xos, Ior, Xos, Ior, Rr, Ior, Ior, Xol, Xos, Ior, Ior, Ior, Rr, Rr, Rr, Xos, Xos
+Xu, Xu, Xos, Xos, Xos, Rr, Rr, Xos, Xos, Xos^Efs, Ior, Ior, Rr, Rr, Rr, Xos^Efs, Xos^Efs, Xos, Xos, Xos, Xos, Xos, Xos^Efs, Xos^Efs, Rr, Rr, Rr, Ior, Ior, Ior, Ior, Xos, Xos, Ior, Ior, Ior, Rr, Xos, Xos
+Xos, Xos, Ior, Ior, Ior, Ior, Ior, Ior, Ior, Ior, Xos, Xos, Rr, Rr, Rr, Rr, Rr, Xos, Rr, Xos, Rr, Xos, Rr, Rr, Rr, Rr, Rr, Xos, Xos, Ior, Ior, Ior, Xos, Xos, Xos^Efs, Ior, Ior, Xos, Xos
+Xos, Xos, Ior^Ebn, Ior, Xos, Xos, Uu, Ior, Ior, Xos, Rr, Rr, Rr, Xos, Rr, Rr, Rr, Rr, Rr^Es, Rr, Rr, Rr, Rr, Rr, Rr, Xos, Rr, Rr, Rr^Eb, Xos, Ior, Ior, Ior, Xos^Efs, Ior, Ior, Ior, Xos, Xos
 Xu, Xos, Xos, Xos, Uu, Uu, Uu, Xos, Xos, Xos, Rr^Es, Rr^Es, Rr, Xos, Rr, Rr, Rr, Xos, Rr, Rr, Rr, Xos, Rr, Rr, Rr, Xos, Rr^Eb, Rr, Rr, Xos, Xos, Ior, Ior, Ior, Ior, Ior^Es, Xos, Xos, Xu
-Mm^Xm, Xu, Xu, Xos, Xos, Uu, Xos, Xos, Xos, Xos, Rr, Rr, Xol, Xol, Rr, Rr, Xos, Xos, Rr, Rr, Rr, Xos, Xos, Rr, Rr, Xol, Xol, Rr^Es, Rr^Es, Xos, Xos, Xos, Xos, Ior, Xos, Xos, Xu, Xu, Mm^Xm
+Mm^Xm, Xu, Xu, Xos, Xos, Uu, Xos, Xos, Xos, Xos, Rr, Rr, Xos^Efs, Xos^Efs, Rr, Rr, Xos, Xos, Rr, Rr, Rr, Xos, Xos, Rr, Rr, Xos^Efs, Xos^Efs, Rr^Es, Rr^Es, Xos, Xos, Xos, Xos, Ior, Xos, Xos, Xu, Xu, Mm^Xm
 Mm^Xm, Mm^Xm, Mm^Xm, Xu, Xu, Xos, Xos, Xos, Xos, Xos, Xos, Xos, Rr, Rr, Rr, Rr, Xos, Rr, Rr, Xos, Rr, Rr, Xos, Rr, Rr, Rr, Rr, Xos, Xos, Xos, Xu, Xu, Xu, Xos, Xu, Xu, Mm^Xm, Mm^Xm, Mm^Xm
 Mm^Xm, Mm^Xm, Mm, Mm, Mm, Xu, Xu, Xos, Xos, Xos, Rr, Rr, Xos, Rr, Xos, Xos, Xos, Rr, Rr, Xos, Rr, Rr, Xos, Xos, Xos, Rr, Xos, Rr, Rr, Xos, Xu, Hh, Hh, Xu, Mm, Mm^Xm, Ww, Mm^Xm, Ww
-Mm, Mm, Hh, Mm, Mm, Mm, Mm, Xu, Xos, Xos, Rr, Rr, Rr, Xol, Xol, Xos, Xos, Rr, Rr, Xos, Rr, Rr, Xos, Xos, Xol, Xol, Rr, Rr, Rr, Xos, Xu, Hh, Hh, Mm, Ww, Ww, Ww, Ww, Ww
+Mm, Mm, Hh, Mm, Mm, Mm, Mm, Xu, Xos, Xos, Rr, Rr, Rr, Xos, Xos^Efs, Xos, Xos, Rr, Rr, Xos, Rr, Rr, Xos, Xos, Xos^Efs, Xos, Rr, Rr, Rr, Xos, Xu, Hh, Hh, Mm, Ww, Ww, Ww, Ww, Ww
 Hh, Gs, Hh^Fmw, Hh^Fmw, Hh, Mm, Hh, Xu, Xu, Xos, Xos, Rr, Rr, Rr, Rr, Rr, Rr, Rr, Rr, Xos, Rr, Rr, Rr, Rr, Rr, Rr, Rr, Rr, Xos, Xos, Xu, Gs, Hh^Fmw, Hh^Fmw, Gs^Fmw, Ww, Hh, Ww, Ww
 Hh, Hh, Gs, Hh, Gs, Gs, Hh, Gs^Es, Gs, Xu, Xu, Xos, Xos, Rr, Rr, Rr, Xos, Rr, Xos, Rr, Xos, Rr, Xos, Rr, Rr, Rr, Xos, Xos, Xu, Xu, Hh, Hh, Gs, Hh^Fmw, Gs, Gs, Gg, Gg, Gg
 Gg, Gg, Hh, Gs, Hh, Gg, Gg, Gs, Gg, Hh, Gs^Es, Xu, Xu, Xos, Xos, Cud, Cud, Cud, Cud, Cud, Cud, Cud, Cud, Cud, Xos, Xos, Xu, Xu, Hh, Hh, Gs, Hh, Gs, Hh, Gg^Vh, Hh, Gg, Hh, Hh

--- a/data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg
@@ -243,8 +243,8 @@ Yet for some reason I fear these brothers more. If Mordak were here it would be 
 
     # Make lit stone walls illuminate the hex south of them.
     [time_area]
-        x= 2,  2,  3, 10, 13, 13, 15, 17, 21, 23, 25, 25, 28, 33, 34
-        y= 9, 10, 10,  8, 13, 16,  9,  3,  3,  9, 13, 16,  7,  7, 10
+        x= 2,  2,  3, 10, 13, 14, 15, 15, 18, 20, 23, 23, 25, 24, 28, 34, 34
+        y= 9, 10, 10,  8, 13, 16,  9,  3,  3,  3,  3,  9, 13, 16,  7,  7, 10
         [time]
             id=indoors_dark_castle_lit
             name= _ "Indoors (lit)"

--- a/data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg
@@ -69,12 +69,12 @@ Yet for some reason I fear these brothers more. If Mordak were here it would be 
         controller=ai
 #ifdef EASY
         recruit=Skeleton,Skeleton Archer,Vampire Bat,Dark Adept,Ghoul,Walking Corpse
-        gold=40
-        income=0
+        gold=30
+        income=-2
 #else
         recruit=Skeleton,Skeleton Archer,Vampire Bat,Ghost,Dark Adept,Ghoul,Walking Corpse
-        gold=60
-        income=6
+        gold=50
+        income=4
 #endif
 
         team_name=evil
@@ -226,6 +226,35 @@ Yet for some reason I fear these brothers more. If Mordak were here it would be 
     #{PLACE_IMAGE items/box.png 27 12}
     #{PLACE_IMAGE items/box.png 27 11}
     #{PLACE_IMAGE items/potion-green.png 26 10}
+
+    [time_area]
+        x=    0,  1-2,  3-4,  5-6,    7,    8, 9-10,11-12,   13,14-15,   16,   17,   18,   19,   20,   21,   22,23-24,   25,26-27,28-29,30-32,   33,34-35,36-37,   38
+        y= 1-10, 1-11, 1-12, 1-13, 1-14, 1-15, 1-16, 1-17, 1-18, 1-15, 1-16, 1-15, 1-15, 1-16, 1-16, 1-16, 1-16, 1-15, 1-18, 1-17, 1-16, 1-12, 1-13, 1-12, 1-11, 1-10
+        [time]
+            id=indoors_dark_castle
+            name= _ "Indoors (dark castle)"
+            image=misc/time-schedules/schedule-indoors.png~CS(-60,-45,-10)
+            lawful_bonus=-25
+            red=-60
+            green=-45
+            blue=-10
+        [/time]
+    [/time_area]
+
+    # Make lit stone walls illuminate the hex south of them.
+    [time_area]
+        x= 2,  2,  3, 10, 13, 13, 15, 17, 21, 23, 25, 25, 28, 33, 34
+        y= 9, 10, 10,  8, 13, 16,  9,  3,  3,  9, 13, 16,  7,  7, 10
+        [time]
+            id=indoors_dark_castle_lit
+            name= _ "Indoors (lit)"
+            image=misc/time-schedules/schedule-indoors.png~BLIT(misc/tod-bright.png)
+            lawful_bonus=0
+            red=20
+            green=-5
+            blue=-10
+        [/time]
+    [/time_area]
 
     [event]
         name=prestart
@@ -560,7 +589,7 @@ Yet for some reason I fear these brothers more. If Mordak were here it would be 
             side=2
             role=Guard2
             name= _ "Guard"
-            type=Bandit
+            type=Thug
             x,y=17,24
             facing=se
         [/unit]
@@ -718,6 +747,30 @@ Yet for some reason I fear these brothers more. If Mordak were here it would be 
                 [/message]
             [/else]
         [/if]
+    [/event]
+
+    # When the player can see most of the castle entryway (40 or more castle
+    # hexes are unshrouded), comment about the lighting in the castle.
+    [event]
+        name=moveto
+        [filter]
+            side=1
+            x=    0,  1-2,  3-4,  5-6,    7,    8, 9-10,11-12,   13,14-15,   16,   17,   18,   19,   20,   21,   22,23-24,   25,26-27,28-29,30-32,   33,34-35,36-37,   38
+            y= 1-10, 1-11, 1-12, 1-13, 1-14, 1-15, 1-16, 1-17, 1-18, 1-15, 1-16, 1-15, 1-15, 1-16, 1-16, 1-16, 1-16, 1-15, 1-18, 1-17, 1-16, 1-12, 1-13, 1-12, 1-11, 1-10
+        [/filter]
+
+        [message]
+            speaker=unit
+            message= _ "This castle seems as dark as a cave!"
+        [/message]
+
+#ifdef EASY
+        [message]
+            speaker=narrator
+            message= _ "This castle is under a constant, <i>chaotic</i> time of day (equivalent to permanent night). Place your units carefully, as your troops will be weaker and enemy units stronger."
+            image=wesnoth-icon.png
+        [/message]
+#endif
     [/event]
 
     [event]


### PR DESCRIPTION
Implemented @stevecotton's fix to #3389 with some slight modifications for gameplay rebalancing (I've playtested, don't know if anyone else wants to?). I didn't modify the lit stone walls to sconces, since scones don't seem to work right now. For 1.15/1.16, once those terrains work, we can fix them then. 

This has some string changes, so probably needs to go in 1.14.7.