### PR TITLE
Spelling corrections for 1.14.6

### DIFF
--- a/data/campaigns/Descent_Into_Darkness/scenarios/02_Peaceful_Valley.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/02_Peaceful_Valley.cfg
@@ -118,7 +118,7 @@
 
         [message]
             speaker=Darken Volk
-            message= _ "In truth, I share your hatred for the orcs. The northlands have been my... home... for many years, and the orcs have been a growing infestation in them. They despoil the beauty of the land wherever they go. If you are interested, I would be happy to take you on as my apprentice so that you can... aid me in the fight against them."
+            message= _ "In truth, I share your hatred for the orcs. The Northlands have been my... home... for many years, and the orcs have been a growing infestation in them. They despoil the beauty of the land wherever they go. If you are interested, I would be happy to take you on as my apprentice so that you can... aid me in the fight against them."
         [/message]
 
         [message]

--- a/data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg
@@ -20,7 +20,7 @@
             {PROLOGUE_STAGE1}
         [/part]
         [part]
-            story= _ "The dwarves of Knalga, cannily reckoning the gains from trade, built strong fortifications around Dwarven Doors. The people who called it home, dwarven and human alike, knew that the wealth of their city might arouse envy from afar — hence they kept their weapons sharp, and reckoned themselves well able to fight off any bandit gang or petty warlord that could arise in the thinly-settled northlands."
+            story= _ "The dwarves of Knalga, cannily reckoning the gains from trade, built strong fortifications around Dwarven Doors. The people who called it home, dwarven and human alike, knew that the wealth of their city might arouse envy from afar — hence they kept their weapons sharp, and reckoned themselves well able to fight off any bandit gang or petty warlord that could arise in the thinly-settled Northlands."
             {NR_BIGMAP}
             {PROLOGUE_STAGE1_END}
         [/part]

--- a/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
@@ -733,7 +733,7 @@
 
                 [message]
                     speaker=Sister Thera
-                    message= _ "If you have no objection, Tallin, we would like to join you. These northlands are hardly safe these days for anyone to be traveling on their own, and we could lend valuable help to your cause."
+                    message= _ "If you have no objection, Tallin, we would like to join you. These Northlands are hardly safe these days for anyone to be traveling on their own, and we could lend valuable help to your cause."
                 [/message]
 
                 [message]

--- a/data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg
@@ -237,7 +237,7 @@
 
                 [message]
                     speaker=Tallin
-                    message= _ "Princess, we are not seeking to do business here: <i>“I do this for you and you do this for me.”</i> No, we seek to build everlasting friendships which will forever ensure the peace and prosperity of these northlands. Therefore, let there be no talk of debts and repayments between us."
+                    message= _ "Princess, we are not seeking to do business here: <i>“I do this for you and you do this for me.”</i> No, we seek to build everlasting friendships which will forever ensure the peace and prosperity of these Northlands. Therefore, let there be no talk of debts and repayments between us."
                 [/message]
 
                 [message]

--- a/data/campaigns/Sceptre_of_Fire/scenarios/3_Searching_for_the_Runecrafter.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/3_Searching_for_the_Runecrafter.cfg
@@ -37,7 +37,7 @@
 
     [story]
         [part]
-            story= _ "The journey to the far northern wastelands was long and perilous. For the tunnels were winding and treacherous, and the paths were not safe from orcs, or worse. Nevertheless, they did reach the northlands, and began to search for the runesmith named Thursagan — the sage of fire."
+            story= _ "The journey to the far northern wastelands was long and perilous. For the tunnels were winding and treacherous, and the paths were not safe from orcs, or worse. Nevertheless, they did reach the Northlands, and began to search for the runesmith named Thursagan — the sage of fire."
         [/part]
     [/story]
 
@@ -221,7 +221,7 @@
         [/message]
         [message]
             speaker=Alanin
-            message= _ "Except for trolls and ogres, right? They live in the far northlands. They’re probably lurking around here somewhere."
+            message= _ "Except for trolls and ogres, right? They live in the far Northlands. They’re probably lurking around here somewhere."
         [/message]
         [message]
             speaker=Baglur

--- a/data/campaigns/Sceptre_of_Fire/scenarios/3t_The_Council_Regathers.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/3t_The_Council_Regathers.cfg
@@ -132,7 +132,7 @@
         [/message]
         [message]
             speaker=Baglur
-            message= _ "Yes, we did. And that is Krawg, who helped us in the northlands."
+            message= _ "Yes, we did. And that is Krawg, who helped us in the Northlands."
         [/message]
         [message]
             speaker=Krawg

--- a/data/campaigns/Sceptre_of_Fire/scenarios/7_Outriding_the_Outriders.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/7_Outriding_the_Outriders.cfg
@@ -270,7 +270,7 @@
             [/else]
         [/if]
 
-        # Fire the event the next time with different dialoge
+        # Fire the event the next time with different dialog
         [event]
             name=die
             first_time_only=no
@@ -562,14 +562,14 @@
                 [message]
                     speaker=Alanin
                     # po: dragoon = his unit type
-                    message= _ "I’m a dragoon, with Haldric II’s personal bodyguard. I was sent on a mission in the northlands, and now elvish horsemen are chasing me. I barely evaded them."
+                    message= _ "I’m a dragoon, with Haldric II’s personal bodyguard. I was sent on a mission in the Northlands, and now elvish horsemen are chasing me. I barely evaded them."
                 [/message]
             [/then]
             [else]
                 [message]
                     speaker=Alanin
                     # po: cavalier = his unit type
-                    message= _ "I’m a cavalier, with Haldric II’s personal bodyguard. I was sent on a mission in the northlands, and now elvish horsemen are chasing me. I barely evaded them."
+                    message= _ "I’m a cavalier, with Haldric II’s personal bodyguard. I was sent on a mission in the Northlands, and now elvish horsemen are chasing me. I barely evaded them."
                 [/message]
             [/else]
         [/if]

--- a/data/campaigns/Sceptre_of_Fire/scenarios/Epilogue.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/Epilogue.cfg
@@ -100,7 +100,7 @@
         [/message]
         [message]
             speaker=Alanin
-            message= _ "Stand aside. I am Alanin, of Haldric’s royal guard, and I bring news from the northlands."
+            message= _ "Stand aside. I am Alanin, of Haldric’s royal guard, and I bring news from the Northlands."
         [/message]
         [message]
             speaker=Gatekeeper
@@ -123,7 +123,7 @@
         {MODIFY_UNIT id=Alanin profile "portraits/alanin-epilogue.png"}
         [message]
             speaker=Alanin
-            message= _ "My King, fifteen years ago you sent me on a mission into the northlands. I have returned. What do you wish to know of my mission?"
+            message= _ "My King, fifteen years ago you sent me on a mission into the Northlands. I have returned. What do you wish to know of my mission?"
         [/message]
         [message]
             speaker=Haldric II

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg
@@ -439,7 +439,7 @@ of Healing"
         [message]
             speaker=narrator
             image=$message_image
-            message= _ "Right click adjacent to your leader to summon the bat."
+            message= _ "Right-click adjacent to your leader to summon the bat."
         [/message]
         [clear_variable]
             name=message_image

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg
@@ -201,7 +201,7 @@
         [message]
             speaker="Shan Taum"
             image=portraits/shan_taum.png~FL()~RIGHT()
-            message= _ "What... Kapou’e! What in the frozen northlands are you doing here?!"
+            message= _ "What... Kapou’e! What in the frozen Northlands are you doing here?!"
         [/message]
 
         [message]

--- a/data/campaigns/The_South_Guard/units/Junior_Commander.cfg
+++ b/data/campaigns/The_South_Guard/units/Junior_Commander.cfg
@@ -22,7 +22,7 @@
     [abilities]
         {ABILITY_LEADERSHIP}
     [/abilities]
-    description= _ "At scarcely 17 or 18 years of age, squires are not yet full knights, but still have the knowledge and skill to master their mounts whilst in full panolpy. Talented squires are sometimes given command of small units in Wesnoth' s army, where they gain experience leading fellow troops and honing their prowess in battle."+{SPECIAL_NOTES}+{SPECIAL_NOTES_LEADERSHIP}
+    description= _ "At scarcely 17 or 18 years of age, squires are not yet full knights, but still have the knowledge and skill to master their mounts whilst in full panoply. Talented squires are sometimes given command of small units in Wesnoth' s army, where they gain experience leading fellow troops and honing their prowess in battle."+{SPECIAL_NOTES}+{SPECIAL_NOTES_LEADERSHIP}
     die_sound=horse-die.ogg
     [attack]
         name=spear

--- a/data/campaigns/The_South_Guard/utils/sg_help.cfg
+++ b/data/campaigns/The_South_Guard/utils/sg_help.cfg
@@ -134,7 +134,7 @@
             [message]
                 speaker=narrator
                 image="units/undead/zombie-attack-s.png~RC(magenta>red)"
-                message= _ "Walking corpses are usually used by weaker practicioners of the black arts, who pilfer dead bodies to practice their profane magic. Alone, they are slow and weak, although they can become dangerous in large groups. Any unit slain by a Walking Corpse will be plagued with undeath and become one as well."
+                message= _ "Walking corpses are usually used by weaker practitioners of the black arts, who pilfer dead bodies to practice their profane magic. Alone, they are slow and weak, although they can become dangerous in large groups. Any unit slain by a Walking Corpse will be plagued with undeath and become one as well."
             [/message]
         [/then]
     [/if]

--- a/data/core/units/elves/Archer.cfg
+++ b/data/core/units/elves/Archer.cfg
@@ -16,7 +16,7 @@
     advances_to=Elvish Ranger,Elvish Marksman
     cost=17
     usage=archer
-    description= _ "As primarily foragers and hunters, most elves learn to become proficient archers from a young age. Besides being only a practical skill, archery is also a common pasttime and many competitions are held in sport for the entertainment of spectators and participants alike. This ability is readily turned to battle in times of war, where many elves will wield bows as their weapons of choice. Though not as sturdy as their human or orc counterparts, Elvish archers are still effective combatants, especially when fighting from the safety of their forests."
+    description= _ "As primarily foragers and hunters, most elves learn to become proficient archers from a young age. Besides being only a practical skill, archery is also a common pastime and many competitions are held in sport for the entertainment of spectators and participants alike. This ability is readily turned to battle in times of war, where many elves will wield bows as their weapons of choice. Though not as sturdy as their human or orc counterparts, Elvish archers are still effective combatants, especially when fighting from the safety of their forests."
     die_sound={SOUND_LIST:ELF_HIT}
     [attack]
         name=sword


### PR DESCRIPTION
I realise we're in a string freeze for 1.14.6 at the moment - this can wait till it's released. In fact, I only found these _because_ I was reviewing the string changes for the 1.14.6 release.

Sending as a PR because I always seem to get things wrong with relation to string updates, especially if pofix is involved. Aside from maybe 'right click', I think these warrant an actual po update because translators may not necessarily know the intended word from the mis-spelled word.