### PR TITLE
Send forum-based MP ban duration remaining to clients

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -61,6 +61,7 @@
  ### Multiplayer server
    * Fix stale temporary bans continuing to have an effect on players until cleared by
      phpBB on the next ban/unban operation.
+   * Forum user handler ban durations are now reported back to banned players.
  ### Packaging
    * new scons option, intended to be used when building releases inside a git repo: autorevision=False
    * Fix build with Boost 1.69. (issue #3646)

--- a/source_lists/boost_unit_tests
+++ b/source_lists/boost_unit_tests
@@ -11,6 +11,7 @@ tests/test_filesystem.cpp
 tests/test_formula_ai.cpp
 tests/test_formula_core.cpp
 tests/test_formula_function.cpp
+tests/test_formula_timespan.cpp
 tests/test_image_modifications.cpp
 tests/test_irdya_date.cpp
 tests/test_lexical_cast.cpp

--- a/src/formula/string_utils.cpp
+++ b/src/formula/string_utils.cpp
@@ -279,6 +279,39 @@ std::string format_disjunct_list(const t_string& empty, const std::vector<t_stri
 	return VGETTEXT("disjunct end^$prefix, or $last", {{"prefix", prefix}, {"last", elems.back()}});
 }
 
+std::string format_timespan(std::time_t time)
+{
+	if(time <= 0) {
+		return _("timespan^expired");
+	}
+
+	static const std::vector<std::tuple<std::time_t, const char*, const char*>> TIME_FACTORS{
+		{ 31104000, N_("timespan^$num year"),   N_("timespan^$num years")   }, // 12 months
+		{ 2592000,  N_("timespan^$num month"),  N_("timespan^$num months")  }, // 30 days
+		{ 604800,   N_("timespan^$num week"),   N_("timespan^$num weeks")   },
+		{ 86400,    N_("timespan^$num day"),    N_("timespan^$num days")    },
+		{ 3600,     N_("timespan^$num hour"),   N_("timespan^$num hours")   },
+		{ 60,       N_("timespan^$num minute"), N_("timespan^$num minutes") },
+		{ 1,        N_("timespan^$num second"), N_("timespan^$num seconds") },
+	};
+
+	std::vector<t_string> display_text;
+	string_map i18n;
+
+	for(const auto& factor : TIME_FACTORS) {
+		const int amount = time / std::get<0>(factor);
+
+		if(amount) {
+			time -= std::get<0>(factor) * amount;
+			i18n["num"] = std::to_string(amount);
+			const auto fmt = amount == 1 ? std::get<1>(factor) : std::get<2>(factor);
+			display_text.emplace_back(VGETTEXT(fmt, i18n));
+		}
+	}
+
+	return format_conjunct_list(_("timespan^expired"), display_text);
+}
+
 }
 
 std::string vgettext_impl(const char *domain

--- a/src/formula/string_utils.hpp
+++ b/src/formula/string_utils.hpp
@@ -20,6 +20,8 @@
 
 #include "serialization/string_utils.hpp"
 
+#include <ctime>
+
 class variable_set;
 
 namespace utils {
@@ -74,6 +76,13 @@ std::string format_conjunct_list(const t_string& empty, const std::vector<t_stri
  */
 std::string format_disjunct_list(const t_string& empty, const std::vector<t_string>& elems);
 
+/**
+ * Formats a timespan into human-readable text.
+ * @param time The timespan in seconds.
+ * @return A string such as "6 days, 12 hours, 4 minutes, 13 seconds". Years,
+ *         months and weeks are also considered.
+ */
+std::string format_timespan(std::time_t time);
 }
 
 /**

--- a/src/game_initialization/multiplayer.cpp
+++ b/src/game_initialization/multiplayer.cpp
@@ -306,6 +306,11 @@ std::pair<wesnothd_connection_ptr, config> open_connection(std::string host)
 				utils::string_map i18n_symbols;
 				i18n_symbols["nick"] = login;
 
+				const bool has_extra_data = error->has_child("data");
+				if(has_extra_data) {
+					i18n_symbols["duration"] = utils::format_timespan((*error).child("data")["duration"]);
+				}
+
 				if((*error)["error_code"] == MP_MUST_LOGIN) {
 					error_message = _("You must login first.");
 				} else if((*error)["error_code"] == MP_NAME_TAKEN_ERROR) {
@@ -323,11 +328,23 @@ std::pair<wesnothd_connection_ptr, config> open_connection(std::string host)
 					error_message = VGETTEXT("The nickname ‘$nick’ is not registered on this server.", i18n_symbols)
 							+ _(" This server disallows unregistered nicknames.");
 				} else if((*error)["error_code"] == MP_NAME_AUTH_BAN_USER_ERROR) {
-					error_message = VGETTEXT("The nickname ‘$nick’ is banned on this server’s forums.", i18n_symbols);
+					if(has_extra_data) {
+						error_message = VGETTEXT("The nickname ‘$nick’ is banned on this server’s forums for $duration|.", i18n_symbols);
+					} else {
+						error_message = VGETTEXT("The nickname ‘$nick’ is banned on this server’s forums.", i18n_symbols);
+					}
 				} else if((*error)["error_code"] == MP_NAME_AUTH_BAN_IP_ERROR) {
-					error_message = _("Your IP address is banned on this server’s forums.");
+					if(has_extra_data) {
+						error_message = VGETTEXT("Your IP address is banned on this server’s forums for $duration|.", i18n_symbols);
+					} else {
+						error_message = _("Your IP address is banned on this server’s forums.");
+					}
 				} else if((*error)["error_code"] == MP_NAME_AUTH_BAN_EMAIL_ERROR) {
-					error_message = VGETTEXT("The email address for the nickname ‘$nick’ is banned on this server’s forums.", i18n_symbols);
+					if(has_extra_data) {
+						error_message = VGETTEXT("The email address for the nickname ‘$nick’ is banned on this server’s forums for $duration|.", i18n_symbols);
+					} else {
+						error_message = VGETTEXT("The email address for the nickname ‘$nick’ is banned on this server’s forums.", i18n_symbols);
+					}
 				} else if((*error)["error_code"] == MP_PASSWORD_REQUEST) {
 					error_message = VGETTEXT("The nickname ‘$nick’ is registered on this server.", i18n_symbols);
 				} else if((*error)["error_code"] == MP_PASSWORD_REQUEST_FOR_LOGGED_IN_NAME) {

--- a/src/server/forum_user_handler.cpp
+++ b/src/server/forum_user_handler.cpp
@@ -172,7 +172,7 @@ void fuh::set_is_moderator(const std::string& name, const bool& is_moderator) {
 	}
 }
 
-fuh::BAN_TYPE fuh::user_is_banned(const std::string& name, const std::string& addr)
+fuh::ban_info fuh::user_is_banned(const std::string& name, const std::string& addr)
 {
 	//
 	// NOTE: glob IP and email address bans are NOT supported yet since they
@@ -186,17 +186,20 @@ fuh::BAN_TYPE fuh::user_is_banned(const std::string& name, const std::string& ad
 	const std::string& is_extant_ban_sql =
 		"ban_exclude = 0 AND (ban_end = 0 OR ban_end >=" + std::to_string(std::time(nullptr)) + ")";
 
+	// TODO: retrieve full ban info in a single statement instead of issuing
+	//       separate queries to check for a ban's existence and its duration.
+
 	try {
 		if(!addr.empty() && prepared_statement<bool>("SELECT 1 FROM `" + db_banlist_table_ + "` WHERE UPPER(ban_ip) = UPPER(?) AND " + is_extant_ban_sql, addr)) {
 			LOG_UH << "User '" << name << "' ip " << addr << " banned by IP address\n";
-			return BAN_IP;
+			return retrieve_ban_info(BAN_IP, addr);
 		}
 	} catch(const sql_error& e) {
 		ERR_UH << "Could not check forum bans on address '" << addr << "' :" << e.message << '\n';
-		return BAN_NONE;
+		return {};
 	}
 
-	if(!user_exists(name)) return BAN_NONE;
+	if(!user_exists(name)) return {};
 
 	try {
 		auto uid = get_detail_for_user<unsigned int>(name, "user_id");
@@ -205,21 +208,67 @@ fuh::BAN_TYPE fuh::user_is_banned(const std::string& name, const std::string& ad
 			ERR_UH << "Invalid user id for user '" << name << "'\n";
 		} else if(prepared_statement<bool>("SELECT 1 FROM `" + db_banlist_table_ + "` WHERE ban_userid = ? AND " + is_extant_ban_sql, uid)) {
 			LOG_UH << "User '" << name << "' uid " << uid << " banned by uid\n";
-			return BAN_USER;
+			return retrieve_ban_info(BAN_USER, uid);
 		}
 
 		auto email = get_detail_for_user<std::string>(name, "user_email");
 
 		if(!email.empty() && prepared_statement<bool>("SELECT 1 FROM `" + db_banlist_table_ + "` WHERE UPPER(ban_email) = UPPER(?) AND " + is_extant_ban_sql, email)) {
 			LOG_UH << "User '" << name << "' email " << email << " banned by email address\n";
-			return BAN_EMAIL;
+			return retrieve_ban_info(BAN_EMAIL, email);
 		}
 
 	} catch(const sql_error& e) {
 		ERR_UH << "Could not check forum bans on user '" << name << "' :" << e.message << '\n';
 	}
 
-	return BAN_NONE;
+	return {};
+}
+
+template<typename T>
+fuh::ban_info fuh::retrieve_ban_info(fuh::BAN_TYPE type, T detail)
+{
+	std::string col;
+
+	switch(type) {
+	case BAN_USER:
+		col = "ban_userid";
+		break;
+	case BAN_EMAIL:
+		col = "ban_email";
+		break;
+	case BAN_IP:
+		col = "ban_ip";
+		break;
+	default:
+		return {};
+	}
+
+	try {
+		return { type, retrieve_ban_duration_internal(col, detail) };
+	} catch(const sql_error& e) {
+		//
+		// NOTE:
+		// If retrieve_ban_internal() fails to fetch the ban row, odds are the ban was
+		// lifted in the meantime (it's meant to be called by user_is_banned(), so we
+		// assume the ban expires in one second instead of returning 0 (permanent ban)
+		// just to err on the safe side (returning BAN_NONE would be a terrible idea,
+		// for that matter).
+		//
+		return { type, 1 };
+	}
+}
+
+std::time_t fuh::retrieve_ban_duration_internal(const std::string& col, const std::string& detail)
+{
+	const std::time_t end_time = prepared_statement<int>("SELECT `ban_end` FROM `" + db_banlist_table_ + "` WHERE UPPER(" + col + ") = UPPER(?)", detail);
+	return end_time ? end_time - std::time(nullptr) : 0;
+}
+
+std::time_t fuh::retrieve_ban_duration_internal(const std::string& col, unsigned int detail)
+{
+	const std::time_t end_time = prepared_statement<int>("SELECT `ban_end` FROM `" + db_banlist_table_ + "` WHERE " + col + " = ?", detail);
+	return end_time ? end_time - std::time(nullptr) : 0;
 }
 
 std::string fuh::user_info(const std::string& name) {

--- a/src/server/forum_user_handler.hpp
+++ b/src/server/forum_user_handler.hpp
@@ -69,7 +69,7 @@ class fuh : public user_handler {
 		bool user_is_moderator(const std::string& name);
 		void set_is_moderator(const std::string& name, const bool& is_moderator);
 
-		BAN_TYPE user_is_banned(const std::string& name, const std::string& addr);
+		ban_info user_is_banned(const std::string& name, const std::string& addr);
 
 		// Throws user_handler::error
 		std::string user_info(const std::string& name);
@@ -90,6 +90,12 @@ class fuh : public user_handler {
 		bool is_inactive(const std::string& user);
 
 		void set_lastlogin(const std::string& user, const time_t& lastlogin);
+
+		template<typename T>
+		ban_info retrieve_ban_info(BAN_TYPE, T detail);
+
+		std::time_t retrieve_ban_duration_internal(const std::string& col, const std::string& detail);
+		std::time_t retrieve_ban_duration_internal(const std::string& col, unsigned int detail);
 
 		std::string db_name_, db_host_, db_user_, db_password_, db_users_table_, db_banlist_table_, db_extra_table_;
 

--- a/src/server/sample_user_handler.cpp
+++ b/src/server/sample_user_handler.cpp
@@ -95,9 +95,9 @@ void suh::set_is_moderator(const std::string& name, const bool& is_moderator) {
 	users_[name].is_moderator = is_moderator;
 }
 
-suh::BAN_TYPE suh::user_is_banned(const std::string&, const std::string&) {
+suh::ban_info suh::user_is_banned(const std::string&, const std::string&) {
 	// FIXME: stub
-	return BAN_NONE;
+	return {};
 }
 
 void suh::set_mail(const std::string& user, const std::string& mail) {

--- a/src/server/sample_user_handler.hpp
+++ b/src/server/sample_user_handler.hpp
@@ -19,8 +19,6 @@
 #include <map>
 #include <vector>
 
-#include <ctime>
-
 /**
  * An example of how to implement user_handler.
  * If you use this on anything real, you are insane.
@@ -43,7 +41,7 @@ class suh : public user_handler {
 		bool user_is_moderator(const std::string& name);
 		void set_is_moderator(const std::string& name, const bool& is_moderator);
 
-		BAN_TYPE user_is_banned(const std::string& name, const std::string&);
+		ban_info user_is_banned(const std::string& name, const std::string&);
 
 		std::string user_info(const std::string& name);
 

--- a/src/server/server_base.cpp
+++ b/src/server/server_base.cpp
@@ -178,32 +178,51 @@ bool check_error(const boost::system::error_code& error, socket_ptr socket)
 	return false;
 }
 
-void async_send_error(socket_ptr socket, const std::string& msg, const char* error_code)
+namespace {
+
+void info_table_into_simple_wml(simple_wml::document& doc, const std::string& parent_name, const info_table& info)
+{
+	if(info.empty()) {
+		return;
+	}
+
+	auto& node = doc.child(parent_name.c_str())->add_child("data");
+	for(const auto& kv : info) {
+		node.set_attr_dup(kv.first.c_str(), kv.second.c_str());
+	}
+}
+
+}
+
+void async_send_error(socket_ptr socket, const std::string& msg, const char* error_code, const info_table& info)
 {
 	simple_wml::document doc;
 	doc.root().add_child("error").set_attr_dup("message", msg.c_str());
 	if(*error_code != '\0') {
 		doc.child("error")->set_attr("error_code", error_code);
 	}
+	info_table_into_simple_wml(doc, "error", info);
 
 	async_send_doc(socket, doc);
 }
 
-void async_send_warning(socket_ptr socket, const std::string& msg, const char* warning_code)
+void async_send_warning(socket_ptr socket, const std::string& msg, const char* warning_code, const info_table& info)
 {
 	simple_wml::document doc;
 	doc.root().add_child("warning").set_attr_dup("message", msg.c_str());
 	if(*warning_code != '\0') {
 		doc.child("warning")->set_attr("warning_code", warning_code);
 	}
+	info_table_into_simple_wml(doc, "warning", info);
 
 	async_send_doc(socket, doc);
 }
 
-void async_send_message(socket_ptr socket, const std::string& msg)
+void async_send_message(socket_ptr socket, const std::string& msg, const info_table& info)
 {
 	simple_wml::document doc;
 	doc.root().add_child("message").set_attr_dup("message", msg.c_str());
+	info_table_into_simple_wml(doc, "message", info);
 
 	async_send_doc(socket, doc);
 }

--- a/src/server/server_base.hpp
+++ b/src/server/server_base.hpp
@@ -21,6 +21,8 @@
 
 #include "exceptions.hpp"
 
+#include <map>
+
 #include <boost/asio.hpp>
 #include <boost/asio/signal_set.hpp>
 #include <boost/shared_array.hpp>
@@ -78,6 +80,8 @@ protected:
 std::string client_address(socket_ptr socket);
 bool check_error(const boost::system::error_code& error, socket_ptr socket);
 
-void async_send_error(socket_ptr socket, const std::string& msg, const char* error_code = "");
-void async_send_warning(socket_ptr socket, const std::string& msg, const char* warning_code = "");
-void async_send_message(socket_ptr socket, const std::string& msg);
+typedef std::map<std::string, std::string> info_table;
+
+void async_send_error(socket_ptr socket, const std::string& msg, const char* error_code = "", const info_table& info = {});
+void async_send_warning(socket_ptr socket, const std::string& msg, const char* warning_code = "", const info_table& info = {});
+void async_send_message(socket_ptr socket, const std::string& msg, const info_table& info = {});

--- a/src/server/user_handler.hpp
+++ b/src/server/user_handler.hpp
@@ -18,6 +18,7 @@ class config;
 
 #include "exceptions.hpp"
 
+#include <ctime>
 #include <string>
 
 /**
@@ -108,12 +109,32 @@ class user_handler {
 		/** Mark this user as a moderator */
 		virtual void set_is_moderator(const std::string& name, const bool& is_moderator) =0;
 
+		/** Ban type values */
 		enum BAN_TYPE
 		{
-			BAN_NONE,
-			BAN_USER,
-			BAN_IP,
-			BAN_EMAIL,
+			BAN_NONE,		/**< Not a ban */
+			BAN_USER,		/**< User account/name ban */
+			BAN_IP,			/**< IP address ban */
+			BAN_EMAIL,		/**< Account email address ban */
+		};
+
+		/** Ban status description */
+		struct ban_info
+		{
+			BAN_TYPE type;			/**< Ban type */
+			std::time_t duration;	/**< Ban duration (0 if permanent) */
+
+			ban_info()
+				: type(BAN_NONE)
+				, duration(0)
+			{
+			}
+
+			ban_info(BAN_TYPE ptype, std::time_t pduration)
+				: type(ptype)
+				, duration(pduration)
+			{
+			}
 		};
 
 		/**
@@ -123,7 +144,7 @@ class user_handler {
 		 *       subclass. Regular IP ban checks are done by @a server_base
 		 *       instead.
 		 */
-		virtual BAN_TYPE user_is_banned(const std::string& name, const std::string& addr="") = 0;
+		virtual ban_info user_is_banned(const std::string& name, const std::string& addr="") = 0;
 
 		struct error : public game::error {
 			error(const std::string& message) : game::error(message) {}

--- a/src/tests/test_formula_timespan.cpp
+++ b/src/tests/test_formula_timespan.cpp
@@ -1,0 +1,154 @@
+/*
+   Copyright (C) 2019 by Iris Morelle <shadowm2006@gmail.com>
+   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#include <boost/test/unit_test.hpp>
+
+#include "formula/string_utils.hpp"
+#include "tstring.hpp"
+
+#include <algorithm>
+
+BOOST_AUTO_TEST_SUITE( formula_timespan )
+
+using std::time_t;
+
+namespace {
+
+enum TIME_FACTORS
+{
+	YEAR = 31104000, /* 12 months */
+	MONTH = 2592000, /* 30 days */
+	WEEK = 604800,
+	DAY = 86400,
+	HOUR = 3600,
+	MIN = 60,
+	SEC = 1,
+};
+
+inline std::string minifmt(time_t t, const std::string& singular, const std::string& plural)
+{
+	return t ? std::to_string(t) + " " + (t > 1 ? plural : singular) : "";
+}
+
+typedef std::tuple<
+	time_t /*sec*/,
+	time_t /*min*/,
+	time_t /*hr*/,
+	time_t /*day*/,
+	time_t /*wk*/,
+	time_t /*mo*/,
+	time_t /*yr*/> time_detailed;
+
+inline time_t gen_as_time_t(const time_detailed& params)
+{
+	time_t sec, min, hr, day, wk, mo, yr;
+	std::tie(sec, min, hr, day, wk, mo, yr) = params;
+
+	return YEAR*yr + MONTH*mo + WEEK*wk + DAY*day + HOUR*hr + MIN*min + SEC*sec;
+}
+
+inline std::string gen_as_str(const time_detailed& params)
+{
+	time_t sec, min, hr, day, wk, mo, yr;
+	std::tie(sec, min, hr, day, wk, mo, yr) = params;
+
+	std::vector<t_string> bits;
+	std::string res;
+
+	bits.emplace_back(minifmt(yr, "year", "years"));
+	bits.emplace_back(minifmt(mo, "month", "months"));
+	bits.emplace_back(minifmt(wk, "week", "weeks"));
+	bits.emplace_back(minifmt(day, "day", "days"));
+	bits.emplace_back(minifmt(hr, "hour", "hours"));
+	bits.emplace_back(minifmt(min, "minute", "minutes"));
+	bits.emplace_back(minifmt(sec, "second", "seconds"));
+
+	// Drop zeroes
+	auto p = std::remove_if(bits.begin(), bits.end(), [](const t_string& t) { return t.empty(); });
+	if(p != bits.end()) {
+		bits.erase(p);
+	}
+
+	return utils::format_conjunct_list("expired", bits);
+}
+
+}
+
+BOOST_AUTO_TEST_CASE( test_formula_timespan )
+{
+	time_detailed t;
+
+	t = { 1, 0, 0, 0, 0, 0, 0 };
+	BOOST_CHECK_EQUAL("1 second", utils::format_timespan(gen_as_time_t(t)));
+
+	t = { 2, 0, 0, 0, 0, 0, 0 };
+	BOOST_CHECK_EQUAL("2 seconds", utils::format_timespan(gen_as_time_t(t)));
+
+	t = { 0, 1, 0, 0, 0, 0, 0 };
+	BOOST_CHECK_EQUAL("1 minute", utils::format_timespan(gen_as_time_t(t)));
+
+	t = { 0, 2, 0, 0, 0, 0, 0 };
+	BOOST_CHECK_EQUAL("2 minutes", utils::format_timespan(gen_as_time_t(t)));
+
+	t = { 0, 0, 1, 0, 0, 0, 0 };
+	BOOST_CHECK_EQUAL("1 hour", utils::format_timespan(gen_as_time_t(t)));
+
+	t = { 0, 0, 2, 0, 0, 0, 0 };
+	BOOST_CHECK_EQUAL("2 hours", utils::format_timespan(gen_as_time_t(t)));
+
+	t = { 0, 0, 0, 1, 0, 0, 0 };
+	BOOST_CHECK_EQUAL("1 day", utils::format_timespan(gen_as_time_t(t)));
+
+	t = { 0, 0, 0, 2, 0, 0, 0 };
+	BOOST_CHECK_EQUAL("2 days", utils::format_timespan(gen_as_time_t(t)));
+
+	t = { 0, 0, 0, 0, 1, 0, 0 };
+	BOOST_CHECK_EQUAL("1 week", utils::format_timespan(gen_as_time_t(t)));
+
+	t = { 0, 0, 0, 0, 2, 0, 0 };
+	BOOST_CHECK_EQUAL("2 weeks", utils::format_timespan(gen_as_time_t(t)));
+
+	t = { 0, 0, 0, 0, 0, 1, 0 };
+	BOOST_CHECK_EQUAL("1 month", utils::format_timespan(gen_as_time_t(t)));
+
+	t = { 0, 0, 0, 0, 0, 2, 0 };
+	BOOST_CHECK_EQUAL("2 months", utils::format_timespan(gen_as_time_t(t)));
+
+	t = { 0, 0, 0, 0, 0, 0, 1 };
+	BOOST_CHECK_EQUAL("1 year", utils::format_timespan(gen_as_time_t(t)));
+
+	t = { 0, 0, 0, 0, 0, 0, 2 };
+	BOOST_CHECK_EQUAL("2 years", utils::format_timespan(gen_as_time_t(t)));
+
+	t = { 12, 1, 23, 3, 2, 5, 2 };
+	BOOST_CHECK_EQUAL(gen_as_str(t), utils::format_timespan(gen_as_time_t(t)));
+
+	t = { 0, 0, 0, 0, 0, 0, 0 };
+	BOOST_CHECK_EQUAL(utils::format_timespan(gen_as_time_t(t)), utils::format_timespan(0));
+	BOOST_CHECK_EQUAL(utils::format_timespan(gen_as_time_t(t)), utils::format_timespan(-10000));
+
+	t = { 4, 0, 49, 0, 0, 0, 0 };
+	BOOST_CHECK_EQUAL("2 days, 1 hour, and 4 seconds", utils::format_timespan(gen_as_time_t(t)));
+
+	t = { 0, 40, 0, 11, 1, 0, 4 };
+	BOOST_CHECK_EQUAL("4 years, 2 weeks, 4 days, and 40 minutes", utils::format_timespan(gen_as_time_t(t)));
+
+	t = { 0, 0, 1, 0, 0, 3, 4 };
+	BOOST_CHECK_EQUAL("4 years, 3 months, and 1 hour", utils::format_timespan(gen_as_time_t(t)));
+
+	t = { 10, 0, 0, 0, 0, 2, 0 };
+	BOOST_CHECK_EQUAL("2 months and 10 seconds", utils::format_timespan(gen_as_time_t(t)));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
See issue #3766.

![image](https://user-images.githubusercontent.com/489895/52076504-93a15e80-256d-11e9-87de-d0e0d25500f2.png)

This has the side-effect of extending the MP server protocol a bit by adding a `[data]` subtag to `[error/warning/message]` responses that can contain an arbitrary set of data in k/v form, used in this PR to send the remaining duration of the ban as a `time_t` value. It could potentially be used for other purposes in the future.

Also note that this introduces around 17 new translatable strings. 