### PR TITLE
fix carryover_percentage not valid when victory_when_enemies_defeated=no in shema test

### DIFF
--- a/data/campaigns/Delfadors_Memoirs/scenarios/08_Ur_Thorodor.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/08_Ur_Thorodor.cfg
@@ -6,7 +6,6 @@
     next_scenario=09_Houses_of_the_Dead
     turns=18
     victory_when_enemies_defeated=no
-    carryover_percentage=0
     {DEFAULT_SCHEDULE}
 
     {SCENARIO_MUSIC elvish-theme.ogg}   # No story part, so no intro music

--- a/data/campaigns/Delfadors_Memoirs/scenarios/08_Ur_Thorodor.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/08_Ur_Thorodor.cfg
@@ -6,6 +6,7 @@
     next_scenario=09_Houses_of_the_Dead
     turns=18
     victory_when_enemies_defeated=no
+    carryover_percentage=0
     {DEFAULT_SCHEDULE}
 
     {SCENARIO_MUSIC elvish-theme.ogg}   # No story part, so no intro music

--- a/data/schema/core/addons.cfg
+++ b/data/schema/core/addons.cfg
@@ -294,15 +294,9 @@
 	{SIMPLE_KEY victory_music string}
 	{SIMPLE_KEY theme string_list}
 	{DEFAULT_KEY victory_when_enemies_defeated bool yes}
-	[if]
-		[not]
-			victory_when_enemies_defeated=no
-		[/not]
-		[then]
-			{SIMPLE_KEY carryover_percentage int}
-			{SIMPLE_KEY carryover_add bool}
-		[/then]
-	[/if]
+	{SIMPLE_KEY carryover_percentage int}
+	{SIMPLE_KEY carryover_add bool}
+
 	{DEFAULT_KEY remove_from_carryover_on_defeat bool yes}
 	{DEFAULT_KEY disallow_recall bool no}
 	{DEFAULT_KEY experience_modifier int_percent 100}


### PR DESCRIPTION
put carryover_percentage in begining of scenarion cause a bug in travis compilation in DM testing.