### PR TITLE
Remove description prefixes from translated strings (1.14)

### DIFF
--- a/po/wesnoth-ai/sk.po
+++ b/po/wesnoth-ai/sk.po
@@ -632,7 +632,7 @@ msgstr "Drak"
 #. [side]
 #: data/ai/micro_ais/scenarios/dragon.cfg:21
 msgid "team_name^Rowck"
-msgstr "team_name^Rowck"
+msgstr "Rowck"
 
 #. [side]: type=Dread Bat, id=Dreadful Bat
 #: data/ai/micro_ais/scenarios/dragon.cfg:33
@@ -773,12 +773,12 @@ msgstr "Saurovia"
 #. [side]
 #: data/ai/micro_ais/scenarios/goto.cfg:125
 msgid "team_name^Animals"
-msgstr "team_name^Zvieratá"
+msgstr "Zvieratá"
 
 #. [side]
 #: data/ai/micro_ais/scenarios/goto.cfg:138
 msgid "team_name^Ghosts"
-msgstr "team_name^Duchovia"
+msgstr "Duchovia"
 
 #. [event]
 #: data/ai/micro_ais/scenarios/goto.cfg:185
@@ -1459,12 +1459,12 @@ msgstr "Zdržiavanie"
 #. [side]: id=Bad Outlaw, type=Outlaw
 #: data/ai/micro_ais/scenarios/hang_out.cfg:23
 msgid "team_name^Bad Outlaw"
-msgstr "team_name^Zlý Štvanec"
+msgstr "Zlý Štvanec"
 
 #. [side]: id=Good Bandit, type=Bandit
 #: data/ai/micro_ais/scenarios/hang_out.cfg:39
 msgid "team_name^Good Bandit"
-msgstr "team_name^Dobrý Bandita"
+msgstr "Dobrý Bandita"
 
 #. [event]
 #: data/ai/micro_ais/scenarios/hang_out.cfg:61
@@ -1601,7 +1601,7 @@ msgstr "Pekzs"
 #. [side]: id=Pekzs, type=Saurian Soothsayer
 #: data/ai/micro_ais/scenarios/lurkers.cfg:204
 msgid "team_name^Pekzs"
-msgstr "team_name^Pekzs"
+msgstr "Pekzs"
 
 #. [side]: type=Saurian Oracle
 #: data/ai/micro_ais/scenarios/lurkers.cfg:220
@@ -1908,12 +1908,12 @@ msgstr "Banditi"
 #. [side]
 #: data/ai/micro_ais/scenarios/patrols.cfg:41
 msgid "team_name^Konrad"
-msgstr "team_name^Konrád"
+msgstr "Konrád"
 
 #. [side]
 #: data/ai/micro_ais/scenarios/patrols.cfg:56
 msgid "team_name^Urudin"
-msgstr "team_name^Urudín"
+msgstr "Urudín"
 
 #. [unit]: type=Orcish Slayer, id=Urudin
 #: data/ai/micro_ais/scenarios/patrols.cfg:114
@@ -2113,7 +2113,7 @@ msgstr "Langzar"
 #: data/ai/micro_ais/scenarios/protect_unit.cfg:24
 #: data/ai/micro_ais/scenarios/recruiting.cfg:23
 msgid "team_name^Langzhar"
-msgstr "team_name^Langhar"
+msgstr "Langhar"
 
 #. [side]: id=Koorzhar, type=Lieutenant
 #: data/ai/micro_ais/scenarios/protect_unit.cfg:34
@@ -2125,7 +2125,7 @@ msgstr "Korzár"
 #: data/ai/micro_ais/scenarios/protect_unit.cfg:41
 #: data/ai/micro_ais/scenarios/recruiting.cfg:38
 msgid "team_name^Koorzhar"
-msgstr "team_name^Korzár"
+msgstr "Korzár"
 
 #. [event]
 #: data/ai/micro_ais/scenarios/protect_unit.cfg:119
@@ -2329,7 +2329,7 @@ msgstr "Krehký Grnk"
 #. [side]: id=Grnk, type=Goblin Spearman
 #: data/ai/micro_ais/scenarios/scenario_micro_ai.cfg:27
 msgid "team_name^Grnk"
-msgstr "team_name^Grnk"
+msgstr "Grnk"
 
 #. [event]
 #. [test]: id=swarm
@@ -2915,7 +2915,7 @@ msgstr "Smrť všetkých gryfov"
 #. [side]
 #: data/ai/micro_ais/scenarios/wolves.cfg:42
 msgid "team_name^Wolves"
-msgstr "team_name^Vlci"
+msgstr "Vlci"
 
 #. [side]
 #: data/ai/micro_ais/scenarios/wolves.cfg:56

--- a/po/wesnoth-anl/bg.po
+++ b/po/wesnoth-anl/bg.po
@@ -62,7 +62,7 @@ msgstr ""
 #: data/multiplayer/scenarios/4p_A_New_Land.cfg:78
 #: data/multiplayer/scenarios/4p_A_New_Land.cfg:94
 msgid "teamname^Settlers"
-msgstr "teamname^Заселници"
+msgstr "Заселници"
 
 #. [side]: type=Death Knight
 #. [side]: type=Orcish Sovereign
@@ -71,7 +71,7 @@ msgstr "teamname^Заселници"
 #: data/multiplayer/scenarios/4p_A_New_Land.cfg:178
 #: data/multiplayer/scenarios/4p_A_New_Land.cfg:210
 msgid "teamname^Enemies"
-msgstr "teamname^Врагове"
+msgstr "Врагове"
 
 #. [side]: type=Death Knight
 #: data/multiplayer/scenarios/4p_A_New_Land.cfg:123
@@ -96,14 +96,14 @@ msgstr "Мал Шики"
 #. [side]
 #: data/multiplayer/scenarios/4p_A_New_Land.cfg:246
 msgid "teamname^Prisoners"
-msgstr "teamname^Затворници"
+msgstr "Затворници"
 
 #. [side]
 #: data/multiplayer/scenarios/4p_A_New_Land.cfg:270
 #, fuzzy
 #| msgid "teamname^Prisoners"
 msgid "teamname^Monsters"
-msgstr "teamname^Затворници"
+msgstr "Затворници"
 
 #. [message]: speaker=narrator
 #: data/multiplayer/scenarios/4p_A_New_Land.cfg:466

--- a/po/wesnoth-editor/af.po
+++ b/po/wesnoth-editor/af.po
@@ -551,7 +551,7 @@ msgstr ""
 #, fuzzy
 #| msgid "(Player)^None"
 msgid "player^None"
-msgstr "(Speler)^Geen"
+msgstr "Geen"
 
 #: src/gui/dialogs/editor/set_starting_position.cpp:97
 msgid "Player $player_number"

--- a/po/wesnoth-editor/cs.po
+++ b/po/wesnoth-editor/cs.po
@@ -182,7 +182,7 @@ msgstr "Po podzimu"
 #. [theme]: id=editor
 #: data/themes/editor.cfg:11
 msgid "theme^Editor"
-msgstr "theme^Editor"
+msgstr "Editor"
 
 #. [menu]: id=menu-editor-file, type=turbo
 #: data/themes/editor.cfg:61

--- a/po/wesnoth-editor/el.po
+++ b/po/wesnoth-editor/el.po
@@ -558,7 +558,7 @@ msgstr ""
 
 #: src/gui/dialogs/editor/set_starting_position.cpp:84
 msgid "player^None"
-msgstr "player^None"
+msgstr ""
 
 #: src/gui/dialogs/editor/set_starting_position.cpp:97
 msgid "Player $player_number"

--- a/po/wesnoth-editor/lt.po
+++ b/po/wesnoth-editor/lt.po
@@ -171,7 +171,7 @@ msgstr "Po Kritimo"
 #. [theme]: id=editor
 #: data/themes/editor.cfg:11
 msgid "theme^Editor"
-msgstr "theme^Redaktorius"
+msgstr "Redaktorius"
 
 #. [menu]: id=menu-editor-file, type=turbo
 #: data/themes/editor.cfg:61

--- a/po/wesnoth-httt/af.po
+++ b/po/wesnoth-httt/af.po
@@ -536,7 +536,7 @@ msgstr "Ons kan nie meer terugkyk nie. Ons moet vinnig gaan!"
 #. [scenario]: id=02_Blackwater_Port
 #: data/campaigns/Heir_To_The_Throne/scenarios/02_Blackwater_Port.cfg:4
 msgid "scenario name^Blackwater Port"
-msgstr "draaiboek naam^Swartwater Hawe"
+msgstr "Swartwater Hawe"
 
 #. [objective]: condition=win
 #: data/campaigns/Heir_To_The_Throne/scenarios/02_Blackwater_Port.cfg:21

--- a/po/wesnoth-httt/it.po
+++ b/po/wesnoth-httt/it.po
@@ -534,7 +534,7 @@ msgstr ""
 #. [scenario]: id=02_Blackwater_Port
 #: data/campaigns/Heir_To_The_Throne/scenarios/02_Blackwater_Port.cfg:4
 msgid "scenario name^Blackwater Port"
-msgstr "scenario name^Blackwater Port"
+msgstr ""
 
 #. [objective]: condition=win
 #: data/campaigns/Heir_To_The_Throne/scenarios/02_Blackwater_Port.cfg:21

--- a/po/wesnoth-l/ru.po
+++ b/po/wesnoth-l/ru.po
@@ -1767,7 +1767,7 @@ msgstr "Питчер"
 #. [message]: speaker=Pitcher
 #: data/campaigns/Liberty/scenarios/07_The_Hunters.cfg:162
 msgid "whisper^<i>Baldras!</i>"
-msgstr "шепчет^<i>Балдрас!</i>"
+msgstr "<i>Балдрас!</i>"
 
 #. [message]: speaker=Harper
 #: data/campaigns/Liberty/scenarios/07_The_Hunters.cfg:166

--- a/po/wesnoth-lib/en_GB.po
+++ b/po/wesnoth-lib/en_GB.po
@@ -5665,11 +5665,11 @@ msgstr "Published ($local_version| installed), outdated on server"
 
 #: src/gui/dialogs/addon/manager.cpp:288 src/gui/widgets/addon_list.cpp:114
 msgid "addon_state^Installed, not ready to publish"
-msgstr "addon_state^Installed, not ready to publish"
+msgstr "Installed, not ready to publish"
 
 #: src/gui/dialogs/addon/manager.cpp:289 src/gui/widgets/addon_list.cpp:114
 msgid "addon_state^Ready to publish"
-msgstr "addon_state^Ready to publish"
+msgstr "Ready to publish"
 
 #: src/gui/dialogs/addon/manager.cpp:293 src/gui/widgets/addon_list.cpp:126
 msgid "addon_state^Installed, broken"

--- a/po/wesnoth-lib/it.po
+++ b/po/wesnoth-lib/it.po
@@ -5431,7 +5431,7 @@ msgstr "$first e $second"
 #. TRANSLATORS: Formats the first two elements of a conjunctive list.
 #: src/formula/string_utils.cpp:254
 msgid "conjunct start^$first, $second"
-msgstr "conjunct start^$first, $second"
+msgstr "$first, $second"
 
 #. TRANSLATORS: Formats successive elements of a conjunctive list.
 #: src/formula/string_utils.cpp:258
@@ -5456,7 +5456,7 @@ msgstr "$first, $second"
 #. TRANSLATORS: Formats successive elements of a disjunctive list.
 #: src/formula/string_utils.cpp:276
 msgid "disjunct mid^$prefix, $next"
-msgstr "disjunct mid^$prefix, $next"
+msgstr "$prefix, $next"
 
 #. TRANSLATORS: Formats the final element of a disjunctive list.
 #: src/formula/string_utils.cpp:279

--- a/po/wesnoth-nr/ga.po
+++ b/po/wesnoth-nr/ga.po
@@ -4312,7 +4312,7 @@ msgstr ""
 #. [message]: speaker=Tallin
 #: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:435
 msgid "whisper^Oh...!"
-msgstr "whisper^Ach...!"
+msgstr "Ach...!"
 
 #. [message]: speaker=Father Morvin
 #: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:442

--- a/po/wesnoth-nr/lt.po
+++ b/po/wesnoth-nr/lt.po
@@ -2852,7 +2852,7 @@ msgstr "teisingumo lazda"
 #. [option]
 #: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1493
 msgid "rod of justice^Leave it"
-msgstr "teisingumo lazda^Palikti"
+msgstr "Palikti"
 
 #. [message]: speaker=narrator
 #: data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg:1520
@@ -4926,7 +4926,7 @@ msgstr ""
 #. [message]: speaker=Tallin
 #: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:425
 msgid "whisper^Camerin, you know him?"
-msgstr "šnabžda^Kamerinai, tu jį pažįsti?"
+msgstr "Kamerinai, tu jį pažįsti?"
 
 #. [message]: speaker=Camerin
 #: data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg:430

--- a/po/wesnoth-tutorial/hr.po
+++ b/po/wesnoth-tutorial/hr.po
@@ -1719,7 +1719,7 @@ msgstr ""
 #. [unit_type]: id=Fighteress, race=human
 #: data/campaigns/tutorial/units/Fighteress.cfg:4
 msgid "female^Fighter"
-msgstr "žena^Borac"
+msgstr "Borac"
 
 #. [unit_type]: id=Quintain, race=mechanical
 #: data/campaigns/tutorial/units/Quintain.cfg:4
@@ -1754,7 +1754,7 @@ msgstr ""
 #, fuzzy
 #| msgid "female^Fighter"
 msgid "female^Warrior"
-msgstr "žena^Borac"
+msgstr "Borac"
 
 #. [message]: speaker=narrator
 #: data/campaigns/tutorial/utils/utils.cfg:57

--- a/po/wesnoth-tutorial/sv.po
+++ b/po/wesnoth-tutorial/sv.po
@@ -55,7 +55,7 @@ msgstr "Wesnoths Träningsspel, del I"
 #: data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg:26
 #: data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg:99
 msgid "team_name^Student"
-msgstr "team_name^Student"
+msgstr ""
 
 #. [unit]: id=Delfador, type=Elder Mage
 #: data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg:74
@@ -953,7 +953,7 @@ msgstr "Wesnoths Träningsspel, del II"
 #. [side]: type=Orcish Warrior, id=Thrag
 #: data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg:43
 msgid "team_name^Orcs"
-msgstr "team_name^Orcs"
+msgstr ""
 
 #. [side]: type=Orcish Warrior, id=Thrag
 #: data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg:47

--- a/po/wesnoth-units/en_GB.po
+++ b/po/wesnoth-units/en_GB.po
@@ -5994,7 +5994,7 @@ msgstr "Wose"
 #: data/core/units/undead/Corpse_Soulless.cfg:212
 #: data/core/units/undead/Corpse_Walking.cfg:211
 msgid "wc_variation^Wolf"
-msgstr "wc_variation^Wolf"
+msgstr "Wolf"
 
 #. [variation]
 #: data/core/units/undead/Corpse_Soulless.cfg:225

--- a/po/wesnoth-utbs/en_GB.po
+++ b/po/wesnoth-utbs/en_GB.po
@@ -15593,7 +15593,7 @@ msgstr ""
 #. [unit_type]: id=Quenoth Shyde, race=elf
 #: data/campaigns/Under_the_Burning_Suns/units/quenoth/Shyde.cfg:5
 msgid "female^Quenoth Shyde"
-msgstr "female^Quenoth Shyde"
+msgstr "Quenoth Shyde"
 
 #. [unit_type]: id=Quenoth Shyde, race=elf
 #: data/campaigns/Under_the_Burning_Suns/units/quenoth/Shyde.cfg:23
@@ -15677,7 +15677,7 @@ msgstr ""
 #. [unit_type]: id=Quenoth Sun Sylph, race=elf
 #: data/campaigns/Under_the_Burning_Suns/units/quenoth/Sun_Sylph.cfg:5
 msgid "female^Quenoth Sun Sylph"
-msgstr "female^Quenoth Sun Sylph"
+msgstr "Quenoth Sun Sylph"
 
 #. [unit_type]: id=Quenoth Sun Sylph, race=elf
 #: data/campaigns/Under_the_Burning_Suns/units/quenoth/Sun_Sylph.cfg:25

--- a/po/wesnoth/af.po
+++ b/po/wesnoth/af.po
@@ -1670,11 +1670,11 @@ msgstr ""
 
 #: data/core/macros/items.cfg:274
 msgid "holy water^Take it"
-msgstr "heilige water^vat dit"
+msgstr "vat dit"
 
 #: data/core/macros/items.cfg:275
 msgid "holy water^Leave it"
-msgstr "heilige water^los dit"
+msgstr "los dit"
 
 #: data/core/macros/items.cfg:276
 #, fuzzy
@@ -1751,11 +1751,11 @@ msgstr "Moet $unit.name die drietandvurk op tel?"
 
 #: data/core/macros/items.cfg:514
 msgid "storm trident^Take it"
-msgstr "storm drietandvurk^los dit"
+msgstr "los dit"
 
 #: data/core/macros/items.cfg:515
 msgid "storm trident^Leave it"
-msgstr "storm drietandvurk^los dit"
+msgstr "los dit"
 
 #: data/core/macros/items.cfg:516
 msgid ""
@@ -3788,13 +3788,13 @@ msgstr ""
 #. [lua]: set_status
 #: data/lua/wml/harm_unit.lua:126 src/actions/attack.cpp:1061
 msgid "female^poisoned"
-msgstr "vroumens^vergiftig"
+msgstr "vergiftig"
 
 #. #-#-#-#-#  wesnoth.wml.pot (PACKAGE VERSION)  #-#-#-#-#
 #. [lua]: set_status
 #: data/lua/wml/harm_unit.lua:128 src/actions/attack.cpp:1068
 msgid "female^slowed"
-msgstr "vroumens^vertraag"
+msgstr "vertraag"
 
 #. #-#-#-#-#  wesnoth.wml.pot (PACKAGE VERSION)  #-#-#-#-#
 #. [lua]: set_status
@@ -3806,7 +3806,7 @@ msgstr "vertraag"
 #. [lua]: set_status
 #: data/lua/wml/harm_unit.lua:129 src/actions/attack.cpp:1074
 msgid "female^petrified"
-msgstr "vroumens^versteen"
+msgstr "versteen"
 
 #. #-#-#-#-#  wesnoth.wml.pot (PACKAGE VERSION)  #-#-#-#-#
 #. [lua]: set_status
@@ -3818,7 +3818,7 @@ msgstr "versteen"
 #: data/lua/wml/harm_unit.lua:130
 #, fuzzy
 msgid "female^unhealable"
-msgstr "vroumens^"
+msgstr ""
 
 #. [lua]: set_status
 #: data/lua/wml/harm_unit.lua:130
@@ -8123,12 +8123,12 @@ msgstr "chaoties"
 #, fuzzy
 #| msgid "female^lawful"
 msgid "lawful"
-msgstr "vroumens^wettig"
+msgstr "wettig"
 
 #: src/units/types.cpp:545 src/units/types.hpp:182
 #, fuzzy
 msgid "liminal"
-msgstr "vroumens^"
+msgstr ""
 
 #: src/units/types.cpp:545 src/units/types.hpp:180
 msgid "neutral"
@@ -8136,20 +8136,20 @@ msgstr "neutraal"
 
 #: src/units/types.cpp:546 src/units/types.cpp:912
 msgid "female^chaotic"
-msgstr "vroumens^chaoties"
+msgstr "chaoties"
 
 #: src/units/types.cpp:546 src/units/types.cpp:910
 msgid "female^lawful"
-msgstr "vroumens^wettig"
+msgstr "wettig"
 
 #: src/units/types.cpp:546 src/units/types.cpp:911
 msgid "female^neutral"
-msgstr "vroumens^neutraal"
+msgstr "neutraal"
 
 #: src/units/types.cpp:547 src/units/types.cpp:913
 #, fuzzy
 msgid "female^liminal"
-msgstr "vroumens^"
+msgstr ""
 
 #: src/units/unit.cpp:1775
 msgid "$attack_list|: $effect_description"

--- a/po/wesnoth/af.po
+++ b/po/wesnoth/af.po
@@ -1751,11 +1751,11 @@ msgstr "Moet $unit.name die drietandvurk op tel?"
 
 #: data/core/macros/items.cfg:514
 msgid "storm trident^Take it"
-msgstr "los dit"
+msgstr ""
 
 #: data/core/macros/items.cfg:515
 msgid "storm trident^Leave it"
-msgstr "los dit"
+msgstr "Los dit"
 
 #: data/core/macros/items.cfg:516
 msgid ""

--- a/po/wesnoth/cs.po
+++ b/po/wesnoth/cs.po
@@ -6087,7 +6087,7 @@ msgstr "Neznámý věk"
 #: src/game_initialization/lobby_data.cpp:353
 #: src/game_initialization/lobby_data.cpp:386
 msgid "scenario_abbreviation^S"
-msgstr "scenario_abbreviation^S"
+msgstr "S"
 
 #: src/game_initialization/lobby_data.cpp:372
 msgid "Remote scenario"
@@ -6096,7 +6096,7 @@ msgstr "Vzdálený scénář"
 #: src/game_initialization/lobby_data.cpp:394
 #: src/game_initialization/lobby_data.cpp:417
 msgid "campaign_abbreviation^C"
-msgstr "campaign_abbreviation^C"
+msgstr "C"
 
 #: src/game_initialization/lobby_data.cpp:422
 msgid "Unknown scenario"

--- a/po/wesnoth/et.po
+++ b/po/wesnoth/et.po
@@ -6860,7 +6860,7 @@ msgstr ""
 
 #: src/map_command_handler.hpp:218
 msgid "do not translate the 'all'^[all|<command>]"
-msgstr "ära tõlgi klauslit 'all'^[all|<command>]"
+msgstr ""
 
 #: src/map_command_handler.hpp:263
 msgid "Missing argument $arg_id"
@@ -7039,7 +7039,7 @@ msgstr "Lülita osapool arvuti või inimese juhitavaks."
 
 #: src/menu_events.cpp:1186 src/menu_events.cpp:1188
 msgid "do not translate the on/off^[<side> [on/off]]"
-msgstr "ära tõlgi klauslit on/off^[<side> [on/off]]"
+msgstr ""
 
 #: src/menu_events.cpp:1187
 #, fuzzy

--- a/po/wesnoth/lt.po
+++ b/po/wesnoth/lt.po
@@ -30,7 +30,7 @@ msgstr "Spausti išsaugotus žaidimus"
 #. [option]: id=gzip
 #: data/advanced_preferences.cfg:9
 msgid "save_compression^Gzip"
-msgstr "save_compression^Gzip"
+msgstr "Gzip"
 
 #. [option]: id=gzip
 #: data/advanced_preferences.cfg:10
@@ -40,7 +40,7 @@ msgstr "Numatytas spaudimas, greičiau"
 #. [option]: id=bzip2
 #: data/advanced_preferences.cfg:14
 msgid "save_compression^Bzip2"
-msgstr "save_compression^Bzip2"
+msgstr "Bzip2"
 
 #. [option]: id=bzip2
 #: data/advanced_preferences.cfg:15

--- a/po/wesnoth/nl.po
+++ b/po/wesnoth/nl.po
@@ -6963,7 +6963,7 @@ msgstr ""
 
 #: src/map_command_handler.hpp:218
 msgid "do not translate the 'all'^[all|<command>]"
-msgstr "vertaal de 'all'^[all|<command>] niet"
+msgstr ""
 
 #: src/map_command_handler.hpp:263
 msgid "Missing argument $arg_id"
@@ -7127,7 +7127,7 @@ msgstr "Schakel een kant naar/van AI controle."
 
 #: src/menu_events.cpp:1186 src/menu_events.cpp:1188
 msgid "do not translate the on/off^[<side> [on/off]]"
-msgstr "vertaal de on/off^[<zijde>[on/off]] niet"
+msgstr "[<zijde>[on/off]]"
 
 #: src/menu_events.cpp:1187
 msgid "Switch a side to/from idle state."

--- a/po/wesnoth/pl.po
+++ b/po/wesnoth/pl.po
@@ -5453,7 +5453,7 @@ msgstr "Modyfikacja"
 
 #: src/addon/info.cpp:175
 msgid "addon_type^Core"
-msgstr "addon_type^Podstawowy"
+msgstr "Podstawowy"
 
 #: src/addon/info.cpp:177
 msgid "addon_type^Resources"

--- a/po/wesnoth/sv.po
+++ b/po/wesnoth/sv.po
@@ -5268,7 +5268,7 @@ msgstr "(okänd)"
 
 #: src/addon/info.cpp:221
 msgid "unit_byte^B"
-msgstr "unit_byte^B"
+msgstr "B"
 
 #: src/addon/manager_ui.cpp:82 src/addon/manager_ui.cpp:293
 msgid "Network communication error."


### PR DESCRIPTION
Clean-up as described in #2965. See commit message for details.