### PR TITLE
Fix crash after hitting enter when no units match the recruit list filter

### DIFF
--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -278,7 +278,12 @@ void menu_handler::recruit(int side_num, const map_location& last_hex)
 
 	if(dlg.show()) {
 		map_location recruit_hex = last_hex;
-		do_recruit(sample_units[dlg.get_selected_index()]->id(), side_num, recruit_hex);
+		int index = dlg.get_selected_index();
+		if (index < 0) {
+			gui2::show_transient_message("", _("No unit recruited"));
+			return;
+		}
+		do_recruit(sample_units[index]->id(), side_num, recruit_hex);
 	}
 }
 


### PR DESCRIPTION
This is essentially the same as https://github.com/wesnoth/wesnoth/pull/3476, except that it is applied to the recruit dialog rather than the recall dialog.