### PR TITLE
Tutorial S2: Warn about orcs crossing the river when they cross

### DIFF
--- a/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
+++ b/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
@@ -716,8 +716,6 @@ A full list of abilities and weapons specials, along with traits, may be found i
         [fire_event]
             name=check_income
         [/fire_event]
-
-        {TALK_ABOUT_LOC 19,16 ( _ "Beware of those orcs crossing the river! If they get into the forest they’ll be hard to dislodge!")}
     [/event]
 
     [event]
@@ -764,6 +762,7 @@ A full list of abilities and weapons specials, along with traits, may be found i
 
     [event]
         name=check_income
+        first_time_only=no
         [filter_condition]
             [variable]
                 name=spoke_about_income
@@ -797,6 +796,45 @@ A full list of abilities and weapons specials, along with traits, may be found i
         [/if]
 
         {CLEAR_VARIABLE gold}
+    [/event]
+
+    # Warn when the orcs start using the eastern crossing, this is expected to happen around turn 7
+    [event]
+        name=side 1 turn
+        first_time_only=no
+        [filter_condition]
+            [variable]
+                name=spoke_about_orcs_crossing_river
+                boolean_equals=no
+            [/variable]
+        [/filter_condition]
+
+        # A quick wolf could reach 19,15 from 17,19, which is still on the south bank of the river but is on the path that only leads to the eastern crossing. Orcish Grunts and Archers can only trigger it while already standing in the water.
+        # This uses vision range so that it still triggers even if the player has already put an elf ready to counterattack while the orc is on 20% def, because it's better to trigger it then rather than a couple of turns later when the player is already fighting the orcs.
+        [store_reachable_locations]
+            [filter_location]
+                x,y=19,14
+            [/filter_location]
+            [filter]
+                side=2
+            [/filter]
+            moves=max
+            range=vision
+            variable=reachable
+        [/store_reachable_locations]
+
+        [if]
+            [variable]
+                name=reachable.length
+                greater_than=0
+            [/variable]
+            [then]
+                {VARIABLE spoke_about_orcs_crossing_river yes}
+                {TALK_ABOUT_LOC 19,16 ( _ "Beware of those orcs crossing the river! If they get into the forest they’ll be hard to dislodge!")}
+            [/then]
+        [/if]
+
+        {CLEAR_VARIABLE reachable}
     [/event]
 
     [event]
@@ -1192,5 +1230,6 @@ A full list of abilities and weapons specials, along with traits, may be found i
         [/message]
 
         {CLEAR_VARIABLE low_hp_unit_message,lhpu_msg_i}
+        {CLEAR_VARIABLE spoke_about_income,spoke_about_orcs_crossing_river}
     [/event]
 [/tutorial]


### PR DESCRIPTION
Closes issue 2a of #1584

Previously the warning was always given on turn 7. It will still trigger even
if the player has units ready to defend that crossing, because I think it's
better to show the message and let the player think "I'm already ready" than to
have it pop up once some fighting has already happened; and it seems easier to
test this logic than to test logic for not showing the message if the crossing
is currently guarded.

Also add a first_time_only=no to the check_income event, so that it can trigger
on turn 7 if it doesn't trigger on turn 6.