### PR TITLE
Show the turn dialog before updating the GUI for the incoming player.

### DIFF
--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -1217,6 +1217,10 @@ void play_controller::play_turn()
 
 		// If a side is empty skip over it.
 		if (!current_team().is_empty()) {
+			// Show the turn dialog now, before the minimap is redrawn and before healing is animated.
+			if(current_team().is_local_human() && current_team().is_proxy_human()) {
+				show_turn_dialog();
+			}
 			init_side_begin();
 			if(gamestate_->init_side_done()) {
 				// This is the case in a reloaded game where the side was initialized before saving the game.

--- a/src/play_controller.hpp
+++ b/src/play_controller.hpp
@@ -304,6 +304,7 @@ protected:
 	void fire_start();
 	void start_game();
 	virtual void init_gui();
+	virtual void show_turn_dialog() {}
 	void finish_side_turn();
 	void finish_turn(); //this should not throw an end turn or end level exception
 	bool enemies_visible() const;

--- a/src/playmp_controller.cpp
+++ b/src/playmp_controller.cpp
@@ -122,7 +122,6 @@ void playmp_controller::play_human_turn()
 	const std::unique_ptr<countdown_clock> timer(saved_game_.mp_settings().mp_countdown
         ? new countdown_clock(current_team())
         : nullptr);
-	show_turn_dialog();
 	if(undo_stack().can_undo()) {
 		// If we reload a networked mp game we cannot undo moves made before the save
 		// because other players already received them

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -458,8 +458,6 @@ void playsingle_controller::execute_gotos()
 }
 
 void playsingle_controller::play_human_turn() {
-	show_turn_dialog();
-
 	if (!preferences::disable_auto_moves()) {
 		execute_gotos();
 	}

--- a/src/playsingle_controller.hpp
+++ b/src/playsingle_controller.hpp
@@ -65,7 +65,7 @@ public:
 protected:
 	virtual void play_side_impl() override;
 	void before_human_turn();
-	void show_turn_dialog();
+	virtual void show_turn_dialog() override;
 	void execute_gotos();
 	virtual void play_human_turn();
 	virtual void after_human_turn();


### PR DESCRIPTION
In hotseat games, the main map and minimap were updated and healing was animated
before blacking out the display for the turn dialog.

Fixes #4187.