### PR TITLE
Fix issue #3831: Broken unit movement animations

### DIFF
--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1573,7 +1573,7 @@ void unit::write(config& cfg, bool write_all) const
 
 void unit::set_facing(map_location::DIRECTION dir) const
 {
-	if(dir != map_location::NDIRECTIONS) {
+	if(dir != map_location::NDIRECTIONS && dir != facing_) {
 		appearance_changed_ = true;
 		facing_ = dir;
 	}


### PR DESCRIPTION
This fixes Issue #3831. The problem was that the appearance_changed attribute was set in set_facing() even if the direction the unit faces did not change.

The flag is passed to the unit_mover: https://github.com/wesnoth/wesnoth/blob/095edb36a1b4d06d8ab904e3d622e94ac9d65308/src/actions/move.cpp#L544-L545
Which causes the fake unit to be replaced: https://github.com/wesnoth/wesnoth/blob/095edb36a1b4d06d8ab904e3d622e94ac9d65308/src/units/udisplay.cpp#L328-L330