### PR TITLE
backport wesnoth_addon_manager port mapping

### DIFF
--- a/data/tools/wesnoth/campaignserver_client.py
+++ b/data/tools/wesnoth/campaignserver_client.py
@@ -27,6 +27,7 @@ dumpi = 0
 class CampaignClient:
     # First port listed will be used as default.
     portmap = (
+        ("15015", "1.15.x"),
         ("15014", "1.14.x"),
         ("15008", "1.13.x"),
         ("15007", "1.12.x"),


### PR DESCRIPTION
this allows using wesnoth_addon_manager from the stable
branch to upload addons to 1.15.

I think it makes sense because wesnoth_addon_manager is
a tool that by design works with multiple wesnoth versions.

CC @soliton- 