### PR TITLE
[WIP] Update a game's ID when advancing to the next scenario.

### DIFF
--- a/src/server/game.cpp
+++ b/src/server/game.cpp
@@ -2045,4 +2045,26 @@ void game::send_server_message(const char* message, const socket_ptr& sock, simp
 		send_to_player(sock, doc);
 	}
 }
+
+void game::set_next_id()
+{
+	// ID directly accessible from the game instance
+	id_ = id_num++;
+
+	// ID used for list of games to be displayed in the lobby
+	description_->set_attr_int("id", id_);
+
+	// ID used for list of users to be displayed in the lobby
+	for(const auto p : players_) {
+		player_connections_.get<socket_t>().find(p)->info().mark_available(id_, name_);
+	}
+	for(const auto o : observers_) {
+		player_connections_.get<socket_t>().find(o)->info().mark_available(id_, name_);
+	}
+}
+
+void game::set_next_id_bmi()
+{
+	player_connections_.modify(player_connections_.find(owner_), std::bind(&player_record::set_next_game_id, _1));
+}
 } // namespace wesnothd

--- a/src/server/game.hpp
+++ b/src/server/game.hpp
@@ -319,6 +319,12 @@ public:
 	 * Function which returns true iff 'player' controls any of the sides spcified in 'sides'.
 	 */
 	bool controls_side(const std::vector<int>& sides, const socket_ptr& player) const;
+	/**
+	 * Updates the game's id to the next available value.
+	 * For example, for when the next scenario of an MP campaign is loaded.
+	 */
+	void set_next_id_bmi();
+	void set_next_id();
 
 private:
 	// forbidden operations

--- a/src/server/player_connection.cpp
+++ b/src/server/player_connection.cpp
@@ -33,6 +33,14 @@ int player_record::game_id() const
 	return game_ ? game_->id() : 0;
 }
 
+void player_record::set_next_game_id()
+{
+	if(game_)
+	{
+		game_->set_next_id();
+	}
+}
+
 void player_record::set_game(std::shared_ptr<game> new_game)
 {
 	game_ = new_game;

--- a/src/server/player_connection.hpp
+++ b/src/server/player_connection.hpp
@@ -70,6 +70,8 @@ public:
 
 	int game_id() const;
 
+	void set_next_game_id();
+
 	void set_game(std::shared_ptr<game> new_game);
 
 	void enter_lobby();

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -403,6 +403,7 @@ void server::setup_handlers()
 	SETUP_HANDLER("sl", &server::searchlog_handler);
 	SETUP_HANDLER("dul", &server::dul_handler);
 	SETUP_HANDLER("deny_unregistered_login", &server::dul_handler);
+	SETUP_HANDLER("stopgame", &server::stopgame);
 
 #undef SETUP_HANDLER
 }
@@ -2816,6 +2817,26 @@ void server::dul_handler(const std::string& /*issuer_name*/,
 	} catch(const utf8::invalid_utf8_exception& e) {
 		ERR_SERVER << "While handling dul (deny unregistered logins), caught an invalid utf8 exception: " << e.what()
 				   << std::endl;
+	}
+}
+
+void server::stopgame(const std::string& /*issuer_name*/,
+		const std::string& /*query*/,
+		std::string& parameters,
+		std::ostringstream* out)
+{
+	auto player = player_connections_.get<name_t>().find(parameters);
+	
+	if(player != player_connections_.get<name_t>().end()){
+		std::shared_ptr<game> g = player->get_game();
+		if(g){
+			*out << "Player '" << parameters << "' is in game with id '" << g->id() << "' named '" << g->name() << "'.  Ending game...";
+			delete_game(g->id());
+		} else {
+			*out << "Player '" << parameters << "' is not currently in a game.";
+		}
+	} else {
+		*out << "Player '" << parameters << "' is not currently logged in.";
 	}
 }
 

--- a/src/server/server.hpp
+++ b/src/server/server.hpp
@@ -219,6 +219,7 @@ private:
 	void motd_handler(const std::string &, const std::string &, std::string &, std::ostringstream *);
 	void searchlog_handler(const std::string &, const std::string &, std::string &, std::ostringstream *);
 	void dul_handler(const std::string &, const std::string &, std::string &, std::ostringstream *);
+	void stopgame(const std::string &, const std::string &, std::string &, std::ostringstream *);
 
 #ifndef _WIN32
 	void handle_sighup(const boost::system::error_code& error, int signal_number);


### PR DESCRIPTION
On receiving "store_next_scenario", increment wesnothd's game id counter and assign the game the new id.
Currently this is relevant for when an MP campaign advances to the next scenario, in order to avoid primary key conflicts as well as insert a new game_info row for the new scenario.

Also fixes #4281 by adding a db call in "store_next_scenario" to insert the next scenario's game_info row.