### PR TITLE
UI: Highlight enemy units in "Show Enemy Moves" mode

### DIFF
--- a/src/display.hpp
+++ b/src/display.hpp
@@ -1026,7 +1026,6 @@ protected:
 	reach_map reach_map_old_;
 	bool reach_map_changed_;
 	void process_reachmap_changes();
-	std::set<map_location> units_that_can_reach_goal_;
 
 	typedef std::map<map_location, std::vector<overlay>> overlay_map;
 

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -1026,6 +1026,7 @@ protected:
 	reach_map reach_map_old_;
 	bool reach_map_changed_;
 	void process_reachmap_changes();
+	std::set<map_location> units_that_can_reach_goal_;
 
 	typedef std::map<map_location, std::vector<overlay>> overlay_map;
 

--- a/src/game_display.cpp
+++ b/src/game_display.cpp
@@ -565,16 +565,16 @@ void game_display::highlight_another_reach(const pathfind::paths &paths_list,
 	}
 	reach_map_changed_ = true;
 
-	if(goal != map_location::null_location() && paths_list.destinations.contains(goal))
-	{
-		const map_location enemy_unit_location = paths_list.destinations.get_path(paths_list.destinations.find(goal))[0];
-		units_that_can_reach_goal_.emplace(enemy_unit_location);
+	if(goal != map_location::null_location() && paths_list.destinations.contains(goal)) {
+		const auto& path_to_goal = paths_list.destinations.get_path(paths_list.destinations.find(goal));
+		const map_location enemy_unit_location = path_to_goal[0];
+		units_that_can_reach_goal_.insert(enemy_unit_location);
 	}
 }
 
 bool game_display::unhighlight_reach()
 {
-	units_that_can_reach_goal_.erase(units_that_can_reach_goal_.begin(), units_that_can_reach_goal_.end());
+	units_that_can_reach_goal_.clear();
 	if(!reach_map_.empty()) {
 		reach_map_.clear();
 		reach_map_changed_ = true;

--- a/src/game_display.cpp
+++ b/src/game_display.cpp
@@ -556,17 +556,25 @@ void game_display::highlight_reach(const pathfind::paths &paths_list)
 	highlight_another_reach(paths_list);
 }
 
-void game_display::highlight_another_reach(const pathfind::paths &paths_list)
+void game_display::highlight_another_reach(const pathfind::paths &paths_list,
+			const map_location& goal)
 {
 	// Fold endpoints of routes into reachability map.
 	for (const pathfind::paths::step &dest : paths_list.destinations) {
 		reach_map_[dest.curr]++;
 	}
 	reach_map_changed_ = true;
+
+	if(goal != map_location::null_location() && paths_list.destinations.contains(goal))
+	{
+		const map_location enemy_unit_location = paths_list.destinations.get_path(paths_list.destinations.find(goal))[0];
+		units_that_can_reach_goal_.emplace(enemy_unit_location);
+	}
 }
 
 bool game_display::unhighlight_reach()
 {
+	units_that_can_reach_goal_.erase(units_that_can_reach_goal_.begin(), units_that_can_reach_goal_.end());
 	if(!reach_map_.empty()) {
 		reach_map_.clear();
 		reach_map_changed_ = true;

--- a/src/game_display.hpp
+++ b/src/game_display.hpp
@@ -95,13 +95,13 @@ public:
 
 	/**
 	 * Add more paths to highlight.  Print numbers where they overlap.
-	 * Used by Show Enemy Moves.  If goal is not null_location, highlight
-	 * enemy units that can reach goal.
+	 * Used by Show Enemy Moves.  If @a goal is not @c null_location, highlight
+	 * enemy units that can reach @a goal.
 	 */
 	void highlight_another_reach(const pathfind::paths &paths_list,
 			const map_location& goal = map_location::null_location());
 	/**
-	 * Return the locations of units that can reach @a goal (see highlight_another_reach()).
+	 * Return the locations of units that can reach @a goal (@see highlight_another_reach()).
 	 */
 	const std::set<map_location>& units_that_can_reach_goal() const { return units_that_can_reach_goal_; }
 
@@ -150,6 +150,8 @@ protected:
 
 	/** Inherited from display. */
 	virtual overlay_map& get_overlays() override;
+
+	std::set<map_location> units_that_can_reach_goal_;
 
 public:
 	/** Set the attack direction indicator. */

--- a/src/game_display.hpp
+++ b/src/game_display.hpp
@@ -95,9 +95,15 @@ public:
 
 	/**
 	 * Add more paths to highlight.  Print numbers where they overlap.
-	 * Used only by Show Enemy Moves.
+	 * Used by Show Enemy Moves.  If goal is not null_location, highlight
+	 * enemy units that can reach goal.
 	 */
-	void highlight_another_reach(const pathfind::paths &paths_list);
+	void highlight_another_reach(const pathfind::paths &paths_list,
+			const map_location& goal = map_location::null_location());
+	/**
+	 * Return the locations of units that can reach @a goal (see highlight_another_reach()).
+	 */
+	const std::set<map_location>& units_that_can_reach_goal() const { return units_that_can_reach_goal_; }
 
 	/** Reset highlighting of paths. */
 	bool unhighlight_reach();

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -434,6 +434,9 @@ void menu_handler::show_enemy_moves(bool ignore_units, int side_num)
 {
 	wb::future_map future; // use unit positions as if all planned actions were executed
 
+	mouse_handler& mh = pc_.get_mouse_handler_base();
+	const map_location& hex_under_mouse = mh.hovered_hex();
+
 	gui_->unhighlight_reach();
 
 	// Compute enemy movement positions
@@ -446,14 +449,12 @@ void menu_handler::show_enemy_moves(bool ignore_units, int side_num)
 			const pathfind::paths& path
 					= pathfind::paths(u, false, true, teams()[gui_->viewing_team()], 0, false, ignore_units);
 
-			gui_->highlight_another_reach(path);
+			gui_->highlight_another_reach(path, hex_under_mouse);
 		}
 	}
 
 	// Find possible unit (no matter whether friend or foe) under the
 	// mouse cursor.
-	mouse_handler& mh = pc_.get_mouse_handler_base();
-	const map_location& hex_under_mouse = mh.hovered_hex();
 	const bool selected_hex_has_unit = mh.hex_hosts_unit(hex_under_mouse);
 
 	if(selected_hex_has_unit) {

--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -51,8 +51,7 @@ unit_drawer::unit_drawer(display & thedisp) :
 	hex_size(disp.hex_size()),
 	hex_size_by_2(disp.hex_size()/2)
 {
-	if(const game_display *game_display = dynamic_cast<class game_display*>(&disp))
-	{
+	if(const game_display* game_display = dynamic_cast<class game_display*>(&disp)) {
 		units_that_can_reach_goal = game_display->units_that_can_reach_goal();
 	}
 }

--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -17,6 +17,7 @@
 #include "display.hpp"
 #include "display_context.hpp"
 #include "formatter.hpp"
+#include "game_display.hpp"
 #include "preferences/game.hpp"
 #include "halo.hpp"
 #include "map/map.hpp"
@@ -49,7 +50,12 @@ unit_drawer::unit_drawer(display & thedisp) :
 	zoom_factor(disp.get_zoom_factor()),
 	hex_size(disp.hex_size()),
 	hex_size_by_2(disp.hex_size()/2)
-{}
+{
+	if(const game_display *game_display = dynamic_cast<class game_display*>(&disp))
+	{
+		units_that_can_reach_goal = game_display->units_that_can_reach_goal();
+	}
+}
 
 void unit_drawer::redraw_unit (const unit & u) const
 {
@@ -79,6 +85,9 @@ void unit_drawer::redraw_unit (const unit & u) const
 
 	std::string ellipse=u.image_ellipse();
 
+	const bool is_highlighted_enemy = units_that_can_reach_goal.count(loc) > 0;
+	const bool is_selected_hex = (loc == sel_hex || is_highlighted_enemy);
+
 	if(hidden || is_blindfolded || !u.is_visible_to_team(viewing_team_ref, show_everything)) {
 		ac.clear_haloes();
 		if(ac.anim_) {
@@ -107,7 +116,7 @@ void unit_drawer::redraw_unit (const unit & u) const
 	if(u.invisible(loc) && params.highlight_ratio > 0.6) {
 		params.highlight_ratio = 0.6;
 	}
-	if (loc == sel_hex && params.highlight_ratio == 1.0) {
+	if (is_selected_hex && params.highlight_ratio == 1.0) {
 		params.highlight_ratio = 1.5;
 	}
 
@@ -182,7 +191,7 @@ void unit_drawer::redraw_unit (const unit & u) const
 	surface ellipse_back(nullptr);
 	int ellipse_floating = 0;
 	// Always show the ellipse for selected units
-	if(draw_bars && (preferences::show_side_colors() || sel_hex == loc)) {
+	if(draw_bars && (preferences::show_side_colors() || is_selected_hex)) {
 		if(adjusted_params.submerge > 0.0) {
 			// The division by 2 seems to have no real meaning,
 			// It just works fine with the current center of ellipse
@@ -198,7 +207,7 @@ void unit_drawer::redraw_unit (const unit & u) const
 			// check if the unit has a ZoC or can recruit
 			const std::string nozoc    = !emit_zoc      ? "nozoc-"    : "";
 			const std::string leader   = can_recruit    ? "leader-"   : "";
-			const std::string selected = sel_hex == loc ? "selected-" : "";
+			const std::string selected = is_selected_hex? "selected-" : "";
 			const std::string tc       = team::get_side_color_id(side);
 
 			const std::string ellipse_top = formatter() << ellipse << "-" << leader << nozoc << selected << "top.png~RC(ellipse_red>" << tc << ")";
@@ -294,7 +303,7 @@ void unit_drawer::redraw_unit (const unit & u) const
 		const int bar_shift = static_cast<int>(-5*zoom_factor);
 		const int hp_bar_height = static_cast<int>(max_hitpoints * u.hp_bar_scaling());
 
-		const fixed_t bar_alpha = (loc == mouse_hex || loc == sel_hex) ? ftofxp(1.0): ftofxp(0.8);
+		const fixed_t bar_alpha = (loc == mouse_hex || is_selected_hex) ? ftofxp(1.0): ftofxp(0.8);
 
 		draw_bar(*energy_file, xsrc+xoff+bar_shift, ysrc+yoff+adjusted_params.y,
 			loc, hp_bar_height, unit_energy,hp_color, bar_alpha);

--- a/src/units/drawer.hpp
+++ b/src/units/drawer.hpp
@@ -60,6 +60,7 @@ private:
 	map_location sel_hex;
 	map_location mouse_hex;
 	double zoom_factor;
+	std::set<map_location> units_that_can_reach_goal;
 
 	int hex_size;
 	int hex_size_by_2;


### PR DESCRIPTION
Fixes #1989 

Screenshot:
![screenshot_2019-03-03_15-01-33](https://user-images.githubusercontent.com/24784687/53697089-70b0d700-3dc5-11e9-96fb-798af64f0d48.png)

Does the implementation look right? I put the new member function in `game_display` next to the other reach functions, but then I had to use a `dynamic_cast` in unit_drawer because it can be constructed from a plain `display`: https://github.com/wesnoth/wesnoth/blob/53baf3514a8db2a96c6c5fae4d40af76b7e164f4/src/display.cpp#L2536