### PR TITLE
UtBS S09: Non-merfolk get in the ships before they sail off

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg
@@ -2712,6 +2712,14 @@
             message= _ "Then by the Sea God’s hand I call forth the winds. May they confound our enemies and blow these ships to safety!"
         [/message]
 
+        # Elves and troll/dwarf get in the ships, enemies disappear (the enemy side won't persist to the next scenario)
+        [put_to_recall_list]
+            [not]
+                race=merman
+            [/not]
+            heal=yes
+        [/put_to_recall_list]
+
         # Removes the ^Wyc overlay from any location which has it
         [terrain]
             terrain=^


### PR DESCRIPTION
At the end of S09, the heroes have four ships. The narrative is that all the
elves are on the ships, but the in-game visuals were that the ships move while
all the player's units are standing on the shore.

The heal=yes isn't needed since 74c2398f6, but adding it here avoids
a possible bug if this commit is backported to 1.14.