### PR TITLE
Cleaned up various surface-related backend things

### DIFF
--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -85,8 +85,8 @@ bool use_color_cursors()
 
 SDL_Cursor* create_cursor(surface surf)
 {
-	const surface nsurf(make_neutral_surface(surf));
-	if(nsurf == nullptr) {
+	surf.make_neutral();
+	if(surf == nullptr) {
 		return nullptr;
 	}
 
@@ -95,25 +95,25 @@ SDL_Cursor* create_cursor(surface surf)
 #ifdef __APPLE__
 	size_t cursor_width = 16;
 #else
-	size_t cursor_width = nsurf->w;
+	size_t cursor_width = surf->w;
 	if((cursor_width % 8) != 0) {
 		cursor_width += 8 - (cursor_width % 8);
 	}
 #endif
 
-	std::vector<uint8_t> data((cursor_width * nsurf->h) / 8, 0);
+	std::vector<uint8_t> data((cursor_width * surf->h) / 8, 0);
 	std::vector<uint8_t> mask(data.size(), 0);
 
 	// See https://wiki.libsdl.org/SDL_CreateCursor for documentation
 	// on the format that data has to be in to pass to SDL_CreateCursor
-	const_surface_lock lock(nsurf);
+	const_surface_lock lock(surf);
 	const uint32_t* const pixels = lock.pixels();
 
-	for(int y = 0; y != nsurf->h; ++y) {
-		for(int x = 0; x != nsurf->w; ++x) {
+	for(int y = 0; y != surf->h; ++y) {
+		for(int x = 0; x != surf->w; ++x) {
 			if(static_cast<size_t>(x) < cursor_width) {
 				uint8_t r, g, b, a;
-				SDL_GetRGBA(pixels[y * nsurf->w + x], nsurf->format, &r, &g, &b, &a);
+				SDL_GetRGBA(pixels[y * surf->w + x], surf->format, &r, &g, &b, &a);
 
 				const size_t index = y * cursor_width + x;
 				const size_t shift = 7 - (index % 8);
@@ -127,7 +127,7 @@ SDL_Cursor* create_cursor(surface surf)
 		}
 	}
 
-	return SDL_CreateCursor(&data[0], &mask[0], cursor_width, nsurf->h, 0, 0);
+	return SDL_CreateCursor(&data[0], &mask[0], cursor_width, surf->h, 0, 0);
 }
 
 SDL_Cursor* get_cursor(cursor::CURSOR_TYPE type)

--- a/src/editor/action/mouse/mouse_action.cpp
+++ b/src/editor/action/mouse/mouse_action.cpp
@@ -154,7 +154,7 @@ void mouse_action::set_terrain_mouse_overlay(editor_display& disp, const t_trans
 	}
 
 	// Create a transparent surface of the right size.
-	surface image = create_neutral_surface(image_fg->w, image_fg->h);
+	surface image(image_fg->w, image_fg->h);
 
 	// For efficiency the size of the tile is cached.
 	// We assume all tiles are of the same size.
@@ -334,7 +334,7 @@ void mouse_action_paste::set_mouse_overlay(editor_display& disp)
 	surface image60 = image::get_image("icons/action/editor-paste_60.png");
 
 	//TODO avoid hardcoded hex field size
-	surface image = create_neutral_surface(72,72);
+	surface image(72,72);
 
 	SDL_Rect r {6, 6, 0, 0};
 	sdl_blit(image60, nullptr, image, &r);
@@ -452,7 +452,7 @@ void mouse_action_starting_position::set_mouse_overlay(editor_display& disp)
 	surface image60 = image::get_image("icons/action/editor-tool-starting-position_60.png");
 
 	//TODO avoid hardcoded hex field size
-	surface image = create_neutral_surface(72,72);
+	surface image(72,72);
 
 	SDL_Rect r {6, 6, 0, 0};
 	sdl_blit(image60, nullptr, image, &r);

--- a/src/editor/action/mouse/mouse_action_map_label.cpp
+++ b/src/editor/action/mouse/mouse_action_map_label.cpp
@@ -113,7 +113,7 @@ void mouse_action_map_label::set_mouse_overlay(editor_display& disp)
 	surface image60 = image::get_image("icons/action/editor-tool-label_60.png");
 
 	//TODO avoid hardcoded hex field size
-	surface image = create_neutral_surface(72,72);
+	surface image(72,72);
 
 	SDL_Rect r {6, 6, 0, 0};
 	sdl_blit(image60, nullptr, image, &r);

--- a/src/editor/action/mouse/mouse_action_village.cpp
+++ b/src/editor/action/mouse/mouse_action_village.cpp
@@ -42,7 +42,7 @@ void mouse_action_village::set_mouse_overlay(editor_display& disp)
 	surface image60 = image::get_image("icons/action/editor-tool-village_60.png");
 
 	//TODO avoid hardcoded hex field size
-	surface image = create_neutral_surface(72,72);
+	surface image(72,72);
 
 	SDL_Rect r {6, 6, 0, 0};
 	sdl_blit(image60, nullptr, image, &r);

--- a/src/editor/controller/editor_controller.cpp
+++ b/src/editor/controller/editor_controller.cpp
@@ -190,7 +190,7 @@ void editor_controller::do_screenshot(const std::string& screenshot_filename /* 
 {
 	try {
 		surface screenshot = gui().screenshot(true);
-		if(screenshot.null() || image::save_image(screenshot, screenshot_filename) != image::save_result::success) {
+		if(!screenshot || image::save_image(screenshot, screenshot_filename) != image::save_result::success) {
 			ERR_ED << "Screenshot creation failed!\n";
 		}
 	} catch (const wml_exception& e) {

--- a/src/editor/palette/item_palette.cpp
+++ b/src/editor/palette/item_palette.cpp
@@ -75,7 +75,7 @@ void item_palette::draw_item(const overlay& item, surface& image, std::stringstr
 	}
 
 	if(image->w != item_size_ || image->h != item_size_) {
-		image.assign(scale_surface(image, item_size_, item_size_));
+		image = scale_surface(image, item_size_, item_size_);
 	}
 
 	tooltip_text << item.name;

--- a/src/editor/palette/terrain_palettes.cpp
+++ b/src/editor/palette/terrain_palettes.cpp
@@ -185,8 +185,8 @@ void terrain_palette::draw_item(const t_translation::terrain_code& terrain,
 		}
 
 		if(base_image->w != item_size_ || base_image->h != item_size_) {
-			base_image.assign(scale_surface(base_image,
-				item_size_, item_size_));
+			base_image = scale_surface(base_image,
+				item_size_, item_size_);
 		}
 	}
 
@@ -203,8 +203,7 @@ void terrain_palette::draw_item(const t_translation::terrain_code& terrain,
 	}
 
 	if(image->w != item_size_ || image->h != item_size_) {
-		image.assign(scale_surface(image,
-			item_size_, item_size_));
+		image = scale_surface(image, item_size_, item_size_);
 	}
 
 	tooltip_text << map().get_terrain_editor_string(terrain);

--- a/src/editor/palette/tristate_button.cpp
+++ b/src/editor/palette/tristate_button.cpp
@@ -48,33 +48,33 @@ tristate_button::tristate_button(CVideo& video,
 		button_image_name = "buttons/button_selectable/button_selectable_38_";
 	}
 
-	baseImage_.assign(
-			image::get_image(button_image_name + "base.png"));
-	activeBaseImage_.assign(
-			image::get_image(button_image_name + "base-active.png"));
-	touchedBaseImage_.assign(
-			image::get_image(button_image_name + "base-touched.png"));
+	baseImage_ =
+			image::get_image(button_image_name + "base.png");
+	activeBaseImage_ =
+			image::get_image(button_image_name + "base-active.png");
+	touchedBaseImage_ =
+			image::get_image(button_image_name + "base-touched.png");
 
-	touchedBothImage_.assign(
-			image::get_image(button_image_name + "border-touched-both.png"));
-	touchedUpImage_.assign(
-			image::get_image(button_image_name + "border-touched-up.png"));
-	touchedDownImage_.assign(
-			image::get_image(button_image_name + "border-touched-down.png"));
+	touchedBothImage_ =
+			image::get_image(button_image_name + "border-touched-both.png");
+	touchedUpImage_ =
+			image::get_image(button_image_name + "border-touched-up.png");
+	touchedDownImage_ =
+			image::get_image(button_image_name + "border-touched-down.png");
 
-	pressedUpImage_.assign(
-			image::get_image(button_image_name + "border-pressed-up.png"));
-	pressedDownImage_.assign(
-			image::get_image(button_image_name + "border-pressed-down.png"));
-	pressedBothImage_.assign(
-			image::get_image(button_image_name + "border-pressed-both.png"));
+	pressedUpImage_ =
+			image::get_image(button_image_name + "border-pressed-up.png");
+	pressedDownImage_ =
+			image::get_image(button_image_name + "border-pressed-down.png");
+	pressedBothImage_ =
+			image::get_image(button_image_name + "border-pressed-both.png");
 
-	pressedUpActiveImage_.assign(
-			image::get_image(button_image_name + "border-active-pressed-up.png"));
-	pressedDownActiveImage_.assign(
-			image::get_image(button_image_name + "border-active-pressed-down.png"));
-	pressedBothActiveImage_.assign(
-			image::get_image(button_image_name + "border-active-pressed-both.png"));
+	pressedUpActiveImage_ =
+			image::get_image(button_image_name + "border-active-pressed-up.png");
+	pressedDownActiveImage_ =
+			image::get_image(button_image_name + "border-active-pressed-down.png");
+	pressedBothActiveImage_ =
+			image::get_image(button_image_name + "border-active-pressed-both.png");
 
 	//TODO
 //	if (button_image.null()) {
@@ -215,20 +215,16 @@ void tristate_button::draw_contents() {
 
 	const SDL_Rect& loc = location();
 
-	surface scalled_item;
-	scalled_item.assign(scale_surface(itemImage_,
-			36, 36));
+	surface scaled_item = scale_surface(itemImage_, 36, 36);
 
-	surface nitem = make_neutral_surface(scalled_item);
-	surface nbase = make_neutral_surface(base);
+	surface nbase = base.clone();
 
 	//TODO avoid magic numbers
 	SDL_Rect r {1, 1, 0, 0};
-	sdl_blit(nitem, nullptr, nbase, &r);
+	sdl_blit(scaled_item, nullptr, nbase, &r);
 
-	if (!overlay.null()) {
-		surface noverlay = make_neutral_surface(overlay);
-		sdl_blit(noverlay, nullptr, nbase, nullptr);
+	if (overlay) {
+		sdl_blit(overlay, nullptr, nbase, nullptr);
 	}
 
 	bg_restore();

--- a/src/editor/palette/unit_palette.cpp
+++ b/src/editor/palette/unit_palette.cpp
@@ -88,7 +88,7 @@ void unit_palette::draw_item(const unit_type& u, surface& image, std::stringstre
 	}
 
 	if(image->w != item_size_ || image->h != item_size_) {
-		image.assign(scale_surface(image, item_size_, item_size_));
+		image = scale_surface(image, item_size_, item_size_);
 	}
 
 	tooltip_text << u.type_name();

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -89,7 +89,7 @@ int floating_label::xpos(size_t width) const
 
 surface floating_label::create_surface()
 {
-	if(surf_.null()) {
+	if(!surf_) {
 		font::pango_text text;
 		text.set_foreground_color(color_);
 		text.set_font_size(font_size_);
@@ -113,7 +113,7 @@ surface floating_label::create_surface()
 		// combine foreground text with its background
 		if(bgalpha_ != 0) {
 			// background is a dark tooltip box
-			surface background = create_neutral_surface(foreground->w + border_ * 2, foreground->h + border_ * 2);
+			surface background(foreground->w + border_ * 2, foreground->h + border_ * 2);
 
 			if(background == nullptr) {
 				ERR_FT << "could not create tooltip box" << std::endl;
@@ -136,7 +136,7 @@ surface floating_label::create_surface()
 			surf_ = background;
 		} else {
 			// background is blurred shadow of the text
-			surface background = create_neutral_surface(foreground->w + 4, foreground->h + 4);
+			surface background(foreground->w + 4, foreground->h + 4);
 			sdl::fill_surface_rect(background, nullptr, 0);
 			SDL_Rect r{2, 2, 0, 0};
 			sdl_blit(foreground, nullptr, background, &r);
@@ -157,7 +157,7 @@ surface floating_label::create_surface()
 void floating_label::draw(surface screen)
 {
 	if(!visible_) {
-		buf_.assign(nullptr);
+		buf_ = nullptr;
 		return;
 	}
 
@@ -171,7 +171,7 @@ void floating_label::draw(surface screen)
 	}
 
 	if(buf_ == nullptr) {
-		buf_.assign(create_compatible_surface(screen, surf_->w, surf_->h));
+		buf_ = surface(surf_->w, surf_->h);
 		if(buf_ == nullptr) {
 			return;
 		}
@@ -197,7 +197,7 @@ void floating_label::undraw(surface screen)
 		--lifetime_;
 		if(alpha_change_ != 0 && (xmove_ != 0.0 || ymove_ != 0.0) && surf_ != nullptr) {
 			// fade out moving floating labels
-			surf_.assign(adjust_surface_alpha_add(surf_,alpha_change_));
+			surf_ = adjust_surface_alpha_add(surf_,alpha_change_);
 		}
 	}
 }

--- a/src/font/sdl_ttf.cpp
+++ b/src/font/sdl_ttf.cpp
@@ -305,8 +305,8 @@ static surface render_text(const std::string& text, int fontsize, const color_t&
 		surface surf = surfaces.front().front();
 		return surf;
 	} else {
-		surface res(create_compatible_surface(surfaces.front().front(),width,height));
-		if (res.null())
+		surface res(width,height);
+		if (!res)
 			return res;
 
 		size_t ypos = 0;
@@ -341,7 +341,7 @@ SDL_Rect draw_text_line(surface& gui_surface, const SDL_Rect& area, int size,
 		   int x, int y, bool use_tooltips, int style)
 {
 	size = preferences::font_scaled(size);
-	if (gui_surface.null()) {
+	if (!gui_surface) {
 		const text_surface& u = text_cache::find(text_surface(text, size, color, style));
 		return sdl::create_rect(0, 0, u.width(), u.height());
 	}

--- a/src/font/text.cpp
+++ b/src/font/text.cpp
@@ -701,7 +701,7 @@ void pango_text::rerender(const bool force)
 		this->create_surface_buffer(stride * height);
 
 		if (surface_buffer_.empty()) {
-			surface_.assign(create_neutral_surface(0, 0));
+			surface_ = surface(0, 0);
 			return;
 		}
 
@@ -719,11 +719,11 @@ void pango_text::rerender(const bool force)
 		}
 
 #if SDL_VERSION_ATLEAST(2, 0, 6)
-		surface_.assign(SDL_CreateRGBSurfaceWithFormatFrom(
-			&surface_buffer_[0], width, height, 32, stride, SDL_PIXELFORMAT_ARGB8888));
+		surface_ = SDL_CreateRGBSurfaceWithFormatFrom(
+			&surface_buffer_[0], width, height, 32, stride, SDL_PIXELFORMAT_ARGB8888);
 #else
-		surface_.assign(SDL_CreateRGBSurfaceFrom(
-			&surface_buffer_[0], width, height, 32, stride, 0x00FF0000, 0x0000FF00, 0x000000FF, 0xFF000000));
+		surface_ = SDL_CreateRGBSurfaceFrom(
+			&surface_buffer_[0], width, height, 32, stride, 0x00FF0000, 0x0000FF00, 0x000000FF, 0xFF000000);
 #endif
 	}
 }
@@ -731,7 +731,7 @@ void pango_text::rerender(const bool force)
 void pango_text::create_surface_buffer(const size_t size) const
 {
 	// Clear surface.
-	surface_.assign(nullptr);
+	surface_ = nullptr;
 
 	// Resize buffer appropriately and clear all existing data (essentially sets all pixel values to 0).
 	surface_buffer_.assign(size, 0);

--- a/src/font/text_surface.cpp
+++ b/src/font/text_surface.cpp
@@ -185,7 +185,7 @@ const std::vector<surface>& text_surface::get_surfaces() const
 		TTF_Font* ttfont = sdl_ttf::get_font(font_id(chunk.subset, font_size_, style_));
 
 		surface s = surface(TTF_RenderUTF8_Blended(ttfont, chunk.text.c_str(), color_.to_sdl()));
-		if(!s.null())
+		if(s)
 			surfs_.push_back(s);
 	}
 

--- a/src/game_display.cpp
+++ b/src/game_display.cpp
@@ -110,13 +110,13 @@ void game_display::new_turn()
 				if(old_mask != nullptr) {
 					const fixed_t proportion = ftofxp(1.0) - fxpdiv(i,niterations);
 					adjust_surface_alpha(old_mask, proportion);
-					tod_hex_mask1.assign(old_mask);
+					tod_hex_mask1 = old_mask;
 				}
 
 				if(new_mask != nullptr) {
 					const fixed_t proportion = fxpdiv(i,niterations);
 					adjust_surface_alpha(new_mask, proportion);
-					tod_hex_mask2.assign(new_mask);
+					tod_hex_mask2 = new_mask;
 				}
 
 				invalidate_all();
@@ -129,8 +129,8 @@ void game_display::new_turn()
 			}
 		}
 
-		tod_hex_mask1.assign(nullptr);
-		tod_hex_mask2.assign(nullptr);
+		tod_hex_mask1 = nullptr;
+		tod_hex_mask2 = nullptr;
 	}
 
 	first_turn_ = false;

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -1070,7 +1070,7 @@ void image_shape::draw(surface& canvas,
 		return;
 	}
 
-	image_.assign(make_neutral_surface(tmp));
+	image_ = tmp;
 	assert(image_);
 	src_clip_ = {0, 0, image_->w, image_->h};
 
@@ -1363,7 +1363,7 @@ canvas::canvas()
 {
 }
 
-canvas::canvas(canvas&& c)
+canvas::canvas(canvas&& c) NOEXCEPT
 	: shapes_(std::move(c.shapes_))
 	, drawn_shapes_(std::move(c.drawn_shapes_))
 	, blur_depth_(c.blur_depth_)
@@ -1399,12 +1399,12 @@ void canvas::draw(const bool force)
 		variables_.add("height", wfl::variant(h_));
 	}
 
-	if(!canvas_.null()) {
+	if(canvas_) {
 		DBG_GUI_D << "Canvas: use cached canvas.\n";
 	} else {
 		// create surface
 		DBG_GUI_D << "Canvas: create new empty canvas.\n";
-		canvas_.assign(create_neutral_surface(w_, h_));
+		canvas_ = surface(w_, h_);
 	}
 
 	SDL_DestroyRenderer(renderer_);
@@ -1438,7 +1438,7 @@ void canvas::blit(surface& surf, SDL_Rect rect)
 		 * can be seen in the title screen. So also use the not 32 bpp method
 		 * for this situation.
 		 */
-		if(surf != CVideo::get_singleton().getSurface() && is_neutral(surf)) {
+		if(surf != CVideo::get_singleton().getSurface() && surf.is_neutral()) {
 			blur_surface(surf, rect, blur_depth_);
 		} else {
 			// Can't directly blur the surface if not 32 bpp.
@@ -1511,7 +1511,7 @@ void canvas::clear_shapes(const bool force)
 
 void canvas::invalidate_cache()
 {
-	canvas_.assign(nullptr);
+	canvas_ = nullptr;
 
 	if(shapes_.empty()) {
 		shapes_.swap(drawn_shapes_);

--- a/src/gui/core/canvas.hpp
+++ b/src/gui/core/canvas.hpp
@@ -88,7 +88,7 @@ public:
 
 	canvas();
 	canvas(const canvas&) = delete;
-	canvas(canvas&& c);
+	canvas(canvas&& c) NOEXCEPT;
 
 	~canvas();
 

--- a/src/gui/dialogs/title_screen.cpp
+++ b/src/gui/dialogs/title_screen.cpp
@@ -169,8 +169,8 @@ static void launch_lua_console()
 
 static void make_screenshot(window& win)
 {
-	surface screenshot = make_neutral_surface(win.video().getSurface());
-	if(!screenshot.null()) {
+	surface screenshot = win.video().getSurface().clone();
+	if(screenshot) {
 		std::string filename = filesystem::get_screenshot_dir() + "/" + _("Screenshot") + "_";
 		filename = filesystem::get_next_filename(filename, ".png");
 		gui2::dialogs::screenshot_notification::display(filename, screenshot);

--- a/src/halo.cpp
+++ b/src/halo.cpp
@@ -162,7 +162,7 @@ void halo_impl::effect::set_location(int x, int y)
 	if (new_x != x_ || new_y != y_) {
 		x_ = new_x;
 		y_ = new_y;
-		buffer_.assign(nullptr);
+		buffer_ = nullptr;
 		overlayed_hexes_.clear();
 	}
 }
@@ -191,15 +191,15 @@ bool halo_impl::effect::render()
 	}
 
 	images_.update_last_draw_time();
-	surf_.assign(image::get_image(current_image(),image::SCALED_TO_ZOOM));
+	surf_ = image::get_image(current_image(),image::SCALED_TO_ZOOM);
 	if(surf_ == nullptr) {
 		return false;
 	}
 	if(orientation_ == HREVERSE || orientation_ == HVREVERSE) {
-		surf_.assign(image::reverse_image(surf_));
+		surf_ = image::reverse_image(surf_);
 	}
 	if(orientation_ == VREVERSE || orientation_ == HVREVERSE) {
-		surf_.assign(flop_surface(surf_));
+		surf_ = flop_surface(surf_);
 	}
 
 	const int screenx = disp->get_location_x(map_location::ZERO());
@@ -223,7 +223,7 @@ bool halo_impl::effect::render()
 	}
 
 	if(sdl::rects_overlap(rect,clip_rect) == false) {
-		buffer_.assign(nullptr);
+		buffer_ = nullptr;
 		return false;
 	}
 
@@ -232,7 +232,7 @@ bool halo_impl::effect::render()
 	const clip_rect_setter clip_setter(screen, &clip_rect);
 	if(buffer_ == nullptr || buffer_->w != rect.w || buffer_->h != rect.h) {
 		SDL_Rect rect2 = rect_;
-		buffer_.assign(get_surface_portion(screen,rect2));
+		buffer_ = get_surface_portion(screen,rect2);
 	} else {
 		SDL_Rect rect2 = rect_;
 		sdl_copy_portion(screen,&rect2,buffer_,nullptr);

--- a/src/help/help_text_area.cpp
+++ b/src/help/help_text_area.cpp
@@ -344,7 +344,7 @@ void help_text_area::add_text_item(const std::string& text, const std::string& r
 		}
 		else {
 			surface surf(font::get_rendered_text(first_part, scaled_font_size, color, state));
-			if (!surf.null())
+			if (surf)
 				add_item(item(surf, curr_loc_.first, curr_loc_.second, first_part, ref_dst));
 		}
 		if (parts.size() > 1) {
@@ -376,7 +376,7 @@ void help_text_area::add_img_item(const std::string& path, const std::string& al
 								  const bool floating, const bool box)
 {
 	surface surf(image::get_image(path));
-	if (surf.null())
+	if (!surf)
 		return;
 	ALIGNMENT align = str_to_align(alignment);
 	if (align == HERE && floating) {

--- a/src/hotkey/command_executor.cpp
+++ b/src/hotkey/command_executor.cpp
@@ -55,7 +55,7 @@ namespace {
 void make_screenshot(const std::string& name, bool map_screenshot)
 {
 	surface screenshot = display::get_singleton()->screenshot(map_screenshot);
-	if(!screenshot.null()) {
+	if(screenshot) {
 		std::string filename = filesystem::get_screenshot_dir() + "/" + name + "_";
 		filename = filesystem::get_next_filename(filename, ".png");
 		gui2::dialogs::screenshot_notification::display(filename, screenshot);

--- a/src/minimap.cpp
+++ b/src/minimap.cpp
@@ -61,10 +61,10 @@ surface getMinimap(int w, int h, const gamemap &map, const team *vw, const std::
 		//return if there is nothing to draw.
 		//(optimisation)
 		double ratio = std::min<double>( w*1.0 / map_width, h*1.0 / map_height);
-		return create_neutral_surface(map_width * ratio, map_height * ratio);
+		return surface(map_width * ratio, map_height * ratio);
 	}
 
-	surface minimap(create_neutral_surface(map_width, map_height));
+	surface minimap(map_width, map_height);
 	if(minimap == nullptr)
 		return surface(nullptr);
 
@@ -144,13 +144,12 @@ surface getMinimap(int w, int h, const gamemap &map, const team *vw, const std::
 							surface overlay = get_image(overlay_file,image::HEXED);
 
 							if(overlay != nullptr && overlay != tile) {
-								surface combined = create_neutral_surface(tile->w, tile->h);
+								surface combined(tile->w, tile->h);
 								SDL_Rect r {0,0,0,0};
 								sdl_blit(tile, nullptr, combined, &r);
 								r.x = std::max(0, (tile->w - overlay->w)/2);
 								r.y = std::max(0, (tile->h - overlay->h)/2);
-								surface overlay_neutral = make_neutral_surface(overlay);
-								sdl_blit(overlay_neutral, nullptr, combined, &r);
+								sdl_blit(overlay, nullptr, combined, &r);
 								tile = combined;
 							}
 						}

--- a/src/picture.cpp
+++ b/src/picture.cpp
@@ -551,25 +551,14 @@ static std::string get_localized_path(const std::string& file, const std::string
 	return "";
 }
 
-// Ensure PNG images with an indexed palette are converted to 32-bit RGBA.
-static void standardize_surface_format(surface& surf)
-{
-	if(!surf.null() && !is_neutral(surf)) {
-		surf = make_neutral_surface(surf);
-		assert(is_neutral(surf));
-	}
-}
-
 // Load overlay image and compose it with the original surface.
 static void add_localized_overlay(const std::string& ovr_file, surface& orig_surf)
 {
 	filesystem::rwops_ptr rwops = filesystem::make_read_RWops(ovr_file);
 	surface ovr_surf = IMG_Load_RW(rwops.release(), true); // SDL takes ownership of rwops
-	if(ovr_surf.null()) {
+	if(!ovr_surf) {
 		return;
 	}
-
-	standardize_surface_format(ovr_surf);
 
 	SDL_Rect area {0, 0, ovr_surf->w, ovr_surf->h};
 
@@ -593,10 +582,8 @@ static surface load_image_file(const image::locator& loc)
 			filesystem::rwops_ptr rwops = filesystem::make_read_RWops(location);
 			res = IMG_Load_RW(rwops.release(), true); // SDL takes ownership of rwops
 
-			standardize_surface_format(res);
-
 			// If there was no standalone localized image, check if there is an overlay.
-			if(!res.null() && loc_location.empty()) {
+			if(res && loc_location.empty()) {
 				const std::string ovr_location = get_localized_path(location, "--overlay");
 				if(!ovr_location.empty()) {
 					add_localized_overlay(ovr_location, res);
@@ -605,7 +592,7 @@ static surface load_image_file(const image::locator& loc)
 		}
 	}
 
-	if(res.null() && !loc.get_filename().empty()) {
+	if(!res && !loc.get_filename().empty()) {
 		ERR_DP << "could not open image '" << loc.get_filename() << "'" << std::endl;
 		if(game_config::debug && loc.get_filename() != game_config::images::missing)
 			return get_image(game_config::images::missing, UNSCALED);
@@ -759,7 +746,7 @@ static surface apply_light(surface surf, const light_string& ls)
 			// first image will be the base where we blit the others
 			if(lightmap == nullptr) {
 				// copy the cached image to avoid modifying the cache
-				lightmap = make_neutral_surface(lts);
+				lightmap = lts.clone();
 			} else {
 				sdl_blit(lts, nullptr, lightmap, nullptr);
 			}
@@ -939,7 +926,7 @@ static surface get_scaled_to_hex(const locator& i_locator)
 	surface img = get_image(i_locator, HEXED);
 	// return scale_surface(img, zoom, zoom);
 
-	if(!img.null()) {
+	if(img) {
 		return scale_to_hex_func(img, zoom, zoom);
 	}
 
@@ -960,7 +947,7 @@ static surface get_scaled_to_zoom(const locator& i_locator)
 
 	surface res(get_image(i_locator, UNSCALED));
 	// For some reason haloes seems to have invalid images, protect against crashing
-	if(!res.null()) {
+	if(res) {
 		return scale_to_zoom_func(res, ((res->w * zoom) / tile_size), ((res->h * zoom) / tile_size));
 	}
 
@@ -1304,7 +1291,7 @@ save_result save_image(const locator& i_locator, const std::string& filename)
 
 save_result save_image(const surface& surf, const std::string& filename)
 {
-	if(surf.null()) {
+	if(!surf) {
 		return save_result::no_image;
 	}
 

--- a/src/sdl/surface.cpp
+++ b/src/sdl/surface.cpp
@@ -14,8 +14,89 @@
 #include "sdl/surface.hpp"
 
 #include "sdl/rect.hpp"
-#include "sdl/utils.hpp"
 #include "video.hpp"
+
+#include <iostream>
+
+const SDL_PixelFormat surface::neutral_pixel_format = []() {
+	SDL_PixelFormat format;
+
+#if SDL_VERSION_ATLEAST(2, 0, 6)
+	surface surf(
+		SDL_CreateRGBSurfaceWithFormat(0, 1, 1, 32, SDL_PIXELFORMAT_ARGB8888));
+#else
+	surface surf(
+		SDL_CreateRGBSurface(0, 1, 1, 32, SDL_RED_MASK, SDL_GREEN_MASK, SDL_BLUE_MASK, SDL_ALPHA_MASK));
+#endif
+
+	format = *surf->format;
+	format.palette = nullptr;
+
+	return format;
+}();
+
+surface::surface(SDL_Surface* surf)
+	: surface_(surf)
+{
+	make_neutral(); // EXTREMELY IMPORTANT!
+}
+
+surface::surface(int w, int h)
+	: surface_(nullptr)
+{
+	if (w < 0 || h < 0) {
+		std::cerr << "error: creating surface with negative dimensions\n";
+		return;
+	}
+
+#if SDL_VERSION_ATLEAST(2, 0, 6)
+	surface_ = SDL_CreateRGBSurfaceWithFormat(0, w, h, neutral_pixel_format.BitsPerPixel, neutral_pixel_format.format);
+#else
+	surface_ = SDL_CreateRGBSurface(0, w, h,
+		neutral_pixel_format.BitsPerPixel,
+		neutral_pixel_format.Rmask,
+		neutral_pixel_format.Gmask,
+		neutral_pixel_format.Bmask,
+		neutral_pixel_format.Amask);
+#endif
+}
+
+bool surface::is_neutral() const
+{
+	return surface_
+		&& SDL_ISPIXELFORMAT_INDEXED(surface_->format->format) == SDL_FALSE
+		&&  surface_->format->BytesPerPixel == 4
+		&&  surface_->format->Rmask == SDL_RED_MASK
+		&& (surface_->format->Amask | SDL_ALPHA_MASK) == SDL_ALPHA_MASK;
+}
+
+surface& surface::make_neutral()
+{
+	if(surface_ && !is_neutral()) {
+		SDL_Surface* res = SDL_ConvertSurface(surface_, &neutral_pixel_format, 0);
+
+		// Ensure we don't leak memory with the old surface.
+		free_surface();
+
+		surface_ = res;
+	}
+
+	return *this;
+}
+
+surface surface::clone() const
+{
+	// Use SDL_ConvertSurface to make a copy
+	return surface(SDL_ConvertSurface(surface_, &neutral_pixel_format, 0));
+}
+
+void surface::assign_surface_internal(SDL_Surface* surf)
+{
+	add_surface_ref(surf); // Needs to be done before assignment to avoid corruption on "a = a;"
+	free_surface();
+	surface_ = surf;
+	make_neutral(); // EXTREMELY IMPORTANT!
+}
 
 void surface::free_surface()
 {
@@ -59,7 +140,7 @@ surface_restorer::~surface_restorer()
 
 void surface_restorer::restore(const SDL_Rect& dst) const
 {
-	if(surface_.null()) {
+	if(!surface_) {
 		return;
 	}
 
@@ -76,7 +157,7 @@ void surface_restorer::restore(const SDL_Rect& dst) const
 
 void surface_restorer::restore() const
 {
-	if(surface_.null()) {
+	if(!surface_) {
 		return;
 	}
 
@@ -87,15 +168,15 @@ void surface_restorer::restore() const
 void surface_restorer::update()
 {
 	if(rect_.w <= 0 || rect_.h <= 0) {
-		surface_.assign(nullptr);
+		surface_ = nullptr;
 	} else {
-		surface_.assign(::get_surface_portion(target_->getSurface(),rect_));
+		surface_ = ::get_surface_portion(target_->getSurface(),rect_);
 	}
 }
 
 void surface_restorer::cancel()
 {
-	surface_.assign(nullptr);
+	surface_ = nullptr;
 }
 
 bool operator<(const surface& a, const surface& b)

--- a/src/sdl/surface.hpp
+++ b/src/sdl/surface.hpp
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include "global.hpp"
 #include "utils/const_clone.hpp"
 
 #include <SDL2/SDL.h>
@@ -25,15 +26,17 @@ public:
 	surface() : surface_(nullptr)
 	{}
 
-	surface(SDL_Surface* surf) : surface_(surf)
-	{}
+	surface(SDL_Surface* surf);
+
+	/** Allocates a new surface with the given dimensions. */
+	surface(int w, int h);
 
 	surface(const surface& s) : surface_(s.get())
 	{
 		add_surface_ref(surface_);
 	}
 
-	surface(surface&& s) : surface_(s.get())
+	surface(surface&& s) NOEXCEPT : surface_(s.get())
 	{
 		s.surface_ = nullptr;
 	}
@@ -43,23 +46,19 @@ public:
 		free_surface();
 	}
 
-	void assign(SDL_Surface* surf)
-	{
-		assign_surface_internal(surf);
-	}
-
-	void assign(const surface& s)
-	{
-		assign_surface_internal(s.get());
-	}
-
 	surface& operator=(const surface& s)
 	{
-		assign(s);
+		assign_surface_internal(s.get());
 		return *this;
 	}
 
-	surface& operator=(surface&& s)
+	surface& operator=(SDL_Surface* surf)
+	{
+		assign_surface_internal(surf);
+		return *this;
+	}
+
+	surface& operator=(surface&& s) NOEXCEPT
 	{
 		free_surface();
 		surface_ = s.surface_;
@@ -70,13 +69,36 @@ public:
 	// Intended to be used when SDL has already freed the surface
 	void clear_without_free() { surface_ = nullptr; }
 
+	/**
+	 * Check that the surface is neutral bpp 32.
+	 *
+	 * The surface may have an empty alpha channel.
+	 *
+	 * @returns                       The status @c true if neutral, @c false if not.
+	 */
+	bool is_neutral() const;
+
+	/**
+	 * Converts this surface to a neutral format if it is not already.
+	 *
+	 * @returns                       A reference to this object for chaining convenience.
+	 */
+	surface& make_neutral();
+
+	/**
+	 * Makes a copy of this surface. The copy will be in the 'neutral' pixel format.
+	 *
+	 * Note this is creates a new, duplicate surface in memory. Making a copy of this
+	 * 'surface' object will *not* duplicate the surface itself since we only hold a
+	 * pointer to the actual surface.
+	 */
+	surface clone() const;
+
 	operator SDL_Surface*() const { return surface_; }
 
 	SDL_Surface* get() const { return surface_; }
 
 	SDL_Surface* operator->() const { return surface_; }
-
-	bool null() const { return surface_ == nullptr; }
 
 private:
 	static void add_surface_ref(SDL_Surface* surf)
@@ -86,16 +108,13 @@ private:
 		}
 	}
 
-	void assign_surface_internal(SDL_Surface* surf)
-	{
-		add_surface_ref(surf); // Needs to be done before assignment to avoid corruption on "a = a;"
-		free_surface();
-		surface_ = surf;
-	}
+	void assign_surface_internal(SDL_Surface* surf);
 
 	void free_surface();
 
 	SDL_Surface* surface_;
+
+	static const SDL_PixelFormat neutral_pixel_format;
 };
 
 bool operator<(const surface& a, const surface& b);

--- a/src/sdl/utils.cpp
+++ b/src/sdl/utils.cpp
@@ -37,73 +37,6 @@ version_info sdl_get_version()
 	return version_info(sdl_version.major, sdl_version.minor, sdl_version.patch);
 }
 
-bool is_neutral(const surface& surf)
-{
-	return
-		SDL_ISPIXELFORMAT_INDEXED(surf->format->format) == SDL_FALSE &&
-		surf->format->BytesPerPixel == 4 &&
-		surf->format->Rmask == SDL_RED_MASK &&
-		(surf->format->Amask | SDL_ALPHA_MASK) == SDL_ALPHA_MASK;
-}
-
-static SDL_PixelFormat& get_neutral_pixel_format()
-{
-	static bool first_time = true;
-	static SDL_PixelFormat format;
-
-	if(first_time) {
-		first_time = false;
-
-#if SDL_VERSION_ATLEAST(2, 0, 6)
-		surface surf(
-			SDL_CreateRGBSurfaceWithFormat(0, 1, 1, 32, SDL_PIXELFORMAT_ARGB8888));
-#else
-		surface surf(
-			SDL_CreateRGBSurface(0, 1, 1, 32, SDL_RED_MASK, SDL_GREEN_MASK, SDL_BLUE_MASK, SDL_ALPHA_MASK));
-#endif
-
-		format = *surf->format;
-		format.palette = nullptr;
-	}
-
-	return format;
-}
-
-surface make_neutral_surface(const surface &surf)
-{
-	if(surf == nullptr) {
-		std::cerr << "null neutral surface...\n";
-		return nullptr;
-	}
-
-	surface result = SDL_ConvertSurface(surf,&get_neutral_pixel_format(),0);
-
-	return result;
-}
-
-surface create_neutral_surface(int w, int h)
-{
-	if (w < 0 || h < 0) {
-		std::cerr << "error : neutral surface with negative dimensions\n";
-		return nullptr;
-	}
-
-	SDL_PixelFormat format = get_neutral_pixel_format();
-
-#if SDL_VERSION_ATLEAST(2, 0, 6)
-	surface result = SDL_CreateRGBSurfaceWithFormat(0, w, h, format.BitsPerPixel, format.format);
-#else
-	surface result = SDL_CreateRGBSurface(0, w, h,
-			format.BitsPerPixel,
-			format.Rmask,
-			format.Gmask,
-			format.Bmask,
-			format.Amask);
-#endif
-
-	return result;
-}
-
 surface stretch_surface_horizontal(
 		const surface& surf, const unsigned w)
 {
@@ -118,26 +51,23 @@ surface stretch_surface_horizontal(
 	}
 	assert(w > 0);
 
-	surface dst(create_neutral_surface(w, surf->h));
+	surface dst(w, surf->h);
 
-	surface src(make_neutral_surface(surf));
-	// Now both surfaces are always in the "neutral" pixel format
-
-	if(src == nullptr || dst == nullptr) {
+	if(surf == nullptr || dst == nullptr) {
 		std::cerr << "Could not create surface to scale onto\n";
 		return nullptr;
 	}
 
 	{
 		// Extra scoping used for the surface_lock.
-		const_surface_lock src_lock(src);
+		const_surface_lock src_lock(surf);
 		surface_lock dst_lock(dst);
 
 		const uint32_t* const src_pixels = src_lock.pixels();
 		uint32_t* dst_pixels = dst_lock.pixels();
 
-		for(unsigned y = 0; y < static_cast<unsigned>(src->h); ++y) {
-			const uint32_t pixel = src_pixels [y * src->w];
+		for(unsigned y = 0; y < static_cast<unsigned>(surf->h); ++y) {
+			const uint32_t pixel = src_pixels [y * surf->w];
 			for(unsigned x = 0; x < w; ++x) {
 
 				*dst_pixels++ = pixel;
@@ -163,26 +93,23 @@ surface stretch_surface_vertical(
 	}
 	assert(h > 0);
 
-	surface dst(create_neutral_surface(surf->w, h));
+	surface dst(surf->w, h);
 
-	surface src(make_neutral_surface(surf));
-	// Now both surfaces are always in the "neutral" pixel format
-
-	if(src == nullptr || dst == nullptr) {
+	if(surf == nullptr || dst == nullptr) {
 		std::cerr << "Could not create surface to scale onto\n";
 		return nullptr;
 	}
 
 	{
 		// Extra scoping used for the surface_lock.
-		const_surface_lock src_lock(src);
+		const_surface_lock src_lock(surf);
 		surface_lock dst_lock(dst);
 
 		const uint32_t* const src_pixels = src_lock.pixels();
 		uint32_t* dst_pixels = dst_lock.pixels();
 
 		for(unsigned y = 0; y < static_cast<unsigned>(h); ++y) {
-		  for(unsigned x = 0; x < static_cast<unsigned>(src->w); ++x) {
+		  for(unsigned x = 0; x < static_cast<unsigned>(surf->w); ++x) {
 
 				*dst_pixels++ = src_pixels[x];
 			}
@@ -207,22 +134,20 @@ surface scale_surface_xbrz(const surface & surf, size_t z)
 		return temp;
 	}
 
-	surface dst(create_neutral_surface(surf->w *z, surf->h * z));
+	surface dst(surf->w *z, surf->h * z);
 
 	if (z == 0) {
 		std::cerr << "Create an empty image\n";
 		return dst;
 	}
 
-	surface src(make_neutral_surface(surf));
-
-	if(src == nullptr || dst == nullptr) {
+	if(surf == nullptr || dst == nullptr) {
 		std::cerr << "Could not create surface to scale onto\n";
 		return nullptr;
 	}
 
 	{
-		const_surface_lock src_lock(src);
+		const_surface_lock src_lock(surf);
 		surface_lock dst_lock(dst);
 
 		xbrz::scale(z, src_lock.pixels(), dst_lock.pixels(), surf->w, surf->h);
@@ -245,23 +170,20 @@ surface scale_surface_nn (const surface & surf, int w, int h)
 	assert(w >= 0);
 	assert(h >= 0);
 
-	surface dst(create_neutral_surface(w,h));
+	surface dst(w,h);
 
 	if (w == 0 || h ==0) {
 		std::cerr << "Create an empty image\n";
 		return dst;
 	}
 
-	surface src(make_neutral_surface(surf));
-	// Now both surfaces are always in the "neutral" pixel format
-
-	if(src == nullptr || dst == nullptr) {
+	if(surf == nullptr || dst == nullptr) {
 		std::cerr << "Could not create surface to scale onto\n";
 		return nullptr;
 	}
 
 	{
-		const_surface_lock src_lock(src);
+		const_surface_lock src_lock(surf);
 		surface_lock dst_lock(dst);
 
 		xbrz::nearestNeighborScale(src_lock.pixels(), surf->w, surf->h, dst_lock.pixels(), w, h);
@@ -285,23 +207,20 @@ surface scale_surface(const surface &surf, int w, int h)
 	assert(w >= 0);
 	assert(h >= 0);
 
-	surface dst(create_neutral_surface(w,h));
+	surface dst(w,h);
 
 	if (w == 0 || h ==0) {
 		std::cerr << "Create an empty image\n";
 		return dst;
 	}
 
-	surface src(make_neutral_surface(surf));
-	// Now both surfaces are always in the "neutral" pixel format
-
-	if(src == nullptr || dst == nullptr) {
+	if(surf == nullptr || dst == nullptr) {
 		std::cerr << "Could not create surface to scale onto\n";
 		return nullptr;
 	}
 
 	{
-		const_surface_lock src_lock(src);
+		const_surface_lock src_lock(surf);
 		surface_lock dst_lock(dst);
 
 		const uint32_t* const src_pixels = src_lock.pixels();
@@ -317,10 +236,10 @@ surface scale_surface(const surface &surf, int w, int h)
 				const int xsrcint = fxptoi(xsrc);
 				const int ysrcint = fxptoi(ysrc);
 
-				const uint32_t* const src_word = src_pixels + ysrcint*src->w + xsrcint;
+				const uint32_t* const src_word = src_pixels + ysrcint*surf->w + xsrcint;
 				uint32_t* const dst_word = dst_pixels +    ydst*dst->w + xdst;
-				const int dx = (xsrcint + 1 < src->w) ? 1 : 0;
-				const int dy = (ysrcint + 1 < src->h) ? src->w : 0;
+				const int dx = (xsrcint + 1 < surf->w) ? 1 : 0;
+				const int dy = (ysrcint + 1 < surf->h) ? surf->w : 0;
 
 				uint8_t r,g,b,a;
 				uint32_t rr,gg,bb,aa, temp;
@@ -417,18 +336,15 @@ surface scale_surface_legacy(const surface &surf, int w, int h)
 	assert(w >= 0);
 	assert(h >= 0);
 
-	surface dst(create_neutral_surface(w,h));
+	surface dst(w,h);
 
-	surface src(make_neutral_surface(surf));
-	// Now both surfaces are always in the "neutral" pixel format
-
-	if(src == nullptr || dst == nullptr) {
+	if(surf == nullptr || dst == nullptr) {
 		std::cerr << "Could not create surface to scale onto\n";
 		return nullptr;
 	}
 
 	{
-		const_surface_lock src_lock(src);
+		const_surface_lock src_lock(surf);
 		surface_lock dst_lock(dst);
 
 		const uint32_t* const src_pixels = src_lock.pixels();
@@ -444,10 +360,10 @@ surface scale_surface_legacy(const surface &surf, int w, int h)
 				const int xsrcint = fxptoi(xsrc);
 				const int ysrcint = fxptoi(ysrc);
 
-				const uint32_t* const src_word = src_pixels + ysrcint*src->w + xsrcint;
+				const uint32_t* const src_word = src_pixels + ysrcint*surf->w + xsrcint;
 				uint32_t* const dst_word = dst_pixels +    ydst*dst->w + xdst;
-				const int dx = (xsrcint + 1 < src->w) ? 1 : 0;
-				const int dy = (ysrcint + 1 < src->h) ? src->w : 0;
+				const int dx = (xsrcint + 1 < surf->w) ? 1 : 0;
+				const int dy = (ysrcint + 1 < surf->h) ? surf->w : 0;
 
 				uint8_t r,g,b,a;
 				uint32_t rr,gg,bb,aa;
@@ -557,23 +473,20 @@ surface scale_surface_sharp(const surface& surf, int w, int h)
 	assert(w >= 0);
 	assert(h >= 0);
 
-	surface dst(create_neutral_surface(w,h));
+	surface dst(w,h);
 
 	if (w == 0 || h ==0) {
 		std::cerr << "Create an empty image\n";
 		return dst;
 	}
 
-	surface src(make_neutral_surface(surf));
-	// Now both surfaces are always in the "neutral" pixel format
-
-	if(src == nullptr || dst == nullptr) {
+	if(surf == nullptr || dst == nullptr) {
 		std::cerr << "Could not create surface to scale onto\n";
 		return nullptr;
 	}
 
 	{
-		const_surface_lock src_lock(src);
+		const_surface_lock src_lock(surf);
 		surface_lock dst_lock(dst);
 
 		const uint32_t* const src_pixels = src_lock.pixels();
@@ -596,13 +509,13 @@ surface scale_surface_sharp(const surface& surf, int w, int h)
 					const float xsize = std::min<float>(std::floor(xloc+1)-xloc,xsrc+xratio-xloc);
 
 					for(float yloc = ysrc; yloc < ysrc+yratio; yloc += 1) {
-						const int xsrcint = std::max<int>(0,std::min<int>(src->w-1,static_cast<int>(xsrc)));
-						const int ysrcint = std::max<int>(0,std::min<int>(src->h-1,static_cast<int>(ysrc)));
+						const int xsrcint = std::max<int>(0,std::min<int>(surf->w-1,static_cast<int>(xsrc)));
+						const int ysrcint = std::max<int>(0,std::min<int>(surf->h-1,static_cast<int>(ysrc)));
 						const float ysize = std::min<float>(std::floor(yloc+1)-yloc,ysrc+yratio-yloc);
 
 						uint8_t r,g,b,a;
 
-						SDL_GetRGBA(src_pixels[ysrcint*src->w + xsrcint],src->format,&r,&g,&b,&a);
+						SDL_GetRGBA(src_pixels[ysrcint*surf->w + xsrcint],surf->format,&r,&g,&b,&a);
 						float value = xsize * ysize;
 						summation += value;
 						if (!a) continue;
@@ -642,23 +555,22 @@ surface tile_surface(const surface& surf, int w, int h, bool centered)
 		return surf;
 	}
 
-	surface dest(create_neutral_surface(w, h));
-	surface src(make_neutral_surface(surf));
+	surface dest(w, h);
 
-	if (src == nullptr || dest == nullptr) {
+	if (surf == nullptr || dest == nullptr) {
 		std::cerr << "failed to make neutral surface\n";
 		return nullptr;
 	}
 
 	{
-		const_surface_lock srclock(src);
+		const_surface_lock srclock(surf);
 		surface_lock destlock(dest);
 
 		const uint32_t* srcpixels = srclock.pixels();
 		uint32_t* destpixels = destlock.pixels();
 
-		const int& sw = src->w;
-		const int& sh = src->h;
+		const int& sw = surf->w;
+		const int& sh = surf->h;
 
 		const int xoff = centered ? (w - sw) / 2 : 0;
 		const int yoff = centered ? (h - sh) / 2 : 0;
@@ -690,7 +602,7 @@ surface adjust_surface_color(const surface &surf, int red, int green, int blue)
 		return temp;
 	}
 
-	surface nsurf(make_neutral_surface(surf));
+	surface nsurf = surf.clone();
 
 	if(nsurf == nullptr) {
 		std::cerr << "failed to make neutral surface\n";
@@ -730,7 +642,7 @@ surface greyscale_image(const surface &surf)
 	if(surf == nullptr)
 		return nullptr;
 
-	surface nsurf(make_neutral_surface(surf));
+	surface nsurf = surf.clone();
 	if(nsurf == nullptr) {
 		std::cerr << "failed to make neutral surface\n";
 		return nullptr;
@@ -775,7 +687,7 @@ surface monochrome_image(const surface &surf, const int threshold)
 	if(surf == nullptr)
 		return nullptr;
 
-	surface nsurf(make_neutral_surface(surf));
+	surface nsurf = surf.clone();
 	if(nsurf == nullptr) {
 		std::cerr << "failed to make neutral surface\n";
 		return nullptr;
@@ -815,7 +727,7 @@ surface sepia_image(const surface &surf)
 	if(surf == nullptr)
 		return nullptr;
 
-	surface nsurf(make_neutral_surface(surf));
+	surface nsurf = surf.clone();
 	if(nsurf == nullptr) {
 		std::cerr << "failed to make neutral surface\n";
 		return nullptr;
@@ -857,7 +769,7 @@ surface negative_image(const surface &surf, const int thresholdR, const int thre
 	if(surf == nullptr)
 		return nullptr;
 
-	surface nsurf(make_neutral_surface(surf));
+	surface nsurf = surf.clone();
 	if(nsurf == nullptr) {
 		std::cerr << "failed to make neutral surface\n";
 		return nullptr;
@@ -900,7 +812,7 @@ surface alpha_to_greyscale(const surface &surf)
 	if(surf == nullptr)
 		return nullptr;
 
-	surface nsurf(make_neutral_surface(surf));
+	surface nsurf = surf.clone();
 	if(nsurf == nullptr) {
 		std::cerr << "failed to make neutral surface\n";
 		return nullptr;
@@ -928,7 +840,7 @@ surface wipe_alpha(const surface &surf)
 	if(surf == nullptr)
 		return nullptr;
 
-	surface nsurf(make_neutral_surface(surf));
+	surface nsurf = surf.clone();
 	if(nsurf == nullptr) {
 		std::cerr << "failed to make neutral surface\n";
 		return nullptr;
@@ -992,7 +904,7 @@ surface swap_channels_image(const surface& surf, channel r, channel g, channel b
 	if(surf == nullptr)
 		return nullptr;
 
-	surface nsurf(make_neutral_surface(surf));
+	surface nsurf = surf.clone();
 	if(nsurf == nullptr) {
 		std::cerr << "failed to make neutral surface\n";
 		return nullptr;
@@ -1099,7 +1011,7 @@ surface recolor_image(surface surf, const color_range_map& map_rgb)
 		return surf;
 	}
 
-	surface nsurf(make_neutral_surface(surf));
+	surface nsurf = surf.clone();
 	if(nsurf == nullptr) {
 		std::cerr << "failed to make neutral surface" << std::endl;
 		return nullptr;
@@ -1135,7 +1047,7 @@ surface brighten_image(const surface &surf, fixed_t amount)
 		return nullptr;
 	}
 
-	surface nsurf(make_neutral_surface(surf));
+	surface nsurf = surf.clone();
 
 	if(nsurf == nullptr) {
 		std::cerr << "could not make neutral surface...\n";
@@ -1186,7 +1098,7 @@ surface adjust_surface_alpha_add(const surface &surf, int amount)
 		return nullptr;
 	}
 
-	surface nsurf(make_neutral_surface(surf));
+	surface nsurf = surf.clone();
 
 	if(nsurf == nullptr) {
 		std::cerr << "could not make neutral surface...\n";
@@ -1227,8 +1139,8 @@ surface mask_surface(const surface &surf, const surface &mask, bool* empty_resul
 		return surf;
 	}
 
-	surface nsurf = make_neutral_surface(surf);
-	surface nmask(make_neutral_surface(mask));
+	surface nsurf = surf.clone();
+	surface nmask = mask.clone();
 
 	if(nsurf == nullptr || nmask == nullptr) {
 		std::cerr << "could not make neutral surface...\n";
@@ -1301,8 +1213,8 @@ bool in_mask_surface(const surface &surf, const surface &mask)
 		return false;
 	}
 
-	surface nsurf = make_neutral_surface(surf);
-	surface nmask(make_neutral_surface(mask));
+	surface nsurf = surf.clone();
+	surface nmask = mask.clone();
 
 	if(nsurf == nullptr || nmask == nullptr) {
 		std::cerr << "could not make neutral surface...\n";
@@ -1339,7 +1251,7 @@ surface submerge_alpha(const surface &surf, int depth, float alpha_base, float a
 		return nullptr;
 	}
 
-	surface nsurf(make_neutral_surface(surf));
+	surface nsurf = surf.clone();
 
 	{
 		surface_lock lock(nsurf);
@@ -1404,7 +1316,7 @@ surface light_surface(const surface &surf, const surface &lightmap)
 		return surf;
 	}
 
-	surface nsurf = make_neutral_surface(surf);
+	surface nsurf = surf.clone();
 
 	if(nsurf == nullptr) {
 		std::cerr << "could not make neutral surface...\n";
@@ -1467,7 +1379,7 @@ surface blur_surface(const surface &surf, int depth)
 		return nullptr;
 	}
 
-	surface res = make_neutral_surface(surf);
+	surface res = surf.clone();
 
 	if(res == nullptr) {
 		std::cerr << "could not make neutral surface...\n";
@@ -1602,7 +1514,7 @@ surface blur_alpha_surface(const surface &surf, int depth)
 		return nullptr;
 	}
 
-	surface res = make_neutral_surface(surf);
+	surface res = surf.clone();
 
 	if(res == nullptr) {
 		std::cerr << "could not make neutral surface...\n";
@@ -1748,7 +1660,7 @@ surface cut_surface(const surface &surf, const SDL_Rect& r)
 	if(surf == nullptr)
 		return nullptr;
 
-	surface res = create_compatible_surface(surf, r.w, r.h);
+	surface res(r.w, r.h);
 
 	if(res == nullptr) {
 		std::cerr << "Could not create a new surface in cut_surface()\n";
@@ -1810,7 +1722,7 @@ surface blend_surface(
 		return nullptr;
 	}
 
-	surface nsurf(make_neutral_surface(surf));
+	surface nsurf = surf.clone();
 
 	if(nsurf == nullptr) {
 		std::cerr << "could not make neutral surface...\n";
@@ -1878,7 +1790,7 @@ surface rotate_any_surface(const surface& surf, float angle, int zoom, int offse
 		dst_w = static_cast<int>(ceil(std::abs(max_x) - min_x)) / zoom;
 		dst_h = static_cast<int>(ceil(std::abs(max_y) - min_y)) / zoom;
 	}
-	surface dst(create_neutral_surface(dst_w, dst_h));
+	surface dst(dst_w, dst_h);
 	{
 		surface_lock dst_lock(dst);
 		const surface src = scale_surface(surf, src_w, src_h);
@@ -1965,7 +1877,7 @@ surface rotate_180_surface(const surface &surf)
 		return nullptr;
 
 	// Work with a "neutral" surface.
-	surface nsurf(make_neutral_surface(surf));
+	surface nsurf = surf.clone();
 
 	if ( nsurf == nullptr ) {
 		std::cerr << "could not make neutral surface...\n";
@@ -2006,26 +1918,24 @@ surface rotate_90_surface(const surface &surf, bool clockwise)
 	if ( surf == nullptr )
 		return nullptr;
 
-	// Work with "neutral" surfaces.
-	surface dst(create_neutral_surface(surf->h, surf->w)); // Flipped dimensions.
-	surface src(make_neutral_surface(surf));
+	surface dst(surf->h, surf->w); // Flipped dimensions.
 
-	if ( src == nullptr  ||  dst == nullptr ) {
+	if ( surf == nullptr  ||  dst == nullptr ) {
 		std::cerr << "could not make neutral surface...\n";
 		return nullptr;
 	}
 
 	{// Code block to limit the scope of the surface locks.
-		const_surface_lock src_lock(src);
+		const_surface_lock src_lock(surf);
 		surface_lock dst_lock(dst);
 
 		const uint32_t* const src_pixels = src_lock.pixels();
 		uint32_t* const dst_pixels = dst_lock.pixels();
 
 		// Copy the pixels.
-		for ( int y = 0; y != src->h; ++y ) {
-			for ( int x = 0; x != src->w; ++x ) {
-				const int src_index = y*src->w + x;
+		for(int y = 0; y != surf->h; ++y) {
+			for ( int x = 0; x != surf->w; ++x ) {
+				const int src_index = y*surf->w + x;
 				const int dst_index = clockwise ?
 				                          x*dst->w + (dst->w-1-y) :
 				                          (dst->h-1-x)*dst->w + y;
@@ -2044,7 +1954,7 @@ surface flip_surface(const surface &surf)
 		return nullptr;
 	}
 
-	surface nsurf(make_neutral_surface(surf));
+	surface nsurf = surf.clone();
 
 	if(nsurf == nullptr) {
 		std::cerr << "could not make neutral surface...\n";
@@ -2073,7 +1983,7 @@ surface flop_surface(const surface &surf)
 		return nullptr;
 	}
 
-	surface nsurf(make_neutral_surface(surf));
+	surface nsurf = surf.clone();
 
 	if(nsurf == nullptr) {
 		std::cerr << "could not make neutral surface...\n";
@@ -2096,38 +2006,12 @@ surface flop_surface(const surface &surf)
 	return nsurf;
 }
 
-surface create_compatible_surface(const surface &surf, int width, int height)
-{
-	if(surf == nullptr)
-		return nullptr;
-
-	if(width == -1)
-		width = surf->w;
-
-	if(height == -1)
-		height = surf->h;
-
-#if SDL_VERSION_ATLEAST(2, 0, 6)
-	surface s = SDL_CreateRGBSurfaceWithFormat(0, width, height, surf->format->BitsPerPixel, surf->format->format);
-#else
-	surface s = SDL_CreateRGBSurface(0, width, height, surf->format->BitsPerPixel,
-		surf->format->Rmask, surf->format->Gmask, surf->format->Bmask, surf->format->Amask);
-#endif
-
-	if (surf->format->palette) {
-		SDL_SetPaletteColors(s->format->palette, surf->format->palette->colors, 0, surf->format->palette->ncolors);
-	}
-	return s;
-}
-
 void blit_surface(const surface& surf,
 	const SDL_Rect* srcrect, surface& dst, const SDL_Rect* dstrect)
 {
 	assert(surf);
 	assert(dst);
-	assert(is_neutral(dst));
-
-	const surface& src = is_neutral(surf) ? surf : make_neutral_surface(surf);
+	assert(dst.is_neutral());
 
 	// Get the areas to blit
 	SDL_Rect dst_rect {0, 0, dst->w, dst->h};
@@ -2140,7 +2024,7 @@ void blit_surface(const surface& surf,
 
 	}
 
-	SDL_Rect src_rect {0, 0, src->w, src->h};
+	SDL_Rect src_rect {0, 0, surf->w, surf->h};
 	if(srcrect && srcrect->w && srcrect->h) {
 		src_rect.x = srcrect->x;
 		src_rect.y = srcrect->y;
@@ -2164,15 +2048,15 @@ void blit_surface(const surface& surf,
 			src_rect.h += src_rect.y;
 			src_rect.y = 0;
 		}
-		if (src_rect.x + src_rect.w > src->w) {
-            if (src_rect.x >= src->w)
+		if (src_rect.x + src_rect.w > surf->w) {
+            if (src_rect.x >= surf->w)
                 return;
-			src_rect.w = src->w - src_rect.x;
+			src_rect.w = surf->w - src_rect.x;
 		}
-		if (src_rect.y + src_rect.h > src->h) {
-            if (src_rect.y >= src->h)
+		if (src_rect.y + src_rect.h > surf->h) {
+            if (src_rect.y >= surf->h)
                 return;
-			src_rect.h = src->h - src_rect.y;
+			src_rect.h = surf->h - src_rect.y;
 		}
 	}
 
@@ -2185,7 +2069,7 @@ void blit_surface(const surface& surf,
 
 	{
 		// Extra scoping used for the surface_lock.
-		const_surface_lock src_lock(src);
+		const_surface_lock src_lock(surf);
 		surface_lock dst_lock(dst);
 
 		const uint32_t* const src_pixels = src_lock.pixels();
@@ -2202,8 +2086,8 @@ void blit_surface(const surface& surf,
 				// We do these optimizations between the extraction of the variables
 				// to avoid creating variables not used (it might save us some cycles).
 
-				const int src_offset = (y + src_rect.y) * src->w + (x + src_rect.x);
-				assert(src_offset < src->w * src->h);
+				const int src_offset = (y + src_rect.y) * surf->w + (x + src_rect.x);
+				assert(src_offset < surf->w * surf->h);
 				const uint32_t src_pixel = src_pixels[src_offset];
 				const uint8_t src_a = (src_pixel & 0xFF000000) >> 24;
 
@@ -2289,7 +2173,7 @@ surface get_surface_portion(const surface &src, SDL_Rect &area)
 	}
 
 	// use same format as the source (almost always the screen)
-	surface dst = create_compatible_surface(src, area.w, area.h);
+	surface dst(area.w, area.h);
 
 	if(dst == nullptr) {
 		std::cerr << "Could not create a new surface in get_surface_portion()\n";
@@ -2319,7 +2203,7 @@ struct not_alpha
 SDL_Rect get_non_transparent_portion(const surface &surf)
 {
 	SDL_Rect res {0,0,0,0};
-	surface nsurf(make_neutral_surface(surf));
+	surface nsurf = surf.clone();
 	if(nsurf == nullptr) {
 		std::cerr << "failed to make neutral surface\n";
 		return res;

--- a/src/sdl/utils.hpp
+++ b/src/sdl/utils.hpp
@@ -42,20 +42,6 @@ inline void sdl_copy_portion(const surface& screen, SDL_Rect* screen_rect, surfa
 }
 
 /**
- * Check that the surface is neutral bpp 32.
- *
- * The surface may have an empty alpha channel.
- *
- * @param surf                    The surface to test.
- *
- * @returns                       The status @c true if neutral, @c false if not.
- */
-bool is_neutral(const surface& surf);
-
-surface make_neutral_surface(const surface &surf);
-surface create_neutral_surface(int w, int h);
-
-/**
  * Stretches a surface in the horizontal direction.
  *
  *  The stretches a surface it uses the first pixel in the horizontal
@@ -300,7 +286,6 @@ surface rotate_90_surface(const surface &surf, bool clockwise);
 
 surface flip_surface(const surface &surf);
 surface flop_surface(const surface &surf);
-surface create_compatible_surface(const surface &surf, int width = -1, int height = -1);
 
 /**
  * Replacement for sdl_blit.

--- a/src/tests/test_image_modifications.cpp
+++ b/src/tests/test_image_modifications.cpp
@@ -466,7 +466,7 @@ BOOST_AUTO_TEST_CASE(test_blit_modification_decoding_1_arg)
 	// The dynamic_cast returns nullptr if the argument doesn't match the type
 	BOOST_REQUIRE(mod != nullptr);
 
-	BOOST_CHECK(!mod->get_surface().null());
+	BOOST_CHECK(mod->get_surface());
 	BOOST_CHECK_EQUAL(mod->get_x(), 0);
 	BOOST_CHECK_EQUAL(mod->get_y(), 0);
 }
@@ -488,7 +488,7 @@ BOOST_AUTO_TEST_CASE(test_blit_modification_decoding_3_args)
 	BOOST_REQUIRE(mod != nullptr);
 	// The dynamic_cast returns nullptr if the argument doesn't match the type
 
-	BOOST_CHECK(!mod->get_surface().null());
+	BOOST_CHECK(mod->get_surface());
 	BOOST_CHECK_EQUAL(mod->get_x(), 1);
 	BOOST_CHECK_EQUAL(mod->get_y(), 2);
 }
@@ -525,7 +525,7 @@ BOOST_AUTO_TEST_CASE(test_mask_modification_decoding_1_arg)
 	// The dynamic_cast returns nullptr if the argument doesn't match the type
 	BOOST_REQUIRE(mod != nullptr);
 
-	BOOST_CHECK(!mod->get_mask().null());
+	BOOST_CHECK(mod->get_mask());
 	BOOST_CHECK_EQUAL(mod->get_x(), 0);
 	BOOST_CHECK_EQUAL(mod->get_y(), 0);
 }
@@ -547,7 +547,7 @@ BOOST_AUTO_TEST_CASE(test_mask_modification_decoding_3_args)
 	// The dynamic_cast returns nullptr if the argument doesn't match the type
 	BOOST_REQUIRE(mod != nullptr);
 
-	BOOST_CHECK(!mod->get_mask().null());
+	BOOST_CHECK(mod->get_mask());
 	BOOST_CHECK_EQUAL(mod->get_x(), 3);
 	BOOST_CHECK_EQUAL(mod->get_y(), 4);
 }
@@ -593,7 +593,7 @@ BOOST_AUTO_TEST_CASE(test_l_modification_decoding_1_arg)
 	// The dynamic_cast returns nullptr if the argument doesn't match the type
 	BOOST_REQUIRE(mod != nullptr);
 
-	BOOST_CHECK(!mod->get_surface().null());
+	BOOST_CHECK(mod->get_surface());
 }
 
 /// Tests if the SCALE modification without arguments is ignored

--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -215,8 +215,8 @@ void unit_drawer::redraw_unit (const unit & u) const
 			const std::string ellipse_bot = formatter() << ellipse << "-" << leader << nozoc << selected << "bottom.png~RC(ellipse_red>" << tc << ")";
 
 			// Load the ellipse parts recolored to match team color
-			ellipse_back.assign(image::get_image(image::locator(ellipse_top), image::SCALED_TO_ZOOM));
-			ellipse_front.assign(image::get_image(image::locator(ellipse_bot), image::SCALED_TO_ZOOM));
+			ellipse_back = image::get_image(image::locator(ellipse_top), image::SCALED_TO_ZOOM);
+			ellipse_front = image::get_image(image::locator(ellipse_bot), image::SCALED_TO_ZOOM);
 		}
 	}
 	if (ellipse_back != nullptr) {
@@ -240,8 +240,8 @@ void unit_drawer::redraw_unit (const unit & u) const
 		int yoff;
 		if(cfg_offset_x.empty() && cfg_offset_y.empty()) {
 			const surface unit_img = image::get_image(u.default_anim_image(), image::SCALED_TO_ZOOM);
-			xoff = unit_img.null() ? 0 : (hex_size - unit_img->w)/2;
-			yoff = unit_img.null() ? 0 : (hex_size - unit_img->h)/2;
+			xoff = !unit_img ? 0 : (hex_size - unit_img->w)/2;
+			yoff = !unit_img ? 0 : (hex_size - unit_img->h)/2;
 		}
 		else {
 			xoff = cfg_offset_x.to_int();
@@ -319,7 +319,7 @@ void unit_drawer::redraw_unit (const unit & u) const
 
 		if (can_recruit) {
 			surface crown(image::get_image(u.leader_crown(),image::SCALED_TO_ZOOM));
-			if(!crown.null()) {
+			if(crown) {
 				//if(bar_alpha != ftofxp(1.0)) {
 				//	crown = adjust_surface_alpha(crown, bar_alpha);
 				//}
@@ -417,7 +417,7 @@ void unit_drawer::draw_bar(const std::string& image, int xpos, int ypos,
 
 	if(unfilled < height && alpha >= ftofxp(0.3)) {
 		const uint8_t r_alpha = std::min<unsigned>(unsigned(fxpmult(alpha,255)),255);
-		surface filled_surf = create_compatible_surface(bar_surf, bar_loc.w, height - unfilled);
+		surface filled_surf(bar_loc.w, height - unfilled);
 		SDL_Rect filled_area = sdl::create_rect(0, 0, bar_loc.w, height-unfilled);
 		sdl::fill_surface_rect(filled_surf,&filled_area,SDL_MapRGBA(bar_surf->format,col.r,col.g,col.b, r_alpha));
 		disp.drawing_buffer_add(display::LAYER_UNIT_BAR, loc, xpos + bar_loc.x, ypos + bar_loc.y + unfilled, filled_surf);
@@ -440,14 +440,12 @@ const SDL_Rect& unit_drawer::calculate_energy_bar(surface surf) const
 
 	int first_row = -1, last_row = -1, first_col = -1, last_col = -1;
 
-	surface image(make_neutral_surface(surf));
-
-	const_surface_lock image_lock(image);
+	const_surface_lock image_lock(surf);
 	const uint32_t* const begin = image_lock.pixels();
 
-	for(int y = 0; y != image->h; ++y) {
-		const uint32_t* const i1 = begin + image->w*y;
-		const uint32_t* const i2 = i1 + image->w;
+	for(int y = 0; y != surf->h; ++y) {
+		const uint32_t* const i1 = begin + surf->w*y;
+		const uint32_t* const i2 = i1 + surf->w;
 		const uint32_t* const itor = std::find_if(i1,i2,is_energy_color());
 		const int count = std::count_if(itor,i2,is_energy_color());
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -204,17 +204,14 @@ void CVideo::update_framebuffer()
 	}
 
 	surface fb = SDL_GetWindowSurface(*window);
-	if(!frameBuffer) {
-		frameBuffer = fb;
-	} else {
-		if(sdl_get_version() >= version_info(2, 0, 6)) {
-			// Because SDL has already freed the old framebuffer,
-			// ensure that we won't attempt to free it.
-			frameBuffer.clear_without_free();
-		}
 
-		frameBuffer.assign(fb);
+	if(frameBuffer && sdl_get_version() >= version_info(2, 0, 6)) {
+		// Because SDL has already freed the old framebuffer,
+		// ensure that we won't attempt to free it.
+		frameBuffer.clear_without_free();
 	}
+
+	frameBuffer = fb;
 }
 
 void CVideo::init_window()

--- a/src/widgets/button.cpp
+++ b/src/widgets/button.cpp
@@ -103,7 +103,7 @@ void button::load_images() {
 	surface active_image(image::get_image(button_image_name_ + "-active.png"+ button_image_path_suffix_));
 	surface disabled_image;
 	if (filesystem::file_exists(game_config::path + "/images/" + button_image_name_ + "-disabled.png"))
-		disabled_image.assign((image::get_image(button_image_name_ + "-disabled.png"+ button_image_path_suffix_)));
+		disabled_image = image::get_image(button_image_name_ + "-disabled.png"+ button_image_path_suffix_);
 	surface pressed_disabled_image, pressed_active_image, touched_image;
 
 	if (!button_overlay_image_name_.empty()) {
@@ -113,51 +113,51 @@ void button::load_images() {
 			button_overlay_image_name_.resize(button_overlay_image_name_.length() - size_postfix.length());
 		}
 
-		overlayImage_.assign(image::get_image(button_overlay_image_name_ + size_postfix + ".png"+ button_image_path_suffix_));
-		overlayPressedImage_.assign(image::get_image(button_overlay_image_name_ + size_postfix + "-pressed.png"+ button_image_path_suffix_));
+		overlayImage_ = image::get_image(button_overlay_image_name_ + size_postfix + ".png"+ button_image_path_suffix_);
+		overlayPressedImage_ = image::get_image(button_overlay_image_name_ + size_postfix + "-pressed.png"+ button_image_path_suffix_);
 
 		if (filesystem::file_exists(game_config::path + "/images/" + button_overlay_image_name_ + size_postfix + "-active.png"))
-			overlayActiveImage_.assign(image::get_image(button_overlay_image_name_ + size_postfix + "-active.png"+ button_image_path_suffix_));
+			overlayActiveImage_ = image::get_image(button_overlay_image_name_ + size_postfix + "-active.png"+ button_image_path_suffix_);
 
 		if (filesystem::file_exists(game_config::path + "/images/" + button_overlay_image_name_ + size_postfix + "-disabled.png"))
-			overlayDisabledImage_.assign(image::get_image(button_overlay_image_name_ + size_postfix + "-disabled.png"+ button_image_path_suffix_));
-		if (overlayDisabledImage_.null())
+			overlayDisabledImage_ = image::get_image(button_overlay_image_name_ + size_postfix + "-disabled.png"+ button_image_path_suffix_);
+		if (!overlayDisabledImage_)
 			overlayDisabledImage_ = image::get_image(button_overlay_image_name_ + size_postfix + ".png~GS()" + button_image_path_suffix_);
 
 		if (filesystem::file_exists(game_config::path + "/images/" + button_overlay_image_name_ + size_postfix + "-disabled-pressed.png"))
-			overlayPressedDisabledImage_.assign(image::get_image(button_overlay_image_name_ + size_postfix + "-disabled-pressed.png"+ button_image_path_suffix_));
-		if (overlayPressedDisabledImage_.null())
+			overlayPressedDisabledImage_ = image::get_image(button_overlay_image_name_ + size_postfix + "-disabled-pressed.png"+ button_image_path_suffix_);
+		if (!overlayPressedDisabledImage_)
 			overlayPressedDisabledImage_ = image::get_image(button_overlay_image_name_ + size_postfix + "-pressed.png~GS()"+ button_image_path_suffix_);
 	} else {
-		overlayImage_.assign(nullptr);
+		overlayImage_ = nullptr;
 	}
 
 	if (disabled_image == nullptr) {
 		disabled_image = image::get_image(button_image_name_ + ".png~GS()" + button_image_path_suffix_);
 	}
 
-	if (pressed_image.null())
-		pressed_image.assign(button_image);
+	if (!pressed_image)
+		pressed_image = button_image;
 
-	if (active_image.null())
-		active_image.assign(button_image);
+	if (!active_image)
+		active_image = button_image;
 
 	if (type_ == TYPE_CHECK || type_ == TYPE_RADIO) {
-		touched_image.assign(image::get_image(button_image_name_ + "-touched.png"+ button_image_path_suffix_));
-		if (touched_image.null())
-			touched_image.assign(pressed_image);
+		touched_image = image::get_image(button_image_name_ + "-touched.png"+ button_image_path_suffix_);
+		if (!touched_image)
+			touched_image = pressed_image;
 
-		pressed_active_image.assign(image::get_image(button_image_name_ + "-active-pressed.png"+ button_image_path_suffix_));
-		if (pressed_active_image.null())
-			pressed_active_image.assign(pressed_image);
+		pressed_active_image = image::get_image(button_image_name_ + "-active-pressed.png"+ button_image_path_suffix_);
+		if (!pressed_active_image)
+			pressed_active_image = pressed_image;
 
 		if (filesystem::file_exists(game_config::path + "/images/" + button_image_name_ + size_postfix + "-disabled-pressed.png"))
-			pressed_disabled_image.assign(image::get_image(button_image_name_ + "-disabled-pressed.png"+ button_image_path_suffix_));
-		if (pressed_disabled_image.null())
+			pressed_disabled_image = image::get_image(button_image_name_ + "-disabled-pressed.png"+ button_image_path_suffix_);
+		if (!pressed_disabled_image)
 			pressed_disabled_image = image::get_image(button_image_name_ + "-pressed.png~GS()"+ button_image_path_suffix_);
 	}
 
-	if (button_image.null()) {
+	if (!button_image) {
 		std::string err_msg = "error initializing button images! file name: ";
 		err_msg += button_image_name_;
 		err_msg += ".png";
@@ -173,19 +173,19 @@ void button::load_images() {
 	}
 
 	if(type_ == TYPE_PRESS || type_ == TYPE_TURBO) {
-		image_.assign(scale_surface(button_image,location().w,location().h));
-		pressedImage_.assign(scale_surface(pressed_image,location().w,location().h));
-		activeImage_.assign(scale_surface(active_image,location().w,location().h));
-		disabledImage_.assign(scale_surface(disabled_image,location().w,location().h));
+		image_ = scale_surface(button_image,location().w,location().h);
+		pressedImage_ = scale_surface(pressed_image,location().w,location().h);
+		activeImage_ = scale_surface(active_image,location().w,location().h);
+		disabledImage_ = scale_surface(disabled_image,location().w,location().h);
 	} else {
-		image_.assign(scale_surface(button_image,button_image->w,button_image->h));
-		activeImage_.assign(scale_surface(active_image,button_image->w,button_image->h));
-		disabledImage_.assign(scale_surface(disabled_image,button_image->w,button_image->h));
-		pressedImage_.assign(scale_surface(pressed_image,button_image->w,button_image->h));
+		image_ = scale_surface(button_image,button_image->w,button_image->h);
+		activeImage_ = scale_surface(active_image,button_image->w,button_image->h);
+		disabledImage_ = scale_surface(disabled_image,button_image->w,button_image->h);
+		pressedImage_ = scale_surface(pressed_image,button_image->w,button_image->h);
 		if (type_ == TYPE_CHECK || type_ == TYPE_RADIO) {
-			pressedDisabledImage_.assign(scale_surface(pressed_disabled_image,button_image->w,button_image->h));
-			pressedActiveImage_.assign(scale_surface(pressed_active_image, button_image->w, button_image->h));
-			touchedImage_.assign(scale_surface(touched_image, button_image->w, button_image->h));
+			pressedDisabledImage_ = scale_surface(pressed_disabled_image,button_image->w,button_image->h);
+			pressedActiveImage_ = scale_surface(pressed_active_image, button_image->w, button_image->h);
+			touchedImage_ = scale_surface(touched_image, button_image->w, button_image->h);
 		}
 	}
 
@@ -350,31 +350,29 @@ void button::draw_contents()
 		button_color = font::GRAY_COLOR;
 	}
 
-	if (!overlayImage_.null()) {
+	if (overlayImage_) {
 
-		surface noverlay = make_neutral_surface(
-				enabled() ? overlayImage_ : overlayDisabledImage_);
+		surface* noverlay = enabled() ? &overlayImage_ : &overlayDisabledImage_;
 
-		if (!overlayPressedImage_.null()) {
+		if (overlayPressedImage_) {
 			switch (state_) {
 			case ACTIVE:
-				if (!overlayActiveImage_.null())
-					noverlay = make_neutral_surface(overlayActiveImage_);
+				if (overlayActiveImage_)
+					noverlay = &overlayActiveImage_;
 				break;
 			case PRESSED:
 			case PRESSED_ACTIVE:
 			case TOUCHED_NORMAL:
 			case TOUCHED_PRESSED:
-				noverlay = make_neutral_surface( enabled() ?
-						overlayPressedImage_ : overlayPressedDisabledImage_);
+				noverlay = enabled() ? &overlayPressedImage_ : &overlayPressedDisabledImage_;
 				break;
 			default:
 				break;
 			}
 		}
 
-		surface nimage = make_neutral_surface(image);
-		sdl_blit(noverlay, nullptr, nimage, nullptr);
+		surface nimage = image.clone();
+		sdl_blit(*noverlay, nullptr, nimage, nullptr);
 		image = nimage;
 	}
 

--- a/src/widgets/menu_style.cpp
+++ b/src/widgets/menu_style.cpp
@@ -66,7 +66,7 @@ void menu::style::scale_images(int max_width, int max_height)
 surface menu::style::get_item_image(const image::locator& img_loc) const
 {
 	surface surf = image::get_image(img_loc);
-	if(!surf.null())
+	if(surf)
 	{
 		int scale = 100;
 		if(max_img_w_ > 0 && surf->w > max_img_w_) {
@@ -88,7 +88,7 @@ bool menu::imgsel_style::load_image(const std::string &img_sub)
 	std::string path = img_base_ + "-" + img_sub + ".png";
 	const surface image = image::get_image(path);
 	img_map_[img_sub] = image;
-	return(!image.null());
+	return(image);
 }
 
 bool menu::imgsel_style::load_images()

--- a/src/widgets/scrollbar.cpp
+++ b/src/widgets/scrollbar.cpp
@@ -239,21 +239,21 @@ void scrollbar::draw_contents()
 	switch (state_) {
 
 	case NORMAL:
-		top_img.assign(image::get_image(scrollbar_top));
-		mid_img.assign(image::get_image(scrollbar_mid));
-		bottom_img.assign(image::get_image(scrollbar_bottom));
+		top_img = image::get_image(scrollbar_top);
+		mid_img = image::get_image(scrollbar_mid);
+		bottom_img = image::get_image(scrollbar_bottom);
 		break;
 
 	case ACTIVE:
-		top_img.assign(image::get_image(scrollbar_top_hl));
-		mid_img.assign(image::get_image(scrollbar_mid_hl));
-		bottom_img.assign(image::get_image(scrollbar_bottom_hl));
+		top_img = image::get_image(scrollbar_top_hl);
+		mid_img = image::get_image(scrollbar_mid_hl);
+		bottom_img = image::get_image(scrollbar_bottom_hl);
 		break;
 
 	case DRAGGED:
-		top_img.assign(image::get_image(scrollbar_top_pressed));
-		mid_img.assign(image::get_image(scrollbar_mid_pressed));
-		bottom_img.assign(image::get_image(scrollbar_bottom_pressed));
+		top_img = image::get_image(scrollbar_top_pressed);
+		mid_img = image::get_image(scrollbar_mid_pressed);
+		bottom_img = image::get_image(scrollbar_bottom_pressed);
 		break;
 
 	case UNINIT:
@@ -280,8 +280,8 @@ void scrollbar::draw_contents()
 		mid_height = 1;
 	}
 
-	if(mid_scaled_.null() || mid_scaled_->h != mid_height) {
-		mid_scaled_.assign(scale_surface(mid_img, mid_img->w, mid_height));
+	if(!mid_scaled_ || mid_scaled_->h != mid_height) {
+		mid_scaled_ = scale_surface(mid_img, mid_img->w, mid_height);
 	}
 
 	SDL_Rect groove = groove_area();
@@ -290,11 +290,11 @@ void scrollbar::draw_contents()
 		groove_height = 1;
 	}
 
-	if (groove_scaled_.null() || groove_scaled_->h != groove_height) {
-		groove_scaled_.assign(scale_surface(mid_grv, mid_grv->w, groove_height));
+	if (!groove_scaled_ || groove_scaled_->h != groove_height) {
+		groove_scaled_ = scale_surface(mid_grv, mid_grv->w, groove_height);
 	}
 
-	if (mid_scaled_.null() || groove_scaled_.null()) {
+	if (!mid_scaled_ || !groove_scaled_) {
 		std::cerr << "Failure during scrollbar image scale.\n";
 		return;
 	}
@@ -388,7 +388,7 @@ void scrollbar::handle_event(const SDL_Event& event)
 
 	if (new_state != state_) {
 		set_dirty();
-		mid_scaled_.assign(nullptr);
+		mid_scaled_ = nullptr;
 		state_ = new_state;
 	}
 }

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -60,7 +60,7 @@ void textbox::update_location(const SDL_Rect& rect)
 void textbox::set_inner_location(const SDL_Rect& rect)
 {
 	bg_register(rect);
-	if (text_image_.null()) return;
+	if (!text_image_) return;
 	text_pos_ = 0;
 	update_text_cache(false);
 }
@@ -99,7 +99,7 @@ void textbox::append_text(const std::string& text, bool auto_scroll, const color
 	const ucs4::string& wtext = unicode_cast<ucs4::string>(text);
 
 	surface new_text = add_text_line(wtext, color);
-	surface new_surface = create_compatible_surface(text_image_,std::max<size_t>(text_image_->w,new_text->w),text_image_->h+new_text->h);
+	surface new_surface(std::max<size_t>(text_image_->w,new_text->w),text_image_->h+new_text->h);
 
 	adjust_surface_alpha(new_text, SDL_ALPHA_TRANSPARENT);
 	adjust_surface_alpha(text_image_, SDL_ALPHA_TRANSPARENT);
@@ -115,7 +115,7 @@ void textbox::append_text(const std::string& text, bool auto_scroll, const color
 	};
 	SDL_SetSurfaceBlendMode(new_text, SDL_BLENDMODE_NONE);
 	sdl_blit(new_text,nullptr,new_surface,&target);
-	text_image_.assign(new_surface);
+	text_image_ = new_surface;
 
 	text_.insert(text_.end(), wtext.begin(), wtext.end());
 
@@ -371,7 +371,7 @@ void textbox::update_text_cache(bool changed, const color_t& color)
 		char_x_.clear();
 		char_y_.clear();
 
-		text_image_.assign(add_text_line(text_, color));
+		text_image_ = add_text_line(text_, color);
 	}
 
 	int cursor_x = char_x_[cursor_];
@@ -383,7 +383,7 @@ void textbox::update_text_cache(bool changed, const color_t& color)
 	}
 	cursor_pos_ = cursor_x - text_pos_;
 
-	if (!text_image_.null()) {
+	if (text_image_) {
 		set_full_size(text_image_->h);
 		set_shown_size(location().h);
 	}


### PR DESCRIPTION
* Removed create_neutral_surface in favor of a surface ctor that takes w/h dimensions.

* Removed make_neutral_surface in favor of a surface::make_neutral function. Most usecases of this were
  to make a copy of a surface anyway, so I added a new surface::clone function

* Moved the pixel format validation and conversion to the surface class. Now *all* surfaces should be
  guaranteed to be in the 'neutral' format. Any new surface that is created (with clone() or the dimension
  ctor will be in that format, and any time a raw SDL_Surface* ptr is assigned, it is also converted. This
  applies both to the ctor and assignment operators.

* Removed create_compatible_surface. All surfaces should be compatible in the first place.

* Removed surface::assign was in favor of simple assignment operators. The existing assignment operators
  already just called assign().

* Removed surface::null in favor of the implicit SDL_Surface* conversion operator for consistency. We were
  already using null and implicit pointer bool conversion, so I decided to go with the latter. I was going
  to add an operator bool(), but it was ambiguous in surface-to-surface comparisons.