### PR TITLE
Visual Studio 2019 Compilation - master

### DIFF
--- a/src/quit_confirmation.hpp
+++ b/src/quit_confirmation.hpp
@@ -18,6 +18,7 @@ class CVideo;
 
 #include <cassert>
 #include <vector>
+#include <string>
 
 #include "utils/functional.hpp"
 

--- a/src/synced_commands.hpp
+++ b/src/synced_commands.hpp
@@ -16,6 +16,7 @@
 
 #include <map>
 #include <exception>
+#include <string>
 
 #include "utils/functional.hpp"
 


### PR DESCRIPTION
I'm not sure if this is the best way to resolve the compilation errors (how was std::string defined previously?) but maybe it's a case of MSVC compiler being more strict somewhere.