### PR TITLE
HttT S23: Give a more explicit hint on EASY

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/15_The_Lost_General.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/15_The_Lost_General.cfg
@@ -472,7 +472,7 @@
             message= _ "We are desperately trying to rid these tunnels of orcs and trolls! Please help us in our quest."
         [/message]
 #ifdef EASY
-        {NARRATOR_MESSAGE (_ "The dwarves are your allies in this scenario. If you help them survive the battle, they may provide you with useful information.")}
+        {NARRATOR_MESSAGE (_ "The dwarves are your allies in this scenario. If you help their leader survive the battle, he may provide you with useful information.")}
 #endif
     [/event]
 

--- a/data/campaigns/Heir_To_The_Throne/scenarios/15_The_Lost_General.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/15_The_Lost_General.cfg
@@ -471,6 +471,9 @@
             speaker=unit
             message= _ "We are desperately trying to rid these tunnels of orcs and trolls! Please help us in our quest."
         [/message]
+#ifdef EASY
+        {NARRATOR_MESSAGE (_ "The dwarves are your allies in this scenario. If you help them survive the battle, they may provide you with useful information.")}
+#endif
     [/event]
 
     [event]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/23_Test_of_the_Clans.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/23_Test_of_the_Clans.cfg
@@ -308,6 +308,9 @@
             speaker=Sir Alric
             message= _ "Aye."
         [/message]
+#ifdef EASY
+        {NARRATOR_MESSAGE (_ "If you reduce Lord Bayar, Sir Ruga, Sir Daryn, or Sir Alric to 0HP, you’ll receive a reward!")}
+#endif
     [/event]
 
     #

--- a/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
@@ -830,3 +830,11 @@ fire:  +10%"
         [/then]
     [/if]
 #enddef
+
+#define NARRATOR_MESSAGE MSG
+    [message]
+        speaker=narrator
+        image="wesnoth-icon.png"
+        message= {MSG}
+    [/message]
+#enddef


### PR DESCRIPTION
There's a dialog hint just above the diff:

https://github.com/wesnoth/wesnoth/blob/57668733a26e04671025905935cea00555cd06a5/data/campaigns/Heir_To_The_Throne/scenarios/23_Test_of_the_Clans.cfg#L299-L302

But on EASY, make the hint explicit.

Come to think of it, the dialog hint is actually ambiguous: "defeat me personally" can be understood as though Konrad has to attack Lord Bayar, can't it? So how about removing the word "personally" from that line?