### PR TITLE
Fix [leave_game] being ignored by clients during linger.

### DIFF
--- a/src/game_initialization/playcampaign.cpp
+++ b/src/game_initialization/playcampaign.cpp
@@ -45,6 +45,7 @@
 #include "terrain/type_data.hpp"
 #include "wml_exception.hpp"
 #include "formula/string_utils.hpp"
+#include "wesnothd_connection.hpp"
 
 #define LOG_G LOG_STREAM(info, lg::general)
 
@@ -289,6 +290,9 @@ LEVEL_RESULT campaign_controller::play_game()
 			{
 				res = playmp_scenario(end_level);
 			}
+		} catch(const leavegame_wesnothd_error&) {
+			LOG_NG << "The game was remotely ended\n";
+			return LEVEL_RESULT::QUIT;
 		} catch(const game::load_game_failed& e) {
 			gui2::show_error_message(_("The game could not be loaded: ") + e.message);
 			return LEVEL_RESULT::QUIT;

--- a/src/playmp_controller.cpp
+++ b/src/playmp_controller.cpp
@@ -25,6 +25,7 @@
 #include "mp_ui_alerts.hpp"
 #include "playturn.hpp"
 #include "preferences/general.hpp"
+#include "preferences/game.hpp"
 #include "game_initialization/playcampaign.hpp"
 #include "resources.hpp"
 #include "savegame.hpp"
@@ -254,6 +255,15 @@ void playmp_controller::linger()
 		} catch (const savegame::load_game_exception&) {
 			LOG_NG << "caught load-game-exception" << std::endl;
 			// this should not happen, the option to load a game is disabled
+			throw;
+		} catch (const leavegame_wesnothd_error& e) {
+			scoped_savegame_snapshot snapshot(*this);
+			savegame::ingame_savegame save(saved_game_, preferences::save_compression_format());
+			if(e.message == "") {
+				save.save_game_interactive(_("A network disconnection has occurred, and the game cannot continue. Do you want to save the game?"), savegame::savegame::YES_NO);
+			} else {
+				save.save_game_interactive(_("This game has been ended.\nReason: ")+e.message+_("\nDo you want to save the game?"), savegame::savegame::YES_NO);
+			}
 			throw;
 		} catch (const ingame_wesnothd_error&) {
 			LOG_NG << "caught network-error-exception" << std::endl;

--- a/src/playturn.cpp
+++ b/src/playturn.cpp
@@ -157,7 +157,7 @@ turn_info::PROCESS_DATA_RESULT turn_info::process_network_data(const config& cfg
 	}
 	else if (cfg.child("leave_game")) {
 		const bool has_reason = cfg.child("leave_game").has_attribute("reason");
-		throw ingame_wesnothd_error(has_reason ? cfg.child("leave_game")["reason"].str() : "");
+		throw leavegame_wesnothd_error(has_reason ? cfg.child("leave_game")["reason"].str() : "");
 	}
 	else if (const config &turn = cfg.child("turn"))
 	{

--- a/src/wesnothd_connection_error.hpp
+++ b/src/wesnothd_connection_error.hpp
@@ -41,6 +41,10 @@ struct ingame_wesnothd_error : public wesnothd_error ,public lua_jailbreak_excep
 	IMPLEMENT_LUA_JAILBREAK_EXCEPTION(ingame_wesnothd_error)
 };
 
+struct leavegame_wesnothd_error : ingame_wesnothd_error
+{
+    leavegame_wesnothd_error(const std::string& error) : ingame_wesnothd_error(error) {}
+};
 
 ///an error occurred inside the underlying network communication code (boost asio)
 ///TODO: find a short name


### PR DESCRIPTION
This affects the stopgame command and :kick, for example.

Fixes #4370