### PR TITLE
NR S06a: Fix the filter for Tallin complaining that they're sitting in the caves

### DIFF
--- a/data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg
@@ -280,40 +280,24 @@
     [event]
         name=turn 3
 
-        # Store starting point coordinates
-        [store_starting_location]
-            side=1
-            variable=starting_point
-        [/store_starting_location]
-
-        # Check every unit belonging to side 1 in a radius of 10 hexes from starting point that are not within radius of
-        # 5 hexes from starting point.
         [if]
             [have_unit]
                 side=1
                 [filter_location]
-                    x=$starting_point.x
-                    y=$starting_point.y
-                    radius=10
+                    [not]
+                        time_of_day_id=underground
+                    [/not]
                 [/filter_location]
-                [not]
-                    [filter_location]
-                        x=$starting_point.x
-                        y=$starting_point.y
-                        radius=5
-                    [/filter_location]
-                [/not]
+                count=0-5
             [/have_unit]
             [then]
-                # No, Tallin calls for all out charge. "URRAAA!"
+                # Five or less units are outside, Tallin calls for all out charge. "URRAAA!"
                 [message]
                     id=Tallin
                     message= _ "Come on, why are we just sitting here in these caves?! Have you forgotten already all these orcs have done to us! Let us spill their foul blood on the ground!"
                 [/message]
             [/then]
         [/if]
-
-        {CLEAR_VARIABLE starting_point}
     [/event]
 
     # Player somehow breached bad boss cordon, things are going too well, which means we need to throw an army of wolfriders at him


### PR DESCRIPTION
Now it only triggers if five or less units are outside. Every unit in the cave but illuminated by a MoL is counted as inside, not outside.