### PR TITLE
HttT: Avoid "Prince" as a direct address

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/01_The_Elves_Besieged.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/01_The_Elves_Besieged.cfg
@@ -68,7 +68,7 @@
     [side]
         type=Fighter
         id=Konrad
-        name= _"Konrad"
+        name= _"Prince Konrad"
         unrenamable=yes
         profile=portraits/konrad-elvish.png
         side=1
@@ -373,7 +373,8 @@
         [/message]
         [message]
             speaker=Delfador
-            message= _ "Prince... you must keep fighting! Nooooooo!"
+            # po: Delfador addresses Konrad as though Konrad were  son
+            message= _ "Konrad... you must keep fighting! Nooooooo!"
         [/message]
         [message]
             speaker=unit

--- a/data/campaigns/Heir_To_The_Throne/scenarios/01_The_Elves_Besieged.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/01_The_Elves_Besieged.cfg
@@ -373,7 +373,7 @@
         [/message]
         [message]
             speaker=Delfador
-            # po: Delfador addresses Konrad as though Konrad were  son
+            # po: Delfador addresses Konrad as though Konrad were his son
             message= _ "Konrad... you must keep fighting! Nooooooo!"
         [/message]
         [message]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/08_The_Princess_of_Wesnoth.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/08_The_Princess_of_Wesnoth.cfg
@@ -84,7 +84,7 @@
     [side]
         type=Princess
         id="Li'sar"
-        name= _ "Li’sar"
+        name= _ "Princess Li’sar"
         profile=portraits/lisar.png
         side=2
         canrecruit=yes

--- a/data/campaigns/Heir_To_The_Throne/scenarios/09_The_Valley_of_Death.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/09_The_Valley_of_Death.cfg
@@ -421,7 +421,7 @@
                         [/message]
                         [message]
                             speaker=Kalenz
-                            message= _ "He died fighting for you, Prince, just as any of us would be willing to die for you."
+                            message= _ "He died fighting for you, my lord, just as any of us would be willing to die for you."
                         [/message]
                     [/then]
                 [/if]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/11_The_Ford_of_Abez.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/11_The_Ford_of_Abez.cfg
@@ -65,7 +65,7 @@
     [side]
         type=Princess
         id="Li'sar"
-        name= _ "Li’sar"
+        name= _ "Princess Li’sar"
         profile=portraits/lisar.png
         side=2
         canrecruit=yes

--- a/data/campaigns/Heir_To_The_Throne/scenarios/13_The_Dwarven_Doors.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/13_The_Dwarven_Doors.cfg
@@ -748,7 +748,7 @@ end
             message= _ "But Konrad’s party was not alone in entering the caves..."
         [/message]
 
-        {NAMED_LOYAL_UNIT 2 (Princess) 8 44 (Li'sar) ( _ "Li’sar")}
+        {NAMED_LOYAL_UNIT 2 (Princess) 8 44 (Li'sar) ( _ "Princess Li’sar")}
         [+unit]
             profile=portraits/lisar.png
         [/unit]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/14_Plunging_Into_the_Darkness.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/14_Plunging_Into_the_Darkness.cfg
@@ -529,7 +529,8 @@
 
                 [message]
                     speaker=Gryphon Tender
-                    message= _ "I am sorry, Prince Konrad. The young gryphons are breaking their ropes. They are simply getting too large and too restless to restrain anymore!"
+                    # po: "Your Highness" is an Elvish Shaman addressing Prince Konrad
+                    message= _ "I am sorry, Your Highness. The young gryphons are breaking their ropes. They are simply getting too large and too restless to restrain anymore!"
                 [/message]
 
                 # Gryphon runs around some more

--- a/data/campaigns/Heir_To_The_Throne/scenarios/15_The_Lost_General.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/15_The_Lost_General.cfg
@@ -631,7 +631,8 @@
 
                 [message]
                     speaker=Geldar
-                    message= _ "And fine troops they are, Prince, but no dwarf can match a guardsman’s resolute defense. Please accept the service o’ my clan’s defenders, to protect you and your quest."
+                    # po: "Your Highness" is Lord Geldar addressing Prince Kornad.
+                    message= _ "And fine troops they are, Your Highness, but no dwarf can match a guardsman’s resolute defense. Please accept the service o’ my clan’s defenders, to protect you and your quest."
                 [/message]
 
                 [message]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/16_Hasty_Alliance.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/16_Hasty_Alliance.cfg
@@ -90,7 +90,7 @@
         controller=ai
         type=Princess
         id="Li'sar"
-        name= _ "Li’sar"
+        name= _ "Princess Li’sar"
         profile=portraits/lisar.png
         facing=sw
         [ai]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
@@ -665,6 +665,7 @@
                     [message]
                         type=Arch Mage,Great Mage,Silver Mage
                         # po: "din" means "loud noise". It refers to an ambient sound of collapsing cave walls.
+                        # po: one of Prince Konrad's units addresses him
                         message= _ "Your Highness, that din was made by no living thing. It was the sound of the very earth that’s boiling around us, of the fire and lava that are breaching this cave even now. We must tread with caution, for the very ground we stand on may turn against us."
                     [/message]
                 [/then]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
@@ -665,7 +665,7 @@
                     [message]
                         type=Arch Mage,Great Mage,Silver Mage
                         # po: "din" means "loud noise". It refers to an ambient sound of collapsing cave walls.
-                        message= _ "Prince Konrad, that din was made by no living thing. It was the sound of the very earth that’s boiling around us, of the fire and lava that are breaching this cave even now. We must tread with caution, for the very ground we stand on may turn against us."
+                        message= _ "Your Highness, that din was made by no living thing. It was the sound of the very earth that’s boiling around us, of the fire and lava that are breaching this cave even now. We must tread with caution, for the very ground we stand on may turn against us."
                     [/message]
                 [/then]
             [/elseif]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/18_A_Choice_Must_Be_Made.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/18_A_Choice_Must_Be_Made.cfg
@@ -254,7 +254,8 @@
         [/message]
         [message]
             speaker=Konrad
-            message= _ "And will you join us in seeking refuge with the North Elves, Li’sar?"
+            # po: "Cousin" is Konrad addressing Li'sar
+            message= _ "And will you join us in seeking refuge with the North Elves, Cousin?"
         [/message]
         [message]
             speaker="Li'sar"

--- a/data/campaigns/Heir_To_The_Throne/scenarios/18_A_Choice_Must_Be_Made.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/18_A_Choice_Must_Be_Made.cfg
@@ -330,6 +330,7 @@
                 [/message]
                 [message]
                     speaker=Kalenz
+                    # po: Kalenz addresses Li'sar as "whelp".
                     message= _ "Of course not, whelp, else he would have chosen a safer route."
                 [/message]
                 [message]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/18_A_Choice_Must_Be_Made.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/18_A_Choice_Must_Be_Made.cfg
@@ -214,7 +214,8 @@
                 [message]
                     speaker=Kalenz
                     # po: Kalenz addresses Princess Li'sar
-                    message= _ "With all due respect, Your <i>Highness</i>, it is once again we who will spare you, Sceptre or no Sceptre."
+                    # po: "Princess" is not a royal title here, but a colloquial usage, meaning referring to a child in the context that their parents think of them. Kalenz is deliberately belittling Li'sar.
+                    message= _ "With all due respect, <i>princess</i>, it is once again we who will spare you, Sceptre or no Sceptre."
                 [/message]
                 [message]
                     speaker="Li'sar"

--- a/data/campaigns/Heir_To_The_Throne/scenarios/18_A_Choice_Must_Be_Made.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/18_A_Choice_Must_Be_Made.cfg
@@ -241,7 +241,7 @@
         [/message]
         [message]
             speaker=Kalenz
-            message= _ "We should indeed seek refuge there, my lord, but not by going east along the river. Its name means ‘The River of Bones’. Great and evil creatures lurk along its banks, its waters are not fit to drink, and it runs over the Cliffs of Thoria. It has been many centuries since any man or elf has passed over the Cliffs and survived. No, Prince, we must choose another way."
+            message= _ "We should indeed seek refuge there, my lord, but not by going east along the river. Its name means ‘The River of Bones’. Great and evil creatures lurk along its banks, its waters are not fit to drink, and it runs over the Cliffs of Thoria. It has been many centuries since any man or elf has passed over the Cliffs and survived. No, my lord, we must choose another way."
         [/message]
         [message]
             speaker=Konrad
@@ -285,7 +285,7 @@
             [then]
                 [message]
                     speaker=unit
-                    message= _ "Prince Konrad, you need not avoid the Arkan-thoria. We merfolk can lead you downstream; with our vanguard, your company will vanquish any foe, and reach the home of the North Elves much sooner than by either of the land routes. I can not promise a perilless journey, but it is an option for you to consider, my lord."
+                    message= _ "Your Highness, you need not avoid the Arkan-thoria. We merfolk can lead you downstream; with our vanguard, your company will vanquish any foe, and reach the home of the North Elves much sooner than by either of the land routes. I can not promise a perilless journey, but it is an option for you to consider, my lord."
                 [/message]
                 [if]
                     [variable]
@@ -362,7 +362,7 @@
         [/if]
         [message]
             speaker=unit
-            message= _ "Prince Konrad, are you sure you want to do this?"
+            message= _ "My lord, are you sure you want to do this?"
         [/message]
         [message]
             speaker=Konrad

--- a/data/campaigns/Heir_To_The_Throne/scenarios/18_A_Choice_Must_Be_Made.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/18_A_Choice_Must_Be_Made.cfg
@@ -213,6 +213,7 @@
                 [/message]
                 [message]
                     speaker=Kalenz
+                    # po: Kalenz addresses Princess Li'sar
                     message= _ "With all due respect, Your <i>Highness</i>, it is once again we who will spare you, Sceptre or no Sceptre."
                 [/message]
                 [message]
@@ -285,6 +286,7 @@
             [then]
                 [message]
                     speaker=unit
+                    # po: one of Prince Konrad's units addresses him
                     message= _ "Your Highness, you need not avoid the Arkan-thoria. We merfolk can lead you downstream; with our vanguard, your company will vanquish any foe, and reach the home of the North Elves much sooner than by either of the land routes. I can not promise a perilless journey, but it is an option for you to consider, my lord."
                 [/message]
                 [if]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/18_A_Choice_Must_Be_Made.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/18_A_Choice_Must_Be_Made.cfg
@@ -213,7 +213,7 @@
                 [/message]
                 [message]
                     speaker=Kalenz
-                    message= _ "With all due respect, <i>Princess</i>, it is once again we who will spare you, Sceptre or no Sceptre."
+                    message= _ "With all due respect, Your <i>Highness</i>, it is once again we who will spare you, Sceptre or no Sceptre."
                 [/message]
                 [message]
                     speaker="Li'sar"

--- a/data/campaigns/Heir_To_The_Throne/scenarios/19c_Cliffs_of_Thoria.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/19c_Cliffs_of_Thoria.cfg
@@ -346,7 +346,7 @@
         [/message]
         [message]
             speaker=Konrad
-            message= _ "Eh... well of course, sir drake. Let me introduce myself — I am Prince Konrad, leader of the group and heir to the throne of Wesnoth."
+            message= _ "Eh... well of course, sir drake. Let me introduce myself — I am Konrad, heir to the throne of Wesnoth and leader of this group."
         [/message]
         [message]
             speaker="Li'sar"
@@ -366,7 +366,7 @@ Soooo... It is you who sent your subordinates to attack us. Now when we’ve des
         [/message]
         [message]
             speaker=Kalenz
-            message= _ "The Prince speaks the truth."
+            message= _ "His Highness speaks the truth."
         [/message]
         [message]
             speaker=Keh Ohn

--- a/data/campaigns/Heir_To_The_Throne/scenarios/19c_Cliffs_of_Thoria.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/19c_Cliffs_of_Thoria.cfg
@@ -327,6 +327,7 @@
         [/message]
         [message]
             role=merman-advisor
+            # po: the addressees are Prince Konrad and Princess Li'sar
             message= _ "With all due respect, Your Highnesses, you are both wrong. This is not a dragon. This is a drake."
         [/message]
         [message]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/21_Elven_Council.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/21_Elven_Council.cfg
@@ -267,7 +267,7 @@
         [/message]
         [message]
             speaker=Kalenz
-            message= _ "Wisdom has been spoken here today, Delfador. We have been with Li’sar in the most trying of times, and risked life and limb with her. Yet we still have both our lives and our limbs. She lacks experience, and has too much of the brashness of youth, but she will make a good Queen in time."
+            message= _ "Wisdom has been spoken here today, Delfador. We have been with Princess Li’sar in the most trying of times, and risked life and limb with her. Yet we still have both our lives and our limbs. She lacks experience, and has too much of the brashness of youth, but she will make a good Queen in time."
         [/message]
         [message]
             speaker=Delfador

--- a/data/campaigns/Heir_To_The_Throne/scenarios/21_Elven_Council.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/21_Elven_Council.cfg
@@ -195,7 +195,7 @@
                 [/message]
                 [message]
                     speaker=Konrad
-                    message= _ "Delfador! Li’sar has become our friend. I don’t want to fight her! As long as she rules well, what does it matter if she becomes queen?"
+                    message= _ "Delfador! Li’sar is my cousin and our ally. I don’t want to fight her! As long as she rules well, what does it matter if she becomes queen?"
                 [/message]
                 [message]
                     speaker=Delfador

--- a/data/campaigns/Heir_To_The_Throne/scenarios/22_Return_to_Wesnoth.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/22_Return_to_Wesnoth.cfg
@@ -243,7 +243,7 @@
         [/message]
         [message]
             speaker=Dwar-Ni
-            message= _ "Look! It is the traitor Li’sar, with the old mage and the filthy elven lord. Quickly, capture them! The Queen wishes to make them her prisoners."
+            message= _ "Look! It is the traitorous Princess Li’sar, with the old mage and the filthy elven lord. Quickly, capture them! The Queen wishes to make them her prisoners."
         [/message]
         [message]
             speaker="Li'sar"

--- a/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
@@ -715,7 +715,7 @@ fire:  +10%"
 #define NEED_LISAR PLACEMENT
     [unit]
         id="Li'sar"
-        name= _ "Li’sar"
+        name= _ "Princess Li’sar"
         profile=portraits/lisar.png
         unrenamable=yes
         type=Princess

--- a/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
@@ -419,7 +419,7 @@ fire:  +10%"
         [/message]
         [message]
             speaker="Li'sar"
-            message= _ "My first use for it is going to be to help us get out of this hole! I hope you consider that wise."
+            message= _ "My first use for it is going to be to help us get out of this hole! I hope you consider that wise, Cousin."
         [/message]
         [message]
             speaker=Delfador


### PR DESCRIPTION
As suggested in #4367.

Konrad is addressed sometimes by his units, sometimes by Kalenz/Delfador, and sometimes by leaders of allied or enemy sides. I tried to get it right but please review.

@nemaara, are there any further changes you want to make beyond these?

I've also renamed Konrad and Li'sar to `Prince Konrad` and `Princess Li’sar`, to make it clear why he's addressed as a highness.