### PR TITLE
Restore defence modifier display in side-bar

### DIFF
--- a/data/themes/default.cfg
+++ b/data/themes/default.cfg
@@ -151,7 +151,7 @@
             id=label-xp
             font_size={DEFAULT_FONT_TINY}
             text= _ "XP"
-            rect="=,+14,+70,+14"
+            rect="=,+14,+65,+14"
             xanchor=right
             yanchor=fixed
         [/label]
@@ -484,7 +484,7 @@
                 ref=label-def
                 id=unit-defense
                 font_size={DEFAULT_FONT_SMALL}
-                rect="=,+0,+30,+16"
+                rect="=-5,+0,+30,+16"
                 xanchor=right
                 yanchor=fixed
             [/unit_defense]


### PR DESCRIPTION
Tested against master, already resolved for 1.14, resolves #3693.

May be good for @hrubymar10 to double-check this. Submitting as PR because I'm not sure what the figures mean for the theme configuration plus I don't know if the second of the three lines changed (which conflicts with later changes in master) needs further adjustments.