### PR TITLE
Rule of Five for event::sdl_handler

### DIFF
--- a/src/events.hpp
+++ b/src/events.hpp
@@ -51,6 +51,8 @@ public:
 	context(const context&) = delete;
 
 	void add_handler(sdl_handler* ptr);
+	/** Returns true if @a ptr is found in either the handlers or staging_handlers lists */
+	bool has_handler(const sdl_handler* ptr) const;
 	bool remove_handler(sdl_handler* ptr);
 	void cycle_focus();
 	void set_focus(const sdl_handler* ptr);
@@ -95,8 +97,19 @@ public:
 
 	virtual bool has_joined() { return has_joined_;}
 	virtual bool has_joined_global() { return has_joined_global_;}
+
+	/**
+	 * Moving would require two instances' context membership to be handled,
+	 * it's simpler to delete these and require the two instances to be
+	 * separately constructed / destructed.
+	 */
+	sdl_handler &operator=(sdl_handler &&) = delete;
+	sdl_handler(sdl_handler &&) = delete;
+
 protected:
 	sdl_handler(const bool auto_join=true);
+	sdl_handler(const sdl_handler &);
+	sdl_handler &operator=(const sdl_handler &);
 	virtual ~sdl_handler();
 	virtual std::vector<sdl_handler*> handler_members()
 	{

--- a/src/widgets/widget.cpp
+++ b/src/widgets/widget.cpp
@@ -30,27 +30,6 @@ namespace gui {
 
 bool widget::mouse_lock_ = false;
 
-widget::widget(const widget& o)
-	: events::sdl_handler()
-	, focus_(o.focus_)
-	, video_(o.video_)
-	, restorer_(o.restorer_)
-	, rect_(o.rect_)
-	, needs_restore_(o.needs_restore_)
-	, state_(o.state_)
-	, hidden_override_(o.hidden_override_)
-	, enabled_(o.enabled_)
-	, clip_(o.clip_)
-	, clip_rect_(o.clip_rect_)
-	, volatile_(o.volatile_)
-	, help_text_(o.help_text_)
-	, tooltip_text_(o.tooltip_text_)
-	, help_string_(o.help_string_)
-	, id_(o.id_)
-	, mouse_lock_local_(o.mouse_lock_local_)
-{
-}
-
 widget::widget(CVideo& video, const bool auto_join)
 	: events::sdl_handler(auto_join), focus_(true), video_(&video), rect_(EmptyRect), needs_restore_(false),
 	  state_(UNINIT), hidden_override_(false), enabled_(true), clip_(false),

--- a/src/widgets/widget.hpp
+++ b/src/widgets/widget.hpp
@@ -69,7 +69,6 @@ public:
 	virtual void process_tooltip_string(int mousex, int mousey);
 
 protected:
-	widget(const widget& o);
 	widget(CVideo& video, const bool auto_join=true);
 	virtual ~widget();
 


### PR DESCRIPTION
This fixes the default implementations of widget's copy constructor and copy
assignment, which was root cause of the regression in 4139b43cc900 (#4215).

This reverts commit f46ed66f2c9a8acf8d88338d8433fc35689d4c39.