### PR TITLE
resolve color active/inactive colors similars

### DIFF
--- a/src/font/standard_colors.cpp
+++ b/src/font/standard_colors.cpp
@@ -36,8 +36,8 @@ const color_t
 	weapon_color           {245, 230, 193},
 	good_dmg_color         {130, 240, 50 },
 	bad_dmg_color          {250, 140, 80 },
-	weapon_details_color   {166, 146, 117},
-	inactive_details_color {146, 146, 146},
+	weapon_details_color   {196, 176, 147},
+	inactive_details_color { 86,  86,  86},
 	inactive_ability_color {146, 146, 146},
 	unit_type_color        {245, 230, 193},
 	race_color             {166, 146, 117};


### PR DESCRIPTION
This is an resolve to https://github.com/wesnoth/wesnoth/issues/4094 issue.

and the result is here:
![colorsspecials](https://user-images.githubusercontent.com/31768074/58480617-fe992580-815a-11e9-8fb4-aa0e7ac79d07.png)
where backstab (coup  dans le dos)is inactive and poison(empoisonnement) is active.