### PR TITLE
mp_create_game: Show preview if map_file is set

### DIFF
--- a/data/multiplayer/scenarios/2p_Aethermaw.cfg
+++ b/data/multiplayer/scenarios/2p_Aethermaw.cfg
@@ -4,7 +4,7 @@
     name= _ "2p — Aethermaw"
     # wmllint: local spellings Sulla Aethermaw Paterson
     description= _ "Long ago, the Great Mage Sulla was imprisoned in the Aethermaw, a nexus of mystical energy whose chaotic nature was able to prevent her escape. Over the centuries, however, Sulla gradually attuned her powers to the maelstrom of disorder that is the Aethermaw, and has now begun to project its influence onto the material plane, drawing in entire regions of land from hundreds of different worlds, realities and time-periods. She experiments with these disparate pieces of the cosmos, manipulating them, merging them and sending them back and forth between the Aethermaw and their place of origin. Perhaps, as her mastery over the Aethermaw grows, Sulla will one day break free of its bonds. Until that time comes, she will continue to amuse herself by arranging battles between the mortal beings unlucky enough to be drawn into its depths. Designed by Doc Paterson."
-    map_data="{multiplayer/maps/2p_Aethermaw.map}"
+    map_file=multiplayer/maps/2p_Aethermaw.map
     random_start_time="no"
 
     {DEFAULT_SCHEDULE}

--- a/src/gui/dialogs/multiplayer/mp_create_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.cpp
@@ -708,7 +708,7 @@ void mp_create_game::update_details(window& win)
 			create_engine_.get_state().classification().campaign = "";
 
 			find_widget<stacked_widget>(&win, "minimap_stack", false).select_layer(0);
-			const std::string map_data = current_scenario->data()["map_file"].empty()
+			const std::string map_data = !current_scenario->data()["map_data"].empty()
 				? current_scenario->data()["map_data"]
 				: filesystem::read_map(current_scenario->data()["map_file"]);
 			find_widget<minimap>(&win, "minimap", false).set_map_data(map_data);

--- a/src/gui/dialogs/multiplayer/mp_create_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.cpp
@@ -673,7 +673,9 @@ void mp_create_game::update_details(window& win)
 
 	if(create_engine_.current_level_type() == ng::level::TYPE::RANDOM_MAP) {
 		// If the current random map doesn't have data, generate it
-		if(create_engine_.generator_assigned() && create_engine_.current_level().data()["map_data"].empty()) {
+		if(create_engine_.generator_assigned() &&
+			create_engine_.current_level().data()["map_data"].empty() &&
+			create_engine_.current_level().data()["map_file"].empty()) {
 			create_engine_.init_generated_level_data();
 		}
 

--- a/src/gui/dialogs/multiplayer/mp_create_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.cpp
@@ -16,6 +16,7 @@
 
 #include "gui/dialogs/multiplayer/mp_create_game.hpp"
 
+#include "filesystem.hpp"
 #include "game_config_manager.hpp"
 #include "game_initialization/lobby_data.hpp"
 #include "gettext.hpp"
@@ -705,7 +706,10 @@ void mp_create_game::update_details(window& win)
 			create_engine_.get_state().classification().campaign = "";
 
 			find_widget<stacked_widget>(&win, "minimap_stack", false).select_layer(0);
-			find_widget<minimap>(&win, "minimap", false).set_map_data(current_scenario->data()["map_data"]);
+			const std::string map_data = current_scenario->data()["map_file"].empty()
+				? current_scenario->data()["map_data"]
+				: filesystem::read_map(current_scenario->data()["map_file"]);
+			find_widget<minimap>(&win, "minimap", false).set_map_data(map_data);
 
 			players.set_label(std::to_string(current_scenario->num_players()));
 			map_size.set_label(current_scenario->map_size());


### PR DESCRIPTION
Fixes the second bullet of https://github.com/wesnoth/wesnoth/issues/4397#issuecomment-536357310.

Could someone double check the change to the generator_assigned condition? Is it about the case that a scenario file defines both map_file and a map generator? I would have expected that to be an error, actually.