### PR TITLE
fix berserk continue the fight to almost infinite if value negative(1.15/16 version)

### DIFF
--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -143,9 +143,9 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 	petrifies = weapon->bool_ability("petrifies");
 	poisons = !opp.get_state("unpoisonable") && weapon->bool_ability("poison") && !opp.get_state(unit::STATE_POISONED);
 	backstab_pos = is_attacker && backstab_check(u_loc, opp_loc, units, resources::gameboard->teams());
-	rounds = utils::clamp((weapon->get_specials("berserk").highest("value", 1).first), 1, 100);
+	rounds = std::max((weapon->get_specials("berserk").highest("value", 1).first), 1);
 	if(weapon->combat_ability("berserk", 1).second) {
-		rounds = utils::clamp((weapon->combat_ability("berserk", 1).first), 1, 100);
+		rounds = std::max((weapon->combat_ability("berserk", 1).first), 1);
 	}
 	firststrike = weapon->bool_ability("firststrike");
 

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -143,9 +143,9 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 	petrifies = weapon->bool_ability("petrifies");
 	poisons = !opp.get_state("unpoisonable") && weapon->bool_ability("poison") && !opp.get_state(unit::STATE_POISONED);
 	backstab_pos = is_attacker && backstab_check(u_loc, opp_loc, units, resources::gameboard->teams());
-	rounds = std::max(weapon->get_specials("berserk").highest("value", 1).first, 1);
+	rounds = std::abs(weapon->get_specials("berserk").highest("value", 1).first);
 	if(weapon->combat_ability("berserk", 1).second) {
-		rounds = std::max(weapon->combat_ability("berserk", 1).first, 1);
+		rounds = std::abs(weapon->combat_ability("berserk", 1).first);
 	}
 	firststrike = weapon->bool_ability("firststrike");
 
@@ -310,7 +310,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 	drains = !opp_type->musthave_status("undrainable") && weapon->get_special_bool("drains");
 	petrifies = weapon->get_special_bool("petrifies");
 	poisons = !opp_type->musthave_status("unpoisonable") && weapon->get_special_bool("poison");
-	rounds = std::max(weapon->get_specials("berserk").highest("value", 1).first, 1);
+	rounds = std::abs(weapon->get_specials("berserk").highest("value", 1).first);
 	firststrike = weapon->get_special_bool("firststrike");
 	disable = weapon->get_special_bool("disable");
 

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -143,9 +143,9 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 	petrifies = weapon->bool_ability("petrifies");
 	poisons = !opp.get_state("unpoisonable") && weapon->bool_ability("poison") && !opp.get_state(unit::STATE_POISONED);
 	backstab_pos = is_attacker && backstab_check(u_loc, opp_loc, units, resources::gameboard->teams());
-	rounds = std::max((weapon->get_specials("berserk").highest("value", 1).first), 1);
+	rounds = std::max(weapon->get_specials("berserk").highest("value", 1).first, 1);
 	if(weapon->combat_ability("berserk", 1).second) {
-		rounds = std::max((weapon->combat_ability("berserk", 1).first), 1);
+		rounds = std::max(weapon->combat_ability("berserk", 1).first, 1);
 	}
 	firststrike = weapon->bool_ability("firststrike");
 
@@ -310,7 +310,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 	drains = !opp_type->musthave_status("undrainable") && weapon->get_special_bool("drains");
 	petrifies = weapon->get_special_bool("petrifies");
 	poisons = !opp_type->musthave_status("unpoisonable") && weapon->get_special_bool("poison");
-	rounds = utils::clamp((weapon->get_specials("berserk").highest("value", 1).first), 1, 100);
+	rounds = std::max(weapon->get_specials("berserk").highest("value", 1).first, 1);
 	firststrike = weapon->get_special_bool("firststrike");
 	disable = weapon->get_special_bool("disable");
 

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -143,9 +143,9 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 	petrifies = weapon->bool_ability("petrifies");
 	poisons = !opp.get_state("unpoisonable") && weapon->bool_ability("poison") && !opp.get_state(unit::STATE_POISONED);
 	backstab_pos = is_attacker && backstab_check(u_loc, opp_loc, units, resources::gameboard->teams());
-	rounds = std::abs(weapon->get_specials("berserk").highest("value", 1).first);
+	rounds = std::max(0, weapon->get_specials("berserk").highest("value", 1).first);
 	if(weapon->combat_ability("berserk", 1).second) {
-		rounds = std::abs(weapon->combat_ability("berserk", 1).first);
+		rounds = std::max(0, weapon->combat_ability("berserk", 1).first);
 	}
 	firststrike = weapon->bool_ability("firststrike");
 
@@ -310,7 +310,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 	drains = !opp_type->musthave_status("undrainable") && weapon->get_special_bool("drains");
 	petrifies = weapon->get_special_bool("petrifies");
 	poisons = !opp_type->musthave_status("unpoisonable") && weapon->get_special_bool("poison");
-	rounds = std::abs(weapon->get_specials("berserk").highest("value", 1).first);
+	rounds = std::max(0, weapon->get_specials("berserk").highest("value", 1).first);
 	firststrike = weapon->get_special_bool("firststrike");
 	disable = weapon->get_special_bool("disable");
 

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -143,12 +143,10 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 	petrifies = weapon->bool_ability("petrifies");
 	poisons = !opp.get_state("unpoisonable") && weapon->bool_ability("poison") && !opp.get_state(unit::STATE_POISONED);
 	backstab_pos = is_attacker && backstab_check(u_loc, opp_loc, units, resources::gameboard->teams());
-	signed int rds = weapon->get_specials("berserk").highest("value", 1).first;
-	rds = utils::clamp(rds, 1, 100);
+	rounds = utils::clamp((weapon->get_specials("berserk").highest("value", 1).first), 1, 100);
 	if(weapon->combat_ability("berserk", 1).second) {
-		rds = weapon->combat_ability("berserk", 1).first;
+		rounds = utils::clamp((weapon->combat_ability("berserk", 1).first), 1, 100);
 	}
-	rounds = utils::clamp(rds, 1, 100);
 	firststrike = weapon->bool_ability("firststrike");
 
 	{

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -143,10 +143,12 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 	petrifies = weapon->bool_ability("petrifies");
 	poisons = !opp.get_state("unpoisonable") && weapon->bool_ability("poison") && !opp.get_state(unit::STATE_POISONED);
 	backstab_pos = is_attacker && backstab_check(u_loc, opp_loc, units, resources::gameboard->teams());
-	rounds = std::max(0, weapon->get_specials("berserk").highest("value", 1).first);
+	signed int rds = weapon->get_specials("berserk").highest("value", 1).first;
+	rds = std::max(rds, 1);
 	if(weapon->combat_ability("berserk", 1).second) {
-		rounds = std::max(0, weapon->combat_ability("berserk", 1).first);
+		rds = weapon->combat_ability("berserk", 1).first;
 	}
+	rounds = std::max(rds, 1);
 	firststrike = weapon->bool_ability("firststrike");
 
 	{

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -144,11 +144,11 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 	poisons = !opp.get_state("unpoisonable") && weapon->bool_ability("poison") && !opp.get_state(unit::STATE_POISONED);
 	backstab_pos = is_attacker && backstab_check(u_loc, opp_loc, units, resources::gameboard->teams());
 	signed int rds = weapon->get_specials("berserk").highest("value", 1).first;
-	rds = std::max(rds, 1);
+	rds = utils::clamp(rds, 1, 100);
 	if(weapon->combat_ability("berserk", 1).second) {
 		rds = weapon->combat_ability("berserk", 1).first;
 	}
-	rounds = std::max(rds, 1);
+	rounds = utils::clamp(rds, 1, 100);
 	firststrike = weapon->bool_ability("firststrike");
 
 	{

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -310,7 +310,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 	drains = !opp_type->musthave_status("undrainable") && weapon->get_special_bool("drains");
 	petrifies = weapon->get_special_bool("petrifies");
 	poisons = !opp_type->musthave_status("unpoisonable") && weapon->get_special_bool("poison");
-	rounds = weapon->get_specials("berserk").highest("value", 1).first;
+	rounds = utils::clamp((weapon->get_specials("berserk").highest("value", 1).first), 1, 100);
 	firststrike = weapon->get_special_bool("firststrike");
 	disable = weapon->get_special_bool("disable");
 

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -143,9 +143,9 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 	petrifies = weapon->bool_ability("petrifies");
 	poisons = !opp.get_state("unpoisonable") && weapon->bool_ability("poison") && !opp.get_state(unit::STATE_POISONED);
 	backstab_pos = is_attacker && backstab_check(u_loc, opp_loc, units, resources::gameboard->teams());
-	rounds = weapon->get_specials("berserk").highest("value", 1).first;
+	rounds = std::max(0, weapon->get_specials("berserk").highest("value", 1).first);
 	if(weapon->combat_ability("berserk", 1).second) {
-		rounds = weapon->combat_ability("berserk", 1).first;
+		rounds = std::max(0, weapon->combat_ability("berserk", 1).first);
 	}
 	firststrike = weapon->bool_ability("firststrike");
 


### PR DESCRIPTION
if berserk value<0 in both special or abilitie then the fight continue until death of combattant, and the number limit of turn may be infinite. for fix that, the value must be be null or positive only.