### PR TITLE
Bug #3903 Fix.

### DIFF
--- a/data/tools/wesnoth/wmlparser3.py
+++ b/data/tools/wesnoth/wmlparser3.py
@@ -519,7 +519,7 @@ class Parser:
                 self.handle_attribute(line)
         else:
             for i, segment in enumerate(line.split(b"+")):
-                segment = segment.lstrip(b" ")
+                segment = segment.lstrip(b" \t")
 
                 if i > 0:
                     # If the last segment is empty (there was a plus sign


### PR DESCRIPTION
The problem was that in the WML parser, when parsing the outside of a string that is translatable, the code only assumed “spaces” characters could precede it. If there are “tabs” characters the code parses the “_” character as an attribute value.

The solution is to add a stripping code for “tabs” characters.
