### PR TITLE
Show current acceleration speed when activating

### DIFF
--- a/src/hotkey/hotkey_handler.cpp
+++ b/src/hotkey/hotkey_handler.cpp
@@ -214,7 +214,7 @@ void play_controller::hotkey_handler::toggle_accelerated_speed()
 	{
 		utils::string_map symbols;
 		symbols["hk"] = hotkey::get_names(hotkey::hotkey_command::get_command_by_command(hotkey::HOTKEY_ACCELERATED).command);
-		gui()->announce(_("Accelerated speed enabled!") + " (" + preferences::get("turbo_speed") + "x)\n" + VGETTEXT("(press $hk to disable)", symbols), font::NORMAL_COLOR);
+		gui()->announce(_("Accelerated speed enabled!") + " (" + preferences::get("turbo_speed") + "×)\n" + VGETTEXT("(press $hk to disable)", symbols), font::NORMAL_COLOR);
 	}
 	else
 	{

--- a/src/hotkey/hotkey_handler.cpp
+++ b/src/hotkey/hotkey_handler.cpp
@@ -214,7 +214,7 @@ void play_controller::hotkey_handler::toggle_accelerated_speed()
 	{
 		utils::string_map symbols;
 		symbols["hk"] = hotkey::get_names(hotkey::hotkey_command::get_command_by_command(hotkey::HOTKEY_ACCELERATED).command);
-		gui()->announce(_("Accelerated speed enabled!") + "\n" + VGETTEXT("(press $hk to disable)", symbols), font::NORMAL_COLOR);
+		gui()->announce(_("Accelerated speed enabled!") + " (" + preferences::get("turbo_speed") + "x)\n" + VGETTEXT("(press $hk to disable)", symbols), font::NORMAL_COLOR);
 	}
 	else
 	{


### PR DESCRIPTION
Quick attempt to give some sort of feedback for #1311. I'm sure there are better ways to handle this, though, plus I recognise there's no translation handling (I was trying to avoid breaking existing strings). If it is acceptable, however, it can also go in master.