### PR TITLE
codeblock: link to libogg, libvorbis and libvorbisfile for stable branch

### DIFF
--- a/projectfiles/CodeBlocks/wesnoth.cbp
+++ b/projectfiles/CodeBlocks/wesnoth.cbp
@@ -78,6 +78,11 @@
 			<Add library="libboost_timer" />
 			<Add library="libboost_zlib" />
 			<Add library="libcrypto-1_1" />
+			<Add library="libogg" />
+			<Add library="libuuid" />
+			<Add library="libvorbis" />
+			<Add library="libvorbisenc" />
+			<Add library="libvorbisfile" />
 			<Add library="winmm" />
 			<Add directory="./" />
 		</Linker>


### PR DESCRIPTION
Required for pull request #3851 that was recently merged.