### PR TITLE
make overlays contain simple image and add mp_overlays for contains multiple image

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 ## Version 1.15.0-dev
  ### AI
-   * Micro AIs
+   * Micro AIs 
      * Add [avoid] tag functionality to Multipack Wolves, Wolves, Swarm and Goto Micro AIs
      * Support named locations for [micro_ai] tag location keys
      * Goto and Assassin: fix MAIs not working with tunnels when using custom path finding cost functions

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 ## Version 1.15.0-dev
  ### AI
-   * Micro AIs 
+   * Micro AIs
      * Add [avoid] tag functionality to Multipack Wolves, Wolves, Swarm and Goto Micro AIs
      * Support named locations for [micro_ai] tag location keys
      * Goto and Assassin: fix MAIs not working with tunnels when using custom path finding cost functions

--- a/data/campaigns/Dead_Water/scenarios/08_Talking_to_Tyegea.cfg
+++ b/data/campaigns/Dead_Water/scenarios/08_Talking_to_Tyegea.cfg
@@ -240,11 +240,11 @@
                     y=8
                 [/filter]
                 [then]
-                    [unit_overlay]
+                    [unit_mp_overlay]
                         x=15
                         y=8
                         image=overlays/arcane-icon.png
-                    [/unit_overlay]
+                    [/unit_mp_overlay]
                     [remove_item]
                         x,y=15,8
                     [/remove_item]

--- a/data/campaigns/Dead_Water/utils/items.cfg
+++ b/data/campaigns/Dead_Water/utils/items.cfg
@@ -17,11 +17,11 @@
             y={Y}
         [/filter]
         [then]
-            [unit_overlay]
+            [unit_mp_overlay]
                 x={X}
                 y={Y}
                 image=overlays/storm-trident-icon.png
-            [/unit_overlay]
+            [/unit_mp_overlay]
             [remove_item]
                 x={X}
                 y={Y}
@@ -60,11 +60,11 @@
             y={Y}
         [/filter]
         [then]
-            [unit_overlay]
+            [unit_mp_overlay]
                 x={X}
                 y={Y}
                 image=overlays/flame-sword-icon.png
-            [/unit_overlay]
+            [/unit_mp_overlay]
             [remove_item]
                 x={X}
                 y={Y}
@@ -98,11 +98,11 @@
             y={Y}
         [/filter]
         [then]
-            [unit_overlay]
+            [unit_mp_overlay]
                 x={X}
                 y={Y}
                 image=overlays/arcane-icon.png
-            [/unit_overlay]
+            [/unit_mp_overlay]
             [remove_item]
                 x={X}
                 y={Y}
@@ -313,11 +313,11 @@
                         y=$ring_y
                     [/filter]
                     [then]
-                        [unit_overlay]
+                        [unit_mp_overlay]
                             x=$ring_x
                             y=$ring_y
                             image=overlays/silver-ring-icon.png
-                        [/unit_overlay]
+                        [/unit_mp_overlay]
                         [remove_item]
                             x=$ring_x
                             y=$ring_y

--- a/data/campaigns/Descent_Into_Darkness/scenarios/10_Alone_at_Last.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/10_Alone_at_Last.cfg
@@ -196,6 +196,7 @@
         # Removes the loyal trait and other misc stuff
         {CLEAR_VARIABLE stored_Darken.modifications.trait[0]}
         {CLEAR_VARIABLE stored_Darken.overlays}
+        {CLEAR_VARIABLE stored_Darken.mp_overlays}
         {CLEAR_VARIABLE stored_Darken.ellipse}
 
         [unstore_unit]

--- a/data/campaigns/Descent_Into_Darkness/scenarios/10_Alone_at_Last.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/10_Alone_at_Last.cfg
@@ -255,10 +255,10 @@
 
         {CLEAR_VARIABLE hasBook}
 
-        [unit_overlay]
+        [unit_mp_overlay]
             id=Darken Volk
             image="misc/book-icon.png"
-        [/unit_overlay]
+        [/unit_mp_overlay]
 
         {MODIFY_UNIT (id=Darken Volk) facing ne}
 
@@ -791,10 +791,10 @@
             role=book_carrier
         [/role]
 
-        [unit_overlay]
+        [unit_mp_overlay]
             x,y=$x1,$y1
             image="misc/book-icon.png"
-        [/unit_overlay]
+        [/unit_mp_overlay]
 
         [if]
             [have_unit]
@@ -907,10 +907,10 @@
             [/filter_location]
         [/filter]
 
-        [remove_unit_overlay]
+        [remove_unit_mp_overlay]
             role=book_carrier
             image="misc/book-icon.png"
-        [/remove_unit_overlay]
+        [/remove_unit_mp_overlay]
 
         {MOVE_UNIT (id=Malin Keshar) 1 8}
 

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg
@@ -325,10 +325,10 @@
                     x,y={POSITION}
                     role=gold_carrier
                 [/role]
-                [unit_overlay]
+                [unit_mp_overlay]
                     x,y={POSITION}
                     image=items/gold-coins-small.png
-                [/unit_overlay]
+                [/unit_mp_overlay]
             [/then]
         [/object]
     [/event]
@@ -423,10 +423,10 @@
             y=22
         [/filter]
 
-        [remove_unit_overlay]
+        [remove_unit_mp_overlay]
             role=gold_carrier
             image=items/gold-coins-small.png
-        [/remove_unit_overlay]
+        [/remove_unit_mp_overlay]
 
         [endlevel]
             result=victory
@@ -444,10 +444,10 @@
             [proceed_to_next_scenario]
             [/proceed_to_next_scenario]
         [/filter_condition]
-        [remove_unit_overlay]
+        [remove_unit_mp_overlay]
             role=gold_carrier
             image=items/gold-coins-small.png
-        [/remove_unit_overlay]
+        [/remove_unit_mp_overlay]
         [message]
             id=Kalenz
             message= _ "We have recovered our gold; it is well."

--- a/data/campaigns/Sceptre_of_Fire/scenarios/4_Gathering_Materials.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/4_Gathering_Materials.cfg
@@ -688,10 +688,10 @@
             variable=unit
             find_vacant=no
         [/unstore_unit]
-        [unit_overlay]
+        [unit_mp_overlay]
             x,y=$x1,$y1
             image=misc/coal-icon.png
-        [/unit_overlay]
+        [/unit_mp_overlay]
         [remove_item]
             x,y=$x1,$y1
         [/remove_item]
@@ -725,10 +725,10 @@
             variable=unit
             find_vacant=no
         [/unstore_unit]
-        [unit_overlay]
+        [unit_mp_overlay]
             x,y=$x1,$y1
             image=misc/coal-icon.png
-        [/unit_overlay]
+        [/unit_mp_overlay]
         [remove_item]
             x,y=$x1,$y1
         [/remove_item]
@@ -782,10 +782,10 @@
             variable=unit
             find_vacant=no
         [/unstore_unit]
-        [unit_overlay]
+        [unit_mp_overlay]
             x,y=$x1,$y1
             image=misc/gold-icon.png
-        [/unit_overlay]
+        [/unit_mp_overlay]
         [remove_item]
             x,y=$x1,$y1
         [/remove_item]
@@ -849,10 +849,10 @@
                     find_vacant=no
                 [/unstore_unit]
 
-                [unit_overlay]
+                [unit_mp_overlay]
                     x,y=$x1,$y1
                     image=misc/coal-icon.png
-                [/unit_overlay]
+                [/unit_mp_overlay]
 
                 [remove_item]
                     x,y=$x1,$y1
@@ -923,10 +923,10 @@
                     find_vacant=no
                 [/unstore_unit]
 
-                [unit_overlay]
+                [unit_mp_overlay]
                     x,y=$x1,$y1
                     image=misc/gold-icon.png
-                [/unit_overlay]
+                [/unit_mp_overlay]
 
                 [remove_item]
                     x,y=$x1,$y1
@@ -964,10 +964,10 @@
             find_vacant=no
         [/unstore_unit]
 
-        [remove_unit_overlay]
+        [remove_unit_mp_overlay]
             x,y=$x1,$y1
             image=misc/coal-icon.png
-        [/remove_unit_overlay]
+        [/remove_unit_mp_overlay]
 
         [set_variable]
             name=coalin
@@ -1029,10 +1029,10 @@
             find_vacant=no
         [/unstore_unit]
 
-        [remove_unit_overlay]
+        [remove_unit_mp_overlay]
             x,y=$x1,$y1
             image=misc/gold-icon.png
-        [/remove_unit_overlay]
+        [/remove_unit_mp_overlay]
 
         [set_variable]
             name=goldin

--- a/data/campaigns/Secrets_of_the_Ancients/utils/sota-utils.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/utils/sota-utils.cfg
@@ -867,6 +867,7 @@
             facing=$stored_necromancer.facing
             moves=$stored_necromancer.moves
             overlays=$stored_necromancer.overlays
+            mp_overlays=$stored_necromancer.mp_overlays
             hitpoints=$stored_necromancer.hitpoints
             canrecruit=$stored_necromancer.canrecruit
             attacks_left=$stored_necromancer.attacks_left

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/22_The_Rise_of_Wesnoth.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/22_The_Rise_of_Wesnoth.cfg
@@ -240,10 +240,10 @@
             id=Commander Aethyr
         [/recall]
 
-        [unit_overlay]
+        [unit_mp_overlay]
             id=Commander Aethyr
             image=misc/treaty-icon.png
-        [/unit_overlay]
+        [/unit_mp_overlay]
 
         {LIVING_INTEL (Familiar) (Familiar) ( _ "Familiar") "portraits/familiar.png" 2 40 39}
         # wmllint: whofield clear LIVING_INTEL

--- a/data/campaigns/Under_the_Burning_Suns/utils/dehydration-utils.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/utils/dehydration-utils.cfg
@@ -136,10 +136,10 @@ Hd, Dd*, Dd^E*, Rd #enddef
                         {COLOR_HARM}
                     [/unstore_unit]
 
-                    [unit_overlay]
+                    [unit_mp_overlay]
                         x,y=$dehydrating_units[$i].x,$dehydrating_units[$i].y
                         image=misc/dehydration-icon.png
-                    [/unit_overlay]
+                    [/unit_mp_overlay]
                 [/else]
             [/if]
         [/do]
@@ -188,10 +188,10 @@ Hd, Dd*, Dd^E*, Rd #enddef
                 {COLOR_HEAL}
             [/unstore_unit]
 
-            [remove_unit_overlay]
+            [remove_unit_mp_overlay]
                 x,y=$hydrating_units[$i].x,$hydrating_units[$i].y
                 image=misc/dehydration-icon.png
-            [/remove_unit_overlay]
+            [/remove_unit_mp_overlay]
         [/do]
     [/for]
 
@@ -282,10 +282,10 @@ Hd, Dd*, Dd^E*, Rd #enddef
             advance=no
         [/unstore_unit]
 
-        [remove_unit_overlay]
+        [remove_unit_mp_overlay]
             x,y=$unit.x,$unit.y
             image=misc/dehydration-icon.png
-        [/remove_unit_overlay]
+        [/remove_unit_mp_overlay]
     [/event]
 
     [event]
@@ -329,10 +329,10 @@ Hd, Dd*, Dd^E*, Rd #enddef
                     find_vacant=no
                 [/unstore_unit]
 
-                [remove_unit_overlay]
+                [remove_unit_mp_overlay]
                     id=$hydrating_units[$i].id
                     image=misc/dehydration-icon.png
-                [/remove_unit_overlay]
+                [/remove_unit_mp_overlay]
             [/do]
         [/for]
 

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -387,7 +387,7 @@ function wml_actions.unit_overlay(cfg)
 	local img = cfg.image or helper.wml_error( "[unit_overlay] missing required image= attribute" )
 	for i,u in ipairs(wesnoth.get_units(cfg)) do
 	local ucfg = u.__cfg
-		ucfg.overlays= img
+		ucfg.overlays = img
 		wesnoth.put_unit(ucfg)
 	end
 end
@@ -398,14 +398,10 @@ function wml_actions.remove_unit_overlay(cfg)
 	-- Loop through all matching units.
 	for i,u in ipairs(wesnoth.get_units(cfg)) do
 		local ucfg = u.__cfg
-		local t = utils.parenthetical_split(ucfg.overlays)
-		-- Remove the specified image from the overlays.
-		for i = #t,1,-1 do
-			if t[i] == img then table.remove(t, i) end
-		end
-		-- Reassemble the list of remaining overlays.
-		ucfg.overlays = table.concat(t, ',')
+		if ucfg.overlays == img then
+		ucfg.overlays = ""
 		wesnoth.put_unit(ucfg)
+		end
 	end
 end
 

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -347,11 +347,11 @@ function wml_actions.select_unit(cfg)
 	wesnoth.select_unit(u.x, u.y, cfg.highlight, cfg.fire_event)
 end
 
-function wml_actions.unit_overlay(cfg)
-	local img = cfg.image or helper.wml_error( "[unit_overlay] missing required image= attribute" )
+function wml_actions.unit_mp_overlay(cfg)
+	local img = cfg.image or helper.wml_error( "[unit_mp_overlay] missing required image= attribute" )
 	for i,u in ipairs(wesnoth.get_units(cfg)) do
 		local has_already = false
-		for i, w in ipairs(u.overlays) do
+		for i, w in ipairs(u.mp_overlays) do
 			if w == img then has_already = true end
 		end
 		if has_already == false then
@@ -363,6 +363,32 @@ function wml_actions.unit_overlay(cfg)
 				}
 			})
 		end
+	end
+end
+
+function wml_actions.remove_unit_mp_overlay(cfg)
+	local img = cfg.image or helper.wml_error( "[remove_unit_mp_overlay] missing required image= attribute" )
+
+	-- Loop through all matching units.
+	for i,u in ipairs(wesnoth.get_units(cfg)) do
+		local ucfg = u.__cfg
+		local t = utils.parenthetical_split(ucfg.mp_overlays)
+		-- Remove the specified image from the overlays.
+		for i = #t,1,-1 do
+			if t[i] == img then table.remove(t, i) end
+		end
+		-- Reassemble the list of remaining overlays.
+		ucfg.mp_overlays = table.concat(t, ',')
+		wesnoth.put_unit(ucfg)
+	end
+end
+
+function wml_actions.unit_overlay(cfg)
+	local img = cfg.image or helper.wml_error( "[unit_overlay] missing required image= attribute" )
+	for i,u in ipairs(wesnoth.get_units(cfg)) do
+	local ucfg = u.__cfg
+		ucfg.overlays= img
+		wesnoth.put_unit(ucfg)
 	end
 end
 

--- a/data/schema/units/modifications.cfg
+++ b/data/schema/units/modifications.cfg
@@ -155,7 +155,7 @@
 				{LINK_TAG "units/unit_type/extra_anim"}
 			[/case]
 			[case]
-				value=image_mod,overlay
+				value=image_mod,overlays
 				{SIMPLE_KEY replace string}
 				{SIMPLE_KEY add string}
 				{LINK_TAG "game_config/color_range"}
@@ -164,6 +164,10 @@
 			[case]
 				value=ellipse
 				{SIMPLE_KEY ellipse string}
+			[/case]
+            [case]
+				value=overlay
+				{SIMPLE_KEY overlay string}
 			[/case]
 			[case]
 				value=halo

--- a/data/schema/units/modifications.cfg
+++ b/data/schema/units/modifications.cfg
@@ -155,7 +155,7 @@
 				{LINK_TAG "units/unit_type/extra_anim"}
 			[/case]
 			[case]
-				value=image_mod,overlays
+				value=image_mod,overlay
 				{SIMPLE_KEY replace string}
 				{SIMPLE_KEY add string}
 				{LINK_TAG "game_config/color_range"}
@@ -166,7 +166,7 @@
 				{SIMPLE_KEY ellipse string}
 			[/case]
             [case]
-				value=overlay
+				value=sp_overlay
 				{SIMPLE_KEY overlay string}
 			[/case]
 			[case]

--- a/data/schema/units/single.cfg
+++ b/data/schema/units/single.cfg
@@ -14,7 +14,7 @@
 	{SIMPLE_KEY level s_int}
 	{SIMPLE_KEY upkeep upkeep}
 	{SIMPLE_KEY recall_cost s_int}
-	{SIMPLE_KEY overlays string_list}
+	{SIMPLE_KEY mp_overlays string_list}
 	{SIMPLE_KEY max_hitpoints s_int}
 	{SIMPLE_KEY max_experience s_int}
 	{SIMPLE_KEY max_moves s_int}
@@ -34,6 +34,7 @@
 	{SIMPLE_KEY usage ai_usage}
 	{SIMPLE_KEY zoc s_bool}
 	{SIMPLE_KEY ellipse string}
+    {SIMPLE_KEY overlays string}
 	{DEPRECATED_KEY ai_special string} # Not documented
 	{SIMPLE_KEY description t_string} # Not documented
 	{SIMPLE_KEY flag_icon string} # Not documented

--- a/src/gui/dialogs/unit_recall.cpp
+++ b/src/gui/dialogs/unit_recall.cpp
@@ -185,6 +185,10 @@ void unit_recall::pre_show(window& window)
 			mods += "~BLIT(" + overlay + ")";
 		}
 
+		if(!unit->image_overlay().empty()) {
+			mods += "~BLIT(" + unit->image_overlay() + ")";
+		}
+
 		column["use_markup"] = "true";
 
 		column["label"] = unit->absolute_image() + mods;

--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -423,6 +423,10 @@ void unit_preview_pane::set_displayed_unit(const unit& u)
 			mods += "~BLIT(" + overlay + ")";
 		}
 
+		if(!u.image_overlay().empty()) {
+			mods += "~BLIT(" + u.image_overlay() + ")";
+		}
+
 		mods += "~XBRZ(2)~SCALE_INTO_SHARP(144,144)" + image_mods_;
 
 		icon_type_->set_label(u.absolute_image() + mods);

--- a/src/scripting/lua_unit.cpp
+++ b/src/scripting/lua_unit.cpp
@@ -328,8 +328,12 @@ static int impl_unit_get(lua_State *L)
 		lua_push(L, u.modification_advancements());
 		return 1;
 	}
-	if(strcmp(m, "overlays") == 0) {
+	if(strcmp(m, "mp_overlays") == 0) {
 		lua_push(L, u.overlays());
+		return 1;
+	}
+	if(strcmp(m, "overlays") == 0) {
+		lua_push(L, u.image_overlay());
 		return 1;
 	}
 	if(strcmp(m, "traits") == 0) {

--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -83,6 +83,7 @@ void unit_drawer::redraw_unit (const unit & u) const
 	color_t xp_color=u.xp_color();
 
 	std::string ellipse=u.image_ellipse();
+	std::string overlay=u.image_overlay();
 
 	const bool is_highlighted_enemy = units_that_can_reach_goal.count(loc) > 0;
 	const bool is_selected_hex = (loc == sel_hex || is_highlighted_enemy);
@@ -331,6 +332,17 @@ void unit_drawer::redraw_unit (const unit & u) const
 			if(ov_img != nullptr) {
 				disp.drawing_buffer_add(display::LAYER_UNIT_BAR,
 					loc, xsrc+xoff, ysrc+yoff+adjusted_params.y, ov_img);
+			}
+		}
+		
+		if(!overlay.empty()) {
+			surface pov(image::get_image(u.image_overlay(),image::SCALED_TO_ZOOM));
+			if(!pov.null()) {
+				//if(bar_alpha != ftofxp(1.0)) {
+				//	crown = adjust_surface_alpha(crown, bar_alpha);
+				//}
+				disp.drawing_buffer_add(display::LAYER_UNIT_BAR,
+					loc, xsrc+xoff, ysrc+yoff+adjusted_params.y, pov);
 			}
 		}
 	}

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -103,7 +103,7 @@ namespace
 		"ai_special",
 		"side",
 		"underlying_id",
-		"overlays",
+		"mp_overlays",
 		"facing",
 		"race",
 		"level",
@@ -138,6 +138,7 @@ namespace
 		"description",
 		"usage",
 		"halo",
+		"overlays",
 		"ellipse",
 		"upkeep",
 		"random_traits",
@@ -359,6 +360,7 @@ unit::unit(const unit& o)
 	, description_(o.description_)
 	, usage_(copy_or_null(o.usage_))
 	, halo_(copy_or_null(o.halo_))
+	, overlay_(copy_or_null(o.overlay_))
 	, ellipse_(copy_or_null(o.ellipse_))
 	, random_traits_(o.random_traits_)
 	, generate_name_(o.generate_name_)
@@ -439,6 +441,7 @@ unit::unit()
 	, description_()
 	, usage_()
 	, halo_()
+	, overlay_()
 	, ellipse_()
 	, random_traits_(true)
 	, generate_name_(true)
@@ -511,7 +514,7 @@ void unit::init(const config& cfg, bool use_traits, const vconfig* vcfg)
 	// Apply the unit type's data to this unit.
 	advance_to(*type_, use_traits);
 
-	if(const config::attribute_value* v = cfg.get("overlays")) {
+	if(const config::attribute_value* v = cfg.get("mp_overlays")) {
 		overlays_ = utils::parenthetical_split(v->str(), ',');
 		if(overlays_.size() == 1 && overlays_.front().empty()) {
 			overlays_.clear();
@@ -556,6 +559,10 @@ void unit::init(const config& cfg, bool use_traits, const vconfig* vcfg)
 
 	if(const config::attribute_value* v = cfg.get("ellipse")) {
 		set_image_ellipse(*v);
+	}
+
+	if(const config::attribute_value* v = cfg.get("overlays")) {
+		set_image_overlay(*v);
 	}
 
 	if(const config::attribute_value* v = cfg.get("halo")) {
@@ -1444,6 +1451,10 @@ void unit::write(config& cfg, bool write_all) const
 	if(halo_.get()) {
 		cfg["halo"] = *halo_;
 	}
+	
+	if(overlay_.get()) {
+		cfg["overlays"] = *overlay_;
+	}
 
 	if(ellipse_.get()) {
 		cfg["ellipse"] = *ellipse_;
@@ -1496,7 +1507,7 @@ void unit::write(config& cfg, bool write_all) const
 	cfg.clear_children("events");
 	cfg.append(events_);
 
-	cfg["overlays"] = utils::join(overlays_);
+	cfg["mp_overlays"] = utils::join(overlays_);
 
 	cfg["name"] = name_;
 	cfg["id"] = id_;
@@ -1811,7 +1822,7 @@ const std::set<std::string> unit::builtin_effects {
 	"alignment", "attack", "defense", "ellipse", "experience", "fearless",
 	"halo", "healthy", "hitpoints", "image_mod", "jamming", "jamming_costs",
 	"loyal", "max_attacks", "max_experience", "movement", "movement_costs",
-	"new_ability", "new_advancement", "new_animation", "new_attack", "overlay", "profile",
+	"new_ability", "new_advancement", "new_animation", "new_attack", "overlay", "overlays", "profile",
 	"recall_cost", "remove_ability", "remove_advancement", "remove_attacks", "resistance",
 	"status", "type", "variation", "vision", "vision_costs", "zoc"
 };
@@ -2113,9 +2124,11 @@ void unit::apply_builtin_effect(std::string apply_to, const config& effect)
 		anim_comp_->apply_new_animation_effect(effect);
 	} else if(apply_to == "ellipse") {
 		set_image_ellipse(effect["ellipse"]);
+	} else if(apply_to == "overlay") {
+		set_image_overlay(effect["overlay"]);
 	} else if(apply_to == "halo") {
 		set_image_halo(effect["halo"]);
-	} else if(apply_to == "overlay") {
+	} else if(apply_to == "mp_overlay") {
 		const std::string& add = effect["add"];
 		const std::string& replace = effect["replace"];
 

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1822,7 +1822,7 @@ const std::set<std::string> unit::builtin_effects {
 	"alignment", "attack", "defense", "ellipse", "experience", "fearless",
 	"halo", "healthy", "hitpoints", "image_mod", "jamming", "jamming_costs",
 	"loyal", "max_attacks", "max_experience", "movement", "movement_costs",
-	"new_ability", "new_advancement", "new_animation", "new_attack", "overlay", "overlays", "profile",
+	"new_ability", "new_advancement", "new_animation", "new_attack", "sp_overlay", "overlay", "profile",
 	"recall_cost", "remove_ability", "remove_advancement", "remove_attacks", "resistance",
 	"status", "type", "variation", "vision", "vision_costs", "zoc"
 };
@@ -2124,11 +2124,11 @@ void unit::apply_builtin_effect(std::string apply_to, const config& effect)
 		anim_comp_->apply_new_animation_effect(effect);
 	} else if(apply_to == "ellipse") {
 		set_image_ellipse(effect["ellipse"]);
-	} else if(apply_to == "overlay") {
+	} else if(apply_to == "sp_overlay") {
 		set_image_overlay(effect["overlay"]);
 	} else if(apply_to == "halo") {
 		set_image_halo(effect["halo"]);
-	} else if(apply_to == "mp_overlay") {
+	} else if(apply_to == "overlay") {
 		const std::string& add = effect["add"];
 		const std::string& replace = effect["replace"];
 

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1468,11 +1468,22 @@ public:
 		return unit_detail::get_or_default(ellipse_);
 	}
 
+	std::string image_overlay() const
+	{
+		return unit_detail::get_or_default(overlay_);
+	}
+
 	/** Set the unit's ellipse image. */
 	void set_image_ellipse(const std::string& ellipse)
 	{
 		appearance_changed_ = true;
 		ellipse_.reset(new std::string(ellipse));
+	}
+
+	void set_image_overlay(const std::string& overlay)
+	{
+		appearance_changed_ = true;
+		overlay_.reset(new std::string(overlay));
 	}
 
 	/**
@@ -1811,6 +1822,7 @@ private:
 
 	std::unique_ptr<std::string> usage_;
 	std::unique_ptr<std::string> halo_;
+	std::unique_ptr<std::string> overlay_;
 	std::unique_ptr<std::string> ellipse_;
 
 	bool random_traits_;


### PR DESCRIPTION
i hope what this PR will be resolve https://github.com/wesnoth/wesnoth/issues/4058

The common method is to assign overlays a single image to avoid image accumulation without compromising persistence when a unit moves one level. To allow the addition of new images, I propose to create a mp_overlays benefiting from the effect apply_to = overlay instead of the original applicable for the addition of images that are not called to replace hero-icon, loyal -icon or similar. If this does not dispense with reworking the wml code, then the workload for the devellopeur only concerns the addition of these extra and rarely used (in the core) images. When replacing [unit_overlay] by [unit_mp_overlay], it is precisely not to rework all the scenarios where this function is used, but only those where images are added in addition to any crowns to the units.