### PR TITLE
Add either heals= or [heals] to Standard Location Filter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,8 @@
    * Delfador's Memoirs:
      * S20: Improve leveling of units and give player a note about it (Issue#4219)
      * S21: Better indication that the book has gone missing (Issue#4220)
+ ### WML engine
+   * Support [heals] key in SLF (matches villages, oases and similar)
 
 ## Version 1.15.1
  ### Editor

--- a/data/schema/filters/location.cfg
+++ b/data/schema/filters/location.cfg
@@ -22,6 +22,9 @@
 	{FILTER_TAG "filter_vision" vision ()}
 	{FILTER_TAG "filter_adjacent_location" adjacent_location ()}
 	{FILTER_BOOLEAN_OPS location}
+	[tag]
+		name="heals"
+	[/tag]
 [/tag]
 
 [tag]

--- a/data/test/scenarios/slf_heals.cfg
+++ b/data/test/scenarios/slf_heals.cfg
@@ -1,0 +1,56 @@
+[test]
+    name = "Unit Test store healing locations"
+    map_data = "{multiplayer/maps/2p_Ruined_Passage.map}"
+    turns = 1
+    id = store_healing_locations
+    random_start_time = no
+    is_unit_test = yes
+
+    {DEFAULT_SCHEDULE}
+
+    [side]
+        side=1
+        controller=human
+        name = "Alice"
+        type = Elvish Archer
+        id=alice
+        fog=no
+        shroud=no
+        share_view=no
+    [/side]
+    [side]
+        side=2
+        controller=human
+        name = "Bob"
+        type = Orcish Grunt
+        id=bob
+        fog=no
+        shroud=no
+        share_view=no
+    [/side]
+
+    [event]
+        name = side 1 turn 1
+
+        # sanity-check that there are some non-village healing locations on this map
+        [store_locations]
+            terrain="*^Do"
+            variable=oases
+        [/store_locations]
+        {ASSERT {VARIABLE_CONDITIONAL oases.length greater_than 0}}
+
+        [store_locations]
+            terrain="*^V*,*^Do"
+            variable=villages_and_oases
+        [/store_locations]
+
+        [store_locations]
+            [heals]
+            [/heals]
+            variable=healing
+        [/store_locations]
+        {ASSERT {VARIABLE_CONDITIONAL healing.length equals $villages_and_oases.length}}
+
+        {SUCCEED}
+    [/event]
+[/test]

--- a/src/terrain/filter.cpp
+++ b/src/terrain/filter.cpp
@@ -356,6 +356,13 @@ bool terrain_filter::match_internal(const map_location& loc, const unit* ref_uni
 		}
 	}
 
+	if(cfg_.has_child("heals")) {
+		const auto heals = fc_->get_disp_context().map().gives_healing(loc);
+		if(heals <= 0) {
+			return false;
+		}
+	}
+
 	return true;
 }
 

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -230,3 +230,7 @@
 0 event_name_variable_substitution
 # Game mechanics
 0 heal
+#
+# Standard Location Filter
+#
+0 store_healing_locations


### PR DESCRIPTION
One of the features requested in #4227.

The core terrains' villages and oases all heal 8 HP per turn, but the
engine supports other values. So the expected usage to match all
healing terrains is:

    heals=1-{INFINITY}

This doesn't support filtering for negative values of heals, however
I believe no-one is using them (see #4232 ). A harms= key could be
added, but if this is needed then maybe this PR should add a `[heals]`
child to SLF. Or ranges could be expanded to support negative numbers.