### PR TITLE
Allow previewing enemy attacks

### DIFF
--- a/src/mouse_events.cpp
+++ b/src/mouse_events.cpp
@@ -676,12 +676,6 @@ map_location mouse_handler::current_unit_attacks_from(const map_location& loc) c
 			return map_location();
 		}
 
-		// The selected unit must at least belong to the player currently controlling this client.
-		source_eligible &= source_unit->side() == gui_->viewing_side();
-		if(!source_eligible) {
-			return map_location();
-		}
-
 		// In addition:
 		// - If whiteboard is enabled, we allow planning attacks outside of player's turn
 		// - If whiteboard is disabled, it must be the turn of the player controlling this client
@@ -700,8 +694,6 @@ map_location mouse_handler::current_unit_attacks_from(const map_location& loc) c
 
 		// Check the unit TARGET of the attack
 
-		const team& viewer = viewing_team();
-
 		// Check that there's a unit at the target location
 		const unit_map::const_iterator target_unit = find_unit(loc);
 
@@ -710,8 +702,8 @@ map_location mouse_handler::current_unit_attacks_from(const map_location& loc) c
 			return map_location();
 		}
 
-		// The player controlling this client must be an enemy of the target unit's side
-		target_eligible &= viewer.is_enemy(target_unit->side());
+		// The target must be an enemy of the source
+		target_eligible &= pc_.gamestate().board_.get_team(source_unit->side()).is_enemy(target_unit->side());
 		if(!target_eligible) {
 			return map_location();
 		}

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -40,6 +40,10 @@
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
 
+// Forward declarations
+static const unit *get_visible_unit(reports::context & rc);
+static const unit *get_selected_unit(reports::context & rc);
+
 static void add_text(config &report, const std::string &text,
 	const std::string &tooltip, const std::string &help = "")
 {
@@ -94,14 +98,19 @@ static std::string flush(std::ostringstream &s)
 static const time_of_day get_visible_time_of_day_at(reports::context & rc, const map_location & hex)
 {
 	const team &viewing_team = rc.teams()[rc.screen().viewing_team()];
+
+	const unit *u = get_selected_unit(rc);
+	const unit *sec_u = get_visible_unit(rc);
+	const int for_turn = (u && sec_u && u->side() != viewing_team.side() && u->side() < sec_u->side()) ? rc.tod().turn() + 1 : 0;
+
 	if (viewing_team.shrouded(hex)) {
 		// Don't show time on shrouded tiles.
-		return rc.tod().get_time_of_day();
+		return rc.tod().get_time_of_day(for_turn);
 	} else if (viewing_team.fogged(hex)) {
 		// Don't show illuminated time on fogged tiles.
-		return rc.tod().get_time_of_day(hex);
+		return rc.tod().get_time_of_day(hex, for_turn);
 	} else {
-		return rc.tod().get_illuminated_time_of_day(rc.units(), rc.map(), hex);
+		return rc.tod().get_illuminated_time_of_day(rc.units(), rc.map(), hex, for_turn);
 	}
 }
 


### PR DESCRIPTION
@beetlenaut https://forums.wesnoth.org/viewtopic.php?f=12&t=49404

This allows simulating enemy attacks ~~in planning mode~~. Select an enemy unit and mouseover an own unit, you'll see a blue attack indicator arrow similar to the usual red one, and if you have highlighted_unit_weapons or selected_unit_weapons in your theme you'll see the CTH histogram in the sidebar.

(See https://forums.wesnoth.org/viewtopic.php?f=12&t=49404&p=639014#p639014 for how to add those to the theme and https://forums.wesnoth.org/viewtopic.php?f=12&t=49404&p=639014#p638934 for screenshots)

Known issues:

- [x] account for the timeofday changes between your turn and your enemy's
- [x] (should be done, but test) it should be possible to get the blue arrow and histogram even when not in planning mode
- [x] check the `if(!wb_active)` restrictions if they can be relaxed/lifted
- [x] reword commit messages
- [ ] Figure out attack indicator arrow coloring issue https://github.com/wesnoth/wesnoth/pull/3956#issuecomment-471114209
- [ ] Let the attack dialog be opened so the CTH histogram can be viewed in the default theme too https://github.com/wesnoth/wesnoth/pull/3956#issuecomment-474907377

Please review/test