### PR TITLE
SotA S21: Fix the side= in the paladin's move_unit_fake

### DIFF
--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg
@@ -788,7 +788,7 @@ We finally made it out of the mountains. We crossed the Ford of Abez late this m
 
         [move_unit_fake]
             type=Paladin
-            side=3
+            side=2
             x=40, 33
             y=43, 42
         [/move_unit_fake]


### PR DESCRIPTION
Side 3 is the Saurians, the effect of this is just to have the very first
enemy that appears have blue reins instead of green reins during the
move_unit_fake. Only noticed it because I was adding wmllint:recognize
lines for each side's leader.