### PR TITLE
unit_recall: Show unrecallable units grayed out.

### DIFF
--- a/data/gui/window/unit_recall.cfg
+++ b/data/gui/window/unit_recall.cfg
@@ -148,7 +148,7 @@
 															[image]
 																id = "gold_icon"
 																definition = "default"
-																# label set from C++
+																label = "themes/gold.png"
 															[/image]
 														[/column]
 

--- a/data/gui/window/unit_recall.cfg
+++ b/data/gui/window/unit_recall.cfg
@@ -338,6 +338,7 @@
 												id = "filter_box"
 												definition = "default"
 												{FILTER_TEXT_BOX_HINT}
+												tooltip = _ "Search for unit name, unit type name, or unit level."
 											[/text_box]
 
 										[/column]

--- a/data/gui/window/unit_recall.cfg
+++ b/data/gui/window/unit_recall.cfg
@@ -148,8 +148,7 @@
 															[image]
 																id = "gold_icon"
 																definition = "default"
-
-																label = "themes/gold.png"
+																# label set from C++
 															[/image]
 														[/column]
 

--- a/src/font/text_formatting.cpp
+++ b/src/font/text_formatting.cpp
@@ -27,6 +27,11 @@ std::string span_color(const color_t& color)
 	return formatter() << "<span color='" << color.to_hex_string() << "'>";
 }
 
+std::string span_color(const color_t& color, const std::string& data)
+{
+	return span_color(color) + data + "</span>";
+}
+
 std::string get_pango_color_from_id(const std::string& id)
 {
 	const auto color = game_config::team_rgb_colors.find(id);

--- a/src/font/text_formatting.hpp
+++ b/src/font/text_formatting.hpp
@@ -38,6 +38,11 @@ namespace font {
 std::string span_color(const color_t& color);
 
 /**
+ * Like span_color(const color_t&), but append the data string and a "</span>" tag.
+ */
+std::string span_color(const color_t& color, const std::string& data);
+
+/**
  * Returns a hex color string from a color range.
  *
  * @param id           The id of the color range.

--- a/src/gui/dialogs/unit_recall.cpp
+++ b/src/gui/dialogs/unit_recall.cpp
@@ -252,6 +252,14 @@ void unit_recall::pre_show(window& window)
 		// of certain options to filter on.
 		std::string filter_text = unit->type_name() + " " + name + " " + std::to_string(unit->level());
 
+		if(recallable) {
+			// This is to allow filtering for recallable units by typing "vvv" in the search box.
+			// That's intended to be easy to type and unlikely to match unit or type names.
+			//
+			// TODO: document this. (Also, implement a "Hide non-recallable units" checkbox.)
+			filter_text += " " + std::string("vvv");
+		}
+
 		std::string traits;
 		for(const std::string& trait : unit->trait_names()) {
 			traits += (traits.empty() ? "" : "\n") + trait;

--- a/src/gui/dialogs/unit_recall.cpp
+++ b/src/gui/dialogs/unit_recall.cpp
@@ -219,11 +219,7 @@ void unit_recall::pre_show(window& window)
 		column["label"] = maybe_inactive(unit->type_name(), recallable);
 		row_data.emplace("unit_type", column);
 
-		column["label"] = 
-			recallable
-			? "themes/gold.png" 
-			: "themes/gold.png~GS()";
-		row_data.emplace("gold_icon", column);
+		// gold_icon is handled below
 
 		column["label"] =
 			recallable
@@ -271,8 +267,13 @@ void unit_recall::pre_show(window& window)
 					recallable);
 		row_data.emplace("unit_traits", column);
 
-		list.add_row(row_data);
 		filter_options_.push_back(filter_text);
+		grid& grid = list.add_row(row_data);
+		if(!recallable) {
+			image *gold_icon = dynamic_cast<image*>(grid.find("gold_icon", false));
+			assert(gold_icon);
+			gold_icon->set_image(gold_icon->get_image() + "~GS()");
+		}
 	}
 
 	list.register_translatable_sorting_option(0, [this](const int i) { return recall_list_[i]->type_name().str(); });

--- a/src/gui/dialogs/unit_recall.cpp
+++ b/src/gui/dialogs/unit_recall.cpp
@@ -219,6 +219,12 @@ void unit_recall::pre_show(window& window)
 
 		if(!recallable) {
 			mods += "~GS()";
+
+			// Just set the tooltip on every single element in this row.
+			if(wb_gold > 0)
+				column["tooltip"] = _("This unit cannot be recalled because you will not have enough gold at this point in your plan.");
+			else
+				column["tooltip"] = _("This unit cannot be recalled because you do not have enough gold.");
 		}
 
 		column["use_markup"] = "true";

--- a/src/gui/dialogs/unit_recruit.cpp
+++ b/src/gui/dialogs/unit_recruit.cpp
@@ -13,6 +13,7 @@
 
 #define GETTEXT_DOMAIN "wesnoth-lib"
 
+#include "font/text_formatting.hpp"
 #include "gui/auxiliary/find_widget.hpp"
 #include "gui/dialogs/unit_recruit.hpp"
 #include "gui/widgets/button.hpp"
@@ -52,9 +53,11 @@ unit_recruit::unit_recruit(std::vector<const unit_type*>& recruit_list, team& te
 	});
 }
 
-static std::string can_afford_unit(const std::string& text, const bool can_afford)
+static const color_t inactive_row_color(0x96, 0x96, 0x96);
+
+static inline std::string can_afford_unit(const std::string& text, const bool can_afford)
 {
-	return can_afford ? text : "<span color='#ff0000'>" + text + "</span>";
+	return can_afford ? text : font::span_color(inactive_row_color, text);
 }
 
 // Compare unit_create::filter_text_change
@@ -139,7 +142,7 @@ void unit_recruit::pre_show(window& window)
 
 		column["use_markup"] = "true";
 
-		column["label"] = image_string;
+		column["label"] = image_string + (can_afford ? "" : "~GS()");
 		row_data.emplace("unit_image", column);
 
 		column["label"] = can_afford_unit(recruit->type_name(), can_afford);
@@ -148,7 +151,12 @@ void unit_recruit::pre_show(window& window)
 		column["label"] = can_afford_unit(cost_string, can_afford);
 		row_data.emplace("unit_cost", column);
 
-		list.add_row(row_data);
+		grid& grid = list.add_row(row_data);
+		if(!can_afford) {
+			image *gold_icon = dynamic_cast<image*>(grid.find("gold_icon", false));
+			assert(gold_icon);
+			gold_icon->set_image(gold_icon->get_image() + "~GS()");
+		}
 	}
 
 	list_item_clicked(window);

--- a/src/gui/dialogs/unit_recruit.cpp
+++ b/src/gui/dialogs/unit_recruit.cpp
@@ -141,6 +141,13 @@ void unit_recruit::pre_show(window& window)
 		const std::string cost_string = std::to_string(recruit->cost());
 
 		column["use_markup"] = "true";
+		if(!can_afford) {
+			// Just set the tooltip on every single element in this row.
+			if(wb_gold > 0)
+				column["tooltip"] = _("This unit cannot be recruited because you will not have enough gold at this point in your plan.");
+			else
+				column["tooltip"] = _("This unit cannot be recruited because you do not have enough gold.");
+		}
 
 		column["label"] = image_string + (can_afford ? "" : "~GS()");
 		row_data.emplace("unit_image", column);

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -355,9 +355,11 @@ void menu_handler::recall(int side_num, const map_location& last_hex)
 	team& current_team = board().get_team(side_num);
 
 	std::vector<unit_const_ptr> recall_list_team;
+	bool empty;
 	{
 		wb::future_map future; // ensures recall list has planned recalls removed
 		recall_list_team = actions::get_recalls(side_num, last_hex);
+		empty = current_team.recall_list().empty();
 	}
 
 	DBG_WB << "menu_handler::recall: Contents of wb-modified recall list:\n";
@@ -365,7 +367,7 @@ void menu_handler::recall(int side_num, const map_location& last_hex)
 		DBG_WB << unit->name() << " [" << unit->id() << "]\n";
 	}
 
-	if(current_team.recall_list().empty()) {
+	if(empty) {
 		gui2::show_transient_message("",
 			_("There are no troops available to recall\n(You must have veteran survivors from a previous scenario)"));
 		return;

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -600,7 +600,8 @@ public:
 		return unit_value_;
 	}
 
-	/** How much gold it costs to recall this unit. */
+	/** How much gold it costs to recall this unit, or -1 if the side's default
+	 * recall cost is used. */
 	int recall_cost() const
 	{
 		return recall_cost_;


### PR DESCRIPTION
Part of issue #1282.

Looks like this:

![2019-09-18-154113_1024x768_scrot](https://user-images.githubusercontent.com/24784687/65163884-58379f80-da2b-11e9-8428-7c0441f00530.png)

- [x] add a tooltip with the reason the unit is grayed out

<details>

<summary>
test case
</summary>

```
diff --git a/data/campaigns/An_Orcish_Incursion/scenarios/01_Defend_the_Forest.cfg b/data/campaigns/An_Orcish_Incursion/scenarios/01_Defend_the_Forest.cfg
index 53ea5f5be8e..596689ec975 100644
--- a/data/campaigns/An_Orcish_Incursion/scenarios/01_Defend_the_Forest.cfg
+++ b/data/campaigns/An_Orcish_Incursion/scenarios/01_Defend_the_Forest.cfg
@@ -50,7 +50,7 @@
     [side]
         side=1
         controller=human
-        {GOLD 200 150 100}
+        gold=20
         income=0
         team_name=Elves
         user_team_name= _ "Elves"
@@ -61,6 +61,10 @@
 
         facing=nw
 
+        {UNIT 1 Mage recall recall ()}
+        {UNIT 1 Mage recall recall (recall_cost=25)}
+        {UNIT 1 Peasant recall recall ()}
+
         [unit]
             side=1
             type=Elvish Rider
```

</details>