### PR TITLE
Also require observers to enter a game's password.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -66,6 +66,7 @@
    * Don't show in the sidebar the time of day schedule of a shrouded hex. (issue #3638)
    * Make unit_weapons report display weapon specials as active/inactive correctly. (issue #4071)
    * macOS: Dark GUI on macOS Mojave and later when dark appearance is enabled.
+   * Observers are now required to enter a game's password as well, rather than just players needing to enter the password.
  ### Packaging
    * OpenMP support has been removed. It is no longer an optional build-time dependency.
  ### Units

--- a/src/gui/dialogs/multiplayer/lobby.cpp
+++ b/src/gui/dialogs/multiplayer/lobby.cpp
@@ -968,7 +968,7 @@ void mp_lobby::enter_game(const mp::game_info& game, JOIN_MODE mode)
 	join_data["id"] = std::to_string(game.id);
 	join_data["observe"] = try_obsv;
 
-	if(!join_data.empty() && try_join && game.password_required) {
+	if(!join_data.empty() && game.password_required) {
 		std::string password;
 
 		if(!gui2::dialogs::mp_join_game_password_prompt::execute(password)) {

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -1462,7 +1462,7 @@ void server::handle_join_game(socket_ptr socket, simple_wml::node& join)
 		send_server_message(socket, "You are banned from this game.");
 		async_send_doc(socket, games_and_users_list_);
 		return;
-	} else if(!observer && !g->password_matches(password)) {
+	} else if(!g->password_matches(password)) {
 		WRN_SERVER << client_address(socket) << "\t" << player_connections_.find(socket)->info().name()
 				   << "\tattempted to join game:\t\"" << g->name() << "\" (" << game_id << ") with bad password\n";
 		async_send_doc(socket, leave_game_doc);


### PR DESCRIPTION
Current situation:
* All observers allowed (Observers checked).
* No observers allowed (Observers unchecked).

New situation:
* All observers allowed (Observers checked, no password set).
* Some observers allowed (Observers checked, password set).
* No observers allowed (Observers unchecked).