### PR TITLE
Fix parser handles textdomain directives incorrectly

### DIFF
--- a/data/tools/wesnoth/wmlparser3.py
+++ b/data/tools/wesnoth/wmlparser3.py
@@ -507,8 +507,8 @@ class Parser:
         Parse a WML fragment outside of strings.
         """
         if not line: return
-        if line.startswith(b"#textdomain "):
-            self.textdomain = line[12:].strip().decode("utf8")
+        if line.lstrip(b" \t").startswith(b"#textdomain "):
+            self.textdomain = line.lstrip(b" \t")[12:].strip().decode("utf8")
             return
         if not self.temp_key_nodes:
             line = line.lstrip()


### PR DESCRIPTION
The problem is that when parsing #textdomain directives, the parser
expects the directive to be at the start of the line. So if the directive
is preceded by spaces or tabs then it is treated as an attribute.

The solution is to strip all spaces and tabs on the left side of the
parsed line string when checking for #textdomain directive.

Closes #3951