### PR TITLE
Merfolk: increase HP of initiate advancements

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -166,6 +166,7 @@
      * Update various references of mermen to merfolk or mer
  ### Units
    * Add new Water Serpent portrait
+   * Increased Mermaid Initiate advancement line hitpoints (Diviner 41->45, Enchantress 38->39, Priestess 31->35, Siren 49->51)
 
 ## Version 1.14.8
  * Skipped due to needed to reupload the a broken 1.14.7 macOS App Store package as 1.14.8

--- a/data/core/units/merfolk/Diviner.cfg
+++ b/data/core/units/merfolk/Diviner.cfg
@@ -7,7 +7,7 @@
     image="units/merfolk/diviner.png"
     profile=portraits/merfolk/priestess.png
     halo=halo/illuminates-aura.png
-    hitpoints=41
+    hitpoints=45
     [resistance]
         arcane=60
     [/resistance]

--- a/data/core/units/merfolk/Enchantress.cfg
+++ b/data/core/units/merfolk/Enchantress.cfg
@@ -6,7 +6,7 @@
     gender=female
     image="units/merfolk/enchantress.png"
     profile=portraits/merfolk/enchantress.png
-    hitpoints=38
+    hitpoints=39
     movement_type=swimmer
     movement=6
     experience=90

--- a/data/core/units/merfolk/Priestess.cfg
+++ b/data/core/units/merfolk/Priestess.cfg
@@ -6,7 +6,7 @@
     gender=female
     image="units/merfolk/priestess.png"
     profile=portraits/merfolk/priestess.png
-    hitpoints=31
+    hitpoints=35
     [resistance]
         arcane=80
     [/resistance]

--- a/data/core/units/merfolk/Siren.cfg
+++ b/data/core/units/merfolk/Siren.cfg
@@ -6,7 +6,7 @@
     gender=female
     image="units/merfolk/siren.png"
     profile=portraits/merfolk/enchantress.png
-    hitpoints=49
+    hitpoints=51
     movement_type=swimmer
     movement=7
     experience=150


### PR DESCRIPTION
Like the title says, the HP of initiate advancements is extremely low compared to other mages (see elves and humans), so this aims to correct that. Since these units are very hard to get in MP, I don't think we need to worry about MP balance. For SP, this won't throw off campaign balance very much; if anything, it makes merfolk a bit more viable (since they are weak right now).