### PR TITLE
fix #4256 wesnoth.require with relative paths

### DIFF
--- a/data/lua/package.lua
+++ b/data/lua/package.lua
@@ -15,6 +15,7 @@ local mt = {
 local empty_pkg = setmetatable({}, mt)
 
 local function resolve_package(pkg_name)
+	pkg_name = wesnoth.canonical_path(pkg_name)
 	if pkg_name[#pkg_name] == '/' then
 		pkg_name = pkg_name:sub(1, -2)
 	end
@@ -36,7 +37,6 @@ local function resolve_package(pkg_name)
 	return nil
 end
 
--- TODO: Currently if you require a file by different (relative) paths, each will be a different copy.
 function wesnoth.require(pkg_name)
 	-- First, check if the package is already loaded
 	local loaded_name = resolve_package(pkg_name)

--- a/src/scripting/lua_fileops.cpp
+++ b/src/scripting/lua_fileops.cpp
@@ -62,7 +62,7 @@ static std::string get_calling_file(lua_State* L)
 }
 /// resolves @a filename to an absolute path
 /// @returns true if the filename was successfully resolved.
-static bool resolve_filename(std::string& filename, std::string currentdir, std::string* rel = nullptr)
+static bool canonical_path(std::string& filename, std::string currentdir)
 {
 	if(filename.size() < 2) {
 		return false;
@@ -104,6 +104,16 @@ static bool resolve_filename(std::string& filename, std::string currentdir, std:
 	if(filename.find("..") != std::string::npos) {
 		return false;
 	}
+	return true;
+}
+
+/// resolves @a filename to an absolute path
+/// @returns true if the filename was successfully resolved.
+static bool resolve_filename(std::string& filename, std::string currentdir, std::string* rel = nullptr)
+{
+	if(!canonical_path(filename, currentdir)) {
+		return false;
+	}
 	std::string p = filesystem::get_wml_location(filename);
 	if(p.empty()) {
 		return false;
@@ -115,6 +125,16 @@ static bool resolve_filename(std::string& filename, std::string currentdir, std:
 	return true;
 }
 
+int intf_canonical_path(lua_State *L)
+{
+	std::string m = luaL_checkstring(L, 1);
+	if(canonical_path(m, get_calling_file(L))) {
+		lua_push(L, m);
+		return 1;
+	} else {
+		return luaL_argerror(L, 1, "invalid path");
+	}
+}
 /**
  * Checks if a file exists (not necessarily a Lua script).
  * - Arg 1: string containing the file name.

--- a/src/scripting/lua_fileops.hpp
+++ b/src/scripting/lua_fileops.hpp
@@ -24,6 +24,7 @@ namespace lua_fileops {
 
 int intf_have_file(lua_State*);
 int intf_read_file(lua_State*);
+int intf_canonical_path(lua_State*);
 int load_file(lua_State*);
 
 } // end namespace lua_fileops

--- a/src/scripting/lua_kernel_base.cpp
+++ b/src/scripting/lua_kernel_base.cpp
@@ -597,6 +597,7 @@ lua_kernel_base::lua_kernel_base()
 		{ "deprecated_message",       &intf_deprecated_message              },
 		{ "have_file",                &lua_fileops::intf_have_file          },
 		{ "read_file",                &lua_fileops::intf_read_file          },
+		{ "canonical_path",           &lua_fileops::intf_canonical_path     },
 		{ "textdomain",               &lua_common::intf_textdomain   		},
 		{ "tovconfig",                &lua_common::intf_tovconfig		},
 		{ "get_dialog_value",         &lua_gui2::intf_get_dialog_value		},


### PR DESCRIPTION
now wesnoth.require is able to detect when the same file is
required two times using different names (like a/../a/b.lua
a/b.lua) and will only execute it once.

for this a new function wesnoth.canonical_path was added