### PR TITLE
[TRoW] S22: cuttlefish animations use different facing filters

### DIFF
--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/22_The_Rise_of_Wesnoth.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/22_The_Rise_of_Wesnoth.cfg
@@ -991,7 +991,12 @@
                     [/primary_attack]
 
                     [facing]
-                        x,y=23,23
+                        [filter_adjacent_location]
+                            adjacent=sw
+                            [filter]
+                                id=Squiddy
+                            [/filter]
+                        [/filter_adjacent_location]
                     [/facing]
 
                     hits=yes
@@ -1009,7 +1014,12 @@
                     [/primary_attack]
 
                     [facing]
-                        x,y=23,23
+                        [filter_adjacent_location]
+                            adjacent=sw
+                            [filter]
+                                id=Squiddy
+                            [/filter]
+                        [/filter_adjacent_location]
                     [/facing]
 
                     hits=yes
@@ -1119,10 +1129,6 @@
                         range=melee
                     [/primary_attack]
 
-                    [facing]
-                        x,y=43,17
-                    [/facing]
-
                     hits=yes
                 [/animate_unit]
 
@@ -1136,10 +1142,6 @@
                     [primary_attack]
                         range=melee
                     [/primary_attack]
-
-                    [facing]
-                        x,y=43,17
-                    [/facing]
 
                     hits=yes
                 [/animate_unit]
@@ -1239,10 +1241,6 @@
                         range=melee
                     [/primary_attack]
 
-                    [facing]
-                        x,y=41,31
-                    [/facing]
-
                     hits=yes
                 [/animate_unit]
 
@@ -1256,10 +1254,6 @@
                     [primary_attack]
                         range=melee
                     [/primary_attack]
-
-                    [facing]
-                        x,y=41,31
-                    [/facing]
 
                     hits=yes
                 [/animate_unit]


### PR DESCRIPTION
To address #3855. 