### PR TITLE
theme: Add optional argument to REPLAY_THEME for the benefit of user-defined themes

### DIFF
--- a/data/themes/_initial.cfg
+++ b/data/themes/_initial.cfg
@@ -400,13 +400,15 @@
     [/report_countdown]
 #enddef
 #define REPLAY_THEME FONT_SMALL_SIZE
+#arg LEFT_MARGIN
+=#endarg
     [replay]
         [add]
             [panel]
                 id=replay-panel
                 image=themes/editor/classic/toolbar.png
                 ref=top-panel
-                rect="=,+0,+842,+41"
+                rect="{LEFT_MARGIN},+0,842,+41"
                 xanchor=left
                 yanchor=fixed
             [/panel]
@@ -414,7 +416,7 @@
         [change]
             id=main-map
             ref=top-panel
-            rect="=,+41,+842,768"
+            rect="{LEFT_MARGIN},+41,842,768"
         [/change]
         [add]
             [action]


### PR DESCRIPTION
No change for master, but this will allow me to package the asymmetric theme (#4184) as an addon.

<details>

<summary>

Screenshot with the argument at a **non-default** value:

</summary>

![Screenshot_2019-08-10_14-12-51](https://user-images.githubusercontent.com/24784687/62822882-2eac6e00-bb79-11e9-8d9c-910ad54eed06.png)

</details>