### PR TITLE
Help: Show damage type and range icons in unit help pages

### DIFF
--- a/src/help/help_impl.cpp
+++ b/src/help/help_impl.cpp
@@ -1477,7 +1477,7 @@ unsigned image_width(const std::string &filename)
 	return 0;
 }
 
-void push_tab_pair(std::vector<std::pair<std::string, unsigned int>> &v, const std::string &s)
+void push_tab_pair(std::vector<help::item> &v, const std::string &s)
 {
 	v.emplace_back(s, font::line_width(s, normal_font_size));
 }

--- a/src/help/help_impl.cpp
+++ b/src/help/help_impl.cpp
@@ -1477,9 +1477,18 @@ unsigned image_width(const std::string &filename)
 	return 0;
 }
 
-void push_tab_pair(std::vector<help::item> &v, const std::string &s)
+void push_tab_pair(std::vector<help::item> &v, const std::string &s, const boost::optional<std::string> &image, unsigned padding)
 {
-	v.emplace_back(s, font::line_width(s, normal_font_size));
+	help::item item(s, font::line_width(s, normal_font_size));
+	if (image) {
+		// If the image doesn't exist, don't add padding.
+		auto width = image_width(image.get());
+		padding = (width ? padding : 0);
+
+		item.first = "<img>src='" + image.get() + "'</img>" + (padding ? jump(padding) : "") + s;
+		item.second += width + padding;
+	}
+	v.emplace_back(item);
 }
 
 std::string generate_table(const table_spec &tab, const unsigned int spacing)

--- a/src/help/help_impl.hpp
+++ b/src/help/help_impl.hpp
@@ -43,6 +43,7 @@
 #include <vector>                       // for vector, etc
 #include <SDL.h>                  // for SDL_Surface
 #include <boost/logic/tribool.hpp>
+#include <boost/optional.hpp>
 
 class config;
 class unit_type;
@@ -396,7 +397,7 @@ std::string generate_table(const table_spec &tab, const unsigned int spacing=fon
 // Return the width for the image with filename.
 unsigned image_width(const std::string &filename);
 
-// Add to the vector v an help::item for the string s.
-void push_tab_pair(std::vector<help::item> &v, const std::string &s);
+// Add to the vector v an help::item for the string s, preceded by the given image if any.
+void push_tab_pair(std::vector<help::item> &v, const std::string &s, const boost::optional<std::string> &image = {}, unsigned padding = 0);
 
 } // end namespace help

--- a/src/help/help_impl.hpp
+++ b/src/help/help_impl.hpp
@@ -383,7 +383,10 @@ inline std::string bold(const std::string &s)
 		return ss.str();
 	}
 
-typedef std::vector<std::vector<std::pair<std::string, unsigned int >> > table_spec;
+// A string to be displayed and its width.
+typedef std::pair< std::string, unsigned > item;
+
+typedef std::vector<std::vector<help::item> > table_spec;
 // Create a table using the table specs. Return markup with jumps
 // that create a table. The table spec contains a vector with
 // vectors with pairs. The pairs are the markup string that should
@@ -393,6 +396,7 @@ std::string generate_table(const table_spec &tab, const unsigned int spacing=fon
 // Return the width for the image with filename.
 unsigned image_width(const std::string &filename);
 
-void push_tab_pair(std::vector<std::pair<std::string, unsigned int>> &v, const std::string &s);
+// Add to the vector v an help::item for the string s.
+void push_tab_pair(std::vector<help::item> &v, const std::string &s);
 
 } // end namespace help

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -557,10 +557,8 @@ std::string unit_topic_generator::operator()() const {
 		// Dummy element, icons are below.
 		first_row.push_back(item("", 0));
 		push_header(first_row, _("unit help^Name"));
-		first_row.push_back(item("", 0)); // dummy item for type icon
 		push_header(first_row, _("Type"));
 		push_header(first_row, _("Strikes"));
-		first_row.push_back(item("", 0)); // dummy item for range icon
 		push_header(first_row, _("Range"));
 		push_header(first_row, _("Special"));
 		table.push_back(first_row);
@@ -579,14 +577,10 @@ std::string unit_topic_generator::operator()() const {
 			// Attack name
 			push_tab_pair(row, lang_weapon);
 
-			// Damage type icon
+			// Damage type, with icon
+			const auto padding = 5; // TODO amount of padding?
 			const std::string type_icon = "icons/profiles/" + attack.type() + ".png";
-			attack_ss << "<img>src='" << type_icon << "'</img>";
-			row.emplace_back(attack_ss.str(), image_width(type_icon));
-			attack_ss.str(clear_stringstream);
-
-			// Damage type
-			push_tab_pair(row, lang_type);
+			push_tab_pair(row, lang_type, type_icon, padding);
 
 			// damage x strikes
 			attack_ss << attack.damage() << font::weapon_numbers_sep << attack.num_attacks()
@@ -594,18 +588,13 @@ std::string unit_topic_generator::operator()() const {
 			push_tab_pair(row, attack_ss.str());
 			attack_ss.str(clear_stringstream);
 
-			// Range icon
+			// Range, with icon
 			const std::string range_icon = "icons/profiles/" + attack.range() + "_attack.png";
-			attack_ss << "<img>src='" << range_icon << "'</img>";
-			row.emplace_back(attack_ss.str(), image_width(range_icon));
-			attack_ss.str(clear_stringstream);
-
-			// Range
 			if (attack.min_range() > 1 || attack.max_range() > 1) {
 				attack_ss << attack.min_range() << "-" << attack.max_range() << ' ';
 			}
 			attack_ss << string_table["range_" + attack.range()];
-			push_tab_pair(row, attack_ss.str());
+			push_tab_pair(row, attack_ss.str(), range_icon, padding);
 			attack_ss.str(clear_stringstream);
 
 			// Show this attack's special, if it has any. Cross

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -557,8 +557,10 @@ std::string unit_topic_generator::operator()() const {
 		// Dummy element, icons are below.
 		first_row.push_back(item("", 0));
 		push_header(first_row, _("unit help^Name"));
+		first_row.push_back(item("", 0)); // dummy item for type icon
 		push_header(first_row, _("Type"));
 		push_header(first_row, _("Strikes"));
+		first_row.push_back(item("", 0)); // dummy item for range icon
 		push_header(first_row, _("Range"));
 		push_header(first_row, _("Special"));
 		table.push_back(first_row);
@@ -568,21 +570,44 @@ std::string unit_topic_generator::operator()() const {
 			std::string lang_type = string_table["type_" + attack.type()];
 			std::vector<item> row;
 			std::stringstream attack_ss;
+
+			// Attack icon
 			attack_ss << "<img>src='" << attack.icon() << "'</img>";
 			row.emplace_back(attack_ss.str(),image_width(attack.icon()));
-			push_tab_pair(row, lang_weapon);
-			push_tab_pair(row, lang_type);
 			attack_ss.str(clear_stringstream);
+
+			// Attack name
+			push_tab_pair(row, lang_weapon);
+
+			// Damage type icon
+			const std::string type_icon = "icons/profiles/" + attack.type() + ".png";
+			attack_ss << "<img>src='" << type_icon << "'</img>";
+			row.emplace_back(attack_ss.str(), image_width(type_icon));
+			attack_ss.str(clear_stringstream);
+
+			// Damage type
+			push_tab_pair(row, lang_type);
+
+			// damage x strikes
 			attack_ss << attack.damage() << font::weapon_numbers_sep << attack.num_attacks()
 				<< " " << attack.accuracy_parry_description();
 			push_tab_pair(row, attack_ss.str());
 			attack_ss.str(clear_stringstream);
+
+			// Range icon
+			const std::string range_icon = "icons/profiles/" + attack.range() + "_attack.png";
+			attack_ss << "<img>src='" << range_icon << "'</img>";
+			row.emplace_back(attack_ss.str(), image_width(range_icon));
+			attack_ss.str(clear_stringstream);
+
+			// Range
 			if (attack.min_range() > 1 || attack.max_range() > 1) {
 				attack_ss << attack.min_range() << "-" << attack.max_range() << ' ';
 			}
 			attack_ss << string_table["range_" + attack.range()];
 			push_tab_pair(row, attack_ss.str());
 			attack_ss.str(clear_stringstream);
+
 			// Show this attack's special, if it has any. Cross
 			// reference it to the section describing the special.
 			std::vector<std::pair<t_string, t_string>> specials = attack.special_tooltips();

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -557,9 +557,9 @@ std::string unit_topic_generator::operator()() const {
 		// Dummy element, icons are below.
 		first_row.push_back(item("", 0));
 		push_header(first_row, _("unit help^Name"));
-		push_header(first_row, _("Type"));
 		push_header(first_row, _("Strikes"));
 		push_header(first_row, _("Range"));
+		push_header(first_row, _("Type"));
 		push_header(first_row, _("Special"));
 		table.push_back(first_row);
 		// Print information about every attack.
@@ -577,16 +577,14 @@ std::string unit_topic_generator::operator()() const {
 			// Attack name
 			push_tab_pair(row, lang_weapon);
 
-			// Damage type, with icon
-			const auto padding = 5; // TODO amount of padding?
-			const std::string type_icon = "icons/profiles/" + attack.type() + ".png";
-			push_tab_pair(row, lang_type, type_icon, padding);
-
 			// damage x strikes
 			attack_ss << attack.damage() << font::weapon_numbers_sep << attack.num_attacks()
 				<< " " << attack.accuracy_parry_description();
 			push_tab_pair(row, attack_ss.str());
 			attack_ss.str(clear_stringstream);
+
+			// Padding for range and damage type icons
+			const auto padding = 5; // TODO amount of padding?
 
 			// Range, with icon
 			const std::string range_icon = "icons/profiles/" + attack.range() + "_attack.png";
@@ -596,6 +594,10 @@ std::string unit_topic_generator::operator()() const {
 			attack_ss << string_table["range_" + attack.range()];
 			push_tab_pair(row, attack_ss.str(), range_icon, padding);
 			attack_ss.str(clear_stringstream);
+
+			// Damage type, with icon
+			const std::string type_icon = "icons/profiles/" + attack.type() + ".png";
+			push_tab_pair(row, lang_type, type_icon, padding);
 
 			// Show this attack's special, if it has any. Cross
 			// reference it to the section describing the special.

--- a/src/help/help_topic_generators.hpp
+++ b/src/help/help_topic_generators.hpp
@@ -41,8 +41,7 @@ class unit_topic_generator: public topic_generator
 {
 	const unit_type& type_;
 	const std::string variation_;
-	typedef std::pair< std::string, unsigned > item;
-	void push_header(std::vector< item > &row,  const std::string& name) const;
+	void push_header(std::vector< help::item > &row,  const std::string& name) const;
 public:
 	unit_topic_generator(const unit_type &t, std::string variation="") : type_(t), variation_(variation) {}
 	virtual std::string operator()() const;


### PR DESCRIPTION
Following up on #3732, also use the icons in the unit help pages:

![screenshot_2019-02-24_12-55-42](https://user-images.githubusercontent.com/24784687/53299541-86f1ec80-3833-11e9-982c-1498338a5c2e.png)

- [x] add icons to the table
- [x] don't put the icons in their own column but in the existing column
- [x] test it looks right when damage type or range or both have no icon