### PR TITLE
Handle unit overlays as modifications, allow [effect] to remove them

### DIFF
--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -368,18 +368,20 @@ end
 
 function wml_actions.remove_unit_overlay(cfg)
 	local img = cfg.image or helper.wml_error( "[remove_unit_overlay] missing required image= attribute" )
-
-	-- Loop through all matching units.
 	for i,u in ipairs(wesnoth.get_units(cfg)) do
-		local ucfg = u.__cfg
-		local t = utils.parenthetical_split(ucfg.overlays)
-		-- Remove the specified image from the overlays.
-		for i = #t,1,-1 do
-			if t[i] == img then table.remove(t, i) end
+		local has_already = false
+		for i, w in ipairs(u.overlays) do
+			if w == img then has_already = true end
 		end
-		-- Reassemble the list of remaining overlays.
-		ucfg.overlays = table.concat(t, ',')
-		wesnoth.put_unit(ucfg)
+		if has_already then
+			u:add_modification("object", {
+				id = cfg.object_id,
+				wml.tag.effect {
+					apply_to = "overlay",
+					remove = img,
+				}
+			})
+		end
 	end
 end
 

--- a/data/schema/units/modifications.cfg
+++ b/data/schema/units/modifications.cfg
@@ -155,11 +155,17 @@
 				{LINK_TAG "units/unit_type/extra_anim"}
 			[/case]
 			[case]
-				value=image_mod,overlay
+				value=image_mod
 				{SIMPLE_KEY replace string}
 				{SIMPLE_KEY add string}
 				{LINK_TAG "game_config/color_range"}
 				{LINK_TAG "game_config/color_palette"}
+			[/case]
+			[case]
+				value=overlay
+				{SIMPLE_KEY replace string}
+				{SIMPLE_KEY add string}
+				{SIMPLE_KEY remove string}
 			[/case]
 			[case]
 				value=ellipse


### PR DESCRIPTION
Possible fix for #4058, with the following logic (and no WML changes needed):

* If non-empty, [unit]overlay= is handled by adding modifications
* unit::write will always output an empty overlay=
* The Lua API's get_units() will still provide the list of overlays
* [effect]apply_to=overlay can now remove as well as add overlays
* [remove_unit_overlay] is implemented with [effect]apply_to=overlay

Using [object]s with durations hasn't been tested, but expected effects:
* An expired add= followed by a non-expired remove= will simply cause the remove=
    to have no effect when std::remove(overlays_ ...) is called.
* A remove= followed by [remove_unit_overlay] cause the [remove_unit_overlay] to be a no-op,
    and the overlay will reappear when the first remove= expires. This edge case is already
	documented as unsupported on the wiki.