### PR TITLE
Trigger an L4 deprecation message for [terrain_type]vision_alias=

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
    * Added translatable explanations of :droid, :help and :idle's arguments
  ### WML engine
    * Ranges can now have upper limit "infinity" instead of using a big number like "99" or "99999"
+   * Print a deprecation warning for `[terrain_type]`'s partly-implemented `vision_alias`
  ### Miscellaneous and bug fixes
    * Fixed :droid's arguments not all being optional (Issue#4308)
 

--- a/data/schema/terrain/types.cfg
+++ b/data/schema/terrain/types.cfg
@@ -22,8 +22,6 @@
 	{SIMPLE_KEY aliasof string_list}
 	{SIMPLE_KEY def_alias string_list}
 	{SIMPLE_KEY mvt_alias string_list}
-	{SIMPLE_KEY vision_alias string_list}
-	# TODO: Wonder if there's a jamming_alias...
 	{SIMPLE_KEY income_description t_string}
 	{SIMPLE_KEY income_description_ally t_string}
 	{SIMPLE_KEY income_description_enemy t_string}

--- a/src/terrain/terrain.cpp
+++ b/src/terrain/terrain.cpp
@@ -12,6 +12,8 @@
    See the COPYING file for more details.
 */
 
+#include "deprecation.hpp"
+#include "game_version.hpp"
 #include "gettext.hpp"
 #include "log.hpp"
 #include "serialization/string_utils.hpp"
@@ -149,6 +151,10 @@ terrain_type::terrain_type(const config& cfg) :
 
 	const t_translation::ter_list& vision_alias = t_translation::read_list(cfg["vision_alias"].str());
 	if(!vision_alias.empty()) {
+		// Vision costs are calculated in movetype.cpp, but they're calculated based on gamemap::underlying_mvt_terrain().
+		// Having vision costs that are different to movement costs is still supported, but having separate aliases seems
+		// an edge case that shouldn't be introduced until we're ready to test it.
+		deprecated_message("vision_alias", DEP_LEVEL::REMOVED, {1, 15, 2}, "vision_alias was never completely implemented, vision is calculated using mvt_alias instead");
 		vision_type_ = vision_alias;
 	}
 


### PR DESCRIPTION
The feature was never added, a deprecation message saying that it's been
removed is the closest option to the situation. While terrain.cpp itself
supports vision_alias, it was never added to the calculations in movetype.cpp,
therefore it never affected units' vision. It's also not shown in the help
about the terrain.

This doesn't affect the features of units having vision costs different to
movement costs, or of units having a different number of vision points to
movement points, both of which are still supported.

While I'd encourage anyone who wants to implement vision_alias to do so, at the
moment I feel that the still-supported features in the same area haven't been
explored yet, and that vision_alias isn't going to developed before 1.16.0 is
released.

Issue #3148 would be closed by this, as it's a report that the feature isn't implemented.
Would remove the question of support for terrain_vision and terrain_jamming from #4227 .