### PR TITLE
Enforce game-level bans by username as well.

### DIFF
--- a/src/server/game.hpp
+++ b/src/server/game.hpp
@@ -74,8 +74,8 @@ public:
 	bool is_observer(const socket_ptr& player) const;
 	bool is_player(const socket_ptr& player) const;
 
-	/** Checks whether the connection's ip address is banned. */
-	bool player_is_banned(const socket_ptr& player) const;
+	/** Checks whether the connection's ip address or username is banned. */
+	bool player_is_banned(const socket_ptr& player, const std::string& name) const;
 
 	/** when the host sends the new scenario of a mp campaign */
 	void new_scenario(const socket_ptr& player);
@@ -501,7 +501,9 @@ private:
 	int num_turns_;
 	bool all_observers_muted_;
 
+	// IP ban list and name ban list
 	std::vector<std::string> bans_;
+	std::vector<std::string> name_bans_;
 	/// in multiplayer campaigns it can happen that some players are still in the previousl scenario
 	/// keep track of those players because processing certain
 	/// input from those side wil lead to error (oos)

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -1454,7 +1454,7 @@ void server::handle_join_game(socket_ptr socket, simple_wml::node& join)
 		send_server_message(socket, "Only registered users are allowed to join this game.");
 		async_send_doc(socket, games_and_users_list_);
 		return;
-	} else if(g->player_is_banned(socket)) {
+	} else if(g->player_is_banned(socket, player_connections_.find(socket)->info().name())) {
 		DBG_SERVER << client_address(socket)
 				   << "\tReject banned player: " << player_connections_.find(socket)->info().name()
 				   << "\tfrom game:\t\"" << g->name() << "\" (" << game_id << ").\n";


### PR DESCRIPTION
This will have each game track a list of banned usernames in addition to currently tracking banned IPs.