### PR TITLE
Addon manager: Save the last sort order in a hidden preference

### DIFF
--- a/src/gui/dialogs/addon/manager.hpp
+++ b/src/gui/dialogs/addon/manager.hpp
@@ -50,12 +50,18 @@ private:
 	struct addon_order
 	{
 		std::string label;
+		/// The value used in the preferences file
+		std::string as_preference;
 		int column_index; // -1 if there is no such column
 		addon_list::addon_sort_func sort_func_asc;
 		addon_list::addon_sort_func sort_func_desc;
 
-		addon_order(std::string label_, int column, addon_list::addon_sort_func sort_func_asc_, addon_list::addon_sort_func sort_func_desc_)
-			: label(label_), column_index(column), sort_func_asc(sort_func_asc_), sort_func_desc(sort_func_desc_)
+		addon_order(std::string label_, std::string as_preference_, int column, addon_list::addon_sort_func sort_func_asc_, addon_list::addon_sort_func sort_func_desc_)
+			: label(label_)
+			, as_preference(as_preference_)
+			, column_index(column)
+			, sort_func_asc(sort_func_asc_)
+			, sort_func_desc(sort_func_desc_)
 		{}
 	};
 

--- a/src/gui/widgets/listbox.hpp
+++ b/src/gui/widgets/listbox.hpp
@@ -279,6 +279,7 @@ public:
 	/** Registers a special sorting function specifically for translatable values. */
 	void register_translatable_sorting_option(const int col, translatable_sorter_func_t f);
 
+	/// The int values of this enum are serialized by preferences::set_addon_manager_saved_order_direction(), don't change them!
 	enum SORT_ORDER {
 		SORT_NONE,
 		SORT_ASCENDING,

--- a/src/preferences/general.cpp
+++ b/src/preferences/general.cpp
@@ -1074,4 +1074,25 @@ void set_damage_prediction_allow_monte_carlo_simulation(bool value)
 	set("damage_prediction_allow_monte_carlo_simulation", value);
 }
 
+std::string addon_manager_saved_order_name()
+{
+	return get("addon_manager_saved_order_name");
+}
+
+void set_addon_manager_saved_order_name(const std::string& value)
+{
+	set("addon_manager_saved_order_name", value);
+}
+
+int addon_manager_saved_order_direction()
+{
+	return std::atoi(get("addon_manager_saved_order_direction").c_str());
+}
+
+void set_addon_manager_saved_order_direction(const int& value)
+{
+	set("addon_manager_saved_order_direction", std::to_string(value));
+}
+
+
 } // end namespace preferences

--- a/src/preferences/general.hpp
+++ b/src/preferences/general.hpp
@@ -283,4 +283,11 @@ namespace preferences {
 	bool damage_prediction_allow_monte_carlo_simulation();
 	void set_damage_prediction_allow_monte_carlo_simulation(bool value);
 
+	std::string addon_manager_saved_order_name();
+	void set_addon_manager_saved_order_name(const std::string& value);
+
+	// Actually gui2::listbox::SORT_ORDER
+	int addon_manager_saved_order_direction();
+	void set_addon_manager_saved_order_direction(const int& value);
+
 } // end namespace preferences


### PR DESCRIPTION
Is this okay? I assume there's a better way to do the conversions from SORT_ORDER to int and back.