### PR TITLE
[1.14] Use multiple lines for help, and replace "do not translate part" with translation notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -53,6 +53,8 @@
  ### Language and i18n
    * Updated translations: British English, Chinese (Traditional), Dutch,
      French, German, Spanish, Turkish, Portuguese (Brazil), Ukrainian
+   * Changed the :help command's output to split over multiple lines
+   * Added translatable explanations of :droid, :help and :idle's arguments
  ### Multiplayer
    * A New Land:
      * Help menu can be accessed in any turn and doesn't pause the game

--- a/src/map_command_handler.hpp
+++ b/src/map_command_handler.hpp
@@ -215,7 +215,10 @@ protected:
 		register_command("help", &map_command_handler<Worker>::help,
 			_("Available commands list and command-specific help. "
 				"Use \"help all\" to include currently unavailable commands."),
-			_("do not translate the 'all'^[all|<command>]"));
+			// TRANSLATORS: These are the arguments accepted by the "help" command,
+			// which are either "all" or the name of another command.
+			// As with the command's name, "all" is hardcoded, and shouldn't change in the translation.
+			_("[all|<command>]\n“all” = overview of all commands, <command> = name of a specific command (provides more detail)"));
 	}
 	//derived classes initialize the map overriding this function
 	virtual void init_map() = 0;
@@ -323,15 +326,21 @@ protected:
 				ss << _(" No help available.");
 			}
 			else {
-				ss << " - " << c->help;
+				ss << " - " << c->help << "\n";
 			}
 			if (!c->usage.empty()) {
-				ss << " " << _("Usage:") << " " << cmd_prefix_ << cmd << " " << c->usage;
+				ss << _("Usage:") << " " << cmd_prefix_ << cmd << " " << c->usage << "\n";
 			}
-			ss << get_command_flags_description(*c);
+			const auto flags_description = get_command_flags_description(*c);
+			if (!flags_description.empty()) {
+				// This shares the objectives dialog's translation of "Notes:"
+				ss << _("Notes:") << " " << get_command_flags_description(*c) << "\n";
+			}
 			const std::vector<std::string> l = get_aliases(cmd);
 			if (!l.empty()) {
-				ss << " (" << _("aliases:") << " " << utils::join(l, " ") << ")";
+				// TRANSLATORS: alternative names for command-line commands, only shown if
+				// there is at least one of them.
+				ss << _n("command^Alias:", "Aliases:", l.size()) << " " << utils::join(l, " ") << "\n";
 			}
 			print(_("help"), ss.str());
 		}

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -1183,9 +1183,15 @@ protected:
 
 		register_command("refresh", &console_handler::do_refresh, _("Refresh gui."));
 		register_command("droid", &console_handler::do_droid, _("Switch a side to/from AI control."),
-				_("do not translate the on/off^[<side> [on/off]]"));
+				// TRANSLATORS: These are the arguments accepted by the "droid" command,
+				// which must be a side-number and then optionally one of "on", "off" or "full".
+				// As with the command's name, "on" and "off" are hardcoded, and shouldn't change in the translation.
+				_("[<side> [on/off]]\n“on” = enable control by the AI, “off” = side is controlled by the player"));
 		register_command("idle", &console_handler::do_idle, _("Switch a side to/from idle state."),
-				_("do not translate the on/off^[<side> [on/off]]"));
+				// TRANSLATORS: These are the arguments accepted by the "idle" command,
+				// which must be a side-number and then optionally "on" or "off".
+				// As with the command's name, "on" and "off" are hardcoded, and shouldn't change in the translation.
+				_("command_idle^[<side> [on/off]]"));
 		register_command("theme", &console_handler::do_theme);
 		register_command("control", &console_handler::do_control,
 				_("Assign control of a side to a different player or observer."), _("<side> <nickname>"), "N");
@@ -1195,7 +1201,7 @@ protected:
 		register_command("foreground", &console_handler::do_foreground, _("Debug foreground terrain."), "", "D");
 		register_command(
 				"layers", &console_handler::do_layers, _("Debug layers from terrain under the mouse."), "", "D");
-		register_command("fps", &console_handler::do_fps, _("Show fps."));
+		register_command("fps", &console_handler::do_fps, _("Show fps (Frames Per Second)."));
 		register_command("benchmark", &console_handler::do_benchmark);
 		register_command("save", &console_handler::do_save, _("Save game."));
 		register_alias("save", "w");


### PR DESCRIPTION
Backport of #4276

This removes all of the "do not translate part^string part" strings, replacing
them with more help in English and a place for translators to explain what the
untranslatable "all" means. For commands where the usage has notes about the
arguments, this embeds the \n in the strings passed to register_command; that
seems a reasonable balance between usability and effort to implement it.

Cherry-picking between 1.14 and 1.15: In 1.14.x, the "droid" command only has
options "on" and "off". The "full" option was only added in 1.15.