### PR TITLE
[1.15] Use multiple lines for help, and replace "do not translate part" with translation notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
  ### Language and i18n
    * Updated translations: French, Portuguese (Brazil)
    * Set up for translating the Wings of Victory campaign (PR#4265)
+   * Changed the :help command's output to split over multiple lines
+   * Added translatable explanations of :droid, :help and :idle's arguments
 
 ## Version 1.15.1
  ### Editor

--- a/src/map_command_handler.hpp
+++ b/src/map_command_handler.hpp
@@ -215,7 +215,10 @@ protected:
 		register_command("help", &map_command_handler<Worker>::help,
 			_("Available commands list and command-specific help. "
 				"Use \"help all\" to include currently unavailable commands."),
-			_("do not translate the 'all'^[all|<command>]"));
+			// TRANSLATORS: These are the arguments accepted by the "help" command,
+			// which are either "all" or the name of another command.
+			// As with the command's name, "all" is hardcoded, and shouldn't change in the translation.
+			_("[all|<command>]\n“all” = overview of all commands, <command> = name of a specific command (provides more detail)"));
 	}
 	//derived classes initialize the map overriding this function
 	virtual void init_map() = 0;
@@ -323,15 +326,21 @@ protected:
 				ss << _(" No help available.");
 			}
 			else {
-				ss << " - " << c->help;
+				ss << " - " << c->help << "\n";
 			}
 			if (!c->usage.empty()) {
-				ss << " " << _("Usage:") << " " << cmd_prefix_ << cmd << " " << c->usage;
+				ss << _("Usage:") << " " << cmd_prefix_ << cmd << " " << c->usage << "\n";
 			}
-			ss << get_command_flags_description(*c);
+			const auto flags_description = get_command_flags_description(*c);
+			if (!flags_description.empty()) {
+				// This shares the objectives dialog's translation of "Notes:"
+				ss << _("Notes:") << " " << get_command_flags_description(*c) << "\n";
+			}
 			const std::vector<std::string> l = get_aliases(cmd);
 			if (!l.empty()) {
-				ss << " (" << _("aliases:") << " " << utils::join(l, " ") << ")";
+				// TRANSLATORS: alternative names for command-line commands, only shown if
+				// there is at least one of them.
+				ss << _n("command^Alias:", "Aliases:", l.size()) << " " << utils::join(l, " ") << "\n";
 			}
 			print(_("help"), ss.str());
 		}

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -1188,9 +1188,15 @@ protected:
 
 		register_command("refresh", &console_handler::do_refresh, _("Refresh gui."));
 		register_command("droid", &console_handler::do_droid, _("Switch a side to/from AI control."),
-				_("do not translate the on/off/full^[<side> [on/off/full]]"));
+				// TRANSLATORS: These are the arguments accepted by the "droid" command,
+				// which must be a side-number and then optionally one of "on", "off" or "full".
+				// As with the command's name, "on", "off" and "full" are hardcoded, and shouldn't change in the translation.
+				_("[<side> [on/off/full]]\n“on” = enable but retain vision, “full” = as if it’s controlled by another player"));
 		register_command("idle", &console_handler::do_idle, _("Switch a side to/from idle state."),
-				_("do not translate the on/off^[<side> [on/off]]"));
+				// TRANSLATORS: These are the arguments accepted by the "idle" command,
+				// which must be a side-number and then optionally "on" or "off".
+				// As with the command's name, "on" and "off" are hardcoded, and shouldn't change in the translation.
+				_("command_idle^[<side> [on/off]]"));
 		register_command("theme", &console_handler::do_theme);
 		register_command("control", &console_handler::do_control,
 				_("Assign control of a side to a different player or observer."), _("<side> <nickname>"), "N");
@@ -1200,7 +1206,7 @@ protected:
 		register_command("foreground", &console_handler::do_foreground, _("Debug foreground terrain."), "", "D");
 		register_command(
 				"layers", &console_handler::do_layers, _("Debug layers from terrain under the mouse."), "", "D");
-		register_command("fps", &console_handler::do_fps, _("Show fps."));
+		register_command("fps", &console_handler::do_fps, _("Show fps (Frames Per Second)."));
 		register_command("benchmark", &console_handler::do_benchmark);
 		register_command("save", &console_handler::do_save, _("Save game."));
 		register_alias("save", "w");


### PR DESCRIPTION
This was inspired by @Wedge009 's #4271 , where these were one of the hotspots for problems.

However, I'm wondering if we should suggest that the translators add translations of what the non-translated English parts mean. For example:
> en: `[all|<command>]`
> de: `[all|<Befehl>]` <i>(»all« = Hilfe für jedem Befehl)</i>

For the `droid` command's `on` and `full`, that might be useful for English too.