### PR TITLE
Display when observers share IP addresses as well.

### DIFF
--- a/src/server/game.cpp
+++ b/src/server/game.cpp
@@ -1444,7 +1444,7 @@ bool game::add_player(const socket_ptr& player, bool observer)
 		send_user_list();
 	}
 
-	const std::string clones = has_same_ip(player, observer);
+	const std::string clones = has_same_ip(player);
 	if(!clones.empty()) {
 		send_and_record_server_message(
 			player_connections_.find(user)->info().name() + " has the same IP as: " + clones);
@@ -1718,9 +1718,9 @@ bool game::controls_side(const std::vector<int>& sides, const socket_ptr& player
 	return false;
 }
 
-std::string game::has_same_ip(const socket_ptr& user, bool observer) const
+std::string game::has_same_ip(const socket_ptr& user) const
 {
-	const user_vector users = observer ? players_ : all_game_users();
+	const user_vector users = all_game_users();
 	const std::string ip = client_address(user);
 
 	std::string clones;

--- a/src/server/game.hpp
+++ b/src/server/game.hpp
@@ -407,7 +407,7 @@ private:
 	 * If observer is true it only checks against players.
 	 * @return  A comma separated string of members with matching IPs.
 	 */
-	std::string has_same_ip(const socket_ptr& user, bool observer) const;
+	std::string has_same_ip(const socket_ptr& user) const;
 
 	/**
 	 * Function which should be called every time a player ends their turn


### PR DESCRIPTION
Currently, if someone observes with two accounts and then one account becomes a player, at no point is any message displayed about the two accounts having the same IP.
With this change a message will now also be displayed when two observers share an IP address.