### PR TITLE
Main menu "Campaigns" button pt_BR translation fix

### DIFF
--- a/po/wesnoth-lib/pt_BR.po
+++ b/po/wesnoth-lib/pt_BR.po
@@ -8714,8 +8714,6 @@ msgstr "Tutorial"
 # File: data/gui/default/window/title_screen.cfg, line: 257
 #. [grid]
 #: data/gui/window/title_screen.cfg:252
-#, fuzzy
-#| msgid "Campaign"
 msgid "Campaigns"
 msgstr "Campanha"
 


### PR DESCRIPTION
The "Campaigns" button in the main menu is the only button that the Brazilian Portuguese translation is not working.