### PR TITLE
wmlxgettext: fix #4275: not handle objectives.lua's turn counter

### DIFF
--- a/data/tools/pywmlx/state/lua_states.py
+++ b/data/tools/pywmlx/state/lua_states.py
@@ -77,7 +77,7 @@ class LuaCommentState:
 
 class LuaStr00:
     def __init__(self):
-        self.regex = re.compile(r'\b_\b\s*\(')
+        self.regex = re.compile(r'((?:_)|(?:.*\(_)|(?:.*?\s+_))\s*\(')
         self.iffail = 'lua_str01'
 
     def run(self, xline, lineno, match):

--- a/data/tools/pywmlx/state/lua_states.py
+++ b/data/tools/pywmlx/state/lua_states.py
@@ -77,7 +77,7 @@ class LuaCommentState:
 
 class LuaStr00:
     def __init__(self):
-        self.regex = re.compile(r'((?:_)|(?:.*\(_)|(?:.*?\s+_))\s*\(')
+        self.regex = re.compile(r'((?:_)|(?:.*?\(_)|(?:.*?\s+_))\s*\(')
         self.iffail = 'lua_str01'
 
     def run(self, xline, lineno, match):

--- a/data/tools/wmlxgettext
+++ b/data/tools/wmlxgettext
@@ -54,7 +54,7 @@ def commandline(args):
     parser.add_argument(
         '--version',
         action='version',
-        version='wmlxgettext 2018.03.10.py3'
+        version='wmlxgettext 2019.09.03.py3'
     )
     parser.add_argument(
         '-o',


### PR DESCRIPTION
The original fix for #3469 introduced some bugs I did not notice as reported on issue #4275. So I reverted back the code to it's previous status and I re-fixed the bug #3469 with a regexp more similar to the original one and less simplified. This time it sees that wmlxgettext actually work as expected, and seems it is able to handle both mentioned corner cases. The new fix also allow again to recognize lua plural strings. I will attach a test.lua file I use to test the features and the resulting test.pot.     

  >   ./wmlxgettext --domain="test" -o test.pot test.lua

[test.zip](https://github.com/wesnoth/wesnoth/files/3569691/test.zip)

