### PR TITLE
Prepend 'SDL2/' to all SDL includes

### DIFF
--- a/src/ai/default/ca.cpp
+++ b/src/ai/default/ca.cpp
@@ -37,7 +37,7 @@
 #include <numeric>
 #include <boost/dynamic_bitset.hpp>
 
-#include <SDL_timer.h>
+#include <SDL2/SDL_timer.h>
 
 static lg::log_domain log_ai_testing_ai_default("ai/ca/testing_ai_default");
 #define DBG_AI_TESTING_AI_DEFAULT LOG_STREAM(debug, log_ai_testing_ai_default)

--- a/src/ai/manager.cpp
+++ b/src/ai/manager.cpp
@@ -49,7 +49,7 @@
 #include <utility>                      // for pair, make_pair
 #include <vector>                       // for vector, allocator, etc
 
-#include <SDL_timer.h>
+#include <SDL2/SDL_timer.h>
 
 namespace ai {
 

--- a/src/animated.cpp
+++ b/src/animated.cpp
@@ -19,7 +19,7 @@
 
 #include "animated.hpp"
 
-#include <SDL_timer.h>
+#include <SDL2/SDL_timer.h>
 
 // Put these here to ensure that there's only
 // one instance of the current_ticks variable

--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -25,10 +25,10 @@
 
 #include <algorithm>
 
-#include <SDL.h>
-#include <SDL_image.h>
-#include <SDL_mixer.h>
-#include <SDL_ttf.h>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_image.h>
+#include <SDL2/SDL_mixer.h>
+#include <SDL2/SDL_ttf.h>
 
 #include <boost/version.hpp>
 

--- a/src/config_cache.cpp
+++ b/src/config_cache.cpp
@@ -27,7 +27,7 @@
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/iostreams/filter/gzip.hpp>
-#include <SDL_platform.h>
+#include <SDL2/SDL_platform.h>
 
 static lg::log_domain log_cache("cache");
 #define ERR_CACHE LOG_STREAM(err, log_cache)

--- a/src/countdown_clock.hpp
+++ b/src/countdown_clock.hpp
@@ -13,7 +13,7 @@
 
 #pragma once
 #include "events.hpp"
-#include <SDL_timer.h>
+#include <SDL2/SDL_timer.h>
 
 class team;
 class countdown_clock : public events::pump_monitor

--- a/src/desktop/clipboard.cpp
+++ b/src/desktop/clipboard.cpp
@@ -18,8 +18,8 @@
 #include "serialization/unicode.hpp"
 #include <algorithm>
 
-#include <SDL_events.h>
-#include <SDL_clipboard.h>
+#include <SDL2/SDL_events.h>
+#include <SDL2/SDL_clipboard.h>
 
 #define CLIPBOARD_FUNCS_DEFINED
 

--- a/src/desktop/windows_tray_notification.cpp
+++ b/src/desktop/windows_tray_notification.cpp
@@ -14,7 +14,7 @@
 
 #include "desktop/windows_tray_notification.hpp"
 
-#include <SDL_syswm.h>
+#include <SDL2/SDL_syswm.h>
 
 #include "gettext.hpp"
 #include "serialization/string_utils.hpp"

--- a/src/desktop/windows_tray_notification.hpp
+++ b/src/desktop/windows_tray_notification.hpp
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <SDL.h>
+#include <SDL2/SDL.h>
 #include <string>
 //forces to call Unicode winapi functions instead of ASCII (default)
 #ifndef UNICODE

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -51,7 +51,7 @@
 #include "show_dialog.hpp"
 #include "gui/dialogs/loading_screen.hpp"
 
-#include <SDL_image.h>
+#include <SDL2/SDL_image.h>
 
 #include <array>
 #include <cmath>

--- a/src/display_chat_manager.cpp
+++ b/src/display_chat_manager.cpp
@@ -26,7 +26,7 @@
 #include "color.hpp"
 #include "preferences/credentials.hpp"
 
-#include <SDL_timer.h>
+#include <SDL2/SDL_timer.h>
 
 static lg::log_domain log_engine("engine");
 #define ERR_NG LOG_STREAM(err, log_engine)
@@ -192,7 +192,7 @@ void display_chat_manager::prune_chat_messages(bool remove_all)
 	const unsigned message_aging = preferences::chat_message_aging();
 	const unsigned max_chat_messages = preferences::chat_lines();
 	const bool enable_aging = message_aging != 0;
-	
+
 	const unsigned remove_before = enable_aging ? safe_subtract(SDL_GetTicks(), message_aging * 60 * 1000) : 0;
 	int movement = 0;
 

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -32,7 +32,7 @@
 #include <utility>
 #include <vector>
 
-#include <SDL.h>
+#include <SDL2/SDL.h>
 
 #include <boost/range/adaptor/reversed.hpp>
 #include <boost/thread.hpp>
@@ -524,7 +524,7 @@ void pump()
 				if(event.motion.state & SDL_BUTTON(SDL_BUTTON_RIGHT))
 				{
 					SDL_Rect r = CVideo::get_singleton().screen_area();
-					
+
 					// TODO: Check if SDL_FINGERMOTION is actually signaled for COMPLETE motions (I doubt, but tbs)
 					SDL_Event touch_event;
 					touch_event.type = SDL_FINGERMOTION;
@@ -538,7 +538,7 @@ void pump()
 					touch_event.tfinger.y = static_cast<float>(event.motion.y) / r.h;
 					touch_event.tfinger.pressure = 1;
 					::SDL_PushEvent(&touch_event);
-					
+
 					event.motion.state = SDL_BUTTON(SDL_BUTTON_LEFT);
 					event.motion.which = SDL_TOUCH_MOUSEID;
 				}
@@ -549,7 +549,7 @@ void pump()
 				{
 					event.button.button = SDL_BUTTON_LEFT;
 					event.button.which = SDL_TOUCH_MOUSEID;
-					
+
 					SDL_Rect r = CVideo::get_singleton().screen_area();
 					SDL_Event touch_event;
 					touch_event.type = (event.type == SDL_MOUSEBUTTONDOWN) ? SDL_FINGERDOWN : SDL_FINGERUP;
@@ -570,7 +570,7 @@ void pump()
 				break;
 		}
 #endif
-		
+
 		switch(event.type) {
 		case SDL_WINDOWEVENT:
 			switch(event.window.event) {

--- a/src/events.hpp
+++ b/src/events.hpp
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <SDL_events.h>
+#include <SDL2/SDL_events.h>
 #include <vector>
 #include <list>
 #include <functional>

--- a/src/filesystem_boost.cpp
+++ b/src/filesystem_boost.cpp
@@ -56,7 +56,7 @@
 #if defined(__APPLE__) && defined(__MACH__) && defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__)
 
 #define WESNOTH_BOOST_OS_IOS (__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__*1000)
-#include <SDL_filesystem.h>
+#include <SDL2/SDL_filesystem.h>
 
 #endif
 
@@ -542,7 +542,7 @@ static const std::string& get_version_path_suffix()
 
 	return suffix;
 }
-	
+
 #if defined(__APPLE__) && !defined(__IPHONEOS__)
 // Starting from Wesnoth 1.14.6, we have to use sandboxing function on macOS
 // The problem is, that only signed builds can use sandbox. Unsigned builds
@@ -553,13 +553,13 @@ static void migrate_apple_config_directory_for_unsandboxed_builds()
 {
 	const char* home_str = getenv("HOME");
 	bfs::path home = home_str ? home_str : ".";
-	
+
 	// We don't know which of the two is in PREFERENCES_DIR now.
 	boost::filesystem::path old_saves_dir = home / "Library/Application Support/Wesnoth_";
 	old_saves_dir += get_version_path_suffix();
 	boost::filesystem::path new_saves_dir = home / "Library/Containers/org.wesnoth.Wesnoth/Data/Library/Application Support/Wesnoth_";
 	new_saves_dir += get_version_path_suffix();
-	
+
 	if(bfs::is_directory(new_saves_dir)) {
 		if(!bfs::exists(old_saves_dir)) {
 			std::cout << "Apple developer's userdata migration: ";
@@ -579,7 +579,7 @@ static void setup_user_data_dir()
 #if defined(__APPLE__) && !defined(__IPHONEOS__)
 	migrate_apple_config_directory_for_unsandboxed_builds();
 #endif
-	
+
 	if(!create_directory_if_missing_recursive(user_data_dir)) {
 		ERR_FS << "could not open or create user data directory at " << user_data_dir.string() << '\n';
 		return;

--- a/src/filesystem_sdl.cpp
+++ b/src/filesystem_sdl.cpp
@@ -11,8 +11,8 @@
    See the COPYING file for more details.
 */
 
-#include <SDL.h>
-#include <SDL_rwops.h>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_rwops.h>
 
 #include "filesystem.hpp"
 #include "log.hpp"

--- a/src/font/font_id.hpp
+++ b/src/font/font_id.hpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <tuple>
 
-#include <SDL_ttf.h>
+#include <SDL2/SDL_ttf.h>
 
 /***
  * Note: This is specific to SDL_TTF code path

--- a/src/font/marked-up_text.hpp
+++ b/src/font/marked-up_text.hpp
@@ -24,7 +24,7 @@ class surface;
 #include <string>
 #include "serialization/unicode_types.hpp"
 
-#include <SDL_rect.h>
+#include <SDL2/SDL_rect.h>
 
 namespace font {
 

--- a/src/font/sdl_ttf.cpp
+++ b/src/font/sdl_ttf.cpp
@@ -31,7 +31,7 @@
 #include "sdl/surface.hpp"
 #include "serialization/unicode.hpp"
 
-#include <SDL_ttf.h>
+#include <SDL2/SDL_ttf.h>
 
 #include <map>
 #include <string>

--- a/src/font/sdl_ttf.hpp
+++ b/src/font/sdl_ttf.hpp
@@ -21,7 +21,7 @@
 
 #include <string>
 
-#include <SDL_ttf.h>
+#include <SDL2/SDL_ttf.h>
 
 class surface;
 

--- a/src/font/text_surface.cpp
+++ b/src/font/text_surface.cpp
@@ -20,7 +20,7 @@
 
 #include "log.hpp"
 
-#include <SDL_ttf.h>
+#include <SDL2/SDL_ttf.h>
 
 #include <string>
 #include <vector>

--- a/src/font/text_surface.hpp
+++ b/src/font/text_surface.hpp
@@ -17,7 +17,7 @@
 #include "font_id.hpp" // for text_chunk
 #include "color.hpp"
 
-#include <SDL_ttf.h>
+#include <SDL2/SDL_ttf.h>
 
 #include <string>
 #include <vector>

--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -67,7 +67,7 @@
 #include <iostream>                     // for operator<<, basic_ostream, etc
 #include <new>
 #include <utility>                      // for pair
-#include <SDL.h>                        // for SDL_INIT_JOYSTICK, etc
+#include <SDL2/SDL.h>                        // for SDL_INIT_JOYSTICK, etc
 
 #ifdef DEBUG_WINDOW_LAYOUT_GRAPHS
 #include "gui/widgets/debug.hpp"

--- a/src/game_state.cpp
+++ b/src/game_state.cpp
@@ -33,7 +33,7 @@
 #include "gui/dialogs/loading_screen.hpp"
 
 #include "utils/functional.hpp"
-#include <SDL_timer.h>
+#include <SDL2/SDL_timer.h>
 
 #include <algorithm>
 #include <set>

--- a/src/generators/default_map_generator_job.cpp
+++ b/src/generators/default_map_generator_job.cpp
@@ -31,7 +31,7 @@
 #include "seed_rng.hpp"
 #include "wml_exception.hpp"
 
-#include <SDL_timer.h>
+#include <SDL2/SDL_timer.h>
 
 static lg::log_domain log_mapgen("mapgen");
 #define ERR_NG LOG_STREAM(err, log_mapgen)
@@ -692,9 +692,9 @@ static void flood_name(const map_location& start, const std::string& name, std::
 std::string default_map_generator_job::default_generate_map(generator_data data, std::map<map_location,std::string>* labels, const config& cfg)
 {
 	log_scope("map generation");
-	
-	LOG_NG << "default_generate_map parameters" 
-		<< " width=" << data.width 
+
+	LOG_NG << "default_generate_map parameters"
+		<< " width=" << data.width
 		<< " height=" << data.height
 		<< " nplayers=" << data.nplayers
 		<< " nvillages=" << data.nvillages

--- a/src/gui/core/event/dispatcher.hpp
+++ b/src/gui/core/event/dispatcher.hpp
@@ -21,7 +21,7 @@
 #include "utils/functional.hpp"
 #include "utils/type_trait_aliases.hpp"
 
-#include <SDL_events.h>
+#include <SDL2/SDL_events.h>
 
 #include <boost/mpl/int.hpp>
 
@@ -253,8 +253,8 @@ public:
 			  widget& target,
 			  const point& pos,
 			  const point& distance);
-	
-	
+
+
 	/**
 	 * Fires an event which takes touch-gesture parameters.
 	 *
@@ -271,7 +271,7 @@ public:
 			  float dTheta,
 			  float dDist,
 			  Uint8 numFingers);
-	
+
 
 	/**
 	 * Fires an event which takes notification parameters.

--- a/src/gui/core/event/dispatcher_private.hpp
+++ b/src/gui/core/event/dispatcher_private.hpp
@@ -19,7 +19,7 @@
 #include "gui/widgets/widget.hpp"
 #include "utils/type_trait_aliases.hpp"
 
-#include <SDL_events.h>
+#include <SDL2/SDL_events.h>
 
 #include <boost/mpl/for_each.hpp>
 #include <boost/range/adaptor/reversed.hpp>

--- a/src/gui/core/timer.cpp
+++ b/src/gui/core/timer.cpp
@@ -17,7 +17,7 @@
 #include "events.hpp"
 #include "gui/core/log.hpp"
 
-#include <SDL_timer.h>
+#include <SDL2/SDL_timer.h>
 
 #include <map>
 #include <mutex>
@@ -45,7 +45,7 @@ static std::map<size_t, timer>& get_timers()
 	static std::map<size_t, timer>* ptimers = new std::map<size_t, timer>();
 	return *ptimers;
 }
-/** 
+/**
 	The id of the event being executed, 0 if none.
 	NOTE: it is possible that multiple timers are executed at the same time
 	      if one of the timer starts an event loop for example if its handler

--- a/src/gui/core/timer.hpp
+++ b/src/gui/core/timer.hpp
@@ -31,7 +31,7 @@
 
 #include "utils/functional.hpp"
 
-#include <SDL_types.h>
+#include <SDL2/SDL_types.h>
 
 namespace gui2
 {

--- a/src/gui/dialogs/end_credits.hpp
+++ b/src/gui/dialogs/end_credits.hpp
@@ -15,7 +15,7 @@
 
 #include "gui/dialogs/modal_dialog.hpp"
 
-#include <SDL_keycode.h>
+#include <SDL2/SDL_keycode.h>
 #include <vector>
 
 class display;

--- a/src/gui/dialogs/game_load.hpp
+++ b/src/gui/dialogs/game_load.hpp
@@ -20,7 +20,7 @@
 #include "save_index.hpp"
 #include "gettext.hpp"
 
-#include <SDL_keycode.h>
+#include <SDL2/SDL_keycode.h>
 
 namespace gui2
 {

--- a/src/gui/dialogs/hotkey_bind.cpp
+++ b/src/gui/dialogs/hotkey_bind.cpp
@@ -18,7 +18,7 @@
 #include "gui/widgets/settings.hpp"
 #include "gui/widgets/window.hpp"
 
-#include <SDL.h>
+#include <SDL2/SDL.h>
 
 namespace gui2
 {

--- a/src/gui/dialogs/hotkey_bind.hpp
+++ b/src/gui/dialogs/hotkey_bind.hpp
@@ -16,7 +16,7 @@
 #include "gui/dialogs/modal_dialog.hpp"
 #include "hotkey/hotkey_item.hpp"
 
-#include <SDL_keycode.h>
+#include <SDL2/SDL_keycode.h>
 
 #include <string>
 

--- a/src/gui/dialogs/tooltip.hpp
+++ b/src/gui/dialogs/tooltip.hpp
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <SDL_rect.h>
+#include <SDL2/SDL_rect.h>
 #include <string>
 
 class t_string;

--- a/src/gui/widgets/helper.cpp
+++ b/src/gui/widgets/helper.cpp
@@ -25,7 +25,7 @@
 #include "sdl/rect.hpp"
 #include "tstring.hpp"
 
-#include <SDL.h>
+#include <SDL2/SDL.h>
 
 namespace gui2
 {

--- a/src/help/help.cpp
+++ b/src/help/help.cpp
@@ -43,7 +43,7 @@
 #include <algorithm>                    // for min
 #include <ostream>                      // for basic_ostream, operator<<, etc
 #include <vector>                       // for vector, vector<>::iterator
-#include <SDL.h>
+#include <SDL2/SDL.h>
 
 
 static lg::log_domain log_display("display");

--- a/src/help/help_browser.cpp
+++ b/src/help/help_browser.cpp
@@ -14,7 +14,7 @@
 
 #include "help/help_browser.hpp"
 #include <iostream>                     // for operator<<, basic_ostream, etc
-#include <SDL_mouse.h>                  // for SDL_GetMouseState, etc
+#include <SDL2/SDL_mouse.h>                  // for SDL_GetMouseState, etc
 #include "cursor.hpp"                   // for set, CURSOR_TYPE::HYPERLINK, etc
 #include "font/constants.hpp"           // for relative_size
 #include "gettext.hpp"                  // for _

--- a/src/help/help_browser.hpp
+++ b/src/help/help_browser.hpp
@@ -16,7 +16,7 @@
 
 #include <deque>                        // for deque
 #include <string>                       // for string
-#include <SDL_events.h>                 // for SDL_Event
+#include <SDL2/SDL_events.h>                 // for SDL_Event
 #include "help_menu.hpp"				// for help_menu
 #include "help_text_area.hpp"           // for help_text_area
 #include "widgets/button.hpp"           // for button

--- a/src/help/help_impl.cpp
+++ b/src/help/help_impl.cpp
@@ -51,7 +51,7 @@
 #include <iterator>                     // for back_insert_iterator, etc
 #include <map>                          // for map, etc
 #include <set>
-#include <SDL.h>
+#include <SDL2/SDL.h>
 
 static lg::log_domain log_display("display");
 #define WRN_DP LOG_STREAM(warn, log_display)

--- a/src/help/help_impl.hpp
+++ b/src/help/help_impl.hpp
@@ -41,7 +41,7 @@
 #include <string>                       // for string, allocator, etc
 #include <utility>                      // for pair, make_pair
 #include <vector>                       // for vector, etc
-#include <SDL.h>                  // for SDL_Surface
+#include <SDL2/SDL.h>                  // for SDL_Surface
 #include <boost/logic/tribool.hpp>
 
 class config;

--- a/src/help/help_menu.cpp
+++ b/src/help/help_menu.cpp
@@ -23,7 +23,7 @@
 #include <iostream>                     // for basic_ostream, operator<<, etc
 #include <list>                         // for _List_const_iterator, etc
 #include <utility>                      // for pair
-#include <SDL.h>
+#include <SDL2/SDL.h>
 
 class CVideo;  // lines 56-56
 

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -34,7 +34,7 @@
 #include <iostream>                     // for operator<<, basic_ostream, etc
 #include <map>                          // for map, etc
 #include <set>
-#include <SDL.h>
+#include <SDL2/SDL.h>
 
 static lg::log_domain log_help("help");
 #define WRN_HP LOG_STREAM(warn, log_help)
@@ -694,7 +694,7 @@ std::string unit_topic_generator::operator()() const {
 			}
 
 			if (info.union_type().size() == 1 && info.union_type()[0] == info.number() && info.is_nonnull()) {
-				terrain_movement_info movement_info = 
+				terrain_movement_info movement_info =
 				{
 					info.name(),
 					info.id(),
@@ -840,7 +840,7 @@ std::string unit_topic_generator::operator()() const {
 
 			table.push_back(row);
 		}
-		
+
 		ss << generate_table(table);
 	} else {
 		WRN_HP << "When building unit help topics, the display object was null and we couldn't get the terrain info we need.\n";

--- a/src/hotkey/command_executor.cpp
+++ b/src/hotkey/command_executor.cpp
@@ -35,7 +35,7 @@
 
 #include "utils/functional.hpp"
 
-#include <SDL_image.h>
+#include <SDL2/SDL_image.h>
 
 #include <cassert>
 #include <ios>

--- a/src/hotkey/hotkey_item.cpp
+++ b/src/hotkey/hotkey_item.cpp
@@ -24,7 +24,7 @@
 #include <boost/algorithm/string.hpp>
 #include "utils/functional.hpp"
 
-#include <SDL.h>
+#include <SDL2/SDL.h>
 #include <key.hpp>
 #include <serialization/unicode.hpp>
 

--- a/src/hotkey/hotkey_item.hpp
+++ b/src/hotkey/hotkey_item.hpp
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include <SDL_events.h>
-#include <SDL.h>
+#include <SDL2/SDL_events.h>
+#include <SDL2/SDL.h>
 #include <memory>
 #include <vector>
 #include <string>

--- a/src/joystick.hpp
+++ b/src/joystick.hpp
@@ -17,7 +17,7 @@
 #include <vector>
 #include "map/location.hpp"
 
-#include <SDL.h>
+#include <SDL2/SDL.h>
 
 class joystick_manager {
 

--- a/src/key.hpp
+++ b/src/key.hpp
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <cstdint>
-#include <SDL.h>
+#include <SDL2/SDL.h>
 
 /**
  * Class that keeps track of all the keys on the keyboard.

--- a/src/map/label.hpp
+++ b/src/map/label.hpp
@@ -19,7 +19,7 @@
 #include "map/location.hpp"
 #include "tstring.hpp"
 
-#include <SDL_rect.h>
+#include <SDL2/SDL_rect.h>
 #include <map>
 #include <string>
 

--- a/src/mouse_events.hpp
+++ b/src/mouse_events.hpp
@@ -23,7 +23,7 @@
 
 #include <set>                          // for set
 #include <vector>                       // for vector
-#include <SDL_events.h>                 // for SDL_MouseButtonEvent
+#include <SDL2/SDL_events.h>                 // for SDL_MouseButtonEvent
 
 class game_display;
 class battle_context;  // lines 23-23
@@ -84,7 +84,7 @@ public:
 		const bool fire_event = true);
 
 	void move_action(bool browse);
-	
+
 	void touch_action(const map_location hex, bool browse);
 
 	void select_or_action(bool browse);

--- a/src/mouse_handler_base.hpp
+++ b/src/mouse_handler_base.hpp
@@ -17,7 +17,7 @@
 
 #include "map/location.hpp"
 
-#include <SDL_events.h>
+#include <SDL2/SDL_events.h>
 
 class display;
 
@@ -48,7 +48,7 @@ public:
 
 	/** Const version of @ref gui */
 	virtual const display& gui() const = 0;
-	
+
 	/** If mouse/finger has moved far enough to consider it move/swipe, and not a click/touch */
 	bool dragging_started() const;
 

--- a/src/picture.cpp
+++ b/src/picture.cpp
@@ -34,7 +34,7 @@
 #include "sdl/rect.hpp"
 #include "utils/general.hpp"
 
-#include <SDL_image.h>
+#include <SDL2/SDL_image.h>
 
 #include "utils/functional.hpp"
 

--- a/src/picture.hpp
+++ b/src/picture.hpp
@@ -18,7 +18,7 @@
 #include "terrain/translation.hpp"
 #include "game_config.hpp"
 
-#include <SDL.h>
+#include <SDL2/SDL.h>
 #include <unordered_map>
 
 class surface;

--- a/src/save_blocker.hpp
+++ b/src/save_blocker.hpp
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <SDL_mutex.h>
+#include <SDL2/SDL_mutex.h>
 
 #include <cassert>
 

--- a/src/scripting/application_lua_kernel.cpp
+++ b/src/scripting/application_lua_kernel.cpp
@@ -47,7 +47,7 @@
 
 #include "utils/functional.hpp"
 #include <boost/range/adaptors.hpp>
-#include <SDL.h>
+#include <SDL2/SDL.h>
 
 #include "lua/lauxlib.h"
 #include "lua/lua.h"

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -122,7 +122,7 @@
 #include <utility>                      // for pair
 #include <algorithm>
 #include <vector>                       // for vector, etc
-#include <SDL_timer.h>                  // for SDL_GetTicks
+#include <SDL2/SDL_timer.h>                  // for SDL_GetTicks
 #include "lua/lauxlib.h"                // for luaL_checkinteger, etc
 #include "lua/lua.h"                    // for lua_setfield, etc
 

--- a/src/sdl/exception.cpp
+++ b/src/sdl/exception.cpp
@@ -14,7 +14,7 @@
 
 #include "sdl/exception.hpp"
 
-#include <SDL_error.h>
+#include <SDL2/SDL_error.h>
 
 namespace sdl
 {

--- a/src/sdl/point.hpp
+++ b/src/sdl/point.hpp
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <SDL_rect.h>
+#include <SDL2/SDL_rect.h>
 
 #include <iosfwd>
 #include <tuple>

--- a/src/sdl/rect.hpp
+++ b/src/sdl/rect.hpp
@@ -22,7 +22,7 @@
 #include "global.hpp"
 #include "utils.hpp"
 
-#include <SDL_rect.h>
+#include <SDL2/SDL_rect.h>
 
 struct point;
 

--- a/src/sdl/surface.hpp
+++ b/src/sdl/surface.hpp
@@ -15,7 +15,7 @@
 
 #include "utils/const_clone.hpp"
 
-#include <SDL.h>
+#include <SDL2/SDL.h>
 
 class CVideo;
 

--- a/src/sdl/userevent.hpp
+++ b/src/sdl/userevent.hpp
@@ -13,7 +13,7 @@
 
 #pragma once
 
-#include <SDL_events.h>
+#include <SDL2/SDL_events.h>
 
 #include <cstring>
 

--- a/src/sdl/utils.hpp
+++ b/src/sdl/utils.hpp
@@ -22,7 +22,7 @@
 #include "utils/math.hpp"
 #include "game_version.hpp"
 
-#include <SDL.h>
+#include <SDL2/SDL.h>
 
 #include <cstdlib>
 #include <map>

--- a/src/sdl/window.cpp
+++ b/src/sdl/window.cpp
@@ -17,7 +17,7 @@
 
 #include "sdl/exception.hpp"
 
-#include <SDL_render.h>
+#include <SDL2/SDL_render.h>
 
 namespace sdl
 {

--- a/src/sdl/window.hpp
+++ b/src/sdl/window.hpp
@@ -19,7 +19,7 @@
  * Contains a wrapper class for the @ref SDL_Window class.
  */
 
-#include <SDL_video.h>
+#include <SDL2/SDL_video.h>
 
 #include <string>
 

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -21,8 +21,8 @@
 #include "serialization/string_utils.hpp"
 #include "sound_music_track.hpp"
 
-#include <SDL.h> // Travis doesn't like this, although it works on my machine -> '#include <SDL_sound.h>
-#include <SDL_mixer.h>
+#include <SDL2/SDL.h> // Travis doesn't like this, although it works on my machine -> '#include <SDL2/SDL_sound.h>
+#include <SDL2/SDL_mixer.h>
 
 #include <list>
 #include <sstream>

--- a/src/soundsource.cpp
+++ b/src/soundsource.cpp
@@ -18,7 +18,7 @@
 #include "sound.hpp"
 #include "soundsource.hpp"
 
-#include <SDL_timer.h>
+#include <SDL2/SDL_timer.h>
 
 namespace soundsource {
 

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -35,7 +35,7 @@
 
 #include <fstream>
 
-#include <SDL.h>
+#include <SDL2/SDL.h>
 
 #include "filesystem.hpp"
 #include "game_config.hpp"

--- a/src/theme.hpp
+++ b/src/theme.hpp
@@ -24,7 +24,7 @@
 #include "generic_event.hpp"
 
 #include <memory>
-#include <SDL_rect.h>
+#include <SDL2/SDL_rect.h>
 
 struct _rect { size_t x1,y1,x2,y2; };
 

--- a/src/tooltips.cpp
+++ b/src/tooltips.cpp
@@ -20,7 +20,7 @@
 #include "help/help.hpp"
 #include "video.hpp"
 
-#include <SDL_rect.h> // Travis doesn't like this, although it works on my machine -> '#include <SDL_sound.h>
+#include <SDL2/SDL_rect.h> // Travis doesn't like this, although it works on my machine -> '#include <SDL2/SDL_sound.h>
 
 namespace {
 

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -66,7 +66,7 @@
 #include <fenv.h>
 #endif // _MSC_VER
 
-#include <SDL.h> // for SDL_Init, SDL_INIT_TIMER
+#include <SDL2/SDL.h> // for SDL_Init, SDL_INIT_TIMER
 
 #include <boost/iostreams/categories.hpp>   // for input, output
 #include <boost/iostreams/copy.hpp>         // for copy
@@ -1099,11 +1099,11 @@ int main(int argc, char** argv)
 
 	// Mac's touchpad generates touch events too.
 	// Ignore them until Macs have a touchscreen: https://forums.libsdl.org/viewtopic.php?p=45758
-#if defined(__APPLE__) && !defined(__IPHONEOS__) 
+#if defined(__APPLE__) && !defined(__IPHONEOS__)
 	SDL_EventState(SDL_FINGERMOTION, SDL_DISABLE);
 	SDL_EventState(SDL_FINGERDOWN, SDL_DISABLE);
 	SDL_EventState(SDL_FINGERUP, SDL_DISABLE);
-#endif	
+#endif
 
 	// declare this here so that it will always be at the front of the event queue.
 	events::event_context global_context;

--- a/src/wesnothd_connection.cpp
+++ b/src/wesnothd_connection.cpp
@@ -20,7 +20,7 @@
 #include "serialization/parser.hpp"
 #include "utils/functional.hpp"
 
-#include <SDL_timer.h>
+#include <SDL2/SDL_timer.h>
 
 #include <boost/thread.hpp>
 


### PR DESCRIPTION
This was needed to get the build working with vcpkg's version of SDL, where all the SDL files are
in their own SDL folder. However, our cmake config also has a note saying it was a deliberate choice
to move our SDL files *out* of their SDL2 folder due to certain distros (FreeBSD is mentioned) not
putting the files in said folder in the first place.

Testing here to see what breaks...