### PR TITLE
Bug #3862 Fix.

### DIFF
--- a/data/tools/wesnoth/wmlparser3.py
+++ b/data/tools/wesnoth/wmlparser3.py
@@ -503,13 +503,12 @@ class Parser:
         Parse a WML fragment outside of strings.
         """
         if not line: return
+        if line.startswith(b"#textdomain "):
+            self.textdomain = line[12:].strip().decode("utf8")
+            return
         if not self.temp_key_nodes:
             line = line.lstrip()
             if not line: return
-
-            if line.startswith(b"#textdomain "):
-                self.textdomain = line[12:].strip().decode("utf8")
-                return
 
             # Is it a tag?
             if line.startswith(b"["):


### PR DESCRIPTION
The problem was that in the wml parser, when a node creation spans multiple lines, the code doesn’t take in account that one of those line can contain a #textdomain directive.

In the method “parse_outside_strings” (line 501), the code that processes the #textdomain directive is inside an if block that is true only if the node creation doesn’t span across multiple lines (self.temp_key_nodes is null).

The solution implemented is that in the method “parse_outside_strings” (line 501), the code that check if a line starts with #textdomain is moved from inside the block that is true only if the node creation doesn’t spans across multiple lines and put in the method scope after the first if block that checks if the line is empty.