### PR TITLE
Fixes incorrect handling of Xue transitions. 

### DIFF
--- a/data/core/terrain-graphics.cfg
+++ b/data/core/terrain-graphics.cfg
@@ -767,7 +767,7 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 {NEW:WALL             (Cud,Kud)      (!,Cud,Kud,X*)                            castle/dwarven-castle}
 
 {NEW:WALL             Xue            (Qx*,Ql*)                                 cave/earthy-wall-rough-chasm}
-{NEW:WALL             Xue            (!,Xu*)                                   cave/earthy-wall-rough}
+{NEW:WALL             Xue            (!,Xu*,Xo*)                                   cave/earthy-wall-rough}
 {NEW:WALL             Xuc,Xuce       (Qx*,Ql*)                                 walls/wall-mine-chasm}
 {NEW:WALL             Xuc,Xuce       (!,Xu*,Xo*)                                   walls/wall-mine}
 {NEW:WALL             Xu*            (Qx*,Ql*)                                 cave/wall-rough-chasm}


### PR DESCRIPTION
The transitions from the Xue terrain to the Xoc / Xos / Xoi / Xom terrains were displayed incorrectly.

Fixes #4154.