### PR TITLE
Schema: Fix travis error by allowing additional keys in two situations

### DIFF
--- a/data/schema/core/addons.cfg
+++ b/data/schema/core/addons.cfg
@@ -302,6 +302,10 @@
 			{SIMPLE_KEY carryover_percentage int}
 			{SIMPLE_KEY carryover_add bool}
 		[/then]
+		[else]
+			{DEFAULT_KEY carryover_percentage int 80}
+			{DEFAULT_KEY carryover_add bool no}
+		[/else]
 	[/if]
 	{DEFAULT_KEY remove_from_carryover_on_defeat bool yes}
 	{DEFAULT_KEY disallow_recall bool no}
@@ -468,6 +472,7 @@
 		max=infinite
 		{SIMPLE_KEY x range_list}
 		{SIMPLE_KEY y range_list}
+		{DEFAULT_KEY current_time int 0}
 		{LINK_TAG "scenario/time"}
 	[/tag]
 	[tag]


### PR DESCRIPTION
1. Allow carryover_percentage & carryover_add with
victory_when_enemies_defeated=no. Code from newfrenchy83 (taken from previous discussion)

2. Allow use of current_time in [time_area]. (wiki says it's valid & it works in-game)

The errors are in this report for Wings of Victory
https://travis-ci.org/wesnoth/wesnoth/jobs/552459607
