### PR TITLE
THoT S12: After breaking down a door or teleporting, clear the shroud

### DIFF
--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/12_The_Underlevels.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/12_The_Underlevels.cfg
@@ -487,7 +487,10 @@
             y=18,19
             terrain=Ur^Pr/o
         [/terrain]
-        [redraw][/redraw]
+        [redraw]
+            clear_shroud=yes
+            side=1
+        [/redraw]
 
         [delay]
             time=1000
@@ -553,7 +556,10 @@
             x,y=43,6
             terrain=Ur^Pr/o
         [/terrain]
-        [redraw][/redraw]
+        [redraw]
+            clear_shroud=yes
+            side=1
+        [/redraw]
     [/event]
 
     [event]
@@ -585,7 +591,10 @@
             x,y=41,37
             terrain=Ur^Pr\o
         [/terrain]
-        [redraw][/redraw]
+        [redraw]
+            clear_shroud=yes
+            side=1
+        [/redraw]
     [/event]
 
     #########################################################################################
@@ -811,6 +820,11 @@
         [kill]
             x,y=$x1,$y1
         [/kill]
+
+        [redraw]
+            clear_shroud=yes
+            side=1
+        [/redraw]
     [/event]
 
     [event]
@@ -972,6 +986,11 @@
         [kill]
             x,y=$x1,$y1
         [/kill]
+
+        [redraw]
+            clear_shroud=yes
+            side=1
+        [/redraw]
     [/event]
 
     [event]


### PR DESCRIPTION
Otherwise the shroud doesn't update until the unit moves again.  When
teleporting that could lead to the unit being stuck in a shrouded location,
although that's unlike to happen except when running around the map using debug
commands.

The two teleports from the center to the north and south don't need this,
because they're only enabled after a unit has stood on the destination rune.