### PR TITLE
Dark forecast backport [WIP]

### DIFF
--- a/data/multiplayer/scenarios/2p_Dark_Forecast.cfg
+++ b/data/multiplayer/scenarios/2p_Dark_Forecast.cfg
@@ -186,12 +186,32 @@ The weather will also change randomly, affecting the layout of the map.
         [/message]
     [/event]
 
+    # 1.14 workaround for bug 3981
     [event]
         name="turn 1"
         [set_variable]
             name="next_final_spawn"
             value="$($final_turn + 2)"
         [/set_variable]
+    [/event]
+
+    # 1.14 workaround for bug 3890
+    [event]
+        name=unit placed
+        first_time_only=no
+        [filter]
+            side=1,2
+            [filter_location]
+                terrain=*^V*
+            [/filter_location]
+        [/filter]
+
+        [capture_village]
+            x,y=$x1,$y1
+            [filter_side]
+                side=1
+            [/filter_side]
+        [/capture_village]
     [/event]
 
     [event]


### PR DESCRIPTION
1.14 OOS save backport of 05cd152

Don't merge yet, as it's not tested. Closes #3890.

@Vultraz might rename 1.14.8 milestone to 1.14.9