### PR TITLE
SoF S2: Dialogue fixes (no dwarves outside, repeated comment about side entrances)

### DIFF
--- a/data/campaigns/Sceptre_of_Fire/scenarios/2_Closing_the_Gates.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/2_Closing_the_Gates.cfg
@@ -435,30 +435,13 @@
     [/foreach]
 #enddef
 
-    # We reach the northern side entrance
+    # Northern and southern side entrances, shown the first time one of the glyphs near them is activated
 
     [event]
         name=moveto
         [filter]
-            x,y=3,5
-            side=1
-        [/filter]
-        [message]
-            speaker=unit
-            message= _ "But what about this entrance? The elves can come through it just as easily as the main gate, and it cannot be closed!"
-        [/message]
-        [message]
-            speaker=Baglur
-            message= _ "I think it can be sealed up somehow... Yes, look, activating that glyph seems to have closed up the gap."
-        [/message]
-    [/event]
-
-    # We reach the southern side entrance
-
-    [event]
-        name=moveto
-        [filter]
-            x,y=23,24
+            x=3,23
+            y=5,24
             side=1
         [/filter]
         [message]
@@ -512,10 +495,27 @@
                     speaker=Rugnur
                     message= _ "We have everyone positioned on the glyphs! What do we do now?"
                 [/message]
-                [message]
-                    speaker=Baglur
-                    message= _ "Just watch. The gates wi’ close very soon. Then the elves outside — and, unfortunately, our dwarves who are still out there — wi’ become irrelevant."
-                [/message]
+                [if]
+                    [have_unit]
+                        [filter_location]
+                            find_in=locations_outside
+                        [/filter_location]
+                        side=1
+                    [/have_unit]
+                    [then]
+                        [message]
+                            speaker=Baglur
+                            message= _ "Just watch. The gates wi’ close very soon. Then the elves outside — and, unfortunately, our dwarves who are still out there — wi’ become irrelevant."
+                        [/message]
+                    [/then]
+                    [else]
+                        [message]
+                            speaker=Baglur
+                            # po: all the dwarves are inside, although there might still be some elves inside too
+                            message= _ "Just watch. The gates wi’ close very soon. Then the elves outside wi’ become irrelevant."
+                        [/message]
+                    [/else]
+                [/if]
 
                 [scroll_to]
                     x,y=13,13


### PR DESCRIPTION
If all the dwarves are inside when the gate closes, don't say there were some lost outside.

Make the dialogue about the north and south side entrances only trigger once. This dialogue seems OK even if it's Baglur talking to himself.