### PR TITLE
create a simple overlay tag for resolve overlays bug

### DIFF
--- a/data/ai/micro_ais/scenarios/messenger_escort.cfg
+++ b/data/ai/micro_ais/scenarios/messenger_escort.cfg
@@ -74,7 +74,7 @@
             side=2
             x,y=30,27
             random_traits=no
-            overlays=misc/hero-icon.png
+            overlay=misc/hero-icon.png
         [/unit]
         {NOTRAIT_UNIT 2 Dragoon 30 26}
         [unit]

--- a/data/ai/micro_ais/scenarios/protect_unit.cfg
+++ b/data/ai/micro_ais/scenarios/protect_unit.cfg
@@ -111,7 +111,7 @@
             side=1
             x,y=20,9
             upkeep=loyal
-            overlays=misc/hero-icon.png
+            overlay=misc/hero-icon.png
         [/unit]
 
         # Goal signpost for Rossauba

--- a/data/campaigns/Dead_Water/scenarios/10_The_Flaming_Sword.cfg
+++ b/data/campaigns/Dead_Water/scenarios/10_The_Flaming_Sword.cfg
@@ -623,19 +623,6 @@
             [filter]
                 id=Caladon
             [/filter]
-            variable=Caladon_stored
-        [/store_unit]
-
-        [remove_unit_overlay]
-            x=$Caladon_stored.x
-            y=$Caladon_stored.y
-            image=misc/hero-icon.png
-        [/remove_unit_overlay]
-
-        [store_unit]
-            [filter]
-                id=Caladon
-            [/filter]
             kill=yes
             variable=Caladon_stored
         [/store_unit]
@@ -643,6 +630,7 @@
         {VARIABLE Caladon_stored.side 4}
         {VARIABLE Caladon_stored.canrecruit yes}
         {VARIABLE Caladon_stored.ellipse ""}
+        {VARIABLE Caladon_stored.overlay ""}
         # He is not going to recruit, but summon guardians each
         # turn. Still, he needs this variable set to get a crown icon,
         # and to show up in the status table.

--- a/data/campaigns/Dead_Water/scenarios/11_Getting_Help.cfg
+++ b/data/campaigns/Dead_Water/scenarios/11_Getting_Help.cfg
@@ -127,14 +127,13 @@
             name=Tyegea_stored.side
             value=1
         [/set_variable]
+        [set_variable]
+            name=Tyegea_stored.overlay
+            value="misc/loyal-icon.png"
+        [/set_variable]
         [unstore_unit]
             variable=Tyegea_stored
         [/unstore_unit]
-        [unit_overlay]
-            x=$Tyegea_stored.x
-            y=$Tyegea_stored.y
-            image=misc/loyal-icon.png
-        [/unit_overlay]
         [clear_variable]
             name=Tyegea_stored
         [/clear_variable]

--- a/data/campaigns/Dead_Water/scenarios/11_Getting_Help.cfg
+++ b/data/campaigns/Dead_Water/scenarios/11_Getting_Help.cfg
@@ -156,16 +156,10 @@
             [/filter]
             variable=Cylanna_stored
         [/store_unit]
-        [remove_unit_overlay]
-            x=$Cylanna_stored.x
-            y=$Cylanna_stored.y
-            image=misc/hero-icon.png
-        [/remove_unit_overlay]
-        [unit_overlay]
-            x=$Cylanna_stored.x
-            y=$Cylanna_stored.y
-            image=misc/loyal-icon.png
-        [/unit_overlay]
+        [set_variable]
+            name=Cylanna_stored.overlay
+            value="misc/loyal-icon.png"
+        [/set_variable]
         [clear_variable]
             name=Cylanna_stored
         [/clear_variable]

--- a/data/campaigns/Delfadors_Memoirs/scenarios/19_Showdown_in_the_Northern_Swamp.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/19_Showdown_in_the_Northern_Swamp.cfg
@@ -218,6 +218,7 @@
             variable=start_loc
         [/store_starting_location]
         {CLEAR_VARIABLE Lionel.overlays}
+         {CLEAR_VARIABLE Lionel.overlay}
         {CLEAR_VARIABLE Lionel.ellipse}
         {VARIABLE Lionel.canrecruit yes}
         {VARIABLE Lionel.side 2}

--- a/data/campaigns/Delfadors_Memoirs/utils/sides.cfg
+++ b/data/campaigns/Delfadors_Memoirs/utils/sides.cfg
@@ -134,7 +134,7 @@
 
 #define CHANTAL_FOLLOWS_DELFADOR
     {MODIFY_UNIT (id=Chantal) canrecruit no}
-    {MODIFY_UNIT (id=Chantal) overlays "misc/hero-icon.png"}
+    {MODIFY_UNIT (id=Chantal) overlay "misc/hero-icon.png"}
     {MODIFY_UNIT (id=Chantal) ellipse "misc/ellipse-hero"}
     {MODIFY_UNIT (side=3) side 1}
     [modify_side]

--- a/data/campaigns/Descent_Into_Darkness/scenarios/10_Alone_at_Last.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/10_Alone_at_Last.cfg
@@ -196,6 +196,7 @@
         # Removes the loyal trait and other misc stuff
         {CLEAR_VARIABLE stored_Darken.modifications.trait[0]}
         {CLEAR_VARIABLE stored_Darken.overlays}
+        {CLEAR_VARIABLE stored_Darken.overlay}
         {CLEAR_VARIABLE stored_Darken.ellipse}
 
         [unstore_unit]

--- a/data/campaigns/Descent_Into_Darkness/utils/macros.cfg
+++ b/data/campaigns/Descent_Into_Darkness/utils/macros.cfg
@@ -195,6 +195,7 @@
             facing=$stored_necromancer.facing
             moves=$stored_necromancer.moves
             overlays=$stored_necromancer.overlays
+            overlay=$stored_necromancer.overlay
             hitpoints=$stored_necromancer.hitpoints
             canrecruit=$stored_necromancer.canrecruit
             attacks_left=$stored_necromancer.attacks_left

--- a/data/campaigns/Eastern_Invasion/utils/macros.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/macros.cfg
@@ -79,7 +79,7 @@
                 set_type=arcane
             [/effect]
             [effect]
-                apply_to=overlay
+                apply_to=overlays
                 add="misc/arcane-icon.png"
             [/effect]
         [/object]

--- a/data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg
+++ b/data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg
@@ -302,6 +302,7 @@
                     unrenamable=$this_item.unrenamable
                     canrecruit=$this_item.canrecruit
                     overlays=$this_item.overlays
+                    overlay=$this_item.overlay
                     random_traits=$this_item.random_traits
                     role=$this_item.role
 

--- a/data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg
+++ b/data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg
@@ -48,7 +48,7 @@
         profile=portraits/relana.png
         facing=se
         side=2
-        overlays=misc/hero-icon.png
+        overlay=misc/hero-icon.png
         canrecruit=yes
         controller=ai
         [ai]

--- a/data/campaigns/Liberty/scenarios/08_Glory.cfg
+++ b/data/campaigns/Liberty/scenarios/08_Glory.cfg
@@ -323,10 +323,7 @@
         {UNMAKE_HERO Harper}
 
         # He's still a loyal unit with dialogue when he dies
-        [unit_overlay]
-            id=Harper
-            image=misc/loyal-icon.png
-        [/unit_overlay]
+        {MODIFY_UNIT (id=Harper) overlay "misc/loyal-icon.png"}
 
         [message]
             speaker=Baldras

--- a/data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg
@@ -981,7 +981,7 @@
                         equals=Stalrag
                     [/variable]
                     [then]
-                        {VARIABLE this_item.overlays misc/loyal-icon.png}
+                        {VARIABLE this_item.overlay misc/loyal-icon.png}
                         [set_variables]
                             name=this_item.modifications
                             mode=replace
@@ -992,7 +992,7 @@
                         [/set_variables]
                     [/then]
                     [else]
-                        {VARIABLE this_item.overlays misc/hero-icon.png}
+                        {VARIABLE this_item.overlay misc/hero-icon.png}
                         {VARIABLE this_item.ellipse misc/ellipse-hero}
                         [set_variables]
                             name=this_item.modifications

--- a/data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg
@@ -567,17 +567,8 @@
 
         {CLEAR_VARIABLE krash_flies_away}
 
-        # Remove loyalty overlay
-        [remove_unit_overlay]
-            id=Krash
-            image=misc/loyal-icon.png
-        [/remove_unit_overlay]
 
-        # Give expendable overlay
-        [unit_overlay]
-            id=Krash
-            image=misc/leader-expendable.png
-        [/unit_overlay]
+        {MODIFY_UNIT (id=Krash) overlay "misc/leader-expendable.png"}
 
         [move_unit_fake]
             type=Drake Burner

--- a/data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg
@@ -325,17 +325,8 @@
                     y=$eryssa_starts_at.y
                 [/recall]
 
-                # Remove loyalty overlay
-                [remove_unit_overlay]
-                    id=Eryssa
-                    image=misc/loyal-icon.png
-                [/remove_unit_overlay]
-
-                # Give expendable overlay
-                [unit_overlay]
-                    id=Eryssa
-                    image=misc/leader-expendable.png
-                [/unit_overlay]
+     
+                {MODIFY_UNIT (id=Eryssa) overlay "misc/leader-expendable.png"}
 
                 [store_unit]
                     [filter]

--- a/data/campaigns/Northern_Rebirth/utils/utils.cfg
+++ b/data/campaigns/Northern_Rebirth/utils/utils.cfg
@@ -87,16 +87,7 @@
                 [/filter]
                 canrecruit=yes
             [/modify_unit]
-            # Remove loyalty overlay
-            [remove_unit_overlay]
-                id=Krash
-                image=misc/loyal-icon.png
-            [/remove_unit_overlay]
-            # Give expendable overlay
-            [unit_overlay]
-                id=Krash
-                image=misc/leader-expendable.png
-            [/unit_overlay]
+            {MODIFY_UNIT (id=Krash) overlay "misc/leader-expendable.png"}
         [/then]
     [/if]
     {CLEAR_VARIABLE krash,start_loc}

--- a/data/campaigns/Sceptre_of_Fire/scenarios/3_Searching_for_the_Runecrafter.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/3_Searching_for_the_Runecrafter.cfg
@@ -596,10 +596,7 @@
             message= _ "Well, now we are in the caves again! Come on, back south, to the city."
         [/message]
         {UNMAKE_HERO Baglur}
-        [unit_overlay]
-            id=Baglur
-            image=misc/loyal-icon.png
-        [/unit_overlay]
+        {MODIFY_UNIT (id=Baglur) overlay "misc/loyal-icon.pngg"}
         {CLEAR_VARIABLE thur_x,thur_y}
         [endlevel]
             result=victory

--- a/data/campaigns/Sceptre_of_Fire/scenarios/3_Searching_for_the_Runecrafter.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/3_Searching_for_the_Runecrafter.cfg
@@ -596,7 +596,7 @@
             message= _ "Well, now we are in the caves again! Come on, back south, to the city."
         [/message]
         {UNMAKE_HERO Baglur}
-        {MODIFY_UNIT (id=Baglur) overlay "misc/loyal-icon.pngg"}
+        {MODIFY_UNIT (id=Baglur) overlay "misc/loyal-icon.png"}
         {CLEAR_VARIABLE thur_x,thur_y}
         [endlevel]
             result=victory

--- a/data/campaigns/Secrets_of_the_Ancients/utils/sota-utils.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/utils/sota-utils.cfg
@@ -867,6 +867,7 @@
             facing=$stored_necromancer.facing
             moves=$stored_necromancer.moves
             overlays=$stored_necromancer.overlays
+            overlay=$stored_necromancer.overlay
             hitpoints=$stored_necromancer.hitpoints
             canrecruit=$stored_necromancer.canrecruit
             attacks_left=$stored_necromancer.attacks_left

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/02_The_Fall.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/02_The_Fall.cfg
@@ -328,7 +328,7 @@
                         x,y=$wesfolk_leader_store.x,$wesfolk_leader_store.y
                         experience=$wesfolk_leader_store.experience
                         moves=$wesfolk_leader_store.moves
-                        overlays=misc/hero-icon.png
+                        overlay=misc/hero-icon.png
                         random_traits=no
                         profile=portraits/lady_outlaw.png
                         [modifications]

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/07_Return_to_Oldwood.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/07_Return_to_Oldwood.cfg
@@ -270,7 +270,7 @@
             placement=map_overwrite
             facing=$lady_store.facing
             experience=$lady_store.experience
-            overlays=misc/hero-icon.png
+            overlay=misc/hero-icon.png
             random_traits=no
             profile=portraits/jessica.png
             [modifications]

--- a/data/campaigns/The_South_Guard/scenarios/05_Choice_In_The_Fog.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/05_Choice_In_The_Fog.cfg
@@ -89,7 +89,7 @@
         id=Gruth
         name= _ "Gruth"
         canrecruit=yes
-        overlays="misc/leader-expendable.png"
+        overlay="misc/leader-expendable.png"
 
         team_name=undead
         user_team_name=_"Undead"
@@ -104,7 +104,7 @@
             id=Gerd
             name=_ "Gerd"
             canrecruit=yes
-            overlays="misc/leader-expendable.png"
+            overlay="misc/leader-expendable.png"
             x,y=11,26
         [/unit]
         [ai]

--- a/data/campaigns/The_South_Guard/scenarios/07b_Pebbles_in_the_Flood.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/07b_Pebbles_in_the_Flood.cfg
@@ -320,11 +320,11 @@
             id=Minister Hylas
         [/kill]
 
-        {MODIFY_UNIT (id=Sir Gerrick) overlays ""}
+        {MODIFY_UNIT (id=Sir Gerrick) overlay ""}
         {MODIFY_UNIT (id=Sir Gerrick) canrecruit yes}
         {MODIFY_UNIT (id=Sir Gerrick) ellipse ""}
 
-        {MODIFY_UNIT (id=Urza Afalas) overlays "misc/loyal-icon.png"}
+        {MODIFY_UNIT (id=Urza Afalas) overlay "misc/loyal-icon.png"}
         {MODIFY_UNIT (id=Urza Afalas) ellipse ""}
 
         [message]

--- a/data/campaigns/The_South_Guard/scenarios/08b_The_Tides_of_War.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/08b_The_Tides_of_War.cfg
@@ -390,7 +390,7 @@
             x,y=18,8
         [/recall]
 
-        {MODIFY_UNIT (id=Minister Hylas) overlays "misc/loyal-icon.png"}
+        {MODIFY_UNIT (id=Minister Hylas) overlay "misc/loyal-icon.png"}
         {MODIFY_UNIT (id=Minister Hylas) ellipse ""}
 
         [message]
@@ -666,7 +666,7 @@
             [modifications]
                 {TRAIT_LOYAL}
             [/modifications]
-            overlays="misc/loyal-icon.png"
+            overlay="misc/loyal-icon.png"
         )}
         {UNIT 1 (White Mage) 9 2 (
             generate_name=yes
@@ -675,7 +675,7 @@
             [modifications]
                 {TRAIT_LOYAL}
             [/modifications]
-            overlays="misc/loyal-icon.png"
+            overlay="misc/loyal-icon.png"
         )}
     [/event]
 

--- a/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
@@ -538,7 +538,7 @@ Besides... I want my brother back."
         [/move_unit_fake]
 
         {NAMED_UNIT 1 (Iron Mauler) 8 1 Brena _"Brena" (
-            overlays="misc/loyal-icon.png"
+            overlay="misc/loyal-icon.png"
             [modifications]
                 {TRAIT_LOYAL}
                 {TRAIT_STRONG}

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg
@@ -365,7 +365,7 @@
             [filter]
                 id=Grak,Zur
             [/filter]
-            overlays=misc/loyal-icon.png~GS()
+            overlay=misc/loyal-icon.png~GS()
         [/modify_unit]
 
         [message]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
@@ -327,10 +327,7 @@
         # wmllint: recognize Jarl
 
         # put hero icon on troll/dwarf ally
-        [unit_overlay]
-            id=$ally_name
-            image=misc/hero-icon.png
-        [/unit_overlay]
+        {MODIFY_UNIT (id=$ally_name) overlay "misc/hero-icon.png"}
 
         # initialize starting variables
 
@@ -2839,10 +2836,7 @@
 
             # remove hero icon from troll/dwarf ally
 
-            [remove_unit_overlay]
-                id=$ally_name
-                image=misc/hero-icon.png
-            [/remove_unit_overlay]
+            {MODIFY_UNIT (id=$ally_name) overlay ""}
         [/event]
     [/event]
 

--- a/data/core/macros/deprecated-utils.cfg
+++ b/data/core/macros/deprecated-utils.cfg
@@ -164,7 +164,7 @@ _"No gold carried over to the next scenario."#enddef
             {TRAIT_UNDEAD}
             {TRAIT_LOYAL}
         [/modifications]
-        overlays="misc/loyal-icon.png"
+        overlay="misc/loyal-icon.png"
     [/unit]
 #enddef
 

--- a/data/core/macros/image-utils.cfg
+++ b/data/core/macros/image-utils.cfg
@@ -175,10 +175,10 @@
 
 #define MAKE_HERO ID_STRING
     # Give an existing unit a hero overlay
-    [unit_overlay]
+    [unit_simple_overlay]
         id={ID_STRING}
         image=misc/hero-icon.png
-    [/unit_overlay]
+    [/unit_simple_overlay]
     [object]
         silent=yes
         duration=forever
@@ -196,10 +196,10 @@
 
 #define UNMAKE_HERO ID_STRING
     # Remove the hero overlay from a unit
-    [remove_unit_overlay]
+    [remove_unit_simple_overlay]
         id={ID_STRING}
         image=misc/hero-icon.png
-    [/remove_unit_overlay]
+    [/remove_unit_simple_overlay]
     [object]
         silent=yes
         duration=forever

--- a/data/core/macros/image-utils.cfg
+++ b/data/core/macros/image-utils.cfg
@@ -17,18 +17,18 @@
 
 #define IS_HERO
     # Embed this into a unit declaration to add a hero icon to the unit.
-    overlays="misc/hero-icon.png"
+    overlay="misc/hero-icon.png"
     ellipse="misc/ellipse-hero"
 #enddef
 
 #define IS_LOYAL
     # Embed this into a unit declaration to add a loyalty icon to the unit.
-    overlays="misc/loyal-icon.png"
+    overlay="misc/loyal-icon.png"
 #enddef
 
 #define IS_EXPENDABLE_LEADER
     # Embed this into a unit declaration to add an expendable leader icon to the unit.
-    overlays="misc/leader-expendable.png"
+    overlay="misc/leader-expendable.png"
 #enddef
 
 #define NEW_JOURNEY X Y

--- a/data/core/macros/unit-utils.cfg
+++ b/data/core/macros/unit-utils.cfg
@@ -78,7 +78,7 @@
         [modifications]
             {TRAIT_LOYAL}
         [/modifications]
-        overlays="misc/loyal-icon.png"
+        overlay="misc/loyal-icon.png"
     [/unit]
 #enddef
 
@@ -112,7 +112,7 @@
         [modifications]
             {TRAIT_LOYAL}
         [/modifications]
-        overlays="misc/loyal-icon.png"
+        overlay="misc/loyal-icon.png"
     [/unit]
 #enddef
 
@@ -178,7 +178,7 @@
     [+unit]
         upkeep=loyal
         # It's questionable whether we should do this here...
-        overlays="misc/loyal-icon.png"
+        overlay="misc/loyal-icon.png"
     [/unit]
 #enddef
 

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -347,7 +347,7 @@ function wml_actions.select_unit(cfg)
 	wesnoth.select_unit(u.x, u.y, cfg.highlight, cfg.fire_event)
 end
 
-function wml_actions.unit_overlay(cfg)
+function wml_actions.unit_overlays(cfg)
 	local img = cfg.image or helper.wml_error( "[unit_overlay] missing required image= attribute" )
 	for i,u in ipairs(wesnoth.get_units(cfg)) do
 		local has_already = false
@@ -358,7 +358,7 @@ function wml_actions.unit_overlay(cfg)
 			u:add_modification("object", {
 				id = cfg.object_id,
 				wml.tag.effect {
-					apply_to = "overlay",
+					apply_to = "overlays",
 					add = img,
 				}
 			})
@@ -366,7 +366,7 @@ function wml_actions.unit_overlay(cfg)
 	end
 end
 
-function wml_actions.remove_unit_overlay(cfg)
+function wml_actions.remove_unit_overlays(cfg)
 	local img = cfg.image or helper.wml_error( "[remove_unit_overlay] missing required image= attribute" )
 
 	-- Loop through all matching units.
@@ -379,6 +379,32 @@ function wml_actions.remove_unit_overlay(cfg)
 		end
 		-- Reassemble the list of remaining overlays.
 		ucfg.overlays = table.concat(t, ',')
+		wesnoth.put_unit(ucfg)
+	end
+end
+
+function wml_actions.unit_overlay(cfg)
+	local img = cfg.image or helper.wml_error( "[unit_overlay] missing required image= attribute" )
+	for i,u in ipairs(wesnoth.get_units(cfg)) do
+	local ucfg = u.__cfg
+		ucfg.overlay= img
+		wesnoth.put_unit(ucfg)
+	end
+end
+
+function wml_actions.remove_unit_overlay(cfg)
+	local img = cfg.image or helper.wml_error( "[remove_unit_overlay] missing required image= attribute" )
+
+	-- Loop through all matching units.
+	for i,u in ipairs(wesnoth.get_units(cfg)) do
+		local ucfg = u.__cfg
+		local t = utils.parenthetical_split(ucfg.overlay)
+		-- Remove the specified image from the overlays.
+		for i = #t,1,-1 do
+			if t[i] == img then table.remove(t, i) end
+		end
+		-- Reassemble the list of remaining overlays.
+		ucfg.overlay = table.concat(t, ',')
 		wesnoth.put_unit(ucfg)
 	end
 end

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -347,7 +347,7 @@ function wml_actions.select_unit(cfg)
 	wesnoth.select_unit(u.x, u.y, cfg.highlight, cfg.fire_event)
 end
 
-function wml_actions.unit_overlays(cfg)
+function wml_actions.unit_overlay(cfg)
 	local img = cfg.image or helper.wml_error( "[unit_overlay] missing required image= attribute" )
 	for i,u in ipairs(wesnoth.get_units(cfg)) do
 		local has_already = false
@@ -366,7 +366,7 @@ function wml_actions.unit_overlays(cfg)
 	end
 end
 
-function wml_actions.remove_unit_overlays(cfg)
+function wml_actions.remove_unit_overlay(cfg)
 	local img = cfg.image or helper.wml_error( "[remove_unit_overlay] missing required image= attribute" )
 
 	-- Loop through all matching units.
@@ -383,8 +383,8 @@ function wml_actions.remove_unit_overlays(cfg)
 	end
 end
 
-function wml_actions.unit_overlay(cfg)
-	local img = cfg.image or helper.wml_error( "[unit_overlay] missing required image= attribute" )
+function wml_actions.unit_simple_overlay(cfg)
+	local img = cfg.image or helper.wml_error( "[unit_simple_overlay] missing required image= attribute" )
 	for i,u in ipairs(wesnoth.get_units(cfg)) do
 	local ucfg = u.__cfg
 		ucfg.overlay= img
@@ -392,8 +392,8 @@ function wml_actions.unit_overlay(cfg)
 	end
 end
 
-function wml_actions.remove_unit_overlay(cfg)
-	local img = cfg.image or helper.wml_error( "[remove_unit_overlay] missing required image= attribute" )
+function wml_actions.remove_unit_simple_overlay(cfg)
+	local img = cfg.image or helper.wml_error( "[remove_unit_simple_overlay] missing required image= attribute" )
 
 	-- Loop through all matching units.
 	for i,u in ipairs(wesnoth.get_units(cfg)) do

--- a/data/schema/units/modifications.cfg
+++ b/data/schema/units/modifications.cfg
@@ -155,7 +155,7 @@
 				{LINK_TAG "units/unit_type/extra_anim"}
 			[/case]
 			[case]
-				value=image_mod,overlay
+				value=image_mod,overlays
 				{SIMPLE_KEY replace string}
 				{SIMPLE_KEY add string}
 				{LINK_TAG "game_config/color_range"}
@@ -164,6 +164,10 @@
 			[case]
 				value=ellipse
 				{SIMPLE_KEY ellipse string}
+			[/case]
+             [case]
+				value=overlay
+				{SIMPLE_KEY overlay string}
 			[/case]
 			[case]
 				value=halo

--- a/data/schema/units/single.cfg
+++ b/data/schema/units/single.cfg
@@ -34,6 +34,7 @@
 	{SIMPLE_KEY usage ai_usage}
 	{SIMPLE_KEY zoc s_bool}
 	{SIMPLE_KEY ellipse string}
+    {SIMPLE_KEY overlay string}
 	{DEPRECATED_KEY ai_special string} # Not documented
 	{SIMPLE_KEY description t_string} # Not documented
 	{SIMPLE_KEY flag_icon string} # Not documented

--- a/data/schema/units/types.cfg
+++ b/data/schema/units/types.cfg
@@ -11,6 +11,7 @@
 	{SIMPLE_KEY die_sound string}
 	{SIMPLE_KEY do_not_list bool}
 	{SIMPLE_KEY ellipse string}
+    {SIMPLE_KEY overlay string}
 	{SIMPLE_KEY experience int}
 	{SIMPLE_KEY flag_rgb string}
 	{SIMPLE_KEY gender string} # TODO: gender_list type

--- a/src/gui/dialogs/unit_recall.cpp
+++ b/src/gui/dialogs/unit_recall.cpp
@@ -184,6 +184,10 @@ void unit_recall::pre_show(window& window)
 		for(const std::string& overlay : unit->overlays()) {
 			mods += "~BLIT(" + overlay + ")";
 		}
+		
+		if(!unit->image_overlay().empty()) {
+			mods += "~BLIT(" + unit->image_overlay() + ")";
+		}
 
 		column["use_markup"] = "true";
 

--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -422,6 +422,10 @@ void unit_preview_pane::set_displayed_unit(const unit& u)
 		for(const std::string& overlay : u.overlays()) {
 			mods += "~BLIT(" + overlay + ")";
 		}
+		
+		if(!u.image_overlay().empty()) {
+			mods += "~BLIT(" + u.image_overlay() + ")";
+		}
 
 		mods += "~XBRZ(2)~SCALE_INTO_SHARP(144,144)" + image_mods_;
 

--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -83,6 +83,7 @@ void unit_drawer::redraw_unit (const unit & u) const
 	color_t xp_color=u.xp_color();
 
 	std::string ellipse=u.image_ellipse();
+	std::string overlay=u.image_overlay();
 
 	const bool is_highlighted_enemy = units_that_can_reach_goal.count(loc) > 0;
 	const bool is_selected_hex = (loc == sel_hex || is_highlighted_enemy);
@@ -331,6 +332,17 @@ void unit_drawer::redraw_unit (const unit & u) const
 			if(ov_img != nullptr) {
 				disp.drawing_buffer_add(display::LAYER_UNIT_BAR,
 					loc, xsrc+xoff, ysrc+yoff+adjusted_params.y, ov_img);
+			}
+		}
+		
+		if(!overlay.empty()) {
+			surface pov(image::get_image(u.image_overlay(),image::SCALED_TO_ZOOM));
+			if(!pov.null()) {
+				//if(bar_alpha != ftofxp(1.0)) {
+				//	crown = adjust_surface_alpha(crown, bar_alpha);
+				//}
+				disp.drawing_buffer_add(display::LAYER_UNIT_BAR,
+					loc, xsrc+xoff, ysrc+yoff+adjusted_params.y, pov);
 			}
 		}
 	}

--- a/src/units/types.hpp
+++ b/src/units/types.hpp
@@ -164,8 +164,8 @@ public:
 	const std::string &small_profile() const { return small_profile_; }
 	const std::string &big_profile() const { return profile_; }
 	std::string halo() const { return cfg_["halo"]; }
-	std::string ellipse() const { return cfg_["ellipse"]; }
 	std::string overlay() const { return cfg_["overlay"]; }
+	std::string ellipse() const { return cfg_["ellipse"]; }
 	bool generate_name() const { return cfg_["generate_name"].to_bool(true); }
 	const std::vector<unit_animation>& animations() const;
 

--- a/src/units/types.hpp
+++ b/src/units/types.hpp
@@ -165,6 +165,7 @@ public:
 	const std::string &big_profile() const { return profile_; }
 	std::string halo() const { return cfg_["halo"]; }
 	std::string ellipse() const { return cfg_["ellipse"]; }
+	std::string overlay() const { return cfg_["overlay"]; }
 	bool generate_name() const { return cfg_["generate_name"].to_bool(true); }
 	const std::vector<unit_animation>& animations() const;
 

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -138,6 +138,7 @@ namespace
 		"description",
 		"usage",
 		"halo",
+		"overlay",
 		"ellipse",
 		"upkeep",
 		"random_traits",
@@ -359,6 +360,7 @@ unit::unit(const unit& o)
 	, description_(o.description_)
 	, usage_(copy_or_null(o.usage_))
 	, halo_(copy_or_null(o.halo_))
+	, overlay_(copy_or_null(o.overlay_))
 	, ellipse_(copy_or_null(o.ellipse_))
 	, random_traits_(o.random_traits_)
 	, generate_name_(o.generate_name_)
@@ -439,6 +441,7 @@ unit::unit()
 	, description_()
 	, usage_()
 	, halo_()
+	, overlay_()
 	, ellipse_()
 	, random_traits_(true)
 	, generate_name_(true)
@@ -556,6 +559,10 @@ void unit::init(const config& cfg, bool use_traits, const vconfig* vcfg)
 
 	if(const config::attribute_value* v = cfg.get("ellipse")) {
 		set_image_ellipse(*v);
+	}
+
+	if(const config::attribute_value* v = cfg.get("overlay")) {
+		set_image_overlay(*v);
 	}
 
 	if(const config::attribute_value* v = cfg.get("halo")) {
@@ -928,6 +935,9 @@ void unit::advance_to(const unit_type& u_type, bool use_traits)
 	}
 
 	set_image_halo(new_type.halo());
+	if(!new_type.overlay().empty()) {
+		set_image_overlay(new_type.overlay());
+	}
 	if(!new_type.ellipse().empty()) {
 		set_image_ellipse(new_type.ellipse());
 	}
@@ -1445,6 +1455,10 @@ void unit::write(config& cfg, bool write_all) const
 		cfg["halo"] = *halo_;
 	}
 
+	if(overlay_.get()) {
+		cfg["overlay"] = *overlay_;
+	}
+
 	if(ellipse_.get()) {
 		cfg["ellipse"] = *ellipse_;
 	}
@@ -1811,7 +1825,7 @@ const std::set<std::string> unit::builtin_effects {
 	"alignment", "attack", "defense", "ellipse", "experience", "fearless",
 	"halo", "healthy", "hitpoints", "image_mod", "jamming", "jamming_costs",
 	"loyal", "max_attacks", "max_experience", "movement", "movement_costs",
-	"new_ability", "new_advancement", "new_animation", "new_attack", "overlay", "profile",
+	"new_ability", "new_advancement", "new_animation", "new_attack", "overlays", "overlay", "profile",
 	"recall_cost", "remove_ability", "remove_advancement", "remove_attacks", "resistance",
 	"status", "type", "variation", "vision", "vision_costs", "zoc"
 };
@@ -2113,9 +2127,11 @@ void unit::apply_builtin_effect(std::string apply_to, const config& effect)
 		anim_comp_->apply_new_animation_effect(effect);
 	} else if(apply_to == "ellipse") {
 		set_image_ellipse(effect["ellipse"]);
+	} else if(apply_to == "overlay") {
+		set_image_overlay(effect["overlay"]);
 	} else if(apply_to == "halo") {
 		set_image_halo(effect["halo"]);
-	} else if(apply_to == "overlay") {
+	} else if(apply_to == "overlays") {
 		const std::string& add = effect["add"];
 		const std::string& replace = effect["replace"];
 

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1468,11 +1468,22 @@ public:
 		return unit_detail::get_or_default(ellipse_);
 	}
 
+	std::string image_overlay() const
+	{
+		return unit_detail::get_or_default(overlay_);
+	}
+
 	/** Set the unit's ellipse image. */
 	void set_image_ellipse(const std::string& ellipse)
 	{
 		appearance_changed_ = true;
 		ellipse_.reset(new std::string(ellipse));
+	}
+
+	void set_image_overlay(const std::string& overlay)
+	{
+		appearance_changed_ = true;
+		overlay_.reset(new std::string(overlay));
 	}
 
 	/**
@@ -1811,6 +1822,7 @@ private:
 
 	std::unique_ptr<std::string> usage_;
 	std::unique_ptr<std::string> halo_;
+	std::unique_ptr<std::string> overlay_;
 	std::unique_ptr<std::string> ellipse_;
 
 	bool random_traits_;


### PR DESCRIPTION
To solve the problem in the https://github.com/wesnoth/wesnoth/issues/4058 issue, I had the idea to create a simple overlay that could contain only one image and use it for icon 'hero' and 'loyal' instead of overlays multiple that is no persist now. I also reassign unit_overlay and remove_unit_overlay to this unique overlay and add unit_overlays to multiple overlays.
