### PR TITLE
Add actual/expected hit count stats to stats dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,7 +203,7 @@ endif(NOT DEFINED CXX_FLAGS_USER)
 set(COMPILER_FLAGS "-std=c++${CXX_STD} -Wall -Wextra -Werror=non-virtual-dtor -Wno-unused-local-typedefs -Wno-maybe-uninitialized -Wold-style-cast -Wtrampolines")
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-	set(COMPILER_FLAGS "${COMPILER_FLAGS} -Qunused-arguments -Wno-unknown-warning-option -Wmismatched-tags -Wno-conditional-uninitialized")
+	set(COMPILER_FLAGS "${COMPILER_FLAGS} -Qunused-arguments -Wno-unknown-warning-option -Wmismatched-tags -Wno-conditional-uninitialized -Wno-unused-lambda-capture")
 endif()
 
 ### Set strict compiler flags.

--- a/SConstruct
+++ b/SConstruct
@@ -482,7 +482,7 @@ for env in [test_env, client_env, env]:
 
     if "clang" in env["CXX"]:
 # Silence warnings about unused -I options and unknown warning switches.
-        env.AppendUnique(CCFLAGS = Split("-Qunused-arguments -Wno-unknown-warning-option -Wmismatched-tags -Wno-conditional-uninitialized"))
+        env.AppendUnique(CCFLAGS = Split("-Qunused-arguments -Wno-unknown-warning-option -Wmismatched-tags -Wno-conditional-uninitialized -Wno-unused-lambda-capture"))
 
         if env['pedantic']:
             env.AppendUnique(CXXFLAGS = Split("-Wdocumentation -Wno-documentation-deprecated-sync"))

--- a/data/gui/window/statistics_dialog.cfg
+++ b/data/gui/window/statistics_dialog.cfg
@@ -150,8 +150,32 @@
 
 					[label]
 						definition = "default_small"
+						label = _ "" # percentage
+						linked_group = "detail"
+					[/label]
+				[/column]
+
+				[column]
+					horizontal_grow = true
+					border = "all"
+					border_size = 5
+
+					[label]
+						definition = "default_small"
 						label = _ "This Turn"
 						linked_group = "cost"
+					[/label]
+				[/column]
+
+				[column]
+					horizontal_grow = true
+					border = "all"
+					border_size = 5
+
+					[label]
+						definition = "default_small"
+						label = _ "" # percentage
+						linked_group = "detail"
 					[/label]
 				[/column]
 
@@ -197,6 +221,20 @@
 										id = {colid_overall}
 										definition = "default_small"
 										linked_group = "detail"
+									[/label]
+								[/column]
+
+								[column]
+									grow_factor = 0
+									border = "all"
+									border_size = 5
+									horizontal_grow = false
+
+									[label]
+										id = "overall_percent"
+										definition = "default_small"
+										linked_group = "detail"
+										text_alignment = "right"
 										use_markup = true
 									[/label]
 								[/column]
@@ -211,6 +249,20 @@
 										id = {colid_this_turn}
 										definition = "default_small"
 										linked_group = "cost"
+									[/label]
+								[/column]
+
+								[column]
+									grow_factor = 0
+									border = "all"
+									border_size = 5
+									horizontal_grow = false
+
+									[label]
+										id = "this_turn_percent"
+										definition = "default_small"
+										linked_group = "detail"
+										text_alignment = "right"
 										use_markup = true
 									[/label]
 								[/column]

--- a/data/gui/window/statistics_dialog.cfg
+++ b/data/gui/window/statistics_dialog.cfg
@@ -197,6 +197,7 @@
 										id = {colid_overall}
 										definition = "default_small"
 										linked_group = "detail"
+										use_markup = true
 									[/label]
 								[/column]
 
@@ -210,6 +211,7 @@
 										id = {colid_this_turn}
 										definition = "default_small"
 										linked_group = "cost"
+										use_markup = true
 									[/label]
 								[/column]
 

--- a/data/gui/window/statistics_dialog.cfg
+++ b/data/gui/window/statistics_dialog.cfg
@@ -150,7 +150,7 @@
 
 					[label]
 						definition = "default_small"
-						label = _ "" # percentage
+						label = "" # percentage
 						linked_group = "detail"
 					[/label]
 				[/column]
@@ -174,7 +174,7 @@
 
 					[label]
 						definition = "default_small"
-						label = _ "" # percentage
+						label = "" # percentage
 						linked_group = "detail"
 					[/label]
 				[/column]

--- a/data/gui/window/statistics_dialog.cfg
+++ b/data/gui/window/statistics_dialog.cfg
@@ -108,9 +108,9 @@
 	[/listbox]
 #enddef
 
-#define _GUI_DAMAGE_STATS_LIST top_left_label overall_id colid_type colid_overall colid_this_turn ratio_tooltip percent_tooltip
+#define _GUI_DAMAGE_STATS_LIST TOP_LEFT_LABEL OVERALL_ID COLID_TYPE COLID_OVERALL COLID_THIS_TURN RATIO_TOOLTIP PERCENT_TOOLTIP
 	[listbox]
-		id = {overall_id}
+		id = {OVERALL_ID}
 		definition = "default"
 
 		horizontal_scrollbar_mode = "never"
@@ -126,7 +126,7 @@
 
 					[label]
 						definition = "default_small"
-						label = {top_left_label}
+						label = {TOP_LEFT_LABEL}
 						linked_group = "type"
 					[/label]
 				[/column]
@@ -181,7 +181,7 @@
 									horizontal_grow = true
 
 									[label]
-										id = {colid_type}
+										id = {COLID_TYPE}
 										definition = "default"
 										linked_group = "type"
 									[/label]
@@ -203,9 +203,9 @@
                                                 horizontal_grow = true
 
                                                 [label]
-                                                    id = {colid_overall}
+                                                    id = {COLID_OVERALL}
                                                     definition = "default_small"
-                                                    tooltip = {ratio_tooltip}
+                                                    tooltip = {RATIO_TOOLTIP}
                                                 [/label]
                                             [/column]
 
@@ -220,7 +220,7 @@
                                                     definition = "default_small"
                                                     text_alignment = "right"
                                                     use_markup = true
-                                                    tooltip = {percent_tooltip}
+                                                    tooltip = {PERCENT_TOOLTIP}
                                                 [/label]
                                             [/column]
 
@@ -252,9 +252,9 @@
                                                 horizontal_grow = true
 
                                                 [label]
-                                                    id = {colid_this_turn}
+                                                    id = {COLID_THIS_TURN}
                                                     definition = "default_small"
-                                                    tooltip = {ratio_tooltip}
+                                                    tooltip = {RATIO_TOOLTIP}
                                                 [/label]
                                             [/column]
 
@@ -269,7 +269,7 @@
                                                     definition = "default_small"
                                                     text_alignment = "right"
                                                     use_markup = true
-                                                    tooltip = {percent_tooltip}
+                                                    tooltip = {PERCENT_TOOLTIP}
                                                 [/label]
                                             [/column]
 

--- a/data/gui/window/statistics_dialog.cfg
+++ b/data/gui/window/statistics_dialog.cfg
@@ -565,7 +565,7 @@
 											{_GUI_DAMAGE_STATS_LIST
 											 (_ "Hits") stats_list_hits hits_type hits_overall hits_this_turn
 											 (_"stats dialog^Number of hits (actual / expected)")
-											 (_"stats dialog^<i>A priori</i> probabilities of hitting less than, exactly, and more than the actual number of hits")}
+											 (_"stats dialog^<i>A priori</i> probabilities of hitting less than and more than the actual number of hits")}
 										[/column]
 
 									[/row]

--- a/data/gui/window/statistics_dialog.cfg
+++ b/data/gui/window/statistics_dialog.cfg
@@ -150,32 +150,8 @@
 
 					[label]
 						definition = "default_small"
-						label = "" # percentage
-						linked_group = "detail"
-					[/label]
-				[/column]
-
-				[column]
-					horizontal_grow = true
-					border = "all"
-					border_size = 5
-
-					[label]
-						definition = "default_small"
 						label = _ "This Turn"
 						linked_group = "cost"
-					[/label]
-				[/column]
-
-				[column]
-					horizontal_grow = true
-					border = "all"
-					border_size = 5
-
-					[label]
-						definition = "default_small"
-						label = "" # percentage
-						linked_group = "detail"
 					[/label]
 				[/column]
 
@@ -201,7 +177,7 @@
 								[column]
 									grow_factor = 1
 									border = "all"
-									border_size = 5
+									border_size = 0
 									horizontal_grow = true
 
 									[label]
@@ -211,65 +187,95 @@
 									[/label]
 								[/column]
 
-								[column]
-									grow_factor = 1
-									border = "all"
-									border_size = 5
-									horizontal_grow = true
+                                [column]
+                                    grow_factor = 1
+                                    border = "all"
+                                    border_size = 0
+                                    horizontal_grow = true
+                                    [grid]
+                                        linked_group = "detail"
+                                        [row]
 
-									[label]
-										id = {colid_overall}
-										definition = "default_small"
-										linked_group = "detail"
-										tooltip = {ratio_tooltip}
-									[/label]
-								[/column]
+                                            [column]
+                                                grow_factor = 1
+                                                border = "all"
+                                                border_size = 5
+                                                horizontal_grow = true
 
-								[column]
-									grow_factor = 0
-									border = "all"
-									border_size = 5
-									horizontal_grow = false
+                                                [label]
+                                                    id = {colid_overall}
+                                                    definition = "default_small"
+                                                    tooltip = {ratio_tooltip}
+                                                [/label]
+                                            [/column]
 
-									[label]
-										id = "overall_percent"
-										definition = "default_small"
-										linked_group = "detail"
-										text_alignment = "right"
-										use_markup = true
-										tooltip = {percent_tooltip}
-									[/label]
-								[/column]
+                                            [column]
+                                                grow_factor = 0
+                                                border = "all"
+                                                border_size = 5
+                                                horizontal_grow = false
 
-								[column]
-									grow_factor = 1
-									border = "all"
-									border_size = 5
-									horizontal_grow = true
+                                                [label]
+                                                    id = "overall_percent"
+                                                    definition = "default_small"
+                                                    text_alignment = "right"
+                                                    use_markup = true
+                                                    tooltip = {percent_tooltip}
+                                                [/label]
+                                            [/column]
 
-									[label]
-										id = {colid_this_turn}
-										definition = "default_small"
-										linked_group = "cost"
-										tooltip = {ratio_tooltip}
-									[/label]
-								[/column]
+                                            [column]
 
-								[column]
-									grow_factor = 0
-									border = "all"
-									border_size = 5
-									horizontal_grow = false
+                                                # Spacer to make up for showing only one percentage, not two as in the next table
+                                                [spacer]
+                                                    width=10 # TODO: Wild guess. Feel free to adjust
+                                                [/spacer]
+                                            [/column]
 
-									[label]
-										id = "this_turn_percent"
-										definition = "default_small"
-										linked_group = "detail"
-										text_alignment = "right"
-										use_markup = true
-										tooltip = {percent_tooltip}
-									[/label]
-								[/column]
+                                        [/row]
+                                    [/grid]
+                                [/column]
+
+                                [column]
+                                    grow_factor = 1
+                                    border = "all"
+                                    border_size = 0
+                                    horizontal_grow = true
+                                    [grid]
+                                        linked_group = "cost"
+                                        [row]
+
+                                            [column]
+                                                grow_factor = 1
+                                                border = "all"
+                                                border_size = 5
+                                                horizontal_grow = true
+
+                                                [label]
+                                                    id = {colid_this_turn}
+                                                    definition = "default_small"
+                                                    tooltip = {ratio_tooltip}
+                                                [/label]
+                                            [/column]
+
+                                            [column]
+                                                grow_factor = 0
+                                                border = "all"
+                                                border_size = 5
+                                                horizontal_grow = false
+
+                                                [label]
+                                                    id = "this_turn_percent"
+                                                    definition = "default_small"
+                                                    text_alignment = "right"
+                                                    use_markup = true
+                                                    tooltip = {percent_tooltip}
+                                                [/label]
+                                            [/column]
+
+                                        [/row]
+                                    [/grid]
+                                [/column]
 
 							[/row]
 

--- a/data/gui/window/statistics_dialog.cfg
+++ b/data/gui/window/statistics_dialog.cfg
@@ -176,8 +176,8 @@
 
 								[column]
 									grow_factor = 1
-									border = "all"
-									border_size = 0
+									border = "left"
+									border_size = 5
 									horizontal_grow = true
 
 									[label]
@@ -189,8 +189,8 @@
 
                                 [column]
                                     grow_factor = 1
-                                    border = "all"
-                                    border_size = 0
+                                    border = "left"
+                                    border_size = -5
                                     horizontal_grow = true
                                     [grid]
                                         linked_group = "detail"

--- a/data/gui/window/statistics_dialog.cfg
+++ b/data/gui/window/statistics_dialog.cfg
@@ -190,7 +190,7 @@
                                 [column]
                                     grow_factor = 1
                                     border = "left"
-                                    border_size = -5
+                                    border_size = 0
                                     horizontal_grow = true
                                     [grid]
                                         linked_group = "detail"

--- a/data/gui/window/statistics_dialog.cfg
+++ b/data/gui/window/statistics_dialog.cfg
@@ -108,9 +108,9 @@
 	[/listbox]
 #enddef
 
-#define _GUI_DAMAGE_STATS_LIST
+#define _GUI_DAMAGE_STATS_LIST top_left_label overall_id colid_type colid_overall colid_this_turn
 	[listbox]
-		id = "stats_list_damage"
+		id = {overall_id}
 		definition = "default"
 
 		horizontal_scrollbar_mode = "never"
@@ -126,7 +126,7 @@
 
 					[label]
 						definition = "default_small"
-						label = _ "Damage"
+						label = {top_left_label}
 						linked_group = "type"
 					[/label]
 				[/column]
@@ -181,7 +181,7 @@
 									horizontal_grow = true
 
 									[label]
-										id = "damage_type"
+										id = {colid_type}
 										definition = "default"
 										linked_group = "type"
 									[/label]
@@ -194,7 +194,7 @@
 									horizontal_grow = true
 
 									[label]
-										id = "damage_overall"
+										id = {colid_overall}
 										definition = "default_small"
 										linked_group = "detail"
 									[/label]
@@ -207,7 +207,7 @@
 									horizontal_grow = true
 
 									[label]
-										id = "damage_this_turn"
+										id = {colid_this_turn}
 										definition = "default_small"
 										linked_group = "cost"
 									[/label]
@@ -481,7 +481,21 @@
 											horizontal_grow = true
 											vertical_grow = true
 
-											{_GUI_DAMAGE_STATS_LIST}
+											{_GUI_DAMAGE_STATS_LIST (_ "Damage") stats_list_damage damage_type damage_overall damage_this_turn}
+										[/column]
+
+									[/row]
+
+									[row]
+										grow_factor = 1
+
+										[column]
+											border = "all"
+											border_size = 5
+											horizontal_grow = true
+											vertical_grow = true
+
+											{_GUI_DAMAGE_STATS_LIST (_ "Hits") stats_list_hits hits_type hits_overall hits_this_turn}
 										[/column]
 
 									[/row]

--- a/data/gui/window/statistics_dialog.cfg
+++ b/data/gui/window/statistics_dialog.cfg
@@ -108,7 +108,7 @@
 	[/listbox]
 #enddef
 
-#define _GUI_DAMAGE_STATS_LIST top_left_label overall_id colid_type colid_overall colid_this_turn
+#define _GUI_DAMAGE_STATS_LIST top_left_label overall_id colid_type colid_overall colid_this_turn ratio_tooltip percent_tooltip
 	[listbox]
 		id = {overall_id}
 		definition = "default"
@@ -221,6 +221,7 @@
 										id = {colid_overall}
 										definition = "default_small"
 										linked_group = "detail"
+										tooltip = {ratio_tooltip}
 									[/label]
 								[/column]
 
@@ -236,6 +237,7 @@
 										linked_group = "detail"
 										text_alignment = "right"
 										use_markup = true
+										tooltip = {percent_tooltip}
 									[/label]
 								[/column]
 
@@ -249,6 +251,7 @@
 										id = {colid_this_turn}
 										definition = "default_small"
 										linked_group = "cost"
+										tooltip = {ratio_tooltip}
 									[/label]
 								[/column]
 
@@ -264,6 +267,7 @@
 										linked_group = "detail"
 										text_alignment = "right"
 										use_markup = true
+										tooltip = {percent_tooltip}
 									[/label]
 								[/column]
 
@@ -535,7 +539,10 @@
 											horizontal_grow = true
 											vertical_grow = true
 
-											{_GUI_DAMAGE_STATS_LIST (_ "Damage") stats_list_damage damage_type damage_overall damage_this_turn}
+											{_GUI_DAMAGE_STATS_LIST
+											 (_ "Damage") stats_list_damage damage_type damage_overall damage_this_turn
+											 (_"stats dialog^Amount of hitpoints (actual / expected)")
+											 (_"stats dialog^Ratio of actual to expected")}
 										[/column]
 
 									[/row]
@@ -549,7 +556,10 @@
 											horizontal_grow = true
 											vertical_grow = true
 
-											{_GUI_DAMAGE_STATS_LIST (_ "Hits") stats_list_hits hits_type hits_overall hits_this_turn}
+											{_GUI_DAMAGE_STATS_LIST
+											 (_ "Hits") stats_list_hits hits_type hits_overall hits_this_turn
+											 (_"stats dialog^Number of hits (actual / expected)")
+											 (_"stats dialog^<i>A priori</i> probability of getting this result or a more extreme one")}
 										[/column]
 
 									[/row]

--- a/data/gui/window/statistics_dialog.cfg
+++ b/data/gui/window/statistics_dialog.cfg
@@ -565,7 +565,7 @@
 											{_GUI_DAMAGE_STATS_LIST
 											 (_ "Hits") stats_list_hits hits_type hits_overall hits_this_turn
 											 (_"stats dialog^Number of hits (actual / expected)")
-											 (_"stats dialog^<i>A priori</i> probability of getting this result or a more extreme one")}
+											 (_"stats dialog^<i>A priori</i> probabilities of hitting less than, exactly, and more than the actual number of hits")}
 										[/column]
 
 									[/row]

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1096,14 +1096,16 @@ bool attack::perform_hit(bool attacker_turn, statistics::attack_context& stats)
 			? (dies
 				? statistics::attack_context::KILLS
 				: statistics::attack_context::HITS)
-			: statistics::attack_context::MISSES, damage_done, drains_damage
+			: statistics::attack_context::MISSES,
+			attacker.cth_, damage_done, drains_damage
 		);
 	} else {
 		stats.defend_result(hits
 			? (dies
 				? statistics::attack_context::KILLS
 				: statistics::attack_context::HITS)
-			: statistics::attack_context::MISSES, damage_done, drains_damage
+			: statistics::attack_context::MISSES,
+			attacker.cth_, damage_done, drains_damage
 		);
 	}
 

--- a/src/actions/attack.hpp
+++ b/src/actions/attack.hpp
@@ -90,7 +90,7 @@ struct battle_context_unit_stats
 			const_attack_ptr opp_weapon,
 			const unit_map& units);
 
-	/** Used by AI for combat analysis */
+	/** Used by AI for combat analysis, and by statistics_dialog */
 	battle_context_unit_stats(const unit_type* u_type,
 			const_attack_ptr att_weapon,
 			bool attacking,

--- a/src/gui/dialogs/statistics_dialog.cpp
+++ b/src/gui/dialogs/statistics_dialog.cpp
@@ -151,29 +151,29 @@ void statistics_dialog::add_damage_row(
 	const long long dsa = shift * damage      - expected;
 	const long long dst = shift * turn_damage - turn_expected;
 
-	const long long shifted = ((expected * 20) + shift) / (2 * shift);
-	std::ostringstream str;
-	str << damage << " / " << static_cast<double>(shifted) * 0.1;
-	item["label"] = str.str();
+	const auto& damage_str = [shift](long long damage, long long expected) {
+		const long long shifted = ((expected * 20) + shift) / (2 * shift);
+		std::ostringstream str;
+		str << damage << " / " << static_cast<double>(shifted) * 0.1;
+		return str.str();
+	};
+	item["label"] = damage_str(damage, expected);
 	data.emplace("damage_overall", item);
 
-	str.str("");
-	str << (((dsa < 0) ^ (expected < 0)) ? "" : "+")
-		<< (expected == 0 ? 0 : 100 * dsa / expected) << '%';
-	item["label"] = str.str();
+	const auto& percent_str = [](long long dsx, long long expected) {
+		std::ostringstream str;
+		str << (((dsx < 0) ^ (expected < 0)) ? "" : "+")
+			<< (expected == 0 ? 0 : 100 * dsx / expected) << '%';
+		return str.str();
+	};
+	item["label"] = percent_str(dsa, expected);
 	data.emplace("overall_percent", item);
 
 	if(show_this_turn) {
-		const long long turn_shifted = ((turn_expected * 20) + shift) / (2 * shift);
-		str.str("");
-		str << turn_damage << " / " << static_cast<double>(turn_shifted) * 0.1;
-		item["label"] = str.str();
+		item["label"] = damage_str(turn_damage, turn_expected);
 		data.emplace("damage_this_turn", item);
 
-		str.str("");
-		str << (((dst < 0) ^ (turn_expected < 0)) ? "" : "+")
-			<< (turn_expected == 0 ? 0 : 100 * dst / turn_expected) << '%';
-		item["label"] = str.str();
+		item["label"] = percent_str(dst, turn_expected);
 		data.emplace("this_turn_percent", item);
 	}
 

--- a/src/gui/dialogs/statistics_dialog.cpp
+++ b/src/gui/dialogs/statistics_dialog.cpp
@@ -251,21 +251,28 @@ static hitrate_table_element tally(const statistics::stats::hitrate_map& by_cth)
 		const std::vector<double>& final_hp_dist = current_defender->hp_dist;
 		const auto& chance_of_exactly_N_hits = [&final_hp_dist](int n) { return final_hp_dist[final_hp_dist.size() - 1 - n]; };
 
-		double probability = 0.0;
-		if(overall_hits == expected_hits) {
-			probability = chance_of_exactly_N_hits(overall_hits);
-		} else if (overall_hits > expected_hits) {
-			for(unsigned int i = overall_hits; i < final_hp_dist.size(); ++i) {
-				probability += chance_of_exactly_N_hits(i);
-			}
-		} else {
-			for(unsigned int i = 0; i <= overall_hits; ++i) {
-				probability += chance_of_exactly_N_hits(i);
-			}
+		double probability_lt = 0.0;
+		for(unsigned int i = 0; i < overall_hits; ++i) {
+			probability_lt += chance_of_exactly_N_hits(i);
 		}
-		// TODO: document for users what this value is.
-		str2 << font::span_color(game_config::red_to_green(probability * 100.0, true))
-			<< get_probability_string(probability) << "</span>";
+		double probability_eq = chance_of_exactly_N_hits(overall_hits);
+		double probability_gt = 0.0;
+		for(unsigned int i = final_hp_dist.size() - 1; i > overall_hits; --i) {
+			probability_gt += chance_of_exactly_N_hits(i);
+		}
+
+		if(overall_strikes == 0) {
+			// Start of turn
+			str2 << "0%";
+		} else {
+			// TODO: add coloring
+			// TODO: document for users what these values are.
+			str2 << get_probability_string(probability_lt);
+			str2 << ", ";
+			str2 << get_probability_string(probability_eq);
+			str2 << ", ";
+			str2 << get_probability_string(probability_gt);
+		}
 	}
 
 	return hitrate_table_element{str.str(), str2.str()};

--- a/src/gui/dialogs/statistics_dialog.cpp
+++ b/src/gui/dialogs/statistics_dialog.cpp
@@ -151,7 +151,7 @@ void statistics_dialog::add_damage_row(
 	const long long dsa = shift * damage      - expected;
 	const long long dst = shift * turn_damage - turn_expected;
 
-	const auto& damage_str = [shift](long long damage, long long expected) {
+	const auto damage_str = [shift](long long damage, long long expected) {
 		const long long shifted = ((expected * 20) + shift) / (2 * shift);
 		std::ostringstream str;
 		str << damage << " / " << static_cast<double>(shifted) * 0.1;
@@ -160,7 +160,7 @@ void statistics_dialog::add_damage_row(
 	item["label"] = damage_str(damage, expected);
 	data.emplace("damage_overall", item);
 
-	const auto& percent_str = [](long long dsx, long long expected) {
+	const auto percent_str = [](long long dsx, long long expected) {
 		std::ostringstream str;
 		str << (((dsx < 0) ^ (expected < 0)) ? "" : "+")
 			<< (expected == 0 ? 0 : 100 * dsx / expected) << '%';
@@ -264,7 +264,7 @@ static hitrate_table_element tally(const statistics::stats::hitrate_map& by_cth,
 			// Start of turn
 			str2 << "0%";
 		} else {
-			const auto& add_probability = [&str2](double probability, bool more_is_better) {
+			const auto add_probability = [&str2](double probability, bool more_is_better) {
 				str2 << font::span_color(game_config::red_to_green((more_is_better ? probability : 1.0 - probability) * 100.0, true))
 					<< get_probability_string(probability) << "</span>";
 			};

--- a/src/gui/dialogs/statistics_dialog.cpp
+++ b/src/gui/dialogs/statistics_dialog.cpp
@@ -161,6 +161,45 @@ void statistics_dialog::add_damage_row(
 	damage_list.add_row(data);
 }
 
+void statistics_dialog::add_hits_row(
+		window& window,
+		const std::string& type,
+		const std::map<int, struct statistics::stats::by_cth_t>& by_cth,
+		const bool show_this_turn)
+{
+	listbox& hits_list = find_widget<listbox>(&window, "stats_list_hits", false);
+
+	std::map<std::string, string_map> data;
+	string_map item;
+
+	std::ostringstream str;
+
+	item["label"] = type;
+	data.emplace("hits_type", item);
+
+	int overall_hits = 0;
+	double expected_hits = 0;
+
+	for(const auto& i : by_cth) {
+		int cth = i.first;
+		overall_hits += i.second.hits;
+		expected_hits += (cth * 0.01) * i.second.strikes;
+	}
+
+	str.str("");
+	str << overall_hits << " / " << expected_hits;
+
+	item["label"] = str.str();
+	data.emplace("hits_overall", item);
+
+	if(show_this_turn) {
+		item["label"] = "";
+		data.emplace("hits_this_turn", item);
+	}
+
+	hits_list.add_row(data);
+}
+
 void statistics_dialog::update_lists(window& window)
 {
 	//
@@ -197,11 +236,18 @@ void statistics_dialog::update_lists(window& window)
 
 	damage_list.clear();
 
+	listbox& hits_list = find_widget<listbox>(&window, "stats_list_hits", false);
+	hits_list.clear();
+
 	add_damage_row(window, _("Inflicted"),
 		stats.damage_inflicted,
 		stats.expected_damage_inflicted,
 		stats.turn_damage_inflicted,
 		stats.turn_expected_damage_inflicted,
+		show_this_turn
+	);
+	add_hits_row(window, _("Inflicted"),
+		stats.by_cth,
 		show_this_turn
 	);
 
@@ -212,6 +258,7 @@ void statistics_dialog::update_lists(window& window)
 		stats.turn_expected_damage_taken,
 		show_this_turn
 	);
+	// TODO add by_cth_taken/by_cth_inflicted
 }
 
 void statistics_dialog::on_scenario_select(window& window)

--- a/src/gui/dialogs/statistics_dialog.cpp
+++ b/src/gui/dialogs/statistics_dialog.cpp
@@ -184,7 +184,7 @@ void statistics_dialog::add_damage_row(
 }
 
 // Return the strings to use in the "Hits" table, showing actual and expected number of hits.
-static std::pair<std::string, std::string> tally(const std::map<int, struct statistics::stats::by_cth_t>& by_cth)
+static std::pair<std::string, std::string> tally(const statistics::stats::hitrate_map& by_cth)
 {
 	unsigned int overall_hits = 0;
 	double expected_hits = 0;
@@ -268,8 +268,8 @@ static std::pair<std::string, std::string> tally(const std::map<int, struct stat
 void statistics_dialog::add_hits_row(
 		window& window,
 		const std::string& type,
-		const std::map<int, struct statistics::stats::by_cth_t>& by_cth,
-		const std::map<int, struct statistics::stats::by_cth_t>& turn_by_cth,
+		const statistics::stats::hitrate_map& by_cth,
+		const statistics::stats::hitrate_map& turn_by_cth,
 		const bool show_this_turn)
 {
 	listbox& hits_list = find_widget<listbox>(&window, "stats_list_hits", false);

--- a/src/gui/dialogs/statistics_dialog.cpp
+++ b/src/gui/dialogs/statistics_dialog.cpp
@@ -162,8 +162,9 @@ void statistics_dialog::add_damage_row(
 
 	str.str("");
 	str << (((dsa < 0) ^ (expected < 0)) ? "" : "+")
-		<< (expected == 0 ? 0 : 100 * dsa / expected) << '%';
-	item["label"] = str.str() + spacer;
+		<< (expected == 0 ? 0 : 100 * dsa / expected) << '%'
+		<< spacer;
+	item["label"] = str.str();
 	data.emplace("overall_percent", item);
 
 	if(show_this_turn) {
@@ -175,8 +176,9 @@ void statistics_dialog::add_damage_row(
 
 		str.str("");
 		str << (((dst < 0) ^ (turn_expected < 0)) ? "" : "+")
-			<< (turn_expected == 0 ? 0 : 100 * dst / turn_expected) << '%';
-		item["label"] = str.str() + spacer;
+			<< (turn_expected == 0 ? 0 : 100 * dst / turn_expected) << '%'
+			<< spacer;
+		item["label"] = str.str();
 		data.emplace("this_turn_percent", item);
 	}
 
@@ -204,8 +206,8 @@ static std::pair<std::string, std::string> tally(const statistics::stats::hitrat
 	{
 		config defender_cfg(
 			"id", "statistics_dialog_dummy_defender",
-			"hide_help", "yes",
-			"do_not_list", "yes",
+			"hide_help", true,
+			"do_not_list", true,
 			"hitpoints", overall_strikes
 		);
 		unit_type defender_type(defender_cfg);
@@ -218,8 +220,8 @@ static std::pair<std::string, std::string> tally(const statistics::stats::hitrat
 			int cth = i.first;
 			config attacker_cfg(
 				"id", "statistics_dialog_dummy_attacker" + std::to_string(cth),
-				"hide_help", "yes",
-				"do_not_list", "yes",
+				"hide_help", true,
+				"do_not_list", true,
 				"hitpoints", 1
 			);
 			unit_type attacker_type(attacker_cfg);
@@ -237,29 +239,31 @@ static std::pair<std::string, std::string> tally(const statistics::stats::hitrat
 			defender_bc = battle_context_unit_stats(&defender_type, nullptr, false, &attacker_type, attack, 0 /* not used */);
 
 			// Update current_defender with the new defender_bc.
-			combatant attacker(attacker_bc);
 			current_defender.reset(new combatant(*current_defender, defender_bc));
 
+			combatant attacker(attacker_bc);
 			attacker.fight(*current_defender);
 		}
 
 		const std::vector<double>& final_hp_dist = current_defender->hp_dist;
-		const auto& chance_of_exactly_N_hits = [&final_hp_dist](int N) { return final_hp_dist[final_hp_dist.size() - 1 - N]; };
+		const auto& chance_of_exactly_N_hits = [&final_hp_dist](int n) { return final_hp_dist[final_hp_dist.size() - 1 - n]; };
 
 		double probability = 0.0;
 		if(overall_hits == expected_hits) {
 			probability = chance_of_exactly_N_hits(overall_hits);
-		}
-		else if (overall_hits > expected_hits) {
-			for(unsigned int i = overall_hits; i < final_hp_dist.size(); i++)
+		} else if (overall_hits > expected_hits) {
+			for(unsigned int i = overall_hits; i < final_hp_dist.size(); ++i) {
 				probability += chance_of_exactly_N_hits(i);
-		}
-		else {
-			for(unsigned int i = 0; i <= overall_hits; i++)
+			}
+		} else {
+			for(unsigned int i = 0; i <= overall_hits; ++i) {
 				probability += chance_of_exactly_N_hits(i);
+			}
 		}
 		// TODO: document for users what this value is.
-		str2 << font::span_color(game_config::red_to_green(probability * 100.0, true)) << get_probability_string(probability) << "</span>";
+		str2 << font::span_color(game_config::red_to_green(probability * 100.0, true))
+			<< get_probability_string(probability) << "</span>"
+			<< spacer;
 	}
 
 	return std::make_pair(str.str(), str2.str());
@@ -285,14 +289,14 @@ void statistics_dialog::add_hits_row(
 	pair = tally(by_cth);
 	item["label"] = pair.first;
 	data.emplace("hits_overall", item);
-	item["label"] = pair.second + spacer;
+	item["label"] = pair.second;
 	data.emplace("overall_percent", item);
 
 	if(show_this_turn) {
 		pair = tally(turn_by_cth);
 		item["label"] = pair.first;
 		data.emplace("hits_this_turn", item);
-		item["label"] = pair.second + spacer;
+		item["label"] = pair.second;
 		data.emplace("this_turn_percent", item);
 	}
 

--- a/src/gui/dialogs/statistics_dialog.cpp
+++ b/src/gui/dialogs/statistics_dialog.cpp
@@ -185,8 +185,16 @@ void statistics_dialog::add_damage_row(
 	damage_list.add_row(data);
 }
 
+// Custom type to allow tally() to return two values.
+struct hitrate_table_element {
+	// The string with <actual number of hits>/<expected number of hits>
+	std::string hitrate_str;
+	// The string with the a priori probability of that result
+	std::string percentage_str;
+};
+
 // Return the strings to use in the "Hits" table, showing actual and expected number of hits.
-static std::pair<std::string, std::string> tally(const statistics::stats::hitrate_map& by_cth)
+static hitrate_table_element tally(const statistics::stats::hitrate_map& by_cth)
 {
 	unsigned int overall_hits = 0;
 	double expected_hits = 0;
@@ -266,7 +274,7 @@ static std::pair<std::string, std::string> tally(const statistics::stats::hitrat
 			<< spacer;
 	}
 
-	return std::make_pair(str.str(), str2.str());
+	return hitrate_table_element{str.str(), str2.str()};
 }
 
 void statistics_dialog::add_hits_row(
@@ -281,22 +289,22 @@ void statistics_dialog::add_hits_row(
 	std::map<std::string, string_map> data;
 	string_map item;
 
-	std::pair<std::string, std::string> pair;
+	hitrate_table_element element;
 
 	item["label"] = type;
 	data.emplace("hits_type", item);
 
-	pair = tally(by_cth);
-	item["label"] = pair.first;
+	element = tally(by_cth);
+	item["label"] = element.hitrate_str;
 	data.emplace("hits_overall", item);
-	item["label"] = pair.second;
+	item["label"] = element.percentage_str;
 	data.emplace("overall_percent", item);
 
 	if(show_this_turn) {
-		pair = tally(turn_by_cth);
-		item["label"] = pair.first;
+		element = tally(turn_by_cth);
+		item["label"] = element.hitrate_str;
 		data.emplace("hits_this_turn", item);
-		item["label"] = pair.second;
+		item["label"] = element.percentage_str;
 		data.emplace("this_turn_percent", item);
 	}
 

--- a/src/gui/dialogs/statistics_dialog.cpp
+++ b/src/gui/dialogs/statistics_dialog.cpp
@@ -129,9 +129,6 @@ void statistics_dialog::add_stat_row(window& window, const std::string& type, co
 	main_stat_table_.push_back(&value);
 }
 
-// TODO: This is used to adjust the horizontal spacing around the percentages column, but it's ugly. Find a better way.
-static const auto& spacer = "    ";
-
 void statistics_dialog::add_damage_row(
 		window& window,
 		const std::string& type,
@@ -162,8 +159,7 @@ void statistics_dialog::add_damage_row(
 
 	str.str("");
 	str << (((dsa < 0) ^ (expected < 0)) ? "" : "+")
-		<< (expected == 0 ? 0 : 100 * dsa / expected) << '%'
-		<< spacer;
+		<< (expected == 0 ? 0 : 100 * dsa / expected) << '%';
 	item["label"] = str.str();
 	data.emplace("overall_percent", item);
 
@@ -176,8 +172,7 @@ void statistics_dialog::add_damage_row(
 
 		str.str("");
 		str << (((dst < 0) ^ (turn_expected < 0)) ? "" : "+")
-			<< (turn_expected == 0 ? 0 : 100 * dst / turn_expected) << '%'
-			<< spacer;
+			<< (turn_expected == 0 ? 0 : 100 * dst / turn_expected) << '%';
 		item["label"] = str.str();
 		data.emplace("this_turn_percent", item);
 	}
@@ -270,8 +265,7 @@ static hitrate_table_element tally(const statistics::stats::hitrate_map& by_cth)
 		}
 		// TODO: document for users what this value is.
 		str2 << font::span_color(game_config::red_to_green(probability * 100.0, true))
-			<< get_probability_string(probability) << "</span>"
-			<< spacer;
+			<< get_probability_string(probability) << "</span>";
 	}
 
 	return hitrate_table_element{str.str(), str2.str()};

--- a/src/gui/dialogs/statistics_dialog.cpp
+++ b/src/gui/dialogs/statistics_dialog.cpp
@@ -255,7 +255,6 @@ static hitrate_table_element tally(const statistics::stats::hitrate_map& by_cth,
 		for(unsigned int i = 0; i < overall_hits; ++i) {
 			probability_lt += chance_of_exactly_N_hits(i);
 		}
-		double probability_eq = chance_of_exactly_N_hits(overall_hits);
 		double probability_gt = 0.0;
 		for(unsigned int i = final_hp_dist.size() - 1; i > overall_hits; --i) {
 			probability_gt += chance_of_exactly_N_hits(i);
@@ -272,8 +271,6 @@ static hitrate_table_element tally(const statistics::stats::hitrate_map& by_cth,
 
 			// TODO: document for users what these values are.
 			add_probability(probability_lt, !more_is_better);
-			str2 << ", ";
-			str2 << get_probability_string(probability_eq);
 			str2 << ", ";
 			add_probability(probability_gt, more_is_better);
 		}

--- a/src/gui/dialogs/statistics_dialog.cpp
+++ b/src/gui/dialogs/statistics_dialog.cpp
@@ -181,7 +181,8 @@ void statistics_dialog::add_damage_row(
 }
 
 // Custom type to allow tally() to return two values.
-struct hitrate_table_element {
+struct hitrate_table_element
+{
 	// The string with <actual number of hits>/<expected number of hits>
 	std::string hitrate_str;
 	// The string with the a priori probability of that result
@@ -230,7 +231,7 @@ static hitrate_table_element tally(const statistics::stats::hitrate_map& by_cth,
 			unit_type attacker_type(attacker_cfg);
 			unit_types.build_unit_type(attacker_type, unit_type::BUILD_STATUS::FULL);
 
-			attack_ptr attack = std::make_shared<attack_type>(config(
+			auto attack = std::make_shared<attack_type>(config(
 				"type", "blade",
 				"range", "melee",
 				"name", "dummy attack",

--- a/src/gui/dialogs/statistics_dialog.cpp
+++ b/src/gui/dialogs/statistics_dialog.cpp
@@ -247,7 +247,7 @@ void statistics_dialog::update_lists(window& window)
 		show_this_turn
 	);
 	add_hits_row(window, _("Inflicted"),
-		stats.by_cth,
+		stats.by_cth_inflicted,
 		show_this_turn
 	);
 
@@ -258,7 +258,10 @@ void statistics_dialog::update_lists(window& window)
 		stats.turn_expected_damage_taken,
 		show_this_turn
 	);
-	// TODO add by_cth_taken/by_cth_inflicted
+	add_hits_row(window, _("Taken"),
+		stats.by_cth_taken,
+		show_this_turn
+	);
 }
 
 void statistics_dialog::on_scenario_select(window& window)

--- a/src/gui/dialogs/statistics_dialog.cpp
+++ b/src/gui/dialogs/statistics_dialog.cpp
@@ -249,7 +249,7 @@ static hitrate_table_element tally(const statistics::stats::hitrate_map& by_cth,
 		}
 
 		const std::vector<double>& final_hp_dist = current_defender->hp_dist;
-		const auto& chance_of_exactly_N_hits = [&final_hp_dist](int n) { return final_hp_dist[final_hp_dist.size() - 1 - n]; };
+		const auto chance_of_exactly_N_hits = [&final_hp_dist](int n) { return final_hp_dist[final_hp_dist.size() - 1 - n]; };
 
 		double probability_lt = 0.0;
 		for(unsigned int i = 0; i < overall_hits; ++i) {

--- a/src/gui/dialogs/statistics_dialog.hpp
+++ b/src/gui/dialogs/statistics_dialog.hpp
@@ -59,8 +59,8 @@ private:
 	void add_hits_row(
 		window& window,
 		const std::string& type,
-		const std::map<int, struct statistics::stats::by_cth_t>& by_cth,
-		const std::map<int, struct statistics::stats::by_cth_t>& turn_by_cth,
+		const statistics::stats::hitrate_map& by_cth,
+		const statistics::stats::hitrate_map& turn_by_cth,
 		const bool show_this_turn);
 
 	void update_lists(window& window);

--- a/src/gui/dialogs/statistics_dialog.hpp
+++ b/src/gui/dialogs/statistics_dialog.hpp
@@ -45,6 +45,7 @@ private:
 
 	void add_stat_row(window& window, const std::string& type, const statistics::stats::str_int_map& value, const bool has_cost = true);
 
+	/// Add a row to the Damage table
 	void add_damage_row(
 		window& window,
 		const std::string& type,
@@ -52,6 +53,13 @@ private:
 		const long long& expected,
 		const long long& turn_damage,
 		const long long& turn_expected,
+		const bool show_this_turn);
+
+	/// Add a row to the Hits table
+	void add_hits_row(
+		window& window,
+		const std::string& type,
+		const std::map<int, struct statistics::stats::by_cth_t>& by_cth,
 		const bool show_this_turn);
 
 	void update_lists(window& window);

--- a/src/gui/dialogs/statistics_dialog.hpp
+++ b/src/gui/dialogs/statistics_dialog.hpp
@@ -60,6 +60,7 @@ private:
 		window& window,
 		const std::string& type,
 		const std::map<int, struct statistics::stats::by_cth_t>& by_cth,
+		const std::map<int, struct statistics::stats::by_cth_t>& turn_by_cth,
 		const bool show_this_turn);
 
 	void update_lists(window& window);

--- a/src/gui/dialogs/statistics_dialog.hpp
+++ b/src/gui/dialogs/statistics_dialog.hpp
@@ -56,9 +56,12 @@ private:
 		const bool show_this_turn);
 
 	/// Add a row to the Hits table
+	///
+	/// @param more_is_better True for "Inflicted" and false for "Taken". Affects coloring.
 	void add_hits_row(
 		window& window,
 		const std::string& type,
+		const bool more_is_better,
 		const statistics::stats::hitrate_map& by_cth,
 		const statistics::stats::hitrate_map& turn_by_cth,
 		const bool show_this_turn);

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -194,7 +194,7 @@ static stats::battle_result_map read_battle_result_map(const config& cfg)
 	return m;
 }
 
-static config write_by_cth_map(const std::map<int, struct statistics::stats::by_cth_t>& m)
+static config write_by_cth_map(const stats::hitrate_map& m)
 {
 	config res;
 	for(const auto& i : m) {
@@ -208,9 +208,9 @@ static config write_by_cth_map(const std::map<int, struct statistics::stats::by_
 }
 
 static void merge_battle_result_maps(stats::battle_result_map& a, const stats::battle_result_map& b);
-static std::map<int, struct statistics::stats::by_cth_t> read_by_cth_map_from_battle_result_maps(const statistics::stats::battle_result_map& attacks, const statistics::stats::battle_result_map& defends)
+static stats::hitrate_map read_by_cth_map_from_battle_result_maps(const statistics::stats::battle_result_map& attacks, const statistics::stats::battle_result_map& defends)
 {
-	std::map<int, struct statistics::stats::by_cth_t> m;
+	stats::hitrate_map m;
 
 	statistics::stats::battle_result_map merged = attacks;
 	merge_battle_result_maps(merged, defends);
@@ -235,9 +235,9 @@ static std::map<int, struct statistics::stats::by_cth_t> read_by_cth_map_from_ba
 	return m;
 }
 
-static std::map<int, struct statistics::stats::by_cth_t> read_by_cth_map(const config& cfg)
+static stats::hitrate_map read_by_cth_map(const config& cfg)
 {
-	std::map<int, struct statistics::stats::by_cth_t> m;
+	stats::hitrate_map m;
 	for(const config &i : cfg.child_range("keyvalue")) {
 		m.emplace(i["key"], statistics::stats::by_cth_t(i.child("value")));
 	}
@@ -258,7 +258,7 @@ static void merge_battle_result_maps(stats::battle_result_map& a, const stats::b
 	}
 }
 
-static void merge_cth_map(std::map<int, struct statistics::stats::by_cth_t>& a, const std::map<int, struct statistics::stats::by_cth_t>& b)
+static void merge_cth_map(stats::hitrate_map& a, const stats::hitrate_map& b)
 {
 	for(const auto& i : b) {
 		a[i.first].hits += i.second.hits;

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -250,8 +250,8 @@ static void merge_stats(stats& a, const stats& b)
 	merge_cth_map(a.by_cth_inflicted,b.by_cth_inflicted);
 	merge_cth_map(a.by_cth_taken,b.by_cth_taken);
 
-	merge_battle_result_maps(a.attacks,b.attacks);
-	merge_battle_result_maps(a.defends,b.defends);
+	merge_battle_result_maps(a.attacks_inflicted,b.attacks_inflicted);
+	merge_battle_result_maps(a.defends_inflicted,b.defends_inflicted);
 
 	a.recruit_cost += b.recruit_cost;
 	a.recall_cost += b.recall_cost;
@@ -281,8 +281,8 @@ stats::stats() :
 	killed(),
 	recruit_cost(0),
 	recall_cost(0),
-	attacks(),
-	defends(),
+	attacks_inflicted(),
+	defends_inflicted(),
 	damage_inflicted(0),
 	damage_taken(0),
 	turn_damage_inflicted(0),
@@ -306,8 +306,8 @@ stats::stats(const config& cfg) :
 	killed(),
 	recruit_cost(0),
 	recall_cost(0),
-	attacks(),
-	defends(),
+	attacks_inflicted(),
+	defends_inflicted(),
 	damage_inflicted(0),
 	damage_taken(0),
 	turn_damage_inflicted(0),
@@ -333,8 +333,8 @@ config stats::write() const
 	res.add_child("advances",write_str_int_map(advanced_to));
 	res.add_child("deaths",write_str_int_map(deaths));
 	res.add_child("killed",write_str_int_map(killed));
-	res.add_child("attacks",write_battle_result_map(attacks));
-	res.add_child("defends",write_battle_result_map(defends));
+	res.add_child("attacks",write_battle_result_map(attacks_inflicted));
+	res.add_child("defends",write_battle_result_map(defends_inflicted));
 	res.add_child("by_cth_inflicted", write_by_cth_map(by_cth_inflicted));
 	res.add_child("by_cth_taken", write_by_cth_map(by_cth_taken));
 	res.add_child("turn_by_cth_inflicted", write_by_cth_map(turn_by_cth_inflicted));
@@ -376,10 +376,10 @@ void stats::write(config_writer &out) const
 	write_str_int_map(out, killed);
 	out.close_child("killed");
 	out.open_child("attacks");
-	write_battle_result_map(out, attacks);
+	write_battle_result_map(out, attacks_inflicted);
 	out.close_child("attacks");
 	out.open_child("defends");
-	write_battle_result_map(out, defends);
+	write_battle_result_map(out, defends_inflicted);
 	out.close_child("defends");
 	out.open_child("by_cth_inflicted");
 	out.write(write_by_cth_map(by_cth_inflicted));
@@ -431,10 +431,10 @@ void stats::read(const config& cfg)
 		recalls = read_str_int_map(c);
 	}
 	if (const config &c = cfg.child("attacks")) {
-		attacks = read_battle_result_map(c);
+		attacks_inflicted = read_battle_result_map(c);
 	}
 	if (const config &c = cfg.child("defends")) {
-		defends = read_battle_result_map(c);
+		defends_inflicted = read_battle_result_map(c);
 	}
 	if (const config &c = cfg.child("by_cth_inflicted")) {
 		by_cth_inflicted = read_by_cth_map(c);
@@ -497,8 +497,8 @@ attack_context::~attack_context()
 	std::string attacker_key = "s" + attacker_res;
 	std::string defender_key = "s" + defender_res;
 
-	attacker_stats().attacks[chance_to_hit_defender][attacker_key]++;
-	defender_stats().defends[chance_to_hit_attacker][defender_key]++;
+	attacker_stats().attacks_inflicted[chance_to_hit_defender][attacker_key]++;
+	defender_stats().defends_inflicted[chance_to_hit_attacker][defender_key]++;
 }
 
 stats& attack_context::attacker_stats()

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -240,7 +240,7 @@ static stats::hitrate_map read_by_cth_map(const config& cfg)
 {
 	stats::hitrate_map m;
 	for(const config &i : cfg.child_range("keyvalue")) {
-		m.emplace(i["key"], statistics::stats::by_cth_t(i.child("value")));
+		m.emplace(i["key"], statistics::stats::hitrate_t(i.child("value")));
 	}
 	return m;
 }
@@ -823,17 +823,17 @@ int sum_cost_str_int_map(const stats::str_int_map &m)
 	return cost;
 }
 
-config stats::by_cth_t::write() const
+config stats::hitrate_t::write() const
 {
 	return config("hits", hits, "strikes", strikes);
 }
 
-stats::by_cth_t::by_cth_t(const config &cfg) :
+stats::hitrate_t::hitrate_t(const config &cfg) :
 	strikes(cfg["strikes"]),
 	hits(cfg["hits"])
 {}
 
-std::ostream& operator<<(std::ostream& outstream, const statistics::stats::by_cth_t& by_cth) {
+std::ostream& operator<<(std::ostream& outstream, const statistics::stats::hitrate_t& by_cth) {
 	outstream << "[" << by_cth.hits << "/" << by_cth.strikes << "]";
 	return outstream;
 }

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -199,10 +199,10 @@ static config write_by_cth_map(const stats::hitrate_map& m)
 	config res;
 	for(const auto& i : m) {
 		const config child(
-			"key", i.first,
-			"value", i.second.write()
+			"cth", i.first,
+			"stats", i.second.write()
 		);
-		res.add_child("keyvalue", child);
+		res.add_child("hitrate_map_entry", child);
 	}
 	return res;
 }
@@ -239,8 +239,8 @@ static stats::hitrate_map read_by_cth_map_from_battle_result_maps(const statisti
 static stats::hitrate_map read_by_cth_map(const config& cfg)
 {
 	stats::hitrate_map m;
-	for(const config &i : cfg.child_range("keyvalue")) {
-		m.emplace(i["key"], statistics::stats::hitrate_t(i.child("value")));
+	for(const config &i : cfg.child_range("hitrate_map_entry")) {
+		m.emplace(i["cth"], statistics::stats::hitrate_t(i.child("stats")));
 	}
 	return m;
 }

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -223,8 +223,9 @@ static stats::hitrate_map read_by_cth_map_from_battle_result_maps(const statisti
 			const int occurrences = j.second;
 			unsigned int misses = std::count(res.begin(), res.end(), '0');
 			unsigned int hits = std::count(res.begin(), res.end(), '1');
-			if(misses + hits == 0)
+			if(misses + hits == 0) {
 				continue;
+			}
 			misses *= occurrences;
 			hits *= occurrences;
 			m[cth].strikes += misses + hits;
@@ -832,7 +833,7 @@ stats::by_cth_t::by_cth_t(const config &cfg) :
 	hits(cfg["hits"])
 {}
 
-std::ostream& operator<<(std::ostream& outstream, const struct statistics::stats::by_cth_t& by_cth) {
+std::ostream& operator<<(std::ostream& outstream, const statistics::stats::by_cth_t& by_cth) {
 	outstream << "[" << by_cth.hits << "/" << by_cth.strikes << "]";
 	return outstream;
 }

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -300,7 +300,7 @@ config stats::write() const
 	res["expected_damage_inflicted"] = expected_damage_inflicted;
 	res["expected_damage_taken"] = expected_damage_taken;
 
-	// TODO add by_cth here and throughout this file
+	// TODO add by_cth_inflicted/by_cth_taken here and throughout this file
 	res["turn_damage_inflicted"] = turn_damage_inflicted;
 	res["turn_damage_taken"] = turn_damage_taken;
 	res["turn_expected_damage_inflicted"] = turn_expected_damage_inflicted;
@@ -461,9 +461,12 @@ void attack_context::attack_result(hit_result res, int cth, int damage, int drai
 	attacker_res.push_back(res == MISSES ? '0' : '1');
 	stats &att_stats = attacker_stats(), &def_stats = defender_stats();
 
-	if(res != MISSES)
-		++att_stats.by_cth[cth].hits;
-	++att_stats.by_cth[cth].strikes;
+	if(res != MISSES) {
+		++att_stats.by_cth_inflicted[cth].hits;
+		++def_stats.by_cth_taken[cth].hits;
+	}
+	++att_stats.by_cth_inflicted[cth].strikes;
+	++def_stats.by_cth_taken[cth].strikes;
 
 	if(res != MISSES) {
 		// handle drain
@@ -489,9 +492,12 @@ void attack_context::defend_result(hit_result res, int cth, int damage, int drai
 	defender_res.push_back(res == MISSES ? '0' : '1');
 	stats &att_stats = attacker_stats(), &def_stats = defender_stats();
 
-	if(res != MISSES)
-		++def_stats.by_cth[cth].hits;
-	++def_stats.by_cth[cth].strikes;
+	if(res != MISSES) {
+		++def_stats.by_cth_inflicted[cth].hits;
+		++att_stats.by_cth_taken[cth].hits;
+	}
+	++def_stats.by_cth_inflicted[cth].strikes;
+	++att_stats.by_cth_taken[cth].strikes;
 
 	if(res != MISSES) {
 		//handle drain

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -300,6 +300,7 @@ config stats::write() const
 	res["expected_damage_inflicted"] = expected_damage_inflicted;
 	res["expected_damage_taken"] = expected_damage_taken;
 
+	// TODO add by_cth here and throughout this file
 	res["turn_damage_inflicted"] = turn_damage_inflicted;
 	res["turn_damage_taken"] = turn_damage_taken;
 	res["turn_expected_damage_inflicted"] = turn_expected_damage_inflicted;
@@ -455,10 +456,14 @@ void attack_context::attack_expected_damage(double attacker_inflict_, double def
 }
 
 
-void attack_context::attack_result(hit_result res, int damage, int drain)
+void attack_context::attack_result(hit_result res, int cth, int damage, int drain)
 {
 	attacker_res.push_back(res == MISSES ? '0' : '1');
 	stats &att_stats = attacker_stats(), &def_stats = defender_stats();
+
+	if(res != MISSES)
+		++att_stats.by_cth[cth].hits;
+	++att_stats.by_cth[cth].strikes;
 
 	if(res != MISSES) {
 		// handle drain
@@ -479,10 +484,14 @@ void attack_context::attack_result(hit_result res, int damage, int drain)
 	}
 }
 
-void attack_context::defend_result(hit_result res, int damage, int drain)
+void attack_context::defend_result(hit_result res, int cth, int damage, int drain)
 {
 	defender_res.push_back(res == MISSES ? '0' : '1');
 	stats &att_stats = attacker_stats(), &def_stats = defender_stats();
+
+	if(res != MISSES)
+		++def_stats.by_cth[cth].hits;
+	++def_stats.by_cth[cth].strikes;
 
 	if(res != MISSES) {
 		//handle drain
@@ -681,6 +690,11 @@ int sum_cost_str_int_map(const stats::str_int_map &m)
 	}
 
 	return cost;
+}
+
+std::ostream& operator<<(std::ostream& outstream, const struct statistics::stats::by_cth_t& by_cth) {
+	outstream << "[" << by_cth.hits << "/" << by_cth.strikes << "]";
+	return outstream;
 }
 
 } // end namespace statistics

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -252,6 +252,8 @@ static void merge_stats(stats& a, const stats& b)
 
 	merge_battle_result_maps(a.attacks_inflicted,b.attacks_inflicted);
 	merge_battle_result_maps(a.defends_inflicted,b.defends_inflicted);
+	merge_battle_result_maps(a.attacks_taken,b.attacks_taken);
+	merge_battle_result_maps(a.defends_taken,b.defends_taken);
 
 	a.recruit_cost += b.recruit_cost;
 	a.recall_cost += b.recall_cost;
@@ -283,6 +285,8 @@ stats::stats() :
 	recall_cost(0),
 	attacks_inflicted(),
 	defends_inflicted(),
+	attacks_taken(),
+	defends_taken(),
 	damage_inflicted(0),
 	damage_taken(0),
 	turn_damage_inflicted(0),
@@ -308,6 +312,8 @@ stats::stats(const config& cfg) :
 	recall_cost(0),
 	attacks_inflicted(),
 	defends_inflicted(),
+	attacks_taken(),
+	defends_taken(),
 	damage_inflicted(0),
 	damage_taken(0),
 	turn_damage_inflicted(0),
@@ -335,6 +341,8 @@ config stats::write() const
 	res.add_child("killed",write_str_int_map(killed));
 	res.add_child("attacks",write_battle_result_map(attacks_inflicted));
 	res.add_child("defends",write_battle_result_map(defends_inflicted));
+	res.add_child("attacks_taken",write_battle_result_map(attacks_taken));
+	res.add_child("defends_taken",write_battle_result_map(defends_taken));
 	res.add_child("by_cth_inflicted", write_by_cth_map(by_cth_inflicted));
 	res.add_child("by_cth_taken", write_by_cth_map(by_cth_taken));
 	res.add_child("turn_by_cth_inflicted", write_by_cth_map(turn_by_cth_inflicted));
@@ -381,6 +389,12 @@ void stats::write(config_writer &out) const
 	out.open_child("defends");
 	write_battle_result_map(out, defends_inflicted);
 	out.close_child("defends");
+	out.open_child("attacks_taken");
+	write_battle_result_map(out, attacks_taken);
+	out.close_child("attacks_taken");
+	out.open_child("defends_taken");
+	write_battle_result_map(out, defends_taken);
+	out.close_child("defends_taken");
 	out.open_child("by_cth_inflicted");
 	out.write(write_by_cth_map(by_cth_inflicted));
 	out.close_child("by_cth_inflicted");
@@ -435,6 +449,12 @@ void stats::read(const config& cfg)
 	}
 	if (const config &c = cfg.child("defends")) {
 		defends_inflicted = read_battle_result_map(c);
+	}
+	if (const config &c = cfg.child("attacks_taken")) {
+		attacks_taken = read_battle_result_map(c);
+	}
+	if (const config &c = cfg.child("defends_taken")) {
+		defends_taken = read_battle_result_map(c);
 	}
 	if (const config &c = cfg.child("by_cth_inflicted")) {
 		by_cth_inflicted = read_by_cth_map(c);
@@ -499,6 +519,9 @@ attack_context::~attack_context()
 
 	attacker_stats().attacks_inflicted[chance_to_hit_defender][attacker_key]++;
 	defender_stats().defends_inflicted[chance_to_hit_attacker][defender_key]++;
+
+	attacker_stats().attacks_taken[chance_to_hit_attacker][defender_key]++;
+	defender_stats().defends_taken[chance_to_hit_defender][attacker_key]++;
 }
 
 stats& attack_context::attacker_stats()

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -758,7 +758,7 @@ config write_stats()
 
 void write_stats(config_writer &out)
 {
-	out.write_key_val("mid_scenario", mid_scenario ? true : false);
+	out.write_key_val("mid_scenario", mid_scenario);
 
 	for(std::vector<scenario_stats>::const_iterator i = master_stats.begin(); i != master_stats.end(); ++i) {
 		out.open_child("scenario");

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -265,6 +265,9 @@ static void merge_stats(stats& a, const stats& b)
 	a.turn_damage_taken = b.turn_damage_taken;
 	a.turn_expected_damage_inflicted = b.turn_expected_damage_inflicted;
 	a.turn_expected_damage_taken = b.turn_expected_damage_taken;
+	a.turn_by_cth_inflicted = b.turn_by_cth_inflicted;
+	a.turn_by_cth_taken = b.turn_by_cth_taken;
+
 }
 
 namespace statistics
@@ -286,6 +289,8 @@ stats::stats() :
 	turn_damage_taken(0),
 	by_cth_inflicted(),
 	by_cth_taken(),
+	turn_by_cth_inflicted(),
+	turn_by_cth_taken(),
 	expected_damage_inflicted(0),
 	expected_damage_taken(0),
 	turn_expected_damage_inflicted(0),
@@ -309,6 +314,8 @@ stats::stats(const config& cfg) :
 	turn_damage_taken(0),
 	by_cth_inflicted(),
 	by_cth_taken(),
+	turn_by_cth_inflicted(),
+	turn_by_cth_taken(),
 	expected_damage_inflicted(0),
 	expected_damage_taken(0),
 	turn_expected_damage_inflicted(0),
@@ -330,6 +337,8 @@ config stats::write() const
 	res.add_child("defends",write_battle_result_map(defends));
 	res.add_child("by_cth_inflicted", write_by_cth_map(by_cth_inflicted));
 	res.add_child("by_cth_taken", write_by_cth_map(by_cth_taken));
+	res.add_child("turn_by_cth_inflicted", write_by_cth_map(turn_by_cth_inflicted));
+	res.add_child("turn_by_cth_taken", write_by_cth_map(turn_by_cth_taken));
 
 	res["recruit_cost"] = recruit_cost;
 	res["recall_cost"] = recall_cost;
@@ -378,6 +387,12 @@ void stats::write(config_writer &out) const
 	out.open_child("by_cth_taken");
 	out.write(write_by_cth_map(by_cth_taken));
 	out.close_child("by_cth_taken");
+	out.open_child("turn_by_cth_inflicted");
+	out.write(write_by_cth_map(turn_by_cth_inflicted));
+	out.close_child("turn_by_cth_inflicted");
+	out.open_child("turn_by_cth_taken");
+	out.write(write_by_cth_map(turn_by_cth_taken));
+	out.close_child("turn_by_cth_taken");
 
 	out.write_key_val("recruit_cost", recruit_cost);
 	out.write_key_val("recall_cost", recall_cost);
@@ -426,6 +441,12 @@ void stats::read(const config& cfg)
 	}
 	if (const config &c = cfg.child("by_cth_taken")) {
 		by_cth_taken = read_by_cth_map(c);
+	}
+	if (const config &c = cfg.child("turn_by_cth_inflicted")) {
+		turn_by_cth_inflicted = read_by_cth_map(c);
+	}
+	if (const config &c = cfg.child("turn_by_cth_taken")) {
+		turn_by_cth_taken = read_by_cth_map(c);
 	}
 
 	recruit_cost = cfg["recruit_cost"].to_int();
@@ -513,10 +534,14 @@ void attack_context::attack_result(hit_result res, int cth, int damage, int drai
 
 	if(res != MISSES) {
 		++att_stats.by_cth_inflicted[cth].hits;
+		++att_stats.turn_by_cth_inflicted[cth].hits;
 		++def_stats.by_cth_taken[cth].hits;
+		++def_stats.turn_by_cth_taken[cth].hits;
 	}
 	++att_stats.by_cth_inflicted[cth].strikes;
+	++att_stats.turn_by_cth_inflicted[cth].strikes;
 	++def_stats.by_cth_taken[cth].strikes;
+	++def_stats.turn_by_cth_taken[cth].strikes;
 
 	if(res != MISSES) {
 		// handle drain
@@ -544,10 +569,14 @@ void attack_context::defend_result(hit_result res, int cth, int damage, int drai
 
 	if(res != MISSES) {
 		++def_stats.by_cth_inflicted[cth].hits;
+		++def_stats.turn_by_cth_inflicted[cth].hits;
 		++att_stats.by_cth_taken[cth].hits;
+		++att_stats.turn_by_cth_taken[cth].hits;
 	}
 	++def_stats.by_cth_inflicted[cth].strikes;
+	++def_stats.turn_by_cth_inflicted[cth].strikes;
 	++att_stats.by_cth_taken[cth].strikes;
+	++att_stats.turn_by_cth_taken[cth].strikes;
 
 	if(res != MISSES) {
 		//handle drain
@@ -615,6 +644,8 @@ void reset_turn_stats(const std::string & save_id)
 	s.turn_damage_taken = 0;
 	s.turn_expected_damage_inflicted = 0;
 	s.turn_expected_damage_taken = 0;
+	s.turn_by_cth_inflicted.clear();
+	s.turn_by_cth_taken.clear();
 	s.save_id = save_id;
 }
 

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -758,7 +758,7 @@ config write_stats()
 
 void write_stats(config_writer &out)
 {
-	out.write_key_val("mid_scenario", mid_scenario ? "yes" : "no");
+	out.write_key_val("mid_scenario", mid_scenario ? true : false);
 
 	for(std::vector<scenario_stats>::const_iterator i = master_stats.begin(); i != master_stats.end(); ++i) {
 		out.open_child("scenario");

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -198,11 +198,10 @@ static config write_by_cth_map(const stats::hitrate_map& m)
 {
 	config res;
 	for(const auto& i : m) {
-		const config child(
+		res.add_child("hitrate_map_entry", config {
 			"cth", i.first,
 			"stats", i.second.write()
-		);
-		res.add_child("hitrate_map_entry", child);
+		});
 	}
 	return res;
 }

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -59,7 +59,8 @@ namespace statistics
 		long long damage_inflicted, damage_taken;
 		long long turn_damage_inflicted, turn_damage_taken;
 
-		struct hitrate_t {
+		struct hitrate_t
+		{
 			int strikes; //< Number of strike attempts at the given CTH
 			int hits; //< Number of strikes that hit at the given CTH
 			hitrate_t() = default;

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -57,8 +57,8 @@ namespace statistics
 			int hits; //< Number of strikes that hit at the given CTH
 			friend std::ostream& operator<<(std::ostream& outstream, const struct by_cth_t& by_cth);
 		};
-		/// A map of chance-to-hit percentage to a 'struct by_cth_t'.
-		std::map<int, struct by_cth_t> by_cth;
+		/// Maps of chance-to-hit percentage to a 'struct by_cth_t'.
+		std::map<int, struct by_cth_t> by_cth_inflicted, by_cth_taken;
 
 		static const int decimal_shift = 1000;
 

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -52,6 +52,14 @@ namespace statistics
 		long long damage_inflicted, damage_taken;
 		long long turn_damage_inflicted, turn_damage_taken;
 
+		struct by_cth_t {
+			int strikes; //< Number of strike attempts at the given CTH
+			int hits; //< Number of strikes that hit at the given CTH
+			friend std::ostream& operator<<(std::ostream& outstream, const struct by_cth_t& by_cth);
+		};
+		/// A map of chance-to-hit percentage to a 'struct by_cth_t'.
+		std::map<int, struct by_cth_t> by_cth;
+
 		static const int decimal_shift = 1000;
 
 		// Expected value for damage inflicted/taken * 1000, based on
@@ -80,8 +88,8 @@ namespace statistics
 		enum hit_result { MISSES, HITS, KILLS };
 
 		void attack_expected_damage(double attacker_inflict, double defender_inflict);
-		void attack_result(hit_result res, int damage, int drain);
-		void defend_result(hit_result res, int damage, int drain);
+		void attack_result(hit_result res, int cth, int damage, int drain);
+		void defend_result(hit_result res, int cth, int damage, int drain);
 
 	private:
 

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -51,6 +51,10 @@ namespace statistics
 		battle_result_map attacks_inflicted;
 		/// Statistics of this side's attacks on enemies' turns.
 		battle_result_map defends_inflicted;
+		/// Statistics of enemies' counter attacks on this side's turns.
+		battle_result_map attacks_taken;
+		/// Statistics of enemies' attacks against this side on their turns.
+		battle_result_map defends_taken;
 
 		long long damage_inflicted, damage_taken;
 		long long turn_damage_inflicted, turn_damage_taken;

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -65,10 +65,9 @@ namespace statistics
 			by_cth_t() = default;
 			explicit by_cth_t(const config& cfg);
 			config write() const;
-			friend std::ostream& operator<<(std::ostream& outstream, const struct by_cth_t& by_cth);
 		};
 		/// A type that maps chance-to-hit percentage to number of hits and strikes at that CTH.
-		typedef std::map<int, struct by_cth_t> hitrate_map;
+		typedef std::map<int, by_cth_t> hitrate_map;
 		hitrate_map by_cth_inflicted, by_cth_taken;
 		hitrate_map turn_by_cth_inflicted, turn_by_cth_taken;
 
@@ -138,3 +137,4 @@ namespace statistics
 	/// Returns a list of names and stats for each scenario in the current campaign.
 	levels level_stats(const std::string & save_id);
 } // end namespace statistics
+std::ostream& operator<<(std::ostream& outstream, const statistics::stats::by_cth_t& by_cth);

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -59,15 +59,15 @@ namespace statistics
 		long long damage_inflicted, damage_taken;
 		long long turn_damage_inflicted, turn_damage_taken;
 
-		struct by_cth_t {
+		struct hitrate_t {
 			int strikes; //< Number of strike attempts at the given CTH
 			int hits; //< Number of strikes that hit at the given CTH
-			by_cth_t() = default;
-			explicit by_cth_t(const config& cfg);
+			hitrate_t() = default;
+			explicit hitrate_t(const config& cfg);
 			config write() const;
 		};
 		/// A type that maps chance-to-hit percentage to number of hits and strikes at that CTH.
-		typedef std::map<int, by_cth_t> hitrate_map;
+		typedef std::map<int, hitrate_t> hitrate_map;
 		hitrate_map by_cth_inflicted, by_cth_taken;
 		hitrate_map turn_by_cth_inflicted, turn_by_cth_taken;
 
@@ -137,4 +137,4 @@ namespace statistics
 	/// Returns a list of names and stats for each scenario in the current campaign.
 	levels level_stats(const std::string & save_id);
 } // end namespace statistics
-std::ostream& operator<<(std::ostream& outstream, const statistics::stats::by_cth_t& by_cth);
+std::ostream& operator<<(std::ostream& outstream, const statistics::stats::hitrate_t& by_cth);

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -67,9 +67,10 @@ namespace statistics
 			config write() const;
 			friend std::ostream& operator<<(std::ostream& outstream, const struct by_cth_t& by_cth);
 		};
-		/// Maps of chance-to-hit percentage to a 'struct by_cth_t'.
-		std::map<int, struct by_cth_t> by_cth_inflicted, by_cth_taken;
-		std::map<int, struct by_cth_t> turn_by_cth_inflicted, turn_by_cth_taken;
+		/// A type that maps chance-to-hit percentage to number of hits and strikes at that CTH.
+		typedef std::map<int, struct by_cth_t> hitrate_map;
+		hitrate_map by_cth_inflicted, by_cth_taken;
+		hitrate_map turn_by_cth_inflicted, turn_by_cth_taken;
 
 		static const int decimal_shift = 1000;
 

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -47,7 +47,10 @@ namespace statistics
 		/** A type that will map different % chances to hit to different results. */
 		typedef std::map<int,battle_sequence_frequency_map> battle_result_map;
 
-		battle_result_map attacks, defends;
+		/// Statistics of this side's attacks on its own turns.
+		battle_result_map attacks_inflicted;
+		/// Statistics of this side's attacks on enemies' turns.
+		battle_result_map defends_inflicted;
 
 		long long damage_inflicted, damage_taken;
 		long long turn_damage_inflicted, turn_damage_taken;

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -55,6 +55,9 @@ namespace statistics
 		struct by_cth_t {
 			int strikes; //< Number of strike attempts at the given CTH
 			int hits; //< Number of strikes that hit at the given CTH
+			by_cth_t() = default;
+			explicit by_cth_t(const config& cfg);
+			config write() const;
 			friend std::ostream& operator<<(std::ostream& outstream, const struct by_cth_t& by_cth);
 		};
 		/// Maps of chance-to-hit percentage to a 'struct by_cth_t'.

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -62,6 +62,7 @@ namespace statistics
 		};
 		/// Maps of chance-to-hit percentage to a 'struct by_cth_t'.
 		std::map<int, struct by_cth_t> by_cth_inflicted, by_cth_taken;
+		std::map<int, struct by_cth_t> turn_by_cth_inflicted, turn_by_cth_taken;
 
 		static const int decimal_shift = 1000;
 


### PR DESCRIPTION
Fixes #4066, see https://github.com/wesnoth/wesnoth/issues/4066#issuecomment-490973775 for an explanation.

Currently looks like this:

![2019-05-10-112557_1920x1080_scrot](https://user-images.githubusercontent.com/24784687/57524313-f8abe380-7316-11e9-96b4-96c696a446d5.png)

The screenshot shows the status after a single attack by a Silver Mage (9x4 magical) that hit 3/4.