### PR TITLE
Make the cache directory configurable too

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -125,6 +125,7 @@
    * macOS: Wesnoth now uses the app sandboxing feature, which means there is a new location for saves. All saves will be migrated during first launch automatically. For info about backwards compatibility see: https://gist.github.com/hrubymar10/eb5afd896f933a46fac344ced940e020
    * The sidebar, recall dialog, etc now show attack's range (melee/ranged) and
      damage type (arcane/blade/cold/...) using icons. (PR #3732, #3740)
+   * The cache directory is now configurable through a command-line option in the same way as data, user data and user config directories.
 
 ## Version 1.14.8+dev
  ### Campaigns

--- a/data/core/about.cfg
+++ b/data/core/about.cfg
@@ -1250,6 +1250,9 @@
         comment = "wmllint enhancements"
     [/entry]
     [entry]
+        name = "Guillaume Lestringant"
+    [/entry]
+    [entry]
         name = "Guorui Xi (Kevin_Xi)"
         email = "kevin_DOT_xgr_AT_gmail_DOT_com"
     [/entry]

--- a/src/commandline_options.cpp
+++ b/src/commandline_options.cpp
@@ -208,6 +208,8 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 		("strict-validation", "makes validation errors fatal")
 		("translations-over", po::value<unsigned int>(), "Specify the standard for determining whether a translation is complete.")
 		("unsafe-scripts", "makes the \'package\' package available to Lua scripts, so that they can load arbitrary packages. Do not do this with untrusted scripts! This action gives ua the same permissions as the Wesnoth executable.")
+		("usercache-dir", po::value<std::string>(), "sets the path of the cache directory to $HOME/<arg> or My Documents\\My Games\\<arg> for Windows. You can specify also an absolute path outside the $HOME or My Documents\\My Games directory. Defaults to $HOME/.cache/wesnoth on X11 and to the userdata-dir on other systems.")
+		("usercache-path", "prints the path of the cache directory and exits.")
 		("userconfig-dir", po::value<std::string>(), "sets the path of the user config directory to $HOME/<arg> or My Documents\\My Games\\<arg> for Windows. You can specify also an absolute path outside the $HOME or My Documents\\My Games directory. Defaults to $HOME/.config/wesnoth on X11 and to the userdata-dir on other systems.")
 		("userconfig-path", "prints the path of the user config directory and exits.")
 		("userdata-dir", po::value<std::string>(), "sets the path of the userdata directory to $HOME/<arg> or My Documents\\My Games\\<arg> for Windows. You can specify also an absolute path outside the $HOME or My Documents\\My Games directory.")
@@ -485,6 +487,10 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 		multiplayer_turns = vm["turns"].as<std::string>();
 	if (vm.count("strict-validation"))
 		strict_validation = true;
+	if (vm.count("usercache-dir"))
+		usercache_dir = vm["usercache-dir"].as<std::string>();
+	if (vm.count("usercache-path"))
+		usercache_path = true;
 	if (vm.count("userconfig-dir"))
 		userconfig_dir = vm["userconfig-dir"].as<std::string>();
 	if (vm.count("userconfig-path"))

--- a/src/commandline_options.hpp
+++ b/src/commandline_options.hpp
@@ -195,6 +195,10 @@ public:
 	bool noreplaycheck;
 	/// True if --mp-test was given on the command line.
 	bool mptest;
+	/// True if --usercache-path was given on the command line. Prints path to cache directory and exits.
+	bool usercache_path;
+	/// Non-empty if --usercache-dir was given on the command line. Sets the cache dir to the specified one.
+	boost::optional<std::string> usercache_dir;
 	/// True if --userconfig-path was given on the command line. Prints path to user config directory and exits.
 	bool userconfig_path;
 	/// Non-empty if --userconfig-dir was given on the command line. Sets the user config dir to the specified one.

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -734,6 +734,19 @@ void set_user_config_dir(const std::string& newconfigdir)
 	set_user_config_path(newconfigdir);
 }
 
+static void set_cache_path(bfs::path newcache)
+{
+	cache_dir = newcache;
+	if(!create_directory_if_missing_recursive(cache_dir)) {
+		ERR_FS << "could not open or create cache directory at " << cache_dir.string() << '\n';
+	}
+}
+
+void set_cache_dir(const std::string& newcachedir)
+{
+	set_cache_path(newcachedir);
+}
+
 static const bfs::path& get_user_data_path()
 {
 	if(user_data_dir.empty()) {

--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -170,6 +170,7 @@ std::string get_addons_dir();
 std::string get_next_filename(const std::string& name, const std::string& extension);
 void set_user_config_dir(const std::string& path);
 void set_user_data_dir(std::string path);
+void set_cache_dir(const std::string& path);
 
 std::string get_user_config_dir();
 std::string get_user_data_dir();

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -362,6 +362,15 @@ static int process_command_args(const commandline_options& cmdline_opts)
 {
 	// Options that don't change behavior based on any others should be checked alphabetically below.
 
+	if(cmdline_opts.usercache_dir) {
+		filesystem::set_cache_dir(*cmdline_opts.usercache_dir);
+	}
+
+	if(cmdline_opts.usercache_path) {
+		std::cout << filesystem::get_cache_dir() << '\n';
+		return 0;
+	}
+
 	if(cmdline_opts.userconfig_dir) {
 		filesystem::set_user_config_dir(*cmdline_opts.userconfig_dir);
 	}


### PR DESCRIPTION
This PR adds a pair of command-line options (`--usercache-path` and `--usercache-dir`), that allow to define a custom directory for the cache or view the current cache directory.

They are exact counterparts of the `--userconfig-dir` and so on options and work in the exact same way.

The goal is to make the application fully portable by not letting any unnecessary hard-coded path.