### PR TITLE
Revert network_transmission.cpp/hpp to its 1.14.7 version

### DIFF
--- a/src/gui/dialogs/network_transmission.cpp
+++ b/src/gui/dialogs/network_transmission.cpp
@@ -27,63 +27,36 @@
 #include "serialization/string_utils.hpp"
 #include "wesnothd_connection.hpp"
 
-#include <chrono>
-
 namespace gui2
 {
 namespace dialogs
 {
+
 REGISTER_DIALOG(network_transmission)
-
-network_transmission::pump_monitor::pump_monitor(connection_data*& connection)
-	: connection_(connection)
-	, window_()
-	, completed_(0)
-	, total_(0)
-	, stop_(false)
-	, poller_(std::async(std::launch::async, [this]() {
-		while(!stop_) {
-			// Check for updates
-			connection_->poll();
-
-			if(connection_->finished()) {
-				return;
-			}
-
-			completed_ = connection_->current();
-			total_ = connection_->total();
-
-			std::this_thread::sleep_for(std::chrono::milliseconds(10));
-		}
-	}))
-{
-}
 
 void network_transmission::pump_monitor::process(events::pump_info&)
 {
-	if(!window_) {
+	if(!window_)
 		return;
-	}
-
-	// Check if the thread is complete. If it is, loading is done.
-	if(poller_.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready) {
+	connection_->poll();
+	if(connection_->finished()) {
 		window_.get().set_retval(retval::OK);
-		return;
-	}
+	} else {
+		size_t completed, total;
+			completed = connection_->current();
+			total = connection_->total();
+		if(total) {
+			find_widget<progress_bar>(&(window_.get()), "progress", false)
+					.set_percentage((completed * 100.) / total);
 
-	if(total_) {
-		find_widget<progress_bar>(&(window_.get()), "progress", false)
-			.set_percentage((completed_ * 100.) / total_);
+			std::stringstream ss;
+			ss << utils::si_string(completed, true, _("unit_byte^B")) << "/"
+			   << utils::si_string(total, true, _("unit_byte^B"));
 
-		std::ostringstream ss;
-		ss
-			<< utils::si_string(completed_, true, _("unit_byte^B")) << "/"
-			<< utils::si_string(total_, true, _("unit_byte^B"));
-
-		find_widget<label>(&(window_.get()), "numeric_progress", false)
-			.set_label(ss.str());
-
-		window_->invalidate_layout();
+			find_widget<label>(&(window_.get()), "numeric_progress", false)
+					.set_label(ss.str());
+			window_->invalidate_layout();
+		}
 	}
 }
 
@@ -103,8 +76,8 @@ void network_transmission::pre_show(window& window)
 {
 	// ***** ***** ***** ***** Set up the widgets ***** ***** ***** *****
 	if(!subtitle_.empty()) {
-		label& subtitle_label = find_widget<label>(&window, "subtitle", false);
-
+		label& subtitle_label
+				= find_widget<label>(&window, "subtitle", false);
 		subtitle_label.set_label(subtitle_);
 		subtitle_label.set_use_markup(true);
 	}
@@ -117,11 +90,6 @@ void network_transmission::post_show(window& /*window*/)
 	pump_monitor_.window_.reset();
 
 	if(get_retval() == retval::CANCEL) {
-		// We need to wait for the current polling loop to conclude before exiting so we don't invalidate
-		// the pointer mid-loop, so signal that here.
-		pump_monitor_.stop_ = true;
-		pump_monitor_.poller_.wait();
-
 		connection_->cancel();
 	}
 }

--- a/src/gui/dialogs/network_transmission.hpp
+++ b/src/gui/dialogs/network_transmission.hpp
@@ -21,9 +21,6 @@
 
 #include <boost/optional.hpp>
 
-#include <atomic>
-#include <future>
-
 namespace gui2
 {
 namespace dialogs
@@ -56,19 +53,15 @@ private:
 	class pump_monitor : public events::pump_monitor
 	{
 	public:
-		virtual void process(events::pump_info&) override;
-
-		pump_monitor(connection_data*& connection);
-
 		connection_data*& connection_;
+		virtual void process(events::pump_info&);
+
+		pump_monitor(connection_data*& connection)
+			: connection_(connection), window_()
+		{
+		}
 
 		boost::optional<window&> window_;
-
-		std::atomic_size_t completed_, total_;
-
-		std::atomic_bool stop_;
-
-		std::future<void> poller_;
 	} pump_monitor_;
 
 public:


### PR DESCRIPTION
I re-ran the timing test discussed in PR #4201 (comment linked to below), and
saw similar numbers.  The old, simpler code downloads an 86.1MB addon in 25
seconds, the code with the extra thread takes 29 seconds.

https://github.com/wesnoth/wesnoth/pull/4201#issuecomment-517856090