### PR TITLE
TRoW S04a S04b: From Midlands, make Swamp the next scenario

### DIFF
--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/04a_The_Swamp_of_Esten.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/04a_The_Swamp_of_Esten.cfg
@@ -10,14 +10,32 @@
     {SCENARIO_MUSIC wanderer.ogg}
     {EXTRA_SCENARIO_MUSIC knolls.ogg}
 
+    # wmllint: recognize Sir Ladoc
+    # 04b is now an optional scenario that happens before 04a.
     [story]
-        [part]
-            # Same as in 04b!
-            story= _ "So it came to pass that Prince Haldric was forced from his home, never to return. With the help of his father’s noble sacrifice he has escaped through the southern pass. Haldric has left the lands of his home, and before him stretches the vast expanse of the southern kingdoms of his people."
+        [if]
+            [have_unit]
+                id=Sir Ladoc
+                search_recall_list=yes
+            [/have_unit]
+            [then]
+                [part]
+                    # po: the player went to scenario 04b first. The turn limit on this map will be reduced, by a fixed amount that doesn't depend on the number of turns played in scenario 04b.
+                    story= _ "With Sir Ladoc’s news that the road to Southbay was impassible, Prince Haldric turned towards Clearwater Port. Every day brought both the orcs and the winter closer, and the time spent in the Midlands was already gone."
+                    background=story/trow_story_04a-The_Swamp_of_Esten.jpg
+                    music=underground.ogg
+                [/part]
+            [/then]
+            [else]
+                [part]
+                    # Same as in 04b!
+                    story= _ "So it came to pass that Prince Haldric was forced from his home, never to return. With the help of his father’s noble sacrifice he has escaped through the southern pass. Haldric has left the lands of his home, and before him stretches the vast expanse of the southern kingdoms of his people."
 
-            background=story/trow_story_04-Fall_of_Eldaric.jpg
-            music=underground.ogg
-        [/part]
+                    background=story/trow_story_04-Fall_of_Eldaric.jpg
+                    music=underground.ogg
+                [/part]
+            [/else]
+        [/if]
         [part]
             story= _ "The river road follows the Isle’s greatest river to the southeast. This road leads to the Isle’s second largest city, Clearwater Port. It would likely have been the Isle’s largest city save for the events of the Wesfolk War. The Lich-Lords befouled much of the land around the river during the course of a great battle. Now the swamp is home to a Wesfolk-imitating cult."
             background=story/trow_story_04a-The_Swamp_of_Esten.jpg
@@ -118,7 +136,7 @@
     [event]
         name=prestart
 
-        {PLACE_IMAGE (scenery/signpost.png) 15 31}
+        {PLACE_IMAGE (scenery/signpost.png) 34 12}
         {PLACE_IMAGE (scenery/temple1.png) 19 5}
         {PLACE_IMAGE (scenery/temple1.png) 30 10}
         {PLACE_IMAGE (scenery/temple1.png) 34 36}
@@ -148,6 +166,22 @@
         [recall]
             id=Burin the Lost
         [/recall]
+
+        [recall]
+            id=Sir Ladoc
+        [/recall]
+
+        # Subtract a day and a half if the player's been to the Midlands. They have more XP, and an auto-recalled loyal knight.
+        [if]
+            [have_unit]
+                id=Sir Ladoc
+            [/have_unit]
+            [then]
+                [modify_turns]
+                    add=-9
+                [/modify_turns]
+            [/then]
+        [/if]
 
         [objectives]
             side=1
@@ -198,10 +232,29 @@
             message= _ "This is too quiet. I don’t like this one bit, not one bit at all."
         [/message]
 
-        [message]
-            speaker=Prince Haldric
-            message= _ "Wait, I think I hear something... To arms!"
-        [/message]
+        [if]
+            [have_unit]
+                id=Sir Ladoc
+            [/have_unit]
+            [then]
+                [fire_event]
+                    name=enter_sir_ruddry
+                [/fire_event]
+                [message]
+                    speaker=Prince Haldric
+                    message= _ "Wait, I think I hear something... To arms!"
+                [/message]
+                [fire_event]
+                    name=exit_sir_ruddry
+                [/fire_event]
+            [/then]
+            [else]
+                [message]
+                    speaker=Prince Haldric
+                    message= _ "Wait, I think I hear something... To arms!"
+                [/message]
+            [/else]
+        [/if]
     [/event]
 
     [event]
@@ -467,8 +520,8 @@
         name=moveto
         [filter]
             side=1
-            x=15
-            y=31
+            x=34
+            y=12
         [/filter]
 
         [redraw]
@@ -476,9 +529,8 @@
 
         [message]
             speaker=narrator
-            # wmllint: local spelling SW
             #wmllint: display on
-            message= _ "SW — The Oldwood Forest.
+            message= _ "East — The Oldwood Forest.
 Enter at Your Own Risk!"
             #wmllint: display off
             image=scenery/signpost.png
@@ -531,8 +583,10 @@ Enter at Your Own Risk!"
         [/endlevel]
     [/event]
 
+    # This event happens either when enemies are defeated (in which case Sir Ruddry joins you), or at
+    # the beginning if the player has Sir Ladoc (in which case exit_sir_ruddry fires afterwards).
     [event]
-        name=victory
+        name=enter_sir_ruddry
 
         [sound]
             name=horse-canter.wav
@@ -582,10 +636,90 @@ Enter at Your Own Risk!"
             speaker=Sir Ruddry
             message= _ "As far as I know, Sir. We have a large army, and they were pressing all able bodied men and boys into service when I left. That orcish army is huge, but they haven’t met the main body of our forces yet."
         [/message]
+    [/event]
+
+    # If the player already has Sir Ladoc, then Sir Ruddry appears at the start to give the information about the road ahead. But the two knights are really one character, there is dialogue later that's said by whichever of them the player has.
+    # This event fires immediately after Haldric says that he hears a noise, so the screen will have scrolled away from Sir Ruddry.
+    [event]
+        name=exit_sir_ruddry
+
+        [kill]
+            id=Sir Ruddry
+        [/kill]
+
+        [reset_fog]
+            [filter_side]
+                side=1
+            [/filter_side]
+            reset_view=yes
+        [/reset_fog]
+        [redraw]
+            side=1
+            clear_shroud=yes
+        [/redraw]
+
+        [unit]
+            side=3
+            type=Walking Corpse
+            variation=mounted
+            id=Dead Ruddry
+            name= _ "Sir Ruddry"
+            x=35
+            y=35
+        [/unit]
+
+        [event]
+            name=last breath
+            [filter]
+                id=Dead Ruddry
+            [/filter]
+
+            [if]
+                [variable]
+                    name=second_unit.id
+                    equals=Sir Ladoc
+                [/variable]
+
+                [then]
+                    [message]
+                        speaker=Sir Ladoc
+                        # po: "remains" means "dead body", and the speaker has just killed Ruddry's zombie
+                        message= _ "This corpse was the remains of the noble knight who greeted us earlier. I shall be forever in his debt — had you not gone to the Midlands then I would surely have fallen to the orcish blades, yet you would have slain the necromancers before he reached the swamp."
+                    [/message]
+                [/then]
+
+                [else]
+                    [message]
+                        speaker=$second_unit.id
+                        # po: "remains" means "dead body", and the speaker has just killed Ruddry's zombie
+                        message= _ "This corpse was the remains of the knight who greeted us earlier."
+                    [/message]
+
+                    [message]
+                        speaker=Sir Ladoc
+                        message= _ "I shall be forever in this noble knight’s debt. Had you not gone to the Midlands then I would surely have fallen to the orcish blades, yet you would have slain the necromancers before he reached the swamp."
+                    [/message]
+                [/else]
+            [/if]
+
+            [message]
+                speaker=Prince Haldric
+                # po: it's possible that Sir Ladoc has died too, so this needs to work even if the preceding line is "... who greeted us earlier"
+                message= _ "When we reach Clearwater Port, we shall defend his friends."
+            [/message]
+        [/event]
+    [/event]
+
+    [event]
+        name=victory
+
+        [fire_event]
+            name=enter_sir_ruddry
+        [/fire_event]
 
         [message]
             speaker=Prince Haldric
-            message= _ "Well, we can’t go back, and the road ahead is blocked. I guess we’ll have to risk it and go through the Oldwood forest, then make a break for Clearwater Port or Southbay."
+            message= _ "Well, we can’t go back, and the road ahead is blocked. I guess we’ll have to risk it and go through the Oldwood forest, then make a break for Clearwater Port."
         [/message]
 
         [message]

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/04b_The_Midlands.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/04b_The_Midlands.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=04b_The_Midlands
     name= _ "The Midlands"
-    next_scenario=05_The_Oldwood
+    next_scenario=04a_The_Swamp_of_Esten
     map_file=campaigns/The_Rise_Of_Wesnoth/maps/04b_The_Midlands.map
     {TURNS 45 42 39}
     {DEFAULT_SCHEDULE}
@@ -127,7 +127,6 @@
 
     [event]
         name=prestart
-        {PLACE_IMAGE (scenery/signpost.png) 31 22}
         {PLACE_IMAGE (scenery/signpost.png) 18 15}
 
         [recall]
@@ -197,27 +196,6 @@
             speaker=Tan-Hogar
             message= _ "Shut yer mouth! Let’s just get ’em."
         [/message]
-    [/event]
-
-    [event]
-        name=moveto
-        [filter]
-            side=1
-            x=31
-            y=22
-        [/filter]
-
-        [redraw]
-        [/redraw]
-
-        [message]
-            speaker=narrator
-            # wmllint: local spelling SE
-            message= _ "SE — The Oldwood. Enter at Your Own Risk!"
-            image=scenery/signpost.png
-        [/message]
-        [allow_undo]
-        [/allow_undo]
     [/event]
 
     [event]
@@ -407,12 +385,12 @@
 
         [message]
             speaker=Prince Haldric
-            message= _ "Well, we can’t go back, and the road ahead is blocked... I guess we’ll have to risk it and go through the Oldwood forest, then make a break for Clearwater Port."
+            message= _ "Well, we can’t go back, and the road ahead is blocked... I guess we’ll have to risk it and go through the swamp, then make a break for Clearwater Port."
         [/message]
 
         [message]
             speaker=Burin the Lost
-            message= _ "Oh great, now a forest. I should have stayed at home and taken my chances with the orcs!"
+            message= _ "<i>Swamp</i>?! I’m under five feet tall, and I don’t float! ... Argh, have it your way."
             image=portraits/burin-annoyed.png
         [/message]
 

--- a/data/campaigns/The_Rise_Of_Wesnoth/utils/bigmap.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/utils/bigmap.cfg
@@ -1,4 +1,4 @@
-#textdomain wesnoth-httt
+# wmllint: no translatables
 
 #define TROW_GREEN_ISLE_BIGMAP
     [background_layer]
@@ -89,7 +89,23 @@
     {OLD_BATTLE 410 515}
 #enddef
 
-#define JOURNEY_04A_NEW
+#define JOURNEY_04B_NEW
+    {JOURNEY_03_OLD}
+    {NEW_JOURNEY 435 525}
+    {NEW_JOURNEY 458 532}
+    {NEW_JOURNEY 480 538}
+    {NEW_BATTLE 498 549}
+#enddef
+
+#define JOURNEY_04B_OLD
+    {JOURNEY_03_OLD}
+    {OLD_JOURNEY 435 525}
+    {OLD_JOURNEY 458 532}
+    {OLD_JOURNEY 480 538}
+    {OLD_BATTLE 498 549}
+#enddef
+
+#define JOURNEY_HARROWING_TO_SWAMP_NEW
     {JOURNEY_03_OLD}
     {NEW_JOURNEY 437 524}
     {NEW_JOURNEY 466 528}
@@ -98,7 +114,7 @@
     {NEW_BATTLE 551 515}
 #enddef
 
-#define JOURNEY_04A_OLD
+#define JOURNEY_HARROWING_TO_SWAMP_OLD
     {JOURNEY_03_OLD}
     {OLD_JOURNEY 437 524}
     {OLD_JOURNEY 466 528}
@@ -107,27 +123,22 @@
     {OLD_BATTLE 551 515}
 #enddef
 
-#define JOURNEY_04B_NEW
-    {JOURNEY_03_OLD}
-    {NEW_JOURNEY 434 524}
-    {NEW_JOURNEY 459 529}
-    {NEW_JOURNEY 485 533}
-    {NEW_JOURNEY 510 539}
-    {NEW_JOURNEY 533 550}
-    {NEW_BATTLE 556 562}
+#define JOURNEY_MIDLANDS_TO_SWAMP_NEW
+    {JOURNEY_04B_OLD}
+    {NEW_JOURNEY 516 538}
+    {NEW_JOURNEY 532 526}
+    {NEW_BATTLE 551 515}
 #enddef
 
-#define JOURNEY_04B_OLD
-    {JOURNEY_03_OLD}
-    {OLD_JOURNEY 434 524}
-    {OLD_JOURNEY 459 529}
-    {OLD_JOURNEY 485 533}
-    {OLD_JOURNEY 510 539}
-    {OLD_JOURNEY 533 550}
-    {OLD_BATTLE 556 562}
+#define JOURNEY_MIDLANDS_TO_SWAMP_OLD
+    {JOURNEY_04B_OLD}
+    {OLD_JOURNEY 516 538}
+    {OLD_JOURNEY 532 526}
+    {OLD_BATTLE 551 515}
 #enddef
 
-#define JOURNEY_05_NEW
+#define JOURNEY_04A_NEW
+    {JOURNEY_03_OLD}
     [if]
         [variable]
             name=escape_choice
@@ -135,22 +146,42 @@
         [/variable]
 
         [then]
-            {JOURNEY_04A_OLD}
-            {NEW_JOURNEY 577 506}
-            {NEW_JOURNEY 602 495}
-            {NEW_JOURNEY 627 486}
-            {NEW_BATTLE 654 480}
+            {JOURNEY_HARROWING_TO_SWAMP_NEW}
         [/then]
 
         [else]
             {JOURNEY_04B_OLD}
-            {NEW_JOURNEY 585 561}
-            {NEW_JOURNEY 612 553}
-            {NEW_JOURNEY 632 533}
-            {NEW_JOURNEY 645 507}
-            {NEW_BATTLE 654 480}
+            {JOURNEY_MIDLANDS_TO_SWAMP_NEW}
         [/else]
     [/if]
+#enddef
+
+#define JOURNEY_04A_OLD
+    {JOURNEY_03_OLD}
+    [if]
+        [variable]
+            name=escape_choice
+            not_equals=2
+        [/variable]
+
+        [then]
+            {JOURNEY_HARROWING_TO_SWAMP_OLD}
+        [/then]
+
+        [else]
+            {JOURNEY_04B_OLD}
+            {JOURNEY_MIDLANDS_TO_SWAMP_OLD}
+        [/else]
+    [/if]
+#enddef
+
+#define JOURNEY_05_NEW
+    {JOURNEY_04A_OLD}
+    {NEW_JOURNEY 577 506}
+    {NEW_JOURNEY 602 495}
+    {NEW_JOURNEY 627 486}
+    {NEW_BATTLE 654 480}
+
 #enddef
 
 #define JOURNEY_05_OLD


### PR DESCRIPTION
Originally two commits, the first one is now merged. I expect debate and possibly rejection of the remaining commit in this PR.

TRoW S04a S04b: Move Sir Ladoc / Sir Ruddry to the victory event

This means that they join even when debugging with the :next_level command.

The enemies_defeated event could be replaced by victory_when_enemies_defeated
and the appropriate carryover amounts, but that should probably be done as a
single commit updating the entire campaign.

@nemaara - this is similar to #3801, please would you review it?

TRoW S04a S04b: From Midlands, make Swamp the next scenario
---

The Midlands is the more challenging option, but means missing out on an auto-recalled loyal white mage. The journey map also shows that The Oldwood is east of The Swamp of Esten, and it makes little sense that they reach Oldwood without passing through the swamp. Solve both problems by making The Midlands an optional detour which still ends up going through the swamp.

If the player took the extra XP by going through The Midlands, the turn limit on The Swamp is much tighter. Sir Ruddry will appear during the start event, tell Haldric about the road ahead, and then die - Sir Ladoc gets an exposition that only one of the two knights can survive.

I've left the scenario number unchanged, although this means that 04b will occur (if the player chooses to go there) before 04a.