### PR TITLE
DW S3: added event for storm trident

### DIFF
--- a/data/campaigns/Dead_Water/scenarios/03_Wolf_Coast.cfg
+++ b/data/campaigns/Dead_Water/scenarios/03_Wolf_Coast.cfg
@@ -131,7 +131,7 @@
             passive_leader=yes
         [/ai]
 
-        {GOLD4 200 250 300 350}
+        {GOLD4 170 220 270 320}
         {INCOME4 2 6 10 14}
         {FLAG_VARIANT6 ragged}
     [/side]
@@ -258,6 +258,25 @@
         [/if]
     [/event]
 
+# This event makes the storm trident even more obvious
+
+    [event]
+        name=turn 3
+
+        [unit]
+            type=Great Wolf
+            variation=red
+            x=20
+            y=16
+            side=3
+            animate=yes
+        [/unit]
+
+        [message]
+            speaker=Kai Krellis
+            message= _ "I wonder why such a strangely colored wolf emerged from the forest over there."
+        [/message]
+    [/event]
     # The first_time_only moveto event causes a trident *image* to
     # show up on the hex, and causes tridents to be explained. The
     # moved unit gets the option to take it.


### PR DESCRIPTION
As the title says, implemented @CelticMinstrel's suggestion for #3400 (subtracted 30g from the enemy side to compensate for the extra wild wolf).

(Has string changes in it, don't merge for 1.14.6).