### PR TITLE
Fix remove overlay by addition of bis_overlay non persistent

### DIFF
--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -350,18 +350,13 @@ end
 function wml_actions.unit_overlay(cfg)
 	local img = cfg.image or helper.wml_error( "[unit_overlay] missing required image= attribute" )
 	for i,u in ipairs(wesnoth.get_units(cfg)) do
-		local has_already = false
-		for i, w in ipairs(u.overlays) do
-			if w == img then has_already = true end
+				local ucfg = u.__cfg
+		for w in utils.split(ucfg.overlays) do
+			if w == img then ucfg = nil end
 		end
-		if has_already == false then
-			u:add_modification("object", {
-				id = cfg.object_id,
-				wml.tag.effect {
-					apply_to = "overlay",
-					add = img,
-				}
-			})
+		if ucfg then
+			ucfg.overlays = ucfg.overlays .. ',' .. img
+			wesnoth.put_unit(ucfg)
 		end
 	end
 end

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -350,7 +350,7 @@ end
 function wml_actions.unit_overlay(cfg)
 	local img = cfg.image or helper.wml_error( "[unit_overlay] missing required image= attribute" )
 	for i,u in ipairs(wesnoth.get_units(cfg)) do
-				local ucfg = u.__cfg
+		local ucfg = u.__cfg
 		for w in utils.split(ucfg.overlays) do
 			if w == img then ucfg = nil end
 		end

--- a/data/schema/units/modifications.cfg
+++ b/data/schema/units/modifications.cfg
@@ -155,7 +155,7 @@
 				{LINK_TAG "units/unit_type/extra_anim"}
 			[/case]
 			[case]
-				value=image_mod,overlay
+				value=image_mod,overlay,old_overlay
 				{SIMPLE_KEY replace string}
 				{SIMPLE_KEY add string}
 				{LINK_TAG "game_config/color_range"}

--- a/data/schema/units/single.cfg
+++ b/data/schema/units/single.cfg
@@ -15,6 +15,7 @@
 	{SIMPLE_KEY upkeep upkeep}
 	{SIMPLE_KEY recall_cost s_int}
 	{SIMPLE_KEY overlays string_list}
+    {SIMPLE_KEY bis_overlays string_list}
 	{SIMPLE_KEY max_hitpoints s_int}
 	{SIMPLE_KEY max_experience s_int}
 	{SIMPLE_KEY max_moves s_int}

--- a/src/gui/dialogs/unit_recall.cpp
+++ b/src/gui/dialogs/unit_recall.cpp
@@ -185,6 +185,10 @@ void unit_recall::pre_show(window& window)
 			mods += "~BLIT(" + overlay + ")";
 		}
 
+		for(const std::string& bis_overlay : unit->bis_overlays()) {
+			mods += "~BLIT(" + bis_overlay + ")";
+		}
+
 		column["use_markup"] = "true";
 
 		column["label"] = unit->absolute_image() + mods;

--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -423,6 +423,10 @@ void unit_preview_pane::set_displayed_unit(const unit& u)
 			mods += "~BLIT(" + overlay + ")";
 		}
 
+		for(const std::string& bis_overlay : u.bis_overlays()) {
+			mods += "~BLIT(" + bis_overlay + ")";
+		}
+
 		mods += "~XBRZ(2)~SCALE_INTO_SHARP(144,144)" + image_mods_;
 
 		icon_type_->set_label(u.absolute_image() + mods);

--- a/src/scripting/lua_unit.cpp
+++ b/src/scripting/lua_unit.cpp
@@ -332,6 +332,10 @@ static int impl_unit_get(lua_State *L)
 		lua_push(L, u.overlays());
 		return 1;
 	}
+	if(strcmp(m, "bis_overlays") == 0) {
+		lua_push(L, u.bis_overlays());
+		return 1;
+	}
 	if(strcmp(m, "traits") == 0) {
 		lua_push(L, u.get_traits_list());
 		return 1;

--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -335,6 +335,15 @@ void unit_drawer::redraw_unit (const unit & u) const
 		}
 	}
 
+		for(const std::string& bov : u.bis_overlays()) {
+			const surface bov_img(image::get_image(bov, image::SCALED_TO_ZOOM));
+			if(bov_img != nullptr) {
+				disp.drawing_buffer_add(display::LAYER_UNIT_BAR,
+					loc, xsrc+xoff, ysrc+yoff+adjusted_params.y, bov_img);
+			}
+		}
+	}
+
 	// Smooth unit movements from terrain of different elevation.
 	// Do this separately from above so that the health bar doesn't go up and down.
 

--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -333,7 +333,6 @@ void unit_drawer::redraw_unit (const unit & u) const
 					loc, xsrc+xoff, ysrc+yoff+adjusted_params.y, ov_img);
 			}
 		}
-	}
 
 		for(const std::string& bov : u.bis_overlays()) {
 			const surface bov_img(image::get_image(bov, image::SCALED_TO_ZOOM));

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -2135,9 +2135,9 @@ void unit::apply_builtin_effect(std::string apply_to, const config& effect)
 			std::vector<std::string> temp_overlays = utils::parenthetical_split(add, ',');
 			std::vector<std::string>::iterator it;
 			for(it=temp_overlays.begin();it<temp_overlays.end();++it) {
-                auto itr = std::find(overlays_.begin(), overlays_.end(), *it);
-                if (itr != overlays_.end()){}
-                else {overlays_.push_back(*it);}
+				auto itr = std::find(overlays_.begin(), overlays_.end(), *it);
+				if (itr != overlays_.end()){}
+				else {overlays_.push_back(*it);}
 			}
 		}
 		else if(!replace.empty()) {
@@ -2151,7 +2151,7 @@ void unit::apply_builtin_effect(std::string apply_to, const config& effect)
 			std::vector<std::string> temp_overlays = utils::parenthetical_split(add, ',');
 			std::vector<std::string>::iterator it;
 			for(it=temp_overlays.begin();it<temp_overlays.end();++it) {
-                bis_overlays_.push_back(*it);
+				bis_overlays_.push_back(*it);
 			}
 		}
 		else if(!replace.empty()) {

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -990,7 +990,7 @@ void unit::advance_to(const unit_type& u_type, bool use_traits)
 	max_attacks_ = new_type.max_attacks();
 
 	flag_rgb_ = new_type.flag_rgb();
-
+	
 	upkeep_ = upkeep_full();
 	parse_upkeep(new_type.get_cfg()["upkeep"]);
 
@@ -1421,7 +1421,7 @@ bool unit::get_attacks_changed() const
 		if(a_ptr->get_changed()) {
 			return true;
 		}
-
+		
 	}
 	return false;
 }
@@ -2082,7 +2082,7 @@ void unit::apply_builtin_effect(std::string apply_to, const config& effect)
 			movement_type_.get_resistances().merge(ap, effect["replace"].to_bool());
 		}
 	} else if(apply_to == "zoc") {
-		if(const config::attribute_value* v = effect.get("value")) {
+		if(const config::attribute_value* v = effect.get("value")) {			
 			set_attr_changed(UA_ZOC);
 			emit_zoc_ = v->to_bool();
 		}
@@ -2653,7 +2653,7 @@ void unit::clear_changed_attributes()
 {
 	changed_attributes_.reset();
 	for(const auto& a_ptr : attacks_) {
-		a_ptr->set_changed(false);
+		a_ptr->set_changed(false);	
 	}
 }
 

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -2122,9 +2122,9 @@ void unit::apply_builtin_effect(std::string apply_to, const config& effect)
 			std::vector<std::string> temp_overlays = utils::parenthetical_split(add, ',');
 			std::vector<std::string>::iterator it;
 			for(it=temp_overlays.begin();it<temp_overlays.end();++it) {
-				 auto itr = std::find(overlays_.begin(), overlays_.end(), *it);
-				 if (itr != overlays_.end()){}
-				 else {overlays_.push_back(*it);}
+				auto itr = std::find(overlays_.begin(), overlays_.end(), *it);
+				if (itr != overlays_.end()){}
+				else {overlays_.push_back(*it);}
 			}
 		}
 		else if(!replace.empty()) {

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -915,6 +915,7 @@ void unit::advance_to(const unit_type& u_type, bool use_traits)
 	is_fearless_ = false;
 	is_healthy_ = false;
 	image_mods_.clear();
+	std::vector<std::string> temp_overlays = overlays_;
 	overlays_.clear();
 
 	// Clear modification-related caches
@@ -1000,6 +1001,19 @@ void unit::advance_to(const unit_type& u_type, bool use_traits)
 	// since there can be filters on the modifications
 	// that may result in different effects after the advancement.
 	apply_modifications();
+	std::vector<std::string>::iterator it;
+	if(!overlays_.empty()){
+		for(it=temp_overlays.begin();it<temp_overlays.end();++it) {
+			auto itr = std::find(overlays_.begin(), overlays_.end(), *it);
+			if (itr != overlays_.end()) {}
+			else {overlays_.push_back(*it);}
+		}
+	}
+	else {
+		overlays_ = temp_overlays;
+	}
+
+            temp_overlays.clear();
 
 	// Now that modifications are done modifying traits, check if poison should
 	// be cleared.

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -915,8 +915,6 @@ void unit::advance_to(const unit_type& u_type, bool use_traits)
 	is_fearless_ = false;
 	is_healthy_ = false;
 	image_mods_.clear();
-	std::vector<std::string> temp_overlays = overlays_;
-	overlays_.clear();
 
 	// Clear modification-related caches
 	modification_descriptions_.clear();
@@ -1001,19 +999,6 @@ void unit::advance_to(const unit_type& u_type, bool use_traits)
 	// since there can be filters on the modifications
 	// that may result in different effects after the advancement.
 	apply_modifications();
-	std::vector<std::string>::iterator it;
-	if(!overlays_.empty()){
-		for(it=temp_overlays.begin();it<temp_overlays.end();++it) {
-			auto itr = std::find(overlays_.begin(), overlays_.end(), *it);
-			if (itr != overlays_.end()) {}
-			else {overlays_.push_back(*it);}
-		}
-	}
-	else {
-		overlays_ = temp_overlays;
-	}
-
-            temp_overlays.clear();
 
 	// Now that modifications are done modifying traits, check if poison should
 	// be cleared.
@@ -2137,7 +2122,9 @@ void unit::apply_builtin_effect(std::string apply_to, const config& effect)
 			std::vector<std::string> temp_overlays = utils::parenthetical_split(add, ',');
 			std::vector<std::string>::iterator it;
 			for(it=temp_overlays.begin();it<temp_overlays.end();++it) {
-				overlays_.push_back(*it);
+				 auto itr = std::find(overlays_.begin(), overlays_.end(), *it);
+				 if (itr != overlays_.end()){}
+				 else {overlays_.push_back(*it);}
 			}
 		}
 		else if(!replace.empty()) {

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1502,6 +1502,11 @@ public:
 		return overlays_;
 	}
 
+	const std::vector<std::string>& bis_overlays() const
+	{
+		return bis_overlays_;
+	}
+
 	/**
 	 * Color for this unit's *current* hitpoints.
 	 *
@@ -1774,6 +1779,7 @@ private:
 	bool emit_zoc_;
 
 	std::vector<std::string> overlays_;
+	std::vector<std::string> bis_overlays_;
 
 	std::string role_;
 	attack_list attacks_;


### PR DESCRIPTION
THIS PR must be resolve https://github.com/wesnoth/wesnoth/issues/4058 issue.
the main problem that came from the accumulation of a copy of the same image in overlays after each advancement, the best way is to limit the addition to images that are not already present rather than to make overlays non persistent.