### PR TITLE
Try to optimize network_transmission, assuming the problem was CPU usage

### DIFF
--- a/src/gui/dialogs/network_transmission.cpp
+++ b/src/gui/dialogs/network_transmission.cpp
@@ -45,7 +45,8 @@ void network_transmission::pump_monitor::process(events::pump_info&)
 		size_t completed, total;
 			completed = connection_->current();
 			total = connection_->total();
-		if(total) {
+		if(total && completed != shown_size_) {
+			shown_size_ = completed;
 			find_widget<progress_bar>(&(window_.get()), "progress", false)
 					.set_percentage((completed * 100.) / total);
 

--- a/src/gui/dialogs/network_transmission.hpp
+++ b/src/gui/dialogs/network_transmission.hpp
@@ -57,11 +57,18 @@ private:
 		virtual void process(events::pump_info&);
 
 		pump_monitor(connection_data*& connection)
-			: connection_(connection), window_()
+			: connection_(connection),
+			  window_(),
+			  shown_size_(std::numeric_limits<std::size_t>::max())
 		{
 		}
 
 		boost::optional<window&> window_;
+		/**
+		 * The value of current() when the GUI was last refreshed, used so that
+		 * the display isn't refreshed unless the number changes.
+		 */
+		std::size_t shown_size_;
 	} pump_monitor_;
 
 public:


### PR DESCRIPTION
The download speed seemed reasonable to me, but this does improve it slightly
(from 1.2MB/s to 2MB/s, testing connected via my phone). The optimization here
is assuming that redrawing the window is causing another event to be pumped,
and so making this loop a busy loop that is pumping itself.

The PR is created against the old code, so it's easier to review what changed.