### PR TITLE
Replace hot-key markers with initials

### DIFF
--- a/data/gui/window/preferences/02_hotkeys.cfg
+++ b/data/gui/window/preferences/02_hotkeys.cfg
@@ -131,6 +131,7 @@
 								id = "sort_2"
 								definition = "listbox_header"
 								linked_group = "hotkeys_col_type"
+								# po: Translate G as the initial letter for Game
 								label = _ "game_hotkeys^G"
 								tooltip = _ "Available in game"
 							[/toggle_button]
@@ -143,6 +144,7 @@
 								id = "sort_3"
 								definition = "listbox_header"
 								linked_group = "hotkeys_col_type"
+								# po: Translate E as the initial letter for Editor
 								label = _ "editor_hotkeys^E"
 								tooltip = _ "Available in editor"
 							[/toggle_button]
@@ -155,6 +157,7 @@
 								id = "sort_4"
 								definition = "listbox_header"
 								linked_group = "hotkeys_col_type"
+								# po: Translate T as the initial letter for Title Screen
 								label = _ "titlescreen_hotkeys^T"
 								tooltip = _ "Available at main menu"
 							[/toggle_button]

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -813,7 +813,9 @@ listbox& preferences_dialog::setup_hotkey_list(window& window)
 	hotkey_list.clear();
 	visible_hotkeys_.clear();
 
-	std::string text_feature_on =  "<span color='#0f0'>" + _("&#9679;") + "</span>";
+	std::string text_game_feature_on = "<span color='#0f0'>" + _("game_initial^G") + "</span>";
+	std::string text_editor_feature_on = "<span color='#0f0'>" + _("editor_initial^E") + "</span>";
+	std::string text_title_feature_on = "<span color='#0f0'>" + _("title_initial^T") + "</span>";
 
 	for(const auto& hotkey_item : hotkey::get_hotkey_commands()) {
 		if(hotkey_item.hidden) {
@@ -830,11 +832,11 @@ listbox& preferences_dialog::setup_hotkey_list(window& window)
 		row_action = hotkey_item.description;
 		row_hotkey = hotkey::get_names(hotkey_item.command);
 
-		row_is_g = hotkey_item.scope[hotkey::SCOPE_GAME]      ? text_feature_on : "";
+		row_is_g = hotkey_item.scope[hotkey::SCOPE_GAME]      ? text_game_feature_on : "";
 		row_is_g_markup = "true";
-		row_is_e = hotkey_item.scope[hotkey::SCOPE_EDITOR]    ? text_feature_on : "";
+		row_is_e = hotkey_item.scope[hotkey::SCOPE_EDITOR]    ? text_editor_feature_on : "";
 		row_is_e_markup = "true";
-		row_is_t = hotkey_item.scope[hotkey::SCOPE_MAIN_MENU] ? text_feature_on : "";
+		row_is_t = hotkey_item.scope[hotkey::SCOPE_MAIN_MENU] ? text_title_feature_on : "";
 		row_is_t_markup = "true";
 
 		hotkey_list.add_row(row_data);

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -813,9 +813,10 @@ listbox& preferences_dialog::setup_hotkey_list(window& window)
 	hotkey_list.clear();
 	visible_hotkeys_.clear();
 
-	std::string text_game_feature_on = "<span color='#0f0'>" + _("game_initial^G") + "</span>";
-	std::string text_editor_feature_on = "<span color='#0f0'>" + _("editor_initial^E") + "</span>";
-	std::string text_title_feature_on = "<span color='#0f0'>" + _("title_initial^T") + "</span>";
+	// These translated initials should match those used in data/gui/window/preferences/02_hotkeys.cfg
+	std::string text_game_feature_on = "<span color='#0f0'>" + _("game_hotkeys^G") + "</span>";
+	std::string text_editor_feature_on = "<span color='#0f0'>" + _("editor_hotkeys^E") + "</span>";
+	std::string text_title_feature_on = "<span color='#0f0'>" + _("titlescreen_hotkeys^T") + "</span>";
 
 	for(const auto& hotkey_item : hotkey::get_hotkey_commands()) {
 		if(hotkey_item.hidden) {


### PR DESCRIPTION
Suggested in https://github.com/wesnoth/wesnoth/issues/1152#issuecomment-535022785 and mitigates #1499.