### PR TITLE
HttT S11: Correct two places where a typographic quote was used in Li'sar's id

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/11_The_Ford_of_Abez.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/11_The_Ford_of_Abez.cfg
@@ -308,7 +308,7 @@
         [/filter]
         [filter_condition]
             [have_unit]
-                id="Li’sar"
+                id="Li'sar"
             [/have_unit]
             [have_location]
                 x,y=$x1,$y1
@@ -347,7 +347,7 @@
         [/filter]
         [filter_condition]
             [have_unit]
-                id="Li’sar"
+                id="Li'sar"
             [/have_unit]
             [have_location]
                 x,y=$x1,$y1

--- a/data/campaigns/Heir_To_The_Throne/scenarios/16_Hasty_Alliance.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/16_Hasty_Alliance.cfg
@@ -410,8 +410,6 @@
                 {TRAIT_LOYAL}
             [/modifications]
         [/modify_unit]
-
-        {CLEAR_VARIABLE stored_Lisar}
     [/event]
 
     #deaths.cfg only handles death of Li'sar is she’s on side '1', so handle

--- a/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
@@ -717,7 +717,7 @@ fire:  +10%"
 #define NEED_LISAR PLACEMENT
     [unit]
         id="Li'sar"
-        name= _ "Li'sar"
+        name= _ "Li’sar"
         profile=portraits/lisar.png
         unrenamable=yes
         type=Princess


### PR DESCRIPTION
In S11, if the player tries to attack Li'sar then there are supposed to be four
events adding extra guards. Two of them didn't trigger, because the [have_unit]
calls were trying to match her id with a typographic quotation mark.

One change in the opposite direction, where the displayed name could have a
non-typographic quotation mark; this might only happen when using choose_level
to reach a scenario with NEED_LISAR before her unit is on Konrad's recall list.

Remove a CLEAR_VARIABLE that was obsolete since 7778e6f4.