### PR TITLE
fixup! Show the turn dialog before updating the GUI for the incoming player

### DIFF
--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -1218,7 +1218,7 @@ void play_controller::play_turn()
 		// If a side is empty skip over it.
 		if (!current_team().is_empty()) {
 			// Show the turn dialog now, before the minimap is redrawn and before healing is animated.
-			if(current_team().is_local_human() && current_team().is_proxy_human()) {
+			if(current_team().is_local_human() && current_team().is_proxy_human() && !is_replay()) {
 				show_turn_dialog();
 			}
 			init_side_begin();


### PR DESCRIPTION
Fix a regression caused by #4188 (the fix to #4187): the turn dialog would show during replays as well.

I've tested this but it would be great if someone could review this and make sure that #4188 didn't introduce any _other_ regressions.

@linaio