### PR TITLE
Use the MP Moderators forum group to check for mod authority.

### DIFF
--- a/doc/man/wesnothd.6
+++ b/doc/man/wesnothd.6
@@ -252,6 +252,12 @@ section is present in the configuration the server will run without any nick reg
 .B db_game_modification_info_table
 (for user_handler=forum) The name of the table in which wesnothd will save its own data about the modifications used in a game.
 .TP
+.B db_group_table
+(for user_handler=forum) The name of the table in which your phpbb forums saves its user group data. Most likely this will be <table-prefix>_user_group  (e.g. phpbb3_user_group).
+.TP
+.B mp_mod_group
+(for user_handler=forum) The ID of the forum group to be considered as having moderation authority.
+.TP
 .B user_expiration
 (for user_handler=sample) The time after which a registered nick expires (in days).
 .RE
@@ -297,3 +303,4 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 .SH SEE ALSO
 .
 .BR wesnoth (6)
+

--- a/src/server/forum_user_handler.hpp
+++ b/src/server/forum_user_handler.hpp
@@ -105,7 +105,8 @@ class fuh : public user_handler {
 		std::time_t retrieve_ban_duration_internal(const std::string& col, const std::string& detail);
 		std::time_t retrieve_ban_duration_internal(const std::string& col, unsigned int detail);
 
-		std::string db_name_, db_host_, db_user_, db_password_, db_users_table_, db_banlist_table_, db_extra_table_, db_game_info_table_, db_game_player_info_table_, db_game_modification_info_table_;
+		std::string db_name_, db_host_, db_user_, db_password_, db_users_table_, db_banlist_table_, db_extra_table_, db_game_info_table_, db_game_player_info_table_, db_game_modification_info_table_, db_group_table_;
+		unsigned int mp_mod_group_;
 
 		MYSQL *conn;
 
@@ -123,4 +124,7 @@ class fuh : public user_handler {
 
 		// Same as user_exists() but checks if we have a row for this user in the extra table
 		bool extra_row_exists(const std::string& name);
+		
+		bool is_user_in_group(const std::string& name, unsigned int group_id);
 };
+

--- a/utils/mp-server/table_definitions.sql
+++ b/utils/mp-server/table_definitions.sql
@@ -10,6 +10,14 @@
 --     KEY user_type (user_type)
 -- ) ENGINE=InnoDB AUTO_INCREMENT=50 DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
+-- a minimal groups table, if not using a phpbb3 installation
+-- CREATE TABLE user_groups
+-- (
+--     group_id mediumint(8) unsigned NOT NULL,
+--     user_id mediumint(8) unsigned NOT NULL,
+--     PRIMARY KEY (user_id, group_id)
+-- ) ENGINE=InnoDB;
+
 -- table which the forum inserts bans into, which wesnothd checks during login
 -- CREATE TABLE ban
 -- (


### PR DESCRIPTION
People who have MP mod authority for testing or other reasons can continue to use the existing user_is_moderator column check, but for people who are supposed to moderate the server, now the forum group will be used.

This will make it easier to add/remove people to/from the group, and also ensure that the list of actual moderators matches up with the list available to users.

New config attributes added for this are:
* db_group_table - should be, based on the phpbb documentation I found, phpbb_user_group
* mp_mod_group - should be set to Multiplayer Moderators group ID

---

Re-PR of #3964 so I can put this in a separate branch of my fork.

I am also waiting for this before continuing with some additional changes I would like to implement/enforce such as [this](https://github.com/wesnoth/wesnoth/pull/3964#issuecomment-502334805).