### PR TITLE
Fix overlay removed after advancement

### DIFF
--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -350,18 +350,13 @@ end
 function wml_actions.unit_overlay(cfg)
 	local img = cfg.image or helper.wml_error( "[unit_overlay] missing required image= attribute" )
 	for i,u in ipairs(wesnoth.get_units(cfg)) do
-		local has_already = false
-		for i, w in ipairs(u.overlays) do
-			if w == img then has_already = true end
+		local ucfg = u.__cfg
+		for w in utils.split(ucfg.overlays) do
+			if w == img then ucfg = nil end
 		end
-		if has_already == false then
-			u:add_modification("object", {
-				id = cfg.object_id,
-				wml.tag.effect {
-					apply_to = "overlay",
-					add = img,
-				}
-			})
+		if ucfg then
+			ucfg.overlays = ucfg.overlays .. ',' .. img
+			wesnoth.put_unit(ucfg)
 		end
 	end
 end

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -338,6 +338,8 @@ unit::unit(const unit& o)
 	, filter_recall_(o.filter_recall_)
 	, emit_zoc_(o.emit_zoc_)
 	, overlays_(o.overlays_)
+	, meta_overlays_(o.meta_overlays_)
+	, obj_overlays_(o.obj_overlays_)
 	, role_(o.role_)
 	, attacks_(o.attacks_)
 	, facing_(o.facing_)
@@ -418,6 +420,8 @@ unit::unit()
 	, filter_recall_()
 	, emit_zoc_(0)
 	, overlays_()
+	, meta_overlays_()
+	, obj_overlays_()
 	, role_()
 	, attacks_()
 	, facing_(map_location::NDIRECTIONS)
@@ -808,6 +812,8 @@ void unit::swap(unit & o)
 	swap(filter_recall_, o.filter_recall_);
 	swap(emit_zoc_, o.emit_zoc_);
 	swap(overlays_, o.overlays_);
+	swap(meta_overlays_, o.meta_overlays_);
+	swap(obj_overlays_, o.obj_overlays_);
 	swap(role_, o.role_);
 	swap(attacks_, o.attacks_);
 	swap(facing_, o.facing_);

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -338,7 +338,7 @@ unit::unit(const unit& o)
 	, filter_recall_(o.filter_recall_)
 	, emit_zoc_(o.emit_zoc_)
 	, overlays_(o.overlays_)
-	, meta_overlays_(o.meta_overlays_)
+	, nobj_overlays_(o.nobj_overlays_)
 	, obj_overlays_(o.obj_overlays_)
 	, role_(o.role_)
 	, attacks_(o.attacks_)
@@ -420,7 +420,7 @@ unit::unit()
 	, filter_recall_()
 	, emit_zoc_(0)
 	, overlays_()
-	, meta_overlays_()
+	, nobj_overlays_()
 	, obj_overlays_()
 	, role_()
 	, attacks_()
@@ -516,19 +516,19 @@ void unit::init(const config& cfg, bool use_traits, const vconfig* vcfg)
 	advance_to(*type_, use_traits);
 
 	if(const config::attribute_value* v = cfg.get("overlays")) {
-		overlays_ = utils::parenthetical_split(v->str(), ',');
-		if(overlays_.size() == 1 && overlays_.front().empty()) {
-			overlays_.clear();
+		nobj_overlays_ = utils::parenthetical_split(v->str(), ',');
+		if(nobj_overlays_.size() == 1 && nobj_overlays_.front().empty()) {
+			nobj_overlays_.clear();
 		} else {
 			std::vector<std::string>::iterator it;
-			for(it=overlays_.begin();it<overlays_.end();++it) {
-				if (std::find(meta_overlays_.begin(), meta_overlays_.end(), *it) == meta_overlays_.end()){
-					meta_overlays_.push_back(*it);
+			for(it=nobj_overlays_.begin();it<nobj_overlays_.end();++it) {
+				if (std::find(overlays_.begin(), overlays_.end(), *it) == overlays_.end()){
+					overlays_.push_back(*it);
 				}
 			}
 		}
-		if(meta_overlays_.size() == 1 && meta_overlays_.front().empty()) {
-			meta_overlays_.clear();
+		if(overlays_.size() == 1 && overlays_.front().empty()) {
+			overlays_.clear();
 		}
 	}
 
@@ -812,7 +812,7 @@ void unit::swap(unit & o)
 	swap(filter_recall_, o.filter_recall_);
 	swap(emit_zoc_, o.emit_zoc_);
 	swap(overlays_, o.overlays_);
-	swap(meta_overlays_, o.meta_overlays_);
+	swap(nobj_overlays_, o.nobj_overlays_);
 	swap(obj_overlays_, o.obj_overlays_);
 	swap(role_, o.role_);
 	swap(attacks_, o.attacks_);
@@ -931,7 +931,7 @@ void unit::advance_to(const unit_type& u_type, bool use_traits)
 	is_fearless_ = false;
 	is_healthy_ = false;
 	image_mods_.clear();
-	meta_overlays_.clear();
+	overlays_.clear();
 	obj_overlays_.clear();
 
 	// Clear modification-related caches
@@ -1017,11 +1017,11 @@ void unit::advance_to(const unit_type& u_type, bool use_traits)
 	// since there can be filters on the modifications
 	// that may result in different effects after the advancement.
 	apply_modifications();
-	meta_overlays_ = overlays_;
+	overlays_ = nobj_overlays_;
 	std::vector<std::string>::iterator it;
 	for(it=obj_overlays_.begin();it<obj_overlays_.end();++it) {
-		if (std::find(meta_overlays_.begin(), meta_overlays_.end(), *it) == meta_overlays_.end()){
-			meta_overlays_.push_back(*it);
+		if (std::find(overlays_.begin(), overlays_.end(), *it) == overlays_.end()){
+			overlays_.push_back(*it);
 		}
 	}
 
@@ -1520,7 +1520,7 @@ void unit::write(config& cfg, bool write_all) const
 	cfg.clear_children("events");
 	cfg.append(events_);
 
-	cfg["overlays"] = utils::join(meta_overlays_);
+	cfg["overlays"] = utils::join(overlays_);
 
 	cfg["name"] = name_;
 	cfg["id"] = id_;

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -518,9 +518,9 @@ void unit::init(const config& cfg, bool use_traits, const vconfig* vcfg)
 		} else {
 			std::vector<std::string>::iterator it;
 			for(it=overlays_.begin();it<overlays_.end();++it) {
-				auto itr = std::find(meta_overlays_.begin(), meta_overlays_.end(), *it);
-				if (itr != meta_overlays_.end()){}
-				else {meta_overlays_.push_back(*it);}
+				if (std::find(meta_overlays_.begin(), meta_overlays_.end(), *it) == meta_overlays_.end()){
+					meta_overlays_.push_back(*it);
+				}
 			}
 		}
 		if(meta_overlays_.size() == 1 && meta_overlays_.front().empty()) {
@@ -1014,9 +1014,9 @@ void unit::advance_to(const unit_type& u_type, bool use_traits)
 	meta_overlays_ = overlays_;
 	std::vector<std::string>::iterator it;
 	for(it=obj_overlays_.begin();it<obj_overlays_.end();++it) {
-		auto itr = std::find(meta_overlays_.begin(), meta_overlays_.end(), *it);
-		if (itr != meta_overlays_.end()){}
-		else {meta_overlays_.push_back(*it);}
+		if (std::find(meta_overlays_.begin(), meta_overlays_.end(), *it) == meta_overlays_.end()){
+			meta_overlays_.push_back(*it);
+		}
 	}
 
 	// Now that modifications are done modifying traits, check if poison should
@@ -2120,9 +2120,9 @@ void unit::apply_builtin_effect(std::string apply_to, const config& effect)
 			std::vector<std::string> temp_overlays = utils::parenthetical_split(add, ',');
 			std::vector<std::string>::iterator it;
 			for(it=temp_overlays.begin();it<temp_overlays.end();++it) {
-				auto itr = std::find(obj_overlays_.begin(), obj_overlays_.end(), *it);
-				if (itr != obj_overlays_.end()){}
-				else {obj_overlays_.push_back(*it);}
+				if (std::find(obj_overlays_.begin(), obj_overlays_.end(), *it) == obj_overlays_.end()){
+					obj_overlays_.push_back(*it);
+				}
 			}
 		}
 		else if(!replace.empty()) {

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1773,9 +1773,9 @@ private:
 
 	bool emit_zoc_;
 
-	std::vector<std::string> overlays_;
-	std::vector<std::string> meta_overlays_;
-	std::vector<std::string> obj_overlays_;
+	std::vector<std::string> overlays_; //vector used for enter value of overlays without using [modifications]
+	std::vector<std::string> meta_overlays_; // vector who contain values of overlays_ and obj_overlays_ and returned like final result
+	std::vector<std::string> obj_overlays_; //used for enter value of overlays using [modifications]
 
 	std::string role_;
 	attack_list attacks_;

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1499,7 +1499,7 @@ public:
 	/** Get the unit's overlay images. */
 	const std::vector<std::string>& overlays() const
 	{
-		return overlays_;
+		return meta_overlays_;
 	}
 
 	/**
@@ -1774,6 +1774,8 @@ private:
 	bool emit_zoc_;
 
 	std::vector<std::string> overlays_;
+	std::vector<std::string> meta_overlays_;
+	std::vector<std::string> obj_overlays_;
 
 	std::string role_;
 	attack_list attacks_;

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1499,7 +1499,7 @@ public:
 	/** Get the unit's overlay images. */
 	const std::vector<std::string>& overlays() const
 	{
-		return meta_overlays_;
+		return overlays_;
 	}
 
 	/**
@@ -1773,8 +1773,8 @@ private:
 
 	bool emit_zoc_;
 
-	std::vector<std::string> overlays_; //vector used for enter value of overlays without using [modifications]
-	std::vector<std::string> meta_overlays_; // vector who contain values of overlays_ and obj_overlays_ and returned like final result
+	std::vector<std::string> overlays_; // vector who contain values of nobj_overlays_ and obj_overlays_ and returned the final result
+	std::vector<std::string> nobj_overlays_; //vector used for enter value of overlays without using [modifications]
 	std::vector<std::string> obj_overlays_; //used for enter value of overlays using [modifications]
 
 	std::string role_;


### PR DESCRIPTION
i hope resolve https://github.com/wesnoth/wesnoth/issues/4058 issue this time.

For that, i had added two variables for overlays, a variable for modifications, overlays_ who is limited to non modifications case, and meta_overlays, where the data of two others are assembled.
i hope what @gfgtdf will be satisfied.