### PR TITLE
Tutorial menu (S3): Add a scenario where the player can choose the next tutorial

### DIFF
--- a/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
+++ b/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
@@ -4,6 +4,7 @@
     id=2_Tutorial
     name= _ "Wesnoth Tutorial — Part II"
     map_file=campaigns/tutorial/maps/02_Tutorial_part_2.map
+    next_scenario=3_Tutorial
     turns=26
     experience_modifier=100
 

--- a/data/campaigns/tutorial/scenarios/03_Tutorial_part_3.cfg
+++ b/data/campaigns/tutorial/scenarios/03_Tutorial_part_3.cfg
@@ -1,0 +1,219 @@
+#textdomain wesnoth-tutorial
+
+# A menu to enable small puzzles to be added, similar to the Tactics Puzzles add-on.
+# The code for this is similar to the "micro_ai_test" scenario.
+
+[tutorial]
+    id=3_Tutorial
+    name= _ "Wesnoth Tutorial Optional Menu"
+    map_file=campaigns/tutorial/maps/01_Tutorial_part_1.map
+    next_scenario=null
+    victory_when_enemies_defeated=no
+    experience_modifier=100
+    turns=1
+
+    {DEFAULT_SCHEDULE}
+
+    {SCENARIO_MUSIC       battle-epic.ogg}
+    {EXTRA_SCENARIO_MUSIC the_city_falls.ogg}
+    {EXTRA_SCENARIO_MUSIC casualties_of_war.ogg}
+    {EXTRA_SCENARIO_MUSIC heroes_rite.ogg}
+    {EXTRA_SCENARIO_MUSIC northerners.ogg}
+
+    [side]
+        side=1
+        controller=human
+        gold=100
+        save_id=human_player
+        persistent=yes
+        team_name=player
+        user_team_name= _ "team_name^Student"
+
+        type=Fighter
+        id=student
+        name= _"Konrad"
+        unrenamable=yes
+        profile=portraits/konrad.png
+        canrecruit=yes
+
+        facing=se
+    [/side]
+
+    [side]
+        side=2
+        controller=null
+        team_name=hidden
+        no_leader=yes
+        hidden=yes
+    [/side]
+
+    [side]
+        side=3
+        controller=null
+        team_name=player
+        no_leader=yes
+        hidden=yes
+
+        [unit]
+            id=Delfador
+            name= _ "Delfador"
+            type=Elder Mage
+            profile=portraits/delfador.png~RIGHT()
+            x,y=13,5
+            random_traits=no
+            facing=nw
+            {IS_HERO}
+            [modifications]
+                {TRAIT_INTELLIGENT}
+                [object]
+                    [effect]
+                        apply_to=new_animation
+                        [extra_anim]
+                            flag=summon_quintain_raise_staff
+                            start_time=0
+                            [frame]
+                                image="units/human-magi/elder-mage-ranged[1~3].png:100"
+                            [/frame]
+                        [/extra_anim]
+                        [extra_anim]
+                            flag=summon_quintain_lower_staff
+                            start_time=0
+                            [frame]
+                                image="units/human-magi/elder-mage-ranged[3~1].png:150"
+                            [/frame]
+                        [/extra_anim]
+                    [/effect]
+                [/object]
+            [/modifications]
+        [/unit]
+    [/side]
+
+    [event]
+        name=prestart
+        [objectives]
+            side=1
+            [objective]
+                description= _ "End your turn (end tutorial)"
+                condition=win
+            [/objective]
+
+            [objective]
+                description= _ "Move Konrad to a signpost"
+                condition=win
+                [show_if]
+                    [have_unit]
+                        id=student
+                        gender=male
+                    [/have_unit]
+                [/show_if]
+            [/objective]
+
+            [objective]
+                description= _ "Move Li’sar to a signpost"
+                condition=win
+                [show_if]
+                    [have_unit]
+                        id=student
+                        gender=female
+                    [/have_unit]
+                [/show_if]
+            [/objective]
+
+            [note]
+                description= _ "Each signpost has a longer description — right-click on the signpost and select “describe signpost” to read it."
+            [/note]
+        [/objectives]
+
+        # In case a [set_menu_item] is added without the corresponding [clear_menu_item],
+        # ensure that these menu items are only displayed in this scenario.
+        [unit]
+            id=the_s3_quintain
+            type=Quintain
+            ai_special=guardian
+            x,y=18,5
+            side=2
+        [/unit]
+#define SHOW_MENU_ITEM_ON_S3_ONLY
+        [show_if]
+            [have_unit]
+                id=the_s3_quintain
+            [/have_unit]
+        [/show_if]
+#enddef
+
+        {PLACE_IMAGE "scenery/signpost.png" 6 3}
+        {SET_LABEL 6 3 _"Replay Elves vs Orcs"}
+        [set_menu_item]
+            id=s03_menu_replay_elves_vs_orcs
+            description="Describe signpost"
+            [filter_location]
+                x,y=6,3
+            [/filter_location]
+            {SHOW_MENU_ITEM_ON_S3_ONLY}
+            [command]
+                [message]
+                    speaker=narrator
+                    caption= _ "Replay Elves vs Orcs"
+                    image=wesnoth-icon.png
+                    message= _ "Play the main tutorial scenario again, your recall list will already have the experienced troops from your previous playthrough."
+                [/message]
+            [/command]
+        [/set_menu_item]
+        [event]
+            name=moveto
+            first_time_only=no
+            [filter]
+                x,y=6,3
+            [/filter]
+            [endlevel]
+                next_scenario=2_Tutorial
+                result=victory
+                bonus=no
+                carryover_percentage=0
+                carryover_report=no
+                replay_save=no
+                linger_mode=no
+            [/endlevel]
+        [/event]
+
+    [/event]
+
+    [event]
+        name=start
+
+        [message]
+            speaker=narrator
+            caption= _ "You now know enough to play Wesnoth!"
+            image=wesnoth-icon.png
+            message= _ "You could just skip this part of the tutorial and play a campaign. The elves vs orcs scenario has already taught you enough to play the rookie campaigns, and those campaigns will introduce the mechanics for the non-rookie campaigns."
+        [/message]
+
+        [message]
+            speaker=narrator
+            caption= _ "You now know enough to play Wesnoth!"
+            image=wesnoth-icon.png
+            message= _ "In this scenario, each signpost leads to an additional part of the tutorial, after which you’ll return to this menu scenario.
+
+Alternatively, just end turn to return to the title screen, where you can start a campaign."
+        [/message]
+    [/event]
+
+    [event]
+        name=time over
+        [endlevel]
+            result=victory
+            carryover_report=no
+            replay_save=no
+            linger_mode=no
+        [/endlevel]
+    [/event]
+
+    [event]
+        name=victory
+        [clear_menu_item]
+            id=s03_menu_replay_elves_vs_orcs
+        [/clear_menu_item]
+    [/event]
+#undef SHOW_MENU_ITEM_ON_S3_ONLY
+
+[/tutorial]


### PR DESCRIPTION
This is meant to make it clear to the player that they've finished the
"required" tutorial, and are now ready for the campaigns, but also to allow
additional scenarios that are along the lines of the Tactic Puzzles addon.