### PR TITLE
Refactoring [movetype] to deprecate the "flies" key, use "flying" instead

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -119,6 +119,7 @@
    * Support [disallow_end_turn]reason=
    * The {SPECIAL_NOTES_*} macros now start with a newline and a bullet point.
    * Support [unit]jamming=
+   * Support [movetype]flying= and deprecate [movetype]flies=, for consistency with [unit]flying=
  ### Miscellaneous and bug fixes
    * Rest healing now happens on turn 2. (issue #3562)
    * Normal healing now happens on turn 1 for all sides except the first. (issue #3562)

--- a/data/campaigns/Under_the_Burning_Suns/units/units.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/units.cfg
@@ -129,7 +129,7 @@
 
 [movetype]
     name=quenoth_float
-    flies=yes
+    flying=yes
     [movement_costs]
         deep_water={UNREACHABLE}
         shallow_water=1

--- a/data/core/units.cfg
+++ b/data/core/units.cfg
@@ -705,7 +705,7 @@ The life span of the wose is unknown, although the most ancient members of this 
 
     [movetype]
         name=woodlandfloat
-        flies=yes
+        flying=yes
         [movement_costs]
             deep_water=2
             shallow_water=1
@@ -787,7 +787,7 @@ The life span of the wose is unknown, although the most ancient members of this 
 
     [movetype]
         name=fly
-        flies=yes
+        flying=yes
         [movement_costs]
             {FLY_MOVE}
             cave=3
@@ -803,7 +803,7 @@ The life span of the wose is unknown, although the most ancient members of this 
 
     [movetype]
         name=smallfly
-        flies=yes
+        flying=yes
         [movement_costs]
             {FLY_MOVE}
             cave=1
@@ -819,7 +819,7 @@ The life span of the wose is unknown, although the most ancient members of this 
 
     [movetype]
         name=lightfly
-        flies=yes
+        flying=yes
         [movement_costs]
             {FLY_MOVE}
             cave=3
@@ -976,7 +976,7 @@ The life span of the wose is unknown, although the most ancient members of this 
 
     [movetype]
         name=float
-        flies=yes
+        flying=yes
         [movement_costs]
             deep_water=1
             shallow_water=1
@@ -1121,7 +1121,7 @@ The life span of the wose is unknown, although the most ancient members of this 
 
     [movetype]
         name=undeadfly
-        flies=yes
+        flying=yes
         [movement_costs]
             {FLY_MOVE}
             cave=1
@@ -1144,7 +1144,7 @@ The life span of the wose is unknown, although the most ancient members of this 
 
     [movetype]
         name=undeadspirit
-        flies=yes
+        flying=yes
         [movement_costs]
             deep_water=2
             shallow_water=2
@@ -1182,7 +1182,7 @@ The life span of the wose is unknown, although the most ancient members of this 
     #only used in some UMC
     [movetype]
         name=spirit
-        flies=yes
+        flying=yes
         [movement_costs]
             deep_water=4
             shallow_water=3
@@ -1363,7 +1363,7 @@ The life span of the wose is unknown, although the most ancient members of this 
         name=drakefly
         # this has been commented out because it interferes with the standard
         # drake standing/flying animations
-        # flies=yes
+        # flying=yes
 
         # Drakes are huge (easy targets) flying beasts, but are different
         # from the classical flying unit: to fight they have to land
@@ -1392,7 +1392,7 @@ The life span of the wose is unknown, although the most ancient members of this 
 
     [movetype]
         name=drakeglide
-        #flies=yes
+        #flying=yes
         {DRAKEFLY_MOVE}
         [defense]
             {FLY_DEFENSE 60}
@@ -1404,7 +1404,7 @@ The life span of the wose is unknown, although the most ancient members of this 
 
     [movetype]
         name=drakeglide2
-        #flies=yes
+        #flying=yes
         [movement_costs]
             {FLY_MOVE}
             cave=3

--- a/data/schema/units/movetypes.cfg
+++ b/data/schema/units/movetypes.cfg
@@ -3,7 +3,8 @@
 	name="movetype"
 	max=infinite
 	{REQUIRED_KEY name string}
-	{SIMPLE_KEY flies bool}
+	{DEPRECATED_KEY flies bool}
+	{SIMPLE_KEY flying bool}
 	[tag]
 		name="resistance"
 		{ANY_KEY int}

--- a/src/movetype.hpp
+++ b/src/movetype.hpp
@@ -26,8 +26,8 @@ namespace t_translation { struct terrain_code; }
 ///
 /// This class is used for both [movetype] and [unit] configs, which use the
 /// same data in their configs for [movement_costs], [defense], etc. However,
-/// the data for whether the unit flies is held in [movetype]'s "flies" vs
-/// [unit]'s "flying".
+/// the data for whether the unit flies is historically held in [movetype]'s
+/// "flies" vs [unit]'s "flying".
 ///
 /// Existing behavior of 1.14:
 /// * movetype::movetype(const config & cfg) will read only the "flies" key
@@ -296,8 +296,7 @@ public:
 	/// The set of applicable effects for movement types
 	static const std::set<std::string> effects;
 
-	/// Writes the movement type data to the provided config. This uses
-	/// [unit]'s keynames, with "flying" instead of "flies".
+	/// Writes the movement type data to the provided config.
 	void write(config & cfg) const;
 
 private:


### PR DESCRIPTION
This makes [movetype] consistent with [unit]. The code in movetype.cpp is used
for handling both of those tags and so already had support for "flying" in the
merge() and write() functions.

This shouldn't be backported to 1.14. For this reason, it also includes
handling the C++ todos to use C++14's std::make_unique.