### PR TITLE
Display settings: Adjust "Limit FPS" tooltip

### DIFF
--- a/data/gui/window/preferences/03_display.cfg
+++ b/data/gui/window/preferences/03_display.cfg
@@ -272,7 +272,7 @@
 			[toggle_button]
 				id = "fps_limiter"
 				label = _ "Limit FPS"
-				tooltip = _ "Disabling this increases CPU usage to 100% but may slightly improve performance at high resolutions"
+				tooltip = _ "Disabling this increases CPU usage, but may slightly improve performance (requires restart to take effect)"
 			[/toggle_button]
 		[/column]
 	[/row]


### PR DESCRIPTION
The tooltip now mentions that the game must be restarted for the setting to take effect. Restart is required because the setting is stored in a static variable:

https://github.com/wesnoth/wesnoth/blob/b9246dc6b4fee54751fcb37ad3ec97f751e7926a/src/display.cpp#L1662

I also removed "to 100%" and "at high resolutions". These bits provide little information and aren't always accurate.