### PR TITLE
Do a better job of catching pbl parse errors for addons

### DIFF
--- a/src/addon/manager.hpp
+++ b/src/addon/manager.hpp
@@ -48,14 +48,14 @@ struct invalid_pbl_exception : public std::exception
 	/** Destructor.
 	 * Virtual to allow for subclassing.
 	 */
-	virtual ~invalid_pbl_exception() BOOST_NOEXCEPT (){}
+	virtual ~invalid_pbl_exception() BOOST_NOEXCEPT {}
 
 	/** Returns a pointer to the (constant) error description.
 	 *  @return A pointer to a const char*. The underlying memory
 	 *          is in posession of the Exception object. Callers must
 	 *          not attempt to free the memory.
 	 */
-	virtual const char* what() const BOOST_NOEXCEPT (){
+	virtual const char* what() const BOOST_NOEXCEPT {
 		return message.c_str();
 	}
 };

--- a/src/addon/manager.hpp
+++ b/src/addon/manager.hpp
@@ -27,7 +27,7 @@ class version_info;
 /**
  * Exception thrown when the WML parser fails to read a .pbl file.
  */
-struct invalid_pbl_exception
+struct invalid_pbl_exception : public std::exception
 {
 	/**
 	 * Constructor.
@@ -44,6 +44,20 @@ struct invalid_pbl_exception
 
 	/** Error message to display. */
 	const std::string message;
+
+	/** Destructor.
+	 * Virtual to allow for subclassing.
+	 */
+	virtual ~invalid_pbl_exception() throw (){}
+
+	/** Returns a pointer to the (constant) error description.
+	 *  @return A pointer to a const char*. The underlying memory
+	 *          is in posession of the Exception object. Callers must
+	 *          not attempt to free the memory.
+	 */
+	virtual const char* what() const throw (){
+		return message.c_str();
+	}
 };
 
 bool remove_local_addon(const std::string& addon);

--- a/src/addon/manager.hpp
+++ b/src/addon/manager.hpp
@@ -23,7 +23,6 @@ class version_info;
 #include <string>
 #include <vector>
 #include <utility>
-#include <boost/throw_exception.hpp>
 
 /**
  * Exception thrown when the WML parser fails to read a .pbl file.
@@ -49,14 +48,14 @@ struct invalid_pbl_exception : public std::exception
 	/** Destructor.
 	 * Virtual to allow for subclassing.
 	 */
-	virtual ~invalid_pbl_exception() BOOST_NOEXCEPT {}
+	virtual ~invalid_pbl_exception() noexcept {}
 
 	/** Returns a pointer to the (constant) error description.
 	 *  @return A pointer to a const char*. The underlying memory
 	 *          is in posession of the Exception object. Callers must
 	 *          not attempt to free the memory.
 	 */
-	virtual const char* what() const BOOST_NOEXCEPT {
+	virtual const char* what() const noexcept {
 		return message.c_str();
 	}
 };

--- a/src/addon/manager.hpp
+++ b/src/addon/manager.hpp
@@ -48,14 +48,14 @@ struct invalid_pbl_exception : public std::exception
 	/** Destructor.
 	 * Virtual to allow for subclassing.
 	 */
-	virtual ~invalid_pbl_exception() throw (){}
+	virtual ~invalid_pbl_exception() BOOST_NOEXCEPT (){}
 
 	/** Returns a pointer to the (constant) error description.
 	 *  @return A pointer to a const char*. The underlying memory
 	 *          is in posession of the Exception object. Callers must
 	 *          not attempt to free the memory.
 	 */
-	virtual const char* what() const throw (){
+	virtual const char* what() const BOOST_NOEXCEPT (){
 		return message.c_str();
 	}
 };

--- a/src/addon/manager.hpp
+++ b/src/addon/manager.hpp
@@ -23,6 +23,7 @@ class version_info;
 #include <string>
 #include <vector>
 #include <utility>
+#include <boost/throw_exception.hpp>
 
 /**
  * Exception thrown when the WML parser fails to read a .pbl file.

--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -405,7 +405,17 @@ void game_config_manager::load_addons_cfg()
 
 		if(have_addon_pbl_info(addon_id)) {
 			// Publishing info needs to be read from disk.
-			metadata = get_addon_pbl_info(addon_id);
+			try {
+				metadata = get_addon_pbl_info(addon_id);
+			} catch(const invalid_pbl_exception& e) {
+				const std::string log_msg = formatter()
+				<< "The provided addon has an invalid pbl file"
+				<< " for addon "
+				<< addon_id;
+
+				error_addons.push_back(e.message);
+				error_log.push_back(log_msg);
+			}
 		} else if(filesystem::file_exists(info_cfg)) {
 			// Addon server-generated info can be fetched from cache.
 			config temp;


### PR DESCRIPTION
#3971 
Fail gracefully when an addon has an invalid pbl file, and make sure to push errors to the log and addon errors.

Should I include the pbl path somewhere in the logging?