### PR TITLE
Remove non-functional methods from player.hpp.

### DIFF
--- a/src/server/player.hpp
+++ b/src/server/player.hpp
@@ -21,8 +21,6 @@
 
 namespace wesnothd {
 
-class game;
-
 class player
 {
 public:
@@ -51,19 +49,6 @@ public:
 	const simple_wml::node* config_address() const { return &cfg_; }
 
 	bool is_message_flooding();
-
-	/**
-	 * @return true iff the player is in a game
-	 */
-	bool in_game() const { return get_game() != nullptr; }
-
-	/**
-	 * @return a pointer to the game the player is in, or nullptr if he/she is not
-	 * in a game at the moment
-	 */
-	const game* get_game() const;
-
-	void set_game(game* g);
 
 	void set_moderator(bool moderator) { moderator_ = moderator; }
 	bool is_moderator() const { return moderator_; }

--- a/src/server/player_connection.hpp
+++ b/src/server/player_connection.hpp
@@ -31,6 +31,8 @@
 
 namespace wesnothd
 {
+class game;
+
 class player_record
 {
 public:


### PR DESCRIPTION
Attempting to call them results in an error during linking, for example:
undefined reference to `wesnothd::player::set_game(wesnothd::game*)'