### PR TITLE
Disable replay saving based on preferences

### DIFF
--- a/data/advanced_preferences.cfg
+++ b/data/advanced_preferences.cfg
@@ -29,6 +29,13 @@
 [/advanced_preference]
 
 [advanced_preference]
+    field=save_file_includes_replay
+    name= _ "Include replay information in save files"
+    type=boolean
+    default=yes
+[/advanced_preference]
+
+[advanced_preference]
     field=mouse_scrolling
     name= _ "Mouse scrolling"
     type=boolean

--- a/src/preferences/game.cpp
+++ b/src/preferences/game.cpp
@@ -789,6 +789,16 @@ bool save_replays()
 	return preferences::get("save_replays", true);
 }
 
+bool save_file_includes_replay()
+{
+	return preferences::get("save_file_includes_replay", true);
+}
+
+void set_save_file_includes_replay(bool value)
+{
+	preferences::set("save_file_includes_replay", value);
+}
+
 void set_delete_saves(bool value)
 {
 	preferences::set("delete_saves", value);

--- a/src/preferences/game.hpp
+++ b/src/preferences/game.hpp
@@ -175,6 +175,9 @@ class acquaintance;
 	bool save_replays();
 	void set_save_replays(bool value);
 
+	bool save_file_includes_replay();
+	void set_save_file_includes_replay(bool value);
+
 	bool delete_saves();
 	void set_delete_saves(bool value);
 

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -631,7 +631,7 @@ void ingame_savegame::write_game(config_writer &out) {
 	gamestate().write_carryover(out);
 	out.write_child("snapshot",gamestate().get_starting_point());
 
-	if(preferences::save_replays()) {
+	if(preferences::save_file_includes_replay()) {
 		out.write_child("replay_start", gamestate().replay_start());
 		out.open_child("replay");
 		gamestate().get_replay().write(out);

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -630,10 +630,13 @@ void ingame_savegame::write_game(config_writer &out) {
 
 	gamestate().write_carryover(out);
 	out.write_child("snapshot",gamestate().get_starting_point());
-	out.write_child("replay_start", gamestate().replay_start());
-	out.open_child("replay");
-	gamestate().get_replay().write(out);
-	out.close_child("replay");
+
+	if(preferences::save_replays()) {
+		out.write_child("replay_start", gamestate().replay_start());
+		out.open_child("replay");
+		gamestate().get_replay().write(out);
+		out.close_child("replay");
+	}
 }
 
 //changes done during 1.11.0-dev


### PR DESCRIPTION
Feel free to close this if I'm doing this the 'wrong' way, but given the information in #1457 this is what I came up with.

Tested:
- Saving with replay saving enabled retains existing functionality of including replays in save games.
- Saving with replay saving disabled excludes replay sections from save games.
- Switching a game in progress from save-replays to do-not-save-replays functions as expected.
- Switching a game in progress from do-not-save-replays to save-replays functions as expected.
- Finishing a scenario where the start of the game did not have replays saved, but replay saving was introduced mid-game results in a functional replay albeit one which has no information prior to where replays were enabled (of course).