### PR TITLE
[1.14] Fix Wdeprecated-copy in wfl::variant, and add move operations

### DIFF
--- a/src/formula/variant.cpp
+++ b/src/formula/variant.cpp
@@ -180,12 +180,6 @@ variant::variant(const std::map<variant,variant>& map)
 	assert(value_.get());
 }
 
-variant& variant::operator=(const variant& v)
-{
-	value_ = v.value_;
-	return *this;
-}
-
 variant variant::operator[](size_t n) const
 {
 	if(is_callable()) {

--- a/src/formula/variant.hpp
+++ b/src/formula/variant.hpp
@@ -36,6 +36,8 @@ public:
 	explicit variant(const std::vector<variant>& array);
 	explicit variant(const std::string& str);
 	explicit variant(const std::map<variant, variant>& map);
+	variant(const variant& v) = default;
+	variant(variant&& v) = default;
 
 	template<typename T>
 	variant(std::shared_ptr<T> callable)
@@ -44,7 +46,8 @@ public:
 		assert(value_.get());
 	}
 
-	variant& operator=(const variant& v);
+	variant& operator=(const variant& v) = default;
+	variant& operator=(variant&& v) = default;
 
 	variant operator[](size_t n) const;
 	variant operator[](const variant& v) const;


### PR DESCRIPTION
Fixes the majority of the warnings in issue #4166.

This class already shared copies of value_ between instances,
it seems to be the immutable design pattern so can share from
const to non-const instances safely.