### PR TITLE
DiD S09: Unblock the book if one of DV's units is standing on it, clarify objectives

### DIFF
--- a/data/campaigns/Descent_Into_Darkness/maps/09_A_Small_Favor3.map
+++ b/data/campaigns/Descent_Into_Darkness/maps/09_A_Small_Favor3.map
@@ -6,7 +6,7 @@ Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xos, Xos, Uu^Em, Uh^Em, Uu^Em, Uu, Uu^Es, Uu, Ur
 Xu, Xu, Xu, Xu, Xu, Xu, Xos, Xos, Xos, Xos, Uh^Emf, Uu^Em, Uu, Uu^Es, Uu, Ur^Es, Urb, Urb, Urb, Urb, Urb, Ur, Ur^Es, Uu^Em, Uu^Ebn, Xom^Efs, Ur, Ur, Uu^Em, Ur, Xuc, Ur^Es, Ur, Uu^Em, Xu, Xos, Xos
 Xu, Xu, Xu, Xu, Xu, Xu, Xos, Xos, Uu, Uh, Uu^Em, Uu^Ii, Ur, Ur^Es, Ur^Ii, Xoc, Urb, Urb, Urb, Urb, Urb, Ur^Es, Ur, Uu, Ur, Ur^Es, Ur^Es, Uu^Emf, Xom, Xuc, Xos, Xu, Xu, Xu, Xos, Xos, Xos
 Xu, Xu, Xu, Xu, Xu, Xos, Xol, Xos, Ur, Ur, Ur^Es, Ur, Xoc, Irs, Irs, Irs, Urb, Urb, Xos, Urb, Urb, Urb, Urb, Ur^Es, Urb, Uu, Uu, Uu^Em, Xol^Efs, Xos, Uu^Emf, Xu, Xu, Xu, Xu, Xu, Xos
-Xu, Xu, Xu, Xu, Xu, Xol, Uu^Em, Ur^Ebn, Ur^Es, Irs, Irs, Irs, Icr^Ii, Irs, Irs, Irs, Irs, Urb, Urb, Urb, Urb, Urb, Ur^Es, Ur, Urb, Urb, Xos, Urb^Pr/, Urb, Ur, Ur^Eb, Uu^Uf, Uu^Uf, Xu, Xu, Xu, Xos
+Xu, Xu, Xu, Xu, Xu, Xol, Uu^Em, Ur^Ebn, Ur^Es, Irs, Irs, Irs, book_start Icr^Ii, Irs, Irs, Irs, Irs, Urb, Urb, Urb, Urb, Urb, Ur^Es, Ur, Urb, Urb, Xos, Urb^Pr/, Urb, Ur, Ur^Eb, Uu^Uf, Uu^Uf, Xu, Xu, Xu, Xos
 Xu, Xu, Xu, Xu, Uh^Em, Uu^Em, Uu^Ii, Ur^Es, Ur, Xoc, Irs^Ii, Irs, Irs, Irs, Irs^Ii, Xoc, Irs, Urb, Ur, Urb, Urb, Xos, Ur^Es, Ur, Xos, Urb^Pr/, Urb, Urb, Urb, Urb, Uu^Em, Uu^Emf, Urb^Pr/, Xos, Xos, Xu, Xu
 Xu, Xu, Uh^Uf, Uh^Emf, Uu^Em, Uu, Uu, Uu^Em, Ur, Ur^Es, Ur, Ur^Es, Xos, Irs, Irs, Irs, Urb, Ur^Es, Xos, Ur^Es, Ur, Ur^Es, Xos, Xos, Xos, Xol, Xol, Urb, Urb, Ur^Es, Xos, Xos, Xu, Uu^Em, Uh^Uf, Xu, Xu
 Xu, Xu, Uh^Uf, Uu^Uf, Uh^Emf, Uh^Em, Uu^Ii, Ur, Uu, Ur^Es, Uu, Ur, Uu, Ur^Es, Urb, Urb, Urb, Urb, Urb, Urb, Ur^Pr/, Xos, Urc, Urc, Urc, Xol, Xol, Xol, Xol, Ur^Pr/, Ur^Es, Xu, Xu, Uu^Em, Uh^Emf, Xu, Xos

--- a/data/campaigns/Descent_Into_Darkness/scenarios/09_A_Small_Favor3.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/09_A_Small_Favor3.cfg
@@ -103,9 +103,6 @@
     # This macro places the doors and adds the door-opening event
     {MANOR_DOORS 1,3}
 
-    # book
-    {PLACE_IMAGE items/book5.png 12 8}
-
     # scenery
 
     {PLACE_IMAGE items/dragonstatue.png 23 16}
@@ -188,6 +185,12 @@
 
     [event]
         name=prestart
+
+        # place the book's image
+        [item]
+            location_id=book_start
+            image="items/book5.png"
+        [/item]
 
         [objectives]
             side=1
@@ -491,8 +494,10 @@
                         greater_than=4
                     [/variable]
                     [then]
-                        {VARIABLE dest.x 12}
-                        {VARIABLE dest.y 8}
+                        [store_locations]
+                            location_id=book_start
+                            variable=dest
+                        [/store_locations]
                     [/then]
                     [else]
                         {VARIABLE dest.x 16}
@@ -539,6 +544,45 @@
         [/unstore_unit]
 
         {CLEAR_VARIABLE stored_Darken,dest,darken_goto,index}
+    [/event]
+
+    # If there are no enemies, then DV's troops won't move; this event unblocks the book if necessary.
+    [event]
+        name=side 3 turn refresh
+        first_time_only=no
+        [filter_condition]
+            [variable]
+                name=hasBook
+                equals=none
+            [/variable]
+            [have_unit]
+                # This won't be DV himself, otherwise hasBook is not none.
+                side=3
+                [filter_location]
+                    location_id=book_start
+                [/filter_location]
+            [/have_unit]
+            [not]
+                [have_unit]
+                    # Ignore side=4, the city guard is (hopefully for the player) not near the book.
+                    side=2
+                    [filter_vision]
+                        # There are 3 entrance rooms, one of them might still have all of its doors shut.
+                        side=3
+                    [/filter_vision]
+                [/have_unit]
+            [/not]
+        [/filter_condition]
+        [modify_unit]
+            [filter]
+                [filter_location]
+                    location_id=book_start
+                [/filter_location]
+            [/filter]
+            # Somewhere inside the tunnel, but out-of-the-way for the hexes that Malin must move to.
+            goto_x=29
+            goto_y=2
+        [/modify_unit]
     [/event]
 
     # pursuer spawns
@@ -816,7 +860,9 @@ Existence churns and the soul is reborn into endless night.</i>"
         [filter]
             side=1
             canrecruit=no
-            x,y=12,8
+            [filter_location]
+                location_id=book_start
+            [/filter_location]
         [/filter]
         [filter_condition]
             [variable]
@@ -826,13 +872,17 @@ Existence churns and the soul is reborn into endless night.</i>"
         [/filter_condition]
 
         [message]
-            x,y=12,8
+            [filter_location]
+                location_id=book_start
+            [/filter_location]
             message=_ "I have found the book, master!"
         [/message]
 
         [if]
             [have_unit]
-                x,y=12,8
+                [filter_location]
+                    location_id=book_start
+                [/filter_location]
                 race=undead
             [/have_unit]
             [then]
@@ -857,7 +907,9 @@ Existence churns and the soul is reborn into endless night.</i>"
         name=moveto
         [filter]
             id=Malin Keshar
-            x,y=12,8
+            [filter_location]
+                location_id=book_start
+            [/filter_location]
         [/filter]
         [filter_condition]
             [variable]
@@ -867,7 +919,7 @@ Existence churns and the soul is reborn into endless night.</i>"
         [/filter_condition]
 
         [remove_item]
-            x,y=12,8
+            location_id=book_start
         [/remove_item]
 
         {VARIABLE hasBook Malin}
@@ -936,7 +988,9 @@ Existence churns and the soul is reborn into endless night.</i>"
         name=moveto
         [filter]
             id=Darken Volk
-            x,y=12,8
+            [filter_location]
+                location_id=book_start
+            [/filter_location]
         [/filter]
         [filter_condition]
             [variable]
@@ -946,16 +1000,18 @@ Existence churns and the soul is reborn into endless night.</i>"
         [/filter_condition]
 
         [remove_item]
-            x,y=12,8
+            location_id=book_start
         [/remove_item]
 
         {VARIABLE hasBook Darken}
 
+        # A second, non-silent, update triggers when DV moves again (next turn, he's still set to go to the book_start hex this turn).
         [objectives]
             side=1
+            silent=yes
             [objective]
                 condition=win
-                description= _ "Escape the manor"
+                description= _ "Escape via the tunnel in the northeast cellar"
             [/objective]
             [objective]
                 condition=lose
@@ -993,6 +1049,28 @@ Existence churns and the soul is reborn into endless night.</i>"
                 speaker=Malin Keshar
                 message= _ "Wait, you aren’t leaving me behind, are you?"
             [/message]
+
+            [objectives]
+                side=1
+                [objective]
+                    condition=win
+                    description= _ "Escape the manor (Malin reaches the tunnel in the northeast cellar before Darken Volk)"
+                [/objective]
+                [objective]
+                    condition=lose
+                    description= _ "Darken Volk reaches the tunnel before Malin does"
+                [/objective]
+                [objective]
+                    condition=lose
+                    description= _ "Death of Malin Keshar"
+                [/objective]
+                [objective]
+                    condition=lose
+                    description= _ "Death of Darken Volk"
+                [/objective]
+
+                {TURNS_RUN_OUT}
+            [/objectives]
         [/event]
 
         [event]


### PR DESCRIPTION
Refactor to using location_id for the location of the book, because it appears
multiple times in the .cfg file.

An edge case to this edge case: if DV's turn starts with DV next to the book
and one of DV's units on the book, DV doesn't move until the next turn.  This
was also true if the unit moved to attack something, and works in the player's
favor, as it gives Malin an extra turn to grab the book, so I'm treating it as
a feature.

If DV does grab the book, explicitly say in the objectives that it's now a race
to the escape tunnel. This means that the objectives dialog is shown twice:
* DV takes the book (no messages at all)
* start of player's turn: objectives shown (escape to win, deaths to lose)
* player ends turn
* DV moves, Malin asks if he's going to be left behind
* start of player's turn: objectives shown (race to win)

@nemaara , please would you comment on this? Should I drop the changes that aren't specifically about unblocking the book?