### PR TITLE
WoV: Set up for translations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
      * S21: Better indication that the book has gone missing (Issue#4220)
  ### Language and i18n
    * Updated translations: French, Portuguese (Brazil)
+   * Set up for translating the Wings of Victory campaign (PR#4265)
 
 ## Version 1.15.1
  ### Editor

--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -30,6 +30,7 @@ set(NORMAL_DOMAINS
 	wesnoth-tutorial
 	wesnoth-units
 	wesnoth-utbs
+	wesnoth-wov
 )
 
 # All available domains.

--- a/po/wesnoth-wov/FINDCFG
+++ b/po/wesnoth-wov/FINDCFG
@@ -1,0 +1,2 @@
+find data/campaigns/Wings_of_Victory -name '*.cfg' -print
+find data/campaigns/Wings_of_Victory -name '*.lua' -print

--- a/po/wesnoth-wov/LINGUAS
+++ b/po/wesnoth-wov/LINGUAS
@@ -1,0 +1,1 @@
+af ang ang@latin ar ast bg ca ca_ES@valencia cs da de el en_GB en@shaw es eo et eu fi fr fur_IT ga gd gl he hr hu id is it ja ko la lt lv mk mr nl nb_NO pl pt pt_BR racv ro ru sk sl sr sr@ijekavian sr@ijekavianlatin sr@latin sv tl tr uk vi zh_CN zh_TW

--- a/po/wesnoth-wov/Makevars
+++ b/po/wesnoth-wov/Makevars
@@ -1,0 +1,41 @@
+# Makefile variables for PO directory in any package using GNU gettext.
+
+# Usually the message domain is the same as the package name.
+DOMAIN = wesnoth-wov
+
+# These two variables depend on the location of this directory.
+subdir = po/$(DOMAIN)
+top_builddir = ../..
+
+# These options get passed to xgettext.
+XGETTEXT_OPTIONS = --from-code=UTF-8 --sort-by-file --keyword=sgettext --keyword=vgettext --keyword=_n:1,2 --keyword=sngettext:1,2 --keyword=vngettext:1,2 --add-comments=TRANSLATORS:
+
+# This is the copyright holder that gets inserted into the header of the
+# $(DOMAIN).pot file.  Set this to the copyright holder of the surrounding
+# package.  (Note that the msgstr strings, extracted from the package's
+# sources, belong to the copyright holder of the package.)  Translators are
+# expected to transfer the copyright for their translations to this person
+# or entity, or to disclaim their copyright.  The empty string stands for
+# the public domain; in this case the translators are expected to disclaim
+# their copyright.
+COPYRIGHT_HOLDER = Wesnoth development team
+
+# This is the email address or URL to which the translators shall report
+# bugs in the untranslated strings:
+# - Strings which are not entire sentences, see the maintainer guidelines
+#   in the GNU gettext documentation, section 'Preparing Strings'.
+# - Strings which use unclear terms or require additional context to be
+#   understood.
+# - Strings which make invalid assumptions about notation of date, time or
+#   money.
+# - Pluralisation problems.
+# - Incorrect English spelling.
+# - Incorrect formatting.
+# It can be your email address, or a mailing list address where translators
+# can write to without being subscribed, or the URL of a web page through
+# which the translators can contact you.
+MSGID_BUGS_ADDRESS =https://bugs.wesnoth.org/
+
+# This is the list of locale categories, beyond LC_MESSAGES, for which the
+# message catalogs shall be used.  It is usually empty.
+EXTRA_LOCALE_CATEGORIES =

--- a/po/wesnoth-wov/af.po
+++ b/po/wesnoth-wov/af.po
@@ -1,0 +1,2110 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: af\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/ang.po
+++ b/po/wesnoth-wov/ang.po
@@ -1,0 +1,2110 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ang\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/ang@latin.po
+++ b/po/wesnoth-wov/ang@latin.po
@@ -1,0 +1,2110 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ang@latin\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/ar.po
+++ b/po/wesnoth-wov/ar.po
@@ -1,0 +1,2110 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ar\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/ast.po
+++ b/po/wesnoth-wov/ast.po
@@ -1,0 +1,2110 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ast\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/bg.po
+++ b/po/wesnoth-wov/bg.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: bg\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/ca.po
+++ b/po/wesnoth-wov/ca.po
@@ -1,0 +1,2110 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/ca_ES@valencia.po
+++ b/po/wesnoth-wov/ca_ES@valencia.po
@@ -1,0 +1,2110 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ca_ES@valencia\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/cs.po
+++ b/po/wesnoth-wov/cs.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/da.po
+++ b/po/wesnoth-wov/da.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: da\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/de.po
+++ b/po/wesnoth-wov/de.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/el.po
+++ b/po/wesnoth-wov/el.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/en@shaw.po
+++ b/po/wesnoth-wov/en@shaw.po
@@ -1,0 +1,2446 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: en@shaw\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr "Wings of Victory"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr "WoV"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr "(Intermediate level, 11 scenarios.)"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr "Version:"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr "Fledgling"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr "Normal"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr "Aspirant"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr "Challenging"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr "Difficult"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr "Dominant"
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr "Authors"
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr "Alpha Testing and Proofreading"
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr "Campaign Maintenance"
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr "Graphics"
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr "The Hunt"
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr "Drakes"
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr "Galun"
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr "Humans"
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr "Lynxes"
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr "Forest"
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr "Galun is an Aspirant (at least level two) at the end of the hunt"
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr "Death of Galun"
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr "Death of Vank"
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr "Loss of two or more members of your hunting party"
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr "Galun is still a Fledgling (level one) at the end of the hunt"
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr "Galun, I think I spy runners. Away north, past the fields."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr "... What? ... Sorry, I wasn't listening...."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr "What is wrong with you? I have not seen you so distracted in ages."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr "All the ships passing by must be going somewhere."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr "... Right ... Hunters! Take wing!"
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr "Gerth"
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr "Prepare to die, runners."
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr "Better to die free than await the slaughter in a Drake pen!"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr "You shall have your wish."
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr "My dream perishes with me..."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr "Vank! No! You would have been my Chief Intendant..."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr "The hunt has failed. I am not worthy to be an Aspirant."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr "Too many hunters have died. I am not worthy to be an Aspirant."
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr "Ah! A good hunt. Gallopers and runners both."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr "The Raid"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr "Orcs"
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr "Viragar"
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr "Capture Viragar (reduce him to 0 hitpoints or lower)"
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr "Galun has become an impressive Aspirant (reached level three)"
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr "So you think, prey."
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr "Viragar was captured alive and interrogated for a long time."
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr "Galun’s success in the raid earns him much renown."
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr "We are poised to lose this battle, Galun. I fear we must retreat."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr "The Contention"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr "Defeat Gribbel"
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr "Have the advantage when turns run out"
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr "Defeat of Galun"
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr "Fail to have the advantage when turns run out"
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr "Your defeated units will be returned to you after the battle."
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr "Each side is allowed only intendants and recruits for this battle."
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr "Just fly and fight, Vank. I’ll do the worrying."
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr "The chance at my dream, lost..."
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr "No!"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr "We did it!"
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr "The Spiral Path"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr "Reshan'lo"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr "May the pride and power of the Drakes be increased."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr "That...may not always be possible."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr "What?"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr "I am listening."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr "That is difficult to hear."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr "What doom is that?"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr "I hear and understand."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr "Islands"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr "Nagas"
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr "Sariss"
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr "Naulakh"
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr "Shussek"
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr "Defeat all enemy leaders"
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr "Galun’s flight is not yet able to manufacture armor for Clashers."
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr "This scenario takes place during the summer."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr "Be alert, there are large creatures moving under the waves."
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr "Sharpspikes"
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr "Graarrrrrr!"
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr "Shinyscales"
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr "Roarrrrrr!"
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr "Longtooth"
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr "Hissssss!"
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr "Look out, a sea serpent!"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr "That is good! We will seek it out."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr "The Three Sisters"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr "Ogres"
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr "Merkuk"
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr "Monsters"
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr "Midnight Queen"
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr "There are creatures hiding in here."
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr "There is nothing in here."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr "These islands, too, are inhabited."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr "Only by dumb animals. We can take this place, and will."
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr "You will be made to serve... Come admire me. Feel my love."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr "Ahhhh! Get off my islands!"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr "No."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr "This could make a decent home for the flight."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr "Elensefar"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr "Vorlyan"
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr "Defeat Vorlyan"
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr "A village full of runners is ahead."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr "Call the hunt!"
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr "Flying monsters are approaching; sound the alarm!"
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr "You will not enjoy your victory long. The Crown will retake this city."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr "These runners look and taste like the ones back on Morogor."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr "Wesmere"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr "Days of travel later they found themselves over green forest country."
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr "Woses"
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr "Gulladrumm"
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr "Elves"
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr "Daepia"
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr "Saurians"
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr "There is game in those trees. This may be a good place to hunt."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr "Yes. And the flight needs a night on the ground to rest its wings."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr "That was brisk."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr "As you command!"
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr "Wait, what is this? Scuttlers are approaching."
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr "Thatsss not a dragon."
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr "My power is indeed great. I am Galun and this is my Flight."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr "Yes, that is good."
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr "Foothills"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr "Undead"
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr "Naemir"
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr "Spiders"
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr "Serpents"
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr "Defeat Naemir to lift the storm"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr "We are stuck in this cave until the storm lifts."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr "Hopefully the time will pass well."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr "Right you are. It is my storm and this is my domain."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr "Galun, that sounds like prey-speech."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr "Yes, it does. How fitting..."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr "Who are <i>you</i> to challenge us?"
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr "The new servants ask too many questions. I am Naemir, and I rule here."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr "I am Galun, and I am not ‘ruled’ by anyone."
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr "No being of the lesser races may rule a drake."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr "Careful, Galun. We are no longer in Morogor..."
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr "Lesser, am I? I think not."
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr "Rise, my pets, there is food for you."
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr "And you, arrogant one, shall serve me — living or dead, I care not."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr "Walking bones without meat! What kind of abominations are these?"
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr "Yuck, this meat is rancid!"
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr "That did it! The storm outside is lifting."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr "Let’s get out of here."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr "With pleasure!"
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr "Heart Mountains"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr "The flight finally reached the spot Galun wanted to explore."
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr "Trolls"
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr "Sar"
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr "Thruf"
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr "Gryphons"
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr "Koarraa"
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr "Dominate the territory by defeating all enemy leaders"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr "This spot looks good. Let us see what game is available here."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr "They’re waving clubs and look hostile."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr "The giant birds nearby seem aggressive as well."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr "And that one is really big."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr "Fire Meets Steel"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr "Dwarves"
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr "Thurdakor"
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr "Defeat Thurdakor"
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr "One of your Sky Drakes has disappeared."
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr "This scenario takes place during the winter."
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr "Galun, their weapons look well-made, and we are few."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr "Perhaps that could have been put better..."
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr "Confrontation"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr "Defeat Kerath"
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr "Galun!"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+"Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr "Leave, and never trouble me again. Stay, and you will die."
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr "Enough talk. Drakes, attack!"
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr "We have arrived."
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr "You can now recruit Saurians!"
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr "You have failed usss and are not worthy to follow. We are leaving!"
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr "Argh!"
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr "I have killed the traitor!"
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr "Arrgggg!"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr "Good riddance."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr "Indeed."
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr "Epilogue"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr "The thought had crossed my mind."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr "Ultimately, the Drake Way will require expansion off Irdya itself."
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr "Gorer"
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr "Tusks"
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr "Tusk Charge"
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr "Lynx"
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr "claws"
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr "Rabbit"
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr "incisors"
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr "Tusker"
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr "Tusklet"
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr "Vank"
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr "Kerath"
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr "Gribbel"
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr "Xirtrezyx"
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr "Krenix"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr "Vank! No! How will I continue on without you?"
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr "and"
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr "or"

--- a/po/wesnoth-wov/en_GB.po
+++ b/po/wesnoth-wov/en_GB.po
@@ -1,0 +1,2446 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: en_GB\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr "Wings of Victory"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr "WoV"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr "(Intermediate level, 11 scenarios.)"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr "Version:"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr "Fledgling"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr "Normal"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr "Aspirant"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr "Challenging"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr "Difficult"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr "Dominant"
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr "Authors"
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr "Alpha Testing and Proofreading"
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr "Campaign Maintenance"
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr "Graphics"
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr "The Hunt"
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr "Drakes"
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr "Galun"
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr "Humans"
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr "Lynxes"
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr "Forest"
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr "Galun is an Aspirant (at least level two) at the end of the hunt"
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr "Death of Galun"
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr "Death of Vank"
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr "Loss of two or more members of your hunting party"
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr "Galun is still a Fledgling (level one) at the end of the hunt"
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr "Galun, I think I spy runners. Away north, past the fields."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr "... What? ... Sorry, I wasn't listening...."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr "What is wrong with you? I have not seen you so distracted in ages."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr "All the ships passing by must be going somewhere."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr "... Right ... Hunters! Take wing!"
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr "Gerth"
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr "Prepare to die, runners."
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr "Better to die free than await the slaughter in a Drake pen!"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr "You shall have your wish."
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr "My dream perishes with me..."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr "Vank! No! You would have been my Chief Intendant..."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr "The hunt has failed. I am not worthy to be an Aspirant."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr "Too many hunters have died. I am not worthy to be an Aspirant."
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr "Ah! A good hunt. Gallopers and runners both."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr "The Raid"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr "Orcs"
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr "Viragar"
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr "Capture Viragar (reduce him to 0 hitpoints or lower)"
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr "Galun has become an impressive Aspirant (reached level three)"
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr "So you think, prey."
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr "Viragar was captured alive and interrogated for a long time."
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr "Galun’s success in the raid earns him much renown."
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr "We are poised to lose this battle, Galun. I fear we must retreat."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr "The Contention"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr "Defeat Gribbel"
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr "Have the advantage when turns run out"
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr "Defeat of Galun"
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr "Fail to have the advantage when turns run out"
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr "Your defeated units will be returned to you after the battle."
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr "Each side is allowed only intendants and recruits for this battle."
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr "Just fly and fight, Vank. I’ll do the worrying."
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr "The chance at my dream, lost..."
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr "No!"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr "We did it!"
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr "The Spiral Path"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr "Reshan'lo"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr "May the pride and power of the Drakes be increased."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr "That...may not always be possible."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr "What?"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr "I am listening."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr "That is difficult to hear."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr "What doom is that?"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr "I hear and understand."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr "Islands"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr "Nagas"
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr "Sariss"
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr "Naulakh"
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr "Shussek"
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr "Defeat all enemy leaders"
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr "Galun’s flight is not yet able to manufacture armor for Clashers."
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr "This scenario takes place during the summer."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr "Be alert, there are large creatures moving under the waves."
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr "Sharpspikes"
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr "Graarrrrrr!"
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr "Shinyscales"
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr "Roarrrrrr!"
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr "Longtooth"
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr "Hissssss!"
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr "Look out, a sea serpent!"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr "That is good! We will seek it out."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr "The Three Sisters"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr "Ogres"
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr "Merkuk"
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr "Monsters"
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr "Midnight Queen"
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr "There are creatures hiding in here."
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr "There is nothing in here."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr "These islands, too, are inhabited."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr "Only by dumb animals. We can take this place, and will."
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr "You will be made to serve... Come admire me. Feel my love."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr "Ahhhh! Get off my islands!"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr "No."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr "This could make a decent home for the flight."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr "Elensefar"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr "Vorlyan"
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr "Defeat Vorlyan"
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr "A village full of runners is ahead."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr "Call the hunt!"
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr "Flying monsters are approaching; sound the alarm!"
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr "You will not enjoy your victory long. The Crown will retake this city."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr "These runners look and taste like the ones back on Morogor."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr "Wesmere"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr "Days of travel later they found themselves over green forest country."
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr "Woses"
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr "Gulladrumm"
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr "Elves"
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr "Daepia"
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr "Saurians"
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr "There is game in those trees. This may be a good place to hunt."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr "Yes. And the flight needs a night on the ground to rest its wings."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr "That was brisk."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr "As you command!"
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr "Wait, what is this? Scuttlers are approaching."
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr "Thatsss not a dragon."
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr "My power is indeed great. I am Galun and this is my Flight."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr "Yes, that is good."
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr "Foothills"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr "Undead"
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr "Naemir"
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr "Spiders"
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr "Serpents"
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr "Defeat Naemir to lift the storm"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr "We are stuck in this cave until the storm lifts."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr "Hopefully the time will pass well."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr "Right you are. It is my storm and this is my domain."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr "Galun, that sounds like prey-speech."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr "Yes, it does. How fitting..."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr "Who are <i>you</i> to challenge us?"
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr "The new servants ask too many questions. I am Naemir, and I rule here."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr "I am Galun, and I am not ‘ruled’ by anyone."
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr "No being of the lesser races may rule a drake."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr "Careful, Galun. We are no longer in Morogor..."
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr "Lesser, am I? I think not."
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr "Rise, my pets, there is food for you."
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr "And you, arrogant one, shall serve me — living or dead, I care not."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr "Walking bones without meat! What kind of abominations are these?"
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr "Yuck, this meat is rancid!"
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr "That did it! The storm outside is lifting."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr "Let’s get out of here."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr "With pleasure!"
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr "Heart Mountains"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr "The flight finally reached the spot Galun wanted to explore."
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr "Trolls"
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr "Sar"
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr "Thruf"
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr "Gryphons"
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr "Koarraa"
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr "Dominate the territory by defeating all enemy leaders"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr "This spot looks good. Let us see what game is available here."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr "They’re waving clubs and look hostile."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr "The giant birds nearby seem aggressive as well."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr "And that one is really big."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr "Fire Meets Steel"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr "Dwarves"
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr "Thurdakor"
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr "Defeat Thurdakor"
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr "One of your Sky Drakes has disappeared."
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr "This scenario takes place during the winter."
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr "Galun, their weapons look well-made, and we are few."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr "Perhaps that could have been put better..."
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr "Confrontation"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr "Defeat Kerath"
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr "Galun!"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+"Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr "Leave, and never trouble me again. Stay, and you will die."
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr "Enough talk. Drakes, attack!"
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr "We have arrived."
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr "You can now recruit Saurians!"
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr "You have failed usss and are not worthy to follow. We are leaving!"
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr "Argh!"
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr "I have killed the traitor!"
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr "Arrgggg!"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr "Good riddance."
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr "Indeed."
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr "Epilogue"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr "The thought had crossed my mind."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr "Ultimately, the Drake Way will require expansion off Irdya itself."
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr "Gorer"
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr "Tusks"
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr "Tusk Charge"
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr "Lynx"
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr "claws"
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr "Rabbit"
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr "incisors"
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr "Tusker"
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr "Tusklet"
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr "Vank"
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr "Kerath"
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr "Gribbel"
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr "Xirtrezyx"
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr "Krenix"
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr "Vank! No! How will I continue on without you?"
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr "and"
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr "or"

--- a/po/wesnoth-wov/eo.po
+++ b/po/wesnoth-wov/eo.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: eo\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/es.po
+++ b/po/wesnoth-wov/es.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/et.po
+++ b/po/wesnoth-wov/et.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: et\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/eu.po
+++ b/po/wesnoth-wov/eu.po
@@ -1,0 +1,2110 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: eu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/fi.po
+++ b/po/wesnoth-wov/fi.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: fi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/fr.po
+++ b/po/wesnoth-wov/fr.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/fur_IT.po
+++ b/po/wesnoth-wov/fur_IT.po
@@ -1,0 +1,2110 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: fur\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/ga.po
+++ b/po/wesnoth-wov/ga.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ga\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n==2 ? 1 : 2;\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/gd.po
+++ b/po/wesnoth-wov/gd.po
@@ -1,0 +1,2110 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: gd\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/gl.po
+++ b/po/wesnoth-wov/gl.po
@@ -1,0 +1,2110 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: gl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/he.po
+++ b/po/wesnoth-wov/he.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: he\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/hr.po
+++ b/po/wesnoth-wov/hr.po
@@ -1,0 +1,2112 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: hr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/hu.po
+++ b/po/wesnoth-wov/hu.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: hu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/id.po
+++ b/po/wesnoth-wov/id.po
@@ -1,0 +1,2110 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: id\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/is.po
+++ b/po/wesnoth-wov/is.po
@@ -1,0 +1,2110 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: is\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/it.po
+++ b/po/wesnoth-wov/it.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/ja.po
+++ b/po/wesnoth-wov/ja.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/ko.po
+++ b/po/wesnoth-wov/ko.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/la.po
+++ b/po/wesnoth-wov/la.po
@@ -1,0 +1,2110 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: la\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/lt.po
+++ b/po/wesnoth-wov/lt.po
@@ -1,0 +1,2112 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: lt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n"
+"%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/lv.po
+++ b/po/wesnoth-wov/lv.po
@@ -1,0 +1,2112 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: lv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : "
+"2);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/mk.po
+++ b/po/wesnoth-wov/mk.po
@@ -1,0 +1,2110 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: mk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/mr.po
+++ b/po/wesnoth-wov/mr.po
@@ -1,0 +1,2110 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: mr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/nb_NO.po
+++ b/po/wesnoth-wov/nb_NO.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: nb\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/nl.po
+++ b/po/wesnoth-wov/nl.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/pl.po
+++ b/po/wesnoth-wov/pl.po
@@ -1,0 +1,2112 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/pt.po
+++ b/po/wesnoth-wov/pt.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/pt_BR.po
+++ b/po/wesnoth-wov/pt_BR.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/racv.po
+++ b/po/wesnoth-wov/racv.po
@@ -1,0 +1,2110 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: racv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/ro.po
+++ b/po/wesnoth-wov/ro.po
@@ -1,0 +1,2112 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
+"20)) ? 1 : 2;\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/ru.po
+++ b/po/wesnoth-wov/ru.po
@@ -1,0 +1,2112 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/sk.po
+++ b/po/wesnoth-wov/sk.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/sl.po
+++ b/po/wesnoth-wov/sl.po
@@ -1,0 +1,2112 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
+"%100==4 ? 2 : 3);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/sr.po
+++ b/po/wesnoth-wov/sr.po
@@ -1,0 +1,2112 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/sr@ijekavian.po
+++ b/po/wesnoth-wov/sr@ijekavian.po
@@ -1,0 +1,2112 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sr@ijekavian\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/sr@ijekavianlatin.po
+++ b/po/wesnoth-wov/sr@ijekavianlatin.po
@@ -1,0 +1,2112 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sr@ijekavianlatin\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/sr@latin.po
+++ b/po/wesnoth-wov/sr@latin.po
@@ -1,0 +1,2112 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sr@latin\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/sv.po
+++ b/po/wesnoth-wov/sv.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/tl.po
+++ b/po/wesnoth-wov/tl.po
@@ -1,0 +1,2110 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: tl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/tr.po
+++ b/po/wesnoth-wov/tr.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: tr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/uk.po
+++ b/po/wesnoth-wov/uk.po
@@ -1,0 +1,2112 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/vi.po
+++ b/po/wesnoth-wov/vi.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: vi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/wesnoth-wov.pot
+++ b/po/wesnoth-wov/wesnoth-wov.pot
@@ -1,0 +1,2109 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/zh_CN.po
+++ b/po/wesnoth-wov/zh_CN.po
@@ -1,0 +1,2110 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""

--- a/po/wesnoth-wov/zh_TW.po
+++ b/po/wesnoth-wov/zh_TW.po
@@ -1,0 +1,2110 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2019-08-27 18:53 UTC\n"
+"PO-Revision-Date: 2019-08-22 14:23 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:9
+msgid "Wings of Victory"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:10
+msgid "WoV"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:18
+msgid ""
+"Seize, conquer, dominate, expand. That was ever the Way of the Drakes. But "
+"the Brothers of the Spiral Path have seen a vision: Irdya is made like an "
+"egg, and the day will come when there is no more world to conquer — and what "
+"of the Way then? There was a drake named Galun on whom fell the burden of "
+"finding an answer...\n"
+"\n"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:20
+msgid "(Intermediate level, 11 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:21
+msgid "Version:"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Fledgling"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:23
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Aspirant"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:24
+msgid "Challenging"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Difficult"
+msgstr ""
+
+#. [campaign]: id=Wings_of_Victory
+#: data/campaigns/Wings_of_Victory/_main.cfg:25
+msgid "Dominant"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:28
+msgid "Authors"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:40
+msgid "Alpha Testing and Proofreading"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:46
+msgid "Campaign Maintenance"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Wings_of_Victory/_main.cfg:53
+msgid "Graphics"
+msgstr ""
+
+#. [scenario]: id=01_The_Hunt
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:5
+msgid "The Hunt"
+msgstr ""
+
+#. [part]
+#. "Vulcaniad" is an invented term analogous to "Olympiad",
+#. referring to the period between two successive volcanic
+#. eruptions. A "cycle" is an unspecified astronomically-based
+#. time period roughly corresponding to a Drake generation.
+#. A "flight" is an unspecified drake social construct,
+#. roughly comparable to "tribe". The term derives from "fly",
+#. not "flee".
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:27
+msgid ""
+"My name is Reshan’lo, and I was in my youth the Recorder of the Flight of "
+"Kerath. It falls to me to report what came to pass in the 14th cycle of the "
+"5th Vulcaniad — the greatest error of Kerath, the flight's downfall and with "
+"it my own."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:30
+msgid ""
+"For long cycles we Recorders of Morogor had watched the slow rising of the "
+"tides and the sinking of our islands. Each cycle it became slightly more "
+"difficult to feed our hatchlings. Newer flights scraped out a meager "
+"existence on islets of rock their grandsires would have scorned, and some "
+"turned their eyes enviously on the green expanses of the central islands. We "
+"feared a final war was nearly upon us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:34
+msgid ""
+"That war was delayed when the prey ships started passing by our islands. "
+"Drakes began to wonder if ours was the only land in the world, or if there "
+"were yet more lands to be claimed far over the Great Ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:37
+msgid ""
+"There arose in the Flight of Verkon a young drake of subtle and dangerous "
+"mind who dreamed of those lands and spoke of his dream."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:75
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:39
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:45
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:52
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:64
+msgid "Drakes"
+msgstr ""
+
+#. [part]
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:41
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:42
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:40
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:34
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:46
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:49
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:53
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:44
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:6
+msgid "Galun"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:86
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:65
+msgid "Humans"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:100
+msgid "Lynxes"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:109
+msgid "Forest"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:190
+msgid "Galun is an Aspirant (at least level two) at the end of the hunt"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:194
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:94
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:140
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:210
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:104
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:105
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:127
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:160
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:157
+msgid "Death of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:198
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:144
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:214
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:108
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:109
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:131
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:164
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:142
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:161
+msgid "Death of Vank"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:202
+msgid "Loss of two or more members of your hunting party"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:206
+msgid "Galun is still a Fledgling (level one) at the end of the hunt"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:213
+msgid ""
+"The hunt will end when turns run out, or when all enemy units have been "
+"defeated."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Runners refers to the fastest method of locomotion for bipedal animals,
+#. of which humans are the only ones drakes are familiar with at this point.
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:231
+msgid "Galun, I think I spy runners. Away north, past the fields."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:235
+msgid "... What? ... Sorry, I wasn't listening...."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:239
+msgid "What is wrong with you? I have not seen you so distracted in ages."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:243
+msgid ""
+"I’m concerned for all of us. The next hatching is near and prey grows scarce."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:247
+msgid ""
+"And if you don’t bring your mind back to the hunt, Galun, we’ll go hungry "
+"right now. We are not Dominants; what can <i>we</i> do about the future?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:251
+msgid ""
+"I think we must leave Morogor, and seek more land across the Great Ocean."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:255
+msgid ""
+"And just how would you find that land in the Great Ocean without knowing "
+"where to go? Drakes have looked, and found nothing but water everywhere."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:259
+msgid "All the ships passing by must be going somewhere."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:263
+msgid ""
+"That may be, but if you truly aim to lead a flight across the Great Ocean, "
+"you’ll have to become a Dominant first, otherwise no drake will follow you. "
+"(Laughs) And you an <i>Aspirant</i>? Not so long as you dream when the hunt "
+"is called..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:267
+msgid ""
+"Speaking of the hunt, let’s take those runners there. You must have been "
+"distracted or blind yourself, not spotting them before."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:271
+msgid "... Right ... Hunters! Take wing!"
+msgstr ""
+
+#. [unit]: type=Outlaw, id=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:300
+msgid "Gerth"
+msgstr ""
+
+#. [message]: speaker=Gerth
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:309
+msgid ""
+"The damned wyrms have found us! Send the women and children to the caves. To "
+"arms, men."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:313
+msgid "Prepare to die, runners."
+msgstr ""
+
+#. [message]: speaker=Gerth
+#. "pen" as in a pen for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:318
+msgid "Better to die free than await the slaughter in a Drake pen!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:322
+msgid "You shall have your wish."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:358
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:11
+msgid "My dream perishes with me..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:372
+msgid "Vank! No! You would have been my Chief Intendant..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:388
+msgid "The hunt has failed. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:439
+msgid "Too many hunters have died. I am not worthy to be an Aspirant."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. Gallopers refers to the fastest method of locomotion for quadruped animals
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:453
+msgid "Ah! A good hunt. Gallopers and runners both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:457
+msgid ""
+"Indeed, but game is getting hard to find on the ranges, even though we "
+"usually spare the females and young. Too many hunters, not enough game."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/01_The_Hunt.cfg:461
+msgid ""
+"We have taken all the game we can for now. The air is too thick this low; it "
+"clogs my lungs. Let’s fly back to the eyrie."
+msgstr ""
+
+#. [scenario]: id=02_The_Raid
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:5
+msgid "The Raid"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:18
+msgid ""
+"Even though Galun was now an Aspirant, he still needed to win enough honor "
+"to be chosen to represent his caste in the Contention."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:21
+msgid ""
+"An opportunity arose when a ship of prey landed on the northernmost island."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:25
+msgid ""
+"Verkon, having learned from previous encounters with prey on that island, "
+"hid his forces to lull the enemy into a false sense of security."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:28
+msgid ""
+"He then charged Galun with leading the attack and interrogating the leader "
+"in order to learn a way across the ocean to other lands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:31
+msgid ""
+"Determined to succeed without further assistance, Galun’s forces approached "
+"the island under cover of darkness."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:63
+msgid "Orcs"
+msgstr ""
+
+#. [leader]: id=Viragar, type=Orcish Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:67
+msgid "Viragar"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:85
+msgid "Capture Viragar (reduce him to 0 hitpoints or lower)"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:90
+msgid "Galun has become an impressive Aspirant (reached level three)"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:102
+msgid ""
+"Galun has not become more impressive (still level two) after Viragar is "
+"captured"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:118
+msgid ""
+"There they are. Like runners, but filthy. Hopefully the game tastes better "
+"than it looks."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:124
+msgid ""
+"Indeed. Let’s make sure we hold off on eating the leader until we get the "
+"information we need."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:137
+msgid ""
+"Speak, prey. We see ships travel east past these islands, and none return. "
+"Where do they go?"
+msgstr ""
+
+#. [message]: speaker=Viragar
+#. "flies" is the plural of "fly", the noun (small animal).
+#. It's a derogatory term used by an orc speaker for drakes.
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:143
+msgid ""
+"You may have defeated me in battle, little flies, but the secret of the "
+"ships I will take to my grave."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:149
+msgid "So you think, prey."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. "pens" as in pens for holding livestock
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:156
+msgid ""
+"Galun, breaking this prey may take some time. Let us bind him and take him "
+"to the pens."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:170
+msgid "Viragar was captured alive and interrogated for a long time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:175
+msgid ""
+"The interrogation yielded rumors of a land to the east and a way to reach it."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:180
+msgid "Galun’s success in the raid earns him much renown."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:191
+msgid ""
+"However, Galun’s lack of impressive stature and strength causes him to "
+"narrowly miss being chosen for the Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:204
+msgid "We are poised to lose this battle, Galun. I fear we must retreat."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:208
+msgid ""
+"No, Vank. I shall kill these prey or die trying, else I would never become a "
+"Dominant."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/02_The_Raid.cfg:214
+msgid ""
+"Galun and his troops fought gallantly, and their fallen had died with honor, "
+"but it was not enough. It was only with reinforcements from Verkon that "
+"Galun won the island back.\n"
+"\n"
+"So ended Galun’s dream of becoming a Dominant."
+msgstr ""
+
+#. [scenario]: id=03_The_Contention
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:8
+msgid "The Contention"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:22
+msgid ""
+"For ages, we of the Spiral Path have not demurred when our kin of the "
+"Straight Path spoke vaguely of the ’end of the world’ lying beyond the "
+"oceans, receding ever farther as Dominants claim new ranges. However, we "
+"knew better: for we have found it written in the tides and the motion of the "
+"stars that our world is round, made like a drake’s egg."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:25
+msgid ""
+"Every hatchling’s hope is to become the Dominant of a new flight. But the "
+"sinking of our islands may only prefigure a vastly greater tragedy; for if "
+"the world is bounded, our Way must end in a final war of drake against "
+"drake...or a great starvation."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:28
+msgid ""
+"Every turn of the heavens brings us closer to that doom. We of the Spiral "
+"Path seek a way for Drake-kind to step off that wheel, before it is too late."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:137
+msgid "Defeat Gribbel"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:142
+msgid "Have the advantage when turns run out"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:146
+msgid "Defeat of Galun"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:150
+msgid "Fail to have the advantage when turns run out"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:157
+msgid ""
+"For this scenario, only 1 * level xp is earned for kills, as defeated units "
+"are merely removed from play."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:160
+msgid "Your defeated units will be returned to you after the battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:163
+msgid "Each side is allowed only intendants and recruits for this battle."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:166
+msgid ""
+"Each side is forced to recruit unit types evenly before a type is allowed to "
+"be repeated."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:175
+msgid ""
+"And so the day of the Contention came. Each caste elected an Aspirant from "
+"their ranks to become the new Dominant, and each Aspirant brought with him "
+"Intendants to extend his rule over the other castes. Thus, in the ancient "
+"Way of the drakes, six times six: thirty-six drakes in all."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:181
+msgid ""
+"All the skills necessary to protect and provide for a flight were tested. "
+"Each team faced various challenges of martial ability, hunting, group "
+"coordination, strategy, & tactics. The top two teams, with only their "
+"gathered resources and raw recruits, advanced onward to the traditional "
+"arena in the very heart of Morogor."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:186
+msgid ""
+"As was the Way, the teams, lead by Galun of the Flight of Verkon, and "
+"Gribbel of the Flight of Kerath, faced off in a final battle: The Contention."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:191
+msgid ""
+"I can scarce believe we are actually here. The Contention! Are we truly fit "
+"for this?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:195
+msgid "Just fly and fight, Vank. I’ll do the worrying."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:248
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:295
+msgid "The chance at my dream, lost..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. [message]: speaker=Gribbel
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:258
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:285
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:318
+msgid "We did it!"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/03_The_Contention.cfg:323
+msgid ""
+"By his victory, Galun earned the privilege of founding a new Flight in "
+"accordance with the Way. As custom required, he would be gifted with "
+"breeders and fledglings from each of the other Flights."
+msgstr ""
+
+#. [scenario]: id=04_The_Spiral_Path
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:4
+msgid "The Spiral Path"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+msgid ""
+"Galun, you have triumphed in the Contention. It falls to me as the Recorder "
+"of the Contention to give you your reward."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:18
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid "Reshan'lo"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:23
+msgid "May the pride and power of the Drakes be increased."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:28
+msgid "That...may not always be possible."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:33
+msgid "What?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:38
+msgid ""
+"You are intelligent. You can see that our numbers grow beyond the capacity "
+"of the known islands to support us."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:43
+msgid ""
+"Yes. I have learned of a Great Continent to the east beyond the Great Ocean; "
+"I intend to take my new flight to it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:48
+msgid ""
+"Indeed? It is likely that you will all die in the attempt. You know this."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:53
+msgid ""
+"Even with what we have learned, it is still dangerous. But I think there is "
+"no future for us here."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:58
+msgid ""
+"As for the abyss at the end of the great ocean...you have heard, perhaps, "
+"that some drakes believe the world is round like an egg; that there is no "
+"abyss to fall into."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:63
+msgid ""
+"Yes. It was after I learned this rumor that I began to wonder if ours was "
+"truly the only land in the world."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:68
+msgid ""
+"Now I must reveal secrets. You are a Dominant now, if a very new one; I "
+"cannot bind you not to speak them. However, they are secrets for good "
+"reason, and you should think carefully before sharing them. Doing so might "
+"weaken you."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:73
+msgid "I am listening."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:78
+msgid ""
+"There is a brotherhood called the Spiral Path; I am a member. Most of us are "
+"Recorders. We know many things that most drakes, the unknowing followers of "
+"the Straight Path, have never learned; and some things they once knew but "
+"have forgotten."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:83
+msgid ""
+"One of the things they have forgotten is that there is indeed other land in "
+"the world. Long ago, cycles beyond counting, we lived on a great landmass "
+"far to the west of here. We..most of us...chose to forget our origins, "
+"because we were driven from it in a great war. We came to Morogor fleeing "
+"enemies."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:88
+msgid "That is difficult to hear."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:93
+msgid ""
+"Under the pride of the Drakes there is buried shame; lesser races defeated "
+"us. But there is more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:98
+msgid ""
+"It is written in the tides, and in the motions of the moons, that the world "
+"is indeed made in the shape of a drake’s egg. You might very well find new "
+"land to the east of here, farther from whence we came."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:103
+msgid ""
+"Though you cannot fly far enough to escape the doom that waits at the end of "
+"the Straight Path."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:108
+msgid "What doom is that?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:113
+msgid ""
+"Think now of the great green world as an island; if you travel around its "
+"shore long enough, you will end where you began. Galun...what will happen "
+"when the world fills up with drakes?"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:118
+msgid ""
+"I see, I think. You fear a final war, drake against drake. Not just here in "
+"Morogor, but covering whatever other lands there may be."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:123
+msgid ""
+"We do. The Spiral Path seeks a way to prevent that war, The Straight Path of "
+"spawning and swarming cannot continue forever. We must, somehow, learn to "
+"keep our numbers in bounds."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:128
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:45
+msgid "I hear and understand."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:133
+msgid ""
+"I do not know how to solve this, though if I can find new land, I can buy us "
+"time to solve it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/04_The_Spiral_Path.cfg:138
+msgid ""
+"That is all any of us have been able to do, buy time. You are Spiral Path "
+"now. Your breeders and swarmlings await you, flight leader. Good luck!"
+msgstr ""
+
+#. [scenario]: id=05_Islands
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:5
+msgid "Islands"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:19
+msgid ""
+"They had little time to prepare the new flight. The new hatchlings could not "
+"go long without food...but worse, if the breeders grew heavy with eggs they "
+"would lose their ability to fly."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:22
+msgid ""
+"Galun prepared for true long-distance travel by abandoning the massive armor "
+"of the Clashers. The flight took only the lighter tools with it, counting on "
+"re-creating the heavier ones in the new land. Instead, they loaded up with "
+"sling bags of dried meat. That, and the prey they could take from the Great "
+"Ocean on their journey, might see them through."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:25
+msgid ""
+"All the drakes knew that if Galun was successful in finding new land, their "
+"people would have new hope. The Flights of Verkon and Kerath sent Sky Drakes "
+"to assist Galun in finding a way to the Great Continent, and to report back "
+"when it was located."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:29
+msgid ""
+"For many days they flew over unknown waters, growing weary and hungry and "
+"wing-sore. Then Galun, scouting ahead with a few followers, sighted land..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:61
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:81
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:101
+msgid "Nagas"
+msgstr ""
+
+#. [leader]: id=Sariss, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:64
+msgid "Sariss"
+msgstr ""
+
+#. [leader]: id=Naulakh, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:84
+msgid "Naulakh"
+msgstr ""
+
+#. [leader]: id=Shussek, type=Naga Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:104
+msgid "Shussek"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:136
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:206
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:101
+msgid "Defeat all enemy leaders"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:153
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:223
+msgid "Galun’s flight is not yet able to manufacture armor for Clashers."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:226
+msgid "This scenario takes place during the summer."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:165
+msgid ""
+"There are nimble, amphibious reptiles in these islands, Galun. They fight "
+"with swords, but no bows."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:169
+msgid ""
+"Tired though we are, we must claw our rest from these creatures. Attack!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:178
+msgid "Be alert, there are large creatures moving under the waves."
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:211
+msgid "Sharpspikes"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:212
+msgid "Graarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:218
+msgid "Shinyscales"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:219
+msgid "Roarrrrrr!"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:225
+msgid "Longtooth"
+msgstr ""
+
+#. [case]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:226
+msgid "Hissssss!"
+msgstr ""
+
+#. [message]
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:309
+msgid "Look out, a sea serpent!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:322
+msgid ""
+"We have triumphed, though these islands are only a place to rest. We must "
+"continue onward."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:326
+msgid ""
+"It is possible I have seen our destination. I glimpsed something on the "
+"eastern horizon as I scouted high above our enemies. A puff of cloud, the "
+"kind that forms over land."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:330
+msgid "That is good! We will seek it out."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/05_Islands.cfg:338
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:283
+msgid ""
+"The flight is starving and exhausted; we cannot pacify these islands before "
+"we die!"
+msgstr ""
+
+#. [scenario]: id=06_The_Three_Sisters
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:5
+msgid "The Three Sisters"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:19
+msgid ""
+"When they were fully rested, some messengers from the other flights returned "
+"to Morogor to report the location of the islands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:22
+msgid ""
+"After taking a few days to hunt and recover its strength, the flight again "
+"flew east into unknown ocean."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:26
+msgid ""
+"Vank’s eyes had not deceived him. There was indeed land to the east, farther "
+"than he guessed and barely within reach. A great warm current angled up from "
+"the south to intersect the flight’s path, and then led them towards a group "
+"of three islands."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:59
+msgid "Ogres"
+msgstr ""
+
+#. [leader]: id=Merkuk, type=Ogre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:62
+msgid "Merkuk"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:79
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:123
+msgid "Monsters"
+msgstr ""
+
+#. [leader]: id=Midnight Queen, type=Spectre
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:82
+msgid "Midnight Queen"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:132
+msgid "There are creatures hiding in here."
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:150
+msgid "There is nothing in here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:235
+msgid "These islands, too, are inhabited."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:239
+msgid "Only by dumb animals. We can take this place, and will."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:249
+msgid "You will be made to serve... Come admire me. Feel my love."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:253
+msgid "Okay, inhabited only by dumb animals and a crazy, hideous ghost."
+msgstr ""
+
+#. [message]: speaker=Midnight Queen
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:259
+msgid "Ahhhh! Get off my islands!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:263
+msgid "No."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:271
+msgid "This could make a decent home for the flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/06_The_Three_Sisters.cfg:275
+msgid ""
+"Indeed, but we can see the vast mainland from here. Let us scout above and "
+"see if there is a better place for our eyrie."
+msgstr ""
+
+#. [scenario]: id=07_Elensefar
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:5
+msgid "Elensefar"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:19
+msgid ""
+"Galun sent the remaining messengers from the other flights back to report on "
+"the success of finding a way to the Great Continent."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:22
+msgid ""
+"From above The Three Sisters, the keenest eyes in the flight saw a hint of a "
+"great range of mountains to the east and north over the water, such country "
+"as Drakes love to build eyries in."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:25
+msgid ""
+"With the mainland near, shorter flights with heavier loads could be made. "
+"Thus with the fire from the volcanoes the drakes reforged their heavier "
+"tools and armor for the clashers."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:29
+msgid ""
+"When everyone was ready, Galun ordered the flight toward the mountains. On "
+"their way, a settlement was spotted."
+msgstr ""
+
+#. [leader]: id=Vorlyan, type=General
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:69
+msgid "Vorlyan"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:100
+msgid "Defeat Vorlyan"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:123
+msgid "A village full of runners is ahead."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:127
+msgid "Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Vorlyan
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:139
+msgid "Flying monsters are approaching; sound the alarm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:150
+msgid "You will not enjoy your victory long. The Crown will retake this city."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:158
+msgid "These runners look and taste like the ones back on Morogor."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/07_Elensefar.cfg:162
+msgid ""
+"Yes, but they are more organized and dangerous. Their leader was very "
+"confident about this ’Crown’; continuing to hunt them could be a problem."
+msgstr ""
+
+#. [scenario]: id=08_Wesmere
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:5
+msgid "Wesmere"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:20
+msgid "Days of travel later they found themselves over green forest country."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:53
+msgid "Woses"
+msgstr ""
+
+#. [leader]: id=Gulladrumm, type=Ancient Wose
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:57
+msgid "Gulladrumm"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:74
+msgid "Elves"
+msgstr ""
+
+#. [leader]: id=Daepia, type=Elvish Enchantress
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:78
+msgid "Daepia"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:92
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:112
+msgid "Saurians"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:124
+msgid "There is game in those trees. This may be a good place to hunt."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:128
+msgid "Yes. And the flight needs a night on the ground to rest its wings."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:132
+msgid ""
+"Some of the game has two legs rather than four. They don’t quite look like "
+"our runners, though. They move better. And...Galun, I could swear some of "
+"the trees down there are <i>walking</i>!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:136
+msgid ""
+"I see them. Well, if they choose to fight us, our fire should burn them "
+"nicely. Call the hunt!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:144
+msgid "That was brisk."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:148
+msgid ""
+"Yes, and there are more of the two-leggeds heading at us from every "
+"direction. I think I’m undercounting them — they’re cursed hard to spot in "
+"these woods."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:152
+msgid ""
+"Set up a rotating overwatch. We’ll feed and rest here until the overwatch "
+"flyers spot more of them within a half-league, then fly north."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:156
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:225
+msgid "As you command!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#. "scuttler" is a noun formed from the verb "to scuttle"
+#. It means to move quickly, and is often used of insects.
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:208
+msgid "Wait, what is this? Scuttlers are approaching."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:219
+msgid ""
+"O great dragon, we have ssseen you strike at the hated humansss, and wish to "
+"follow you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:223
+msgid "Thatsss not a dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:227
+msgid ""
+"Sssilence! I can sssee that now that we are up close, but the dragon has "
+"beaten the humans and the elvesss, so do not disrespect the dragon."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:232
+msgid ""
+"Great dragon, we have been without a dragon to follow sssince the great "
+"Shek’kahan was ssslain. It is clear that your power is greater than "
+"Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:239
+msgid ""
+"O great ... flying reptiles, we have ssseen you strike at the hated "
+"humansss, and wish to ally with you."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:243
+msgid ""
+"We have been without an alliance sssince the great Shek’kahan was ssslain. "
+"It is clear that your power is greater than Shek’kahan’s ever was."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:251
+msgid ""
+"They would make terrible game, but might be good allies, and alliances in "
+"this new land could prove useful."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:257
+msgid "My power is indeed great. I am Galun and this is my Flight."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:263
+msgid ""
+"We welcome you, but will not slow down our flight to wait for all of you. We "
+"are heading to a new home in the mountains, and wish to be settled in before "
+"winter."
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:267
+msgid ""
+"We are light in weight. Perhapsss your flight can carry a few of our number, "
+"so they might asssist you and learn of your waysss."
+msgstr ""
+
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:271
+msgid ""
+"With their help, the rest of usss will be able to find and join you in the "
+"spring."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/08_Wesmere.cfg:277
+msgid "Yes, that is good."
+msgstr ""
+
+#. [scenario]: id=09_Foothills
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:5
+msgid "Foothills"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:24
+msgid ""
+"Upon leaving the forest, a mountain in the range ahead caught Galun’s "
+"attention, and he led the flight toward it."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:30
+msgid ""
+"As they flew over the rough foothills of what men would someday call the "
+"Heart Mountains, a fierce storm swelled up and forced the flight to land and "
+"take shelter in a cave."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:65
+msgid "Undead"
+msgstr ""
+
+#. [leader]: id=Naemir, type=Lich # This lich is a former elf
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:69
+msgid "Naemir"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:85
+msgid "Spiders"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:105
+msgid "Serpents"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:123
+msgid "Defeat Naemir to lift the storm"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:146
+msgid "We are stuck in this cave until the storm lifts."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:150
+msgid "Hopefully the time will pass well."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:154
+msgid ""
+"Perhaps, old friend. There is something troubling about the storm and this "
+"place."
+msgstr ""
+
+#. [message]: speaker=narrator # Until the lich gives his name
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:166
+msgid "Right you are. It is my storm and this is my domain."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:170
+msgid "Galun, that sounds like prey-speech."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:174
+msgid "Yes, it does. How fitting..."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:178
+msgid "Who are <i>you</i> to challenge us?"
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:185
+msgid "The new servants ask too many questions. I am Naemir, and I rule here."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:189
+msgid "I am Galun, and I am not ‘ruled’ by anyone."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:196
+msgid ""
+"Here, you will either be ruled by me or you will be dead. Or, possibly, both."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:200
+msgid "No being of the lesser races may rule a drake."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:204
+msgid "Careful, Galun. We are no longer in Morogor..."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:211
+msgid "Lesser, am I? I think not."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:218
+msgid "Rise, my pets, there is food for you."
+msgstr ""
+
+#. [message]: speaker=Naemir
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:240
+msgid "And you, arrogant one, shall serve me — living or dead, I care not."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:249
+msgid ""
+"We cannot risk the breeders by escaping through the unnatural storm outside. "
+"We must defeat this foe."
+msgstr ""
+
+#. [message]: race=drake
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:272
+msgid "Walking bones without meat! What kind of abominations are these?"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:288
+msgid "Yuck, this meat is rancid!"
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:302
+msgid "That did it! The storm outside is lifting."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:312
+msgid "Let’s get out of here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/09_Foothills.cfg:316
+msgid "With pleasure!"
+msgstr ""
+
+#. [scenario]: id=10_Heart_Mountains
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:18
+msgid "Heart Mountains"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:35
+msgid "The flight finally reached the spot Galun wanted to explore."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:68
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:86
+msgid "Trolls"
+msgstr ""
+
+#. [leader]: id=Sar, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:72
+msgid "Sar"
+msgstr ""
+
+#. [leader]: id=Thruf, type=Troll Warrior
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:90
+msgid "Thruf"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:104
+msgid "Gryphons"
+msgstr ""
+
+#. [leader]: id=Koarraa, type=Gryphon
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:107
+msgid "Koarraa"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:156
+msgid "Dominate the territory by defeating all enemy leaders"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:179
+msgid "This spot looks good. Let us see what game is available here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:183
+msgid ""
+"That would be those shambling things over there. They look like runners, but "
+"much bigger and uglier."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:201
+msgid "They’re waving clubs and look hostile."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:206
+msgid "The giant birds nearby seem aggressive as well."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:217
+msgid "And that one is really big."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:228
+msgid ""
+"An excellent variety of game! Now let us see if we can dominate this "
+"territory."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:236
+msgid ""
+"We can beat them, and we can eat them. Furthermore, I like the feel of these "
+"mountains. We shall build our eyrie here."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:240
+msgid ""
+"Excellent. The flight will rejoice. However, it’s colder here than Morogor "
+"was. We’ll sleep more."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/10_Heart_Mountains.cfg:244
+msgid ""
+"That’s no bad thing, Vank. We will make the most of our new territory by "
+"drawing on the game as lightly as we can."
+msgstr ""
+
+#. [scenario]: id=11_Fire_Meets_Steel
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:14
+msgid "Fire Meets Steel"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:28
+msgid ""
+"The Drakes began to carve out a new home with fire and tools. They built "
+"watchposts, and chambers for the breeders, and sleeping quarters. They "
+"hunted the trolls and the beasts of the mountains for meat."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:31
+msgid ""
+"Soon, as the days got colder and nights longer they began their hibernation "
+"for the winter."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:34
+msgid ""
+"During their slumber, a Sky Drake disappeared, along with several bags of "
+"provisions. No attempt was made on the breeders’ chambers, so it became "
+"apparent to Galun that the Sky Drake must have gone back to Morogor."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:38
+msgid ""
+"The drakes’ winter slumber continued uneventfully until one day when the "
+"inhabitants of the harsh mountain country came calling."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:73
+msgid "Dwarves"
+msgstr ""
+
+#. [leader]: id=Thurdakor, type=Dwarvish Lord
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:77
+msgid "Thurdakor"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:134
+msgid "Defeat Thurdakor"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:151
+msgid "One of your Sky Drakes has disappeared."
+msgstr ""
+
+#. [note]
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:154
+msgid "This scenario takes place during the winter."
+msgstr ""
+
+#. [message]: speaker=Vank
+#. The drakes just encountered dwarves for the first time, and
+#. describe them as "short runners".
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:166
+msgid ""
+"Galun, warm your blood and rise. The Guard reports runners nearing. But "
+"shorter ones. Small runners, whatever."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:172
+msgid ""
+"Who dares work stone in these mountains wi’out the leave o’ the Dwarves?"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:185
+msgid ""
+"I am Galun, and this is my Flight. Who gives us challenge in the tongue of "
+"prey?"
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:191
+msgid ""
+"I am Thurdakor of Knalga, and nae prey but a lord of the living stone. You "
+"squat on my surface land."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:195
+msgid "Galun, their weapons look well-made, and we are few."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:199
+msgid ""
+"Surface land, eh? Well, here we shall remain. Perhaps if you keep to your "
+"holes we’ll have no trouble."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:203
+msgid "Perhaps that could have been put better..."
+msgstr ""
+
+#. [message]: speaker=Thurdakor
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:209
+msgid ""
+"Keep to our holes? Arrogant one, you shall learn the bite of Dwarven steel "
+"for that taunt."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:217
+msgid ""
+"Those ’Dwarves’ fought well. If there are many more of them in these "
+"mountains, I fear for our hatchlings."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/11_Fire_Meets_Steel.cfg:221
+msgid ""
+"We’ll flee no further. This is a strong, defensible site and the range "
+"around it is full of game. If the dwarves molest us, we’ll blood our young "
+"warriors on them."
+msgstr ""
+
+#. [scenario]: id=12_Confrontation
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:11
+msgid "Confrontation"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:25
+msgid ""
+"After the defeat of the dwarves, the rest of the winter was spent in a "
+"peaceful hibernation. With the arrival of spring, the flight returned to "
+"hunting and the work of preparing for the flight’s first hatching."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:29
+msgid ""
+"As the dawn broke one day, the guard sounded the alarm. The missing Sky "
+"Drake had returned, and he was not alone."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:153
+msgid "Defeat Kerath"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:173
+msgid "Galun!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:179
+msgid "Why have you and your flight left Morogor and come to my eyrie, Kerath?"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:184
+msgid ""
+"You, a new Dominant, are not worthy to have that mountain and for your "
+"descendants to populate this land. I have come to take your mountain and "
+"your breeders for myself."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:191
+msgid ""
+"You would fight to take what is mine when you have breeders of your own and "
+"unclaimed lands are in abundance? Such an attack is a violation of the Ways "
+"of Morogor!"
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:195
+msgid ""
+"We are not in Morogor anymore! There are no other flights around to enforce "
+"customs. Surrender, and I will give you a quick death, and some of your "
+"drakes may be allowed to live and serve me."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:201
+msgid "Leave, and never trouble me again. Stay, and you will die."
+msgstr ""
+
+#. [message]: speaker=Kerath
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:205
+msgid "Enough talk. Drakes, attack!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:243
+msgid "We have arrived."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:259
+msgid "You can now recruit Saurians!"
+msgstr ""
+
+#. [message]: speaker=Xirtrezyx
+#. [message]: speaker=Krenix
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:277
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:281
+msgid "You have failed usss and are not worthy to follow. We are leaving!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:303
+msgid "Argh!"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:307
+msgid "I have killed the traitor!"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:318
+msgid "Arrgggg!"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:322
+msgid "Good riddance."
+msgstr ""
+
+#. [message]: speaker=Vank
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:330
+msgid ""
+"It saddens me that we had to fight our own kind, although we did what we had "
+"to."
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/scenarios/12_Confrontation.cfg:334
+msgid "Indeed."
+msgstr ""
+
+#. [scenario]: id=13_Epilogue
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:4
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:12
+msgid ""
+"In the aftermath of the battle, the breeders from the Flight of Kerath were "
+"found and brought to the eyrie. All the other drakes from the flight were "
+"executed for the treacherous attack, save one."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:15
+msgid ""
+"Reshan’lo, the Recorder of the Flight of Kerath, was taken captive. Galun "
+"spoke with him."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:20
+msgid ""
+"Perhaps you are wondering why I did not execute you with the rest of the "
+"Flight of Kerath, Reshan’lo."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:25
+msgid "The thought had crossed my mind."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:30
+msgid ""
+"I learned the value of the long view of things. You are a Recorder. I spared "
+"you so that your knowledge might be passed on. It would be a tragedy if we "
+"did not learn from these events."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:35
+msgid ""
+"Then I shall speak of what I have learned. On the journey here I have "
+"observed numerous armed prey south of the river, and in the forests and the "
+"mountains of this continent. They all reproduce faster than us drakes. If "
+"they attacked us in numbers, they would suffer losses, but with our present "
+"strength our losses would hurt more."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:40
+msgid ""
+"The Flight of Kerath was one of the largest flights in Morogor. With it "
+"gone, the new flights created by the next few Contentions will likely take "
+"over Kerath’s former territory. Then they will come, one flight of bold "
+"young swarmlings after the next, drawn by the promise of such a vast "
+"unclaimed land. For now though, on this Great Continent, the pride and power "
+"of the Drakes is in your hands."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:48
+msgid ""
+"Reshan’lo pledged his loyalty to Galun, and was allowed to spend the rest of "
+"his days assisting the Recorder of The Flight of Galun."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:51
+msgid ""
+"Galun, looking back on the journey to the Heart Mountains, and looking "
+"forward to the future, considered how the descendants of his flight might "
+"best thrive in this new land."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:55
+msgid ""
+"To guide them in settling the continent while avoiding falling prey to more "
+"aggressive drakes or coming into destructive contact with the fast-breeding "
+"lesser races, Galun proclaims the Edicts:\n"
+"(1) Reaffirmation of the Ways of Morogor\n"
+"(2) Avoidance of dangerous game and respecting them as fellow predators\n"
+"(3) Long sleeps to cut food requirements"
+msgstr ""
+
+#. [part]
+#: data/campaigns/Wings_of_Victory/scenarios/13_Epilogue.cfg:61
+msgid "Ultimately, the Drake Way will require expansion off Irdya itself."
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:4
+msgid "Gorer"
+msgstr ""
+
+#. [unit_type]: id=Gorer, race=monster
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:34
+msgid ""
+"As Tuskers age, their already formidable teeth grow longer and more "
+"numerous. A mature boar gorer is a valuable asset to any farmer. An angry "
+"boar gorer is a challenge even to the best hunters"
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:49
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:48
+msgid "Tusks"
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Gorer.cfg:101
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:101
+msgid "Tusk Charge"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:4
+msgid "Lynx"
+msgstr ""
+
+#. [unit_type]: id=Lynx, race=monster
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:22
+msgid ""
+"The lynx is a predator that lives in forested areas, especially at higher "
+"altitudes. Some of the larger and more aggressive lynxes routinely kill "
+"deer, and a few have been known to attempt human-sized prey."
+msgstr ""
+
+#. [attack]: type=blade
+#: data/campaigns/Wings_of_Victory/units/Lynx.cfg:27
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:35
+msgid "claws"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:4
+msgid "Rabbit"
+msgstr ""
+
+#. [unit_type]: id=Rabbit, race=monster
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:21
+msgid ""
+"The rabbit is a cute creature which lives in fields and forests. Rabbits are "
+"the prey of many larger creatures, for their flesh is sweet and succulent."
+msgstr ""
+
+#. [attack]: type=pierce
+#: data/campaigns/Wings_of_Victory/units/Rabbit.cfg:26
+msgid "incisors"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:4
+msgid "Tusker"
+msgstr ""
+
+#. [unit_type]: id=Tusker, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusker.cfg:34
+msgid ""
+"Tuskers are hardy livestock. Their powerful limbs make them good beasts of "
+"burden. Their thick wool and hides make coarse, but serviceable clothing and "
+"their meat is tough, but filling. But an angry or wild tusker is not to be "
+"trifled with."
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:4
+msgid "Tusklet"
+msgstr ""
+
+#. [unit_type]: id=Tusklet, race=monster
+#: data/campaigns/Wings_of_Victory/units/Tusklet.cfg:33
+msgid ""
+"Young tuskers are as notoriously bad-tempered as the adults of the species, "
+"though less of a challenge to fight. The main danger lies in threatening the "
+"little one while not noticing its parent preparing to charge from behind."
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:52
+msgid "Vank"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:64
+msgid "Kerath"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:74
+msgid "Gribbel"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:84
+msgid "Xirtrezyx"
+msgstr ""
+
+#: data/campaigns/Wings_of_Victory/utils/characters.cfg:95
+msgid "Krenix"
+msgstr ""
+
+#. [message]: speaker=Galun
+#: data/campaigns/Wings_of_Victory/utils/deaths.cfg:25
+msgid "Vank! No! How will I continue on without you?"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:32
+msgid "and"
+msgstr ""
+
+#. [objective]: description=<small>, condition=win
+#: data/campaigns/Wings_of_Victory/utils/wov-macros.cfg:41
+msgid "or"
+msgstr ""


### PR DESCRIPTION
The next scons or cmake pot-update will create all of the empty .po files.

This pushes the Portuguese translation below the 70% threshold.

For the en_GB translation, AFAICS only "honor" and maybe "overwatch" need to change.