### PR TITLE
Unhide recruited unit when both the recruiter and recruitee are invisible to the viewing team

### DIFF
--- a/src/units/udisplay.cpp
+++ b/src/units/udisplay.cpp
@@ -31,6 +31,7 @@
 #include "units/animation_component.hpp"
 #include "units/filter.hpp"
 #include "units/map.hpp"
+#include "utils/scope_exit.hpp"
 
 #define LOG_DP LOG_STREAM(info, display)
 
@@ -746,30 +747,30 @@ void unit_recruited(const map_location& loc,const map_location& leader_loc)
 	unit_map::const_iterator leader = disp->get_units().find(leader_loc); // may be null_location
 	const bool leader_visible = (leader != disp->get_units().end()) && leader->is_visible_to_team(viewing_team, false);
 
-	// TODO: Use a RAII object such as wb::temporary_unit_hider
-	u->set_hidden(true);
-
 	unit_animator animator;
 
-	if (leader_visible && unit_visible) {
-		disp->scroll_to_tiles(loc,leader_loc,game_display::ONSCREEN,true,0.0,false);
-	} else if (leader_visible) {
-		disp->scroll_to_tile(leader_loc,game_display::ONSCREEN,true,false);
-	} else if (unit_visible) {
-		disp->scroll_to_tile(loc,game_display::ONSCREEN,true,false);
-	} else {
-		u->set_hidden(false);
-		return;
-	}
-	if (leader != disp->get_units().end()) {
-		leader->set_facing(leader_loc.get_relative_dir(loc));
-		if (leader_visible) {
-			animator.add_animation(&*leader, "recruiting", leader_loc, loc, 0, true);
-		}
-	}
+	{
+		utils::scope_exit se([u] () { u->set_hidden(false); });
+		u->set_hidden(true);
 
-	disp->draw();
-	u->set_hidden(false);
+		if (leader_visible && unit_visible) {
+			disp->scroll_to_tiles(loc,leader_loc,game_display::ONSCREEN,true,0.0,false);
+		} else if (leader_visible) {
+			disp->scroll_to_tile(leader_loc,game_display::ONSCREEN,true,false);
+		} else if (unit_visible) {
+			disp->scroll_to_tile(loc,game_display::ONSCREEN,true,false);
+		} else {
+			return;
+		}
+		if (leader != disp->get_units().end()) {
+			leader->set_facing(leader_loc.get_relative_dir(loc));
+			if (leader_visible) {
+				animator.add_animation(&*leader, "recruiting", leader_loc, loc, 0, true);
+			}
+		}
+
+		disp->draw();
+	}
 	animator.add_animation(&*u, "recruited", loc, leader_loc);
 	animator.start_animations();
 	animator.wait_for_end();

--- a/src/units/udisplay.cpp
+++ b/src/units/udisplay.cpp
@@ -746,6 +746,7 @@ void unit_recruited(const map_location& loc,const map_location& leader_loc)
 	unit_map::const_iterator leader = disp->get_units().find(leader_loc); // may be null_location
 	const bool leader_visible = (leader != disp->get_units().end()) && leader->is_visible_to_team(viewing_team, false);
 
+	// TODO: Use a RAII object such as wb::temporary_unit_hider
 	u->set_hidden(true);
 
 	unit_animator animator;
@@ -757,6 +758,7 @@ void unit_recruited(const map_location& loc,const map_location& leader_loc)
 	} else if (unit_visible) {
 		disp->scroll_to_tile(loc,game_display::ONSCREEN,true,false);
 	} else {
+		u->set_hidden(false);
 		return;
 	}
 	if (leader != disp->get_units().end()) {


### PR DESCRIPTION
The `return;` prevents the `set_hidden(false);` later in the function from being reached. This looks wrong, as though it would be a regression introduced by #3559, but I found no difference in my testing.

I found this while auditing code in search of a bug reported by @Konrad22 on discord. (In a nutshell, he played EI S17a and at the start of turn 6 an enemy Shadow was adjacent to Konrad's units but had `hidden=yes`.)