### PR TITLE
Fix parser crash in defined multi line str test

### DIFF
--- a/data/tools/wesnoth/wmlparser3.py
+++ b/data/tools/wesnoth/wmlparser3.py
@@ -493,6 +493,8 @@ class Parser:
         else:
             if self.in_string:
                 self.temp_string += line
+            elif self.temp_key_nodes and line.strip(b" \t\n") == b"":
+                return b""
             else:
                 self.parse_outside_strings(line)
 


### PR DESCRIPTION
The problem is that if we have a "#define" directive followed with an
empty line ending with a newline character then the parser presumes the
value is the newline character instead of the actual value (which is
located on a subsequent line).

The solution is that when parsing an empty line, if "self.in_string" is
False and "self.temp_key_nodes" is not None then we ignore the line
instead of parsing it with the "parse_outside_strings" function.

Closes #3947