### PR TITLE
Improve the terrain code's encapsulation

### DIFF
--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -162,7 +162,7 @@ static inline std::string get_mp_tooltip(int total_movement, std::function<int (
 		}
 
 		const terrain_type& info = tdata->get_terrain_info(terrain);
-		if(info.union_type().size() == 1 && info.union_type()[0] == info.number() && info.is_nonnull()) {
+		if(info.is_indivisible() && info.is_nonnull()) {
 			terrain_moves.emplace(info.name(), get(terrain));
 		}
 	}

--- a/src/help/help_impl.cpp
+++ b/src/help/help_impl.cpp
@@ -859,8 +859,8 @@ void generate_terrain_sections(const config* /*help_cfg*/, section& sec, int /*l
 		}
 	}
 
-	for (std::map<std::string, section>::const_iterator it = base_map.begin(); it != base_map.end(); ++it) {
-		sec.add_section(it->second);
+	for (const auto& base : base_map) {
+		sec.add_section(base.second);
 	}
 }
 

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -153,17 +153,14 @@ std::string terrain_topic_generator::operator()() const {
 		return ss.str();
 	}
 
-	if (!(type_.union_type().size() == 1 && type_.union_type()[0] == type_.number() && type_.is_nonnull())) {
-
-		const t_translation::ter_list& underlying_mvt_terrains = tdata->underlying_mvt_terrain(type_.number());
-
+	if (!type_.is_indivisible()) {
 		ss << "\n" << _("Base Terrain: ");
 
 		bool first = true;
-		for (const t_translation::terrain_code& underlying_terrain : underlying_mvt_terrains) {
-			const terrain_type& mvt_base = tdata->get_terrain_info(underlying_terrain);
+		for (const auto& underlying_terrain : type_.union_type()) {
+			const terrain_type& base = tdata->get_terrain_info(underlying_terrain);
 
-			if (mvt_base.editor_name().empty()) continue;
+			if (base.editor_name().empty()) continue;
 
 			if (!first) {
 				ss << ", ";
@@ -171,15 +168,16 @@ std::string terrain_topic_generator::operator()() const {
 				first = false;
 			}
 
-			ss << make_link(mvt_base.editor_name(), ".." + terrain_prefix + mvt_base.id());
+			ss << make_link(base.editor_name(), ".." + terrain_prefix + base.id());
 		}
 
 		ss << "\n";
 
+		const t_translation::ter_list& underlying_mvt_terrains = type_.mvt_type();
 		ss << "\n" << _("Movement properties: ");
 		ss << print_behavior_description(underlying_mvt_terrains.begin(), underlying_mvt_terrains.end(), tdata) << "\n";
 
-		const t_translation::ter_list& underlying_def_terrains = tdata->underlying_def_terrain(type_.number());
+		const t_translation::ter_list& underlying_def_terrains = type_.def_type();
 		ss << "\n" << _("Defense properties: ");
 		ss << print_behavior_description(underlying_def_terrains.begin(), underlying_def_terrains.end(), tdata) << "\n";
 	}
@@ -717,7 +715,7 @@ std::string unit_topic_generator::operator()() const {
 				continue;
 			}
 
-			if (info.union_type().size() == 1 && info.union_type()[0] == info.number() && info.is_nonnull()) {
+			if (info.is_indivisible() && info.is_nonnull()) {
 				terrain_movement_info movement_info =
 				{
 					info.name(),

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -157,7 +157,7 @@ void gamemap::read(const std::string& data, const bool allow_invalid)
 			// Is the terrain valid?
 			t_translation::terrain_code t = tiles_.get(x, y);
 			if(tdata_->map().count(t) == 0) {
-				if(!tdata_->try_merge_terrains(t)) {
+				if(!tdata_->is_known(t)) {
 					std::stringstream ss;
 					ss << "Unknown tile in map: (" << t_translation::write_terrain_code(t)
 						   << ") '" << t << "'";

--- a/src/movetype.cpp
+++ b/src/movetype.cpp
@@ -287,10 +287,8 @@ int movetype::terrain_info::data::calc_value(
 	const t_translation::ter_list & underlying = params_.use_move ?
 			tdata->underlying_mvt_terrain(terrain) :
 			tdata->underlying_def_terrain(terrain);
-	assert(!underlying.empty());
 
-
-	if ( underlying.size() == 1  &&  underlying.front() == terrain )
+	if (terrain_type::is_indivisible(terrain, underlying))
 	{
 		// This is not an alias; get the value directly.
 		int result = params_.default_value;

--- a/src/terrain/translation.cpp
+++ b/src/terrain/translation.cpp
@@ -118,6 +118,11 @@ namespace t_translation {
 
 const terrain_code OFF_MAP_USER = string_to_number_("_off^_usr");
 
+/**
+ * VOID_TERRAIN is used for shrouded hexes. It's also used by terrain_type's
+ * default constructor, but that's only used as the sentinel value for when
+ * terrain_type_data::get_terrain_info() is asked for an unknown terrain code.
+ */
 const terrain_code VOID_TERRAIN = string_to_number_("_s");
 const terrain_code FOGGED = string_to_number_("_f");
 

--- a/src/terrain/type_data.hpp
+++ b/src/terrain/type_data.hpp
@@ -18,40 +18,91 @@
 
 #include <map>
 
+/**
+ * Contains the database of all known terrain types, both those defined
+ * explicitly by WML [terrain_type]s and those made by combining pairs of
+ * (base, overlay).
+ *
+ * A [terrain_type] isn't limited to (only a base) or (only an overlay). For example,
+ * the various impassible mountains Mm^Xm, Ms^Xm, etc are defined by [terrain_type]s
+ * for those specific (base, overlay) pairs.
+ *
+ * Implementation note: the ones defined by WML [terrain_type]'s are loaded
+ * during the first call to lazy_initialization(). Any terrains made by
+ * combining pairs of (base, overlay) are lazy-created during a later call to
+ * find_or_create().
+ *
+ * The is_known() method will trigger creation of the terrain if needed.
+ */
 class terrain_type_data {
 private:
 	mutable t_translation::ter_list terrainList_;
 	using tcodeToTerrain_t = std::map<t_translation::terrain_code, terrain_type>;
 	mutable tcodeToTerrain_t tcodeToTerrain_;
-
 	mutable bool initialized_;
 	const config & game_config_;
 
 public:
 	terrain_type_data(const config & game_config);
 
+	/**
+	 * On the first call to this function, parse all of the [terrain_type]s
+	 * that are defined in WML. This is separated from the constructor so that
+	 * game_config_manager can create an instance while on the title screen,
+	 * without the delay of loading the data (and it's likely that a different
+	 * config will be loaded before entering the game).
+	 */
+	void lazy_initialization() const;
+
 	const t_translation::ter_list & list() const;
 	const std::map<t_translation::terrain_code, terrain_type> & map() const;
 
 	/**
-	 * Get the corresponding terrain_type information object
-	 * for a given type of terrain.
+	 * Get the corresponding terrain_type information object for a given type
+	 * of terrain.
+	 *
+	 * If the given terrain is not known, and can not be constructed from the
+	 * known terrains, returns a default-constructed instance.
 	 */
 	const terrain_type& get_terrain_info(const t_translation::terrain_code & terrain) const;
 
-	// The name of the terrain is the terrain itself,
-	// The underlying terrain is the name of the terrain for game-logic purposes.
-	// I.e. if the terrain is simply an alias, the underlying terrain name
-	// is the name of the terrain that it's aliased to.
+	/**
+	 * The underlying movement type of the terrain.
+	 *
+	 * The underlying terrain is the name of the terrain for game-logic purposes.
+	 * I.e. if the terrain is simply an alias, the underlying terrain name
+	 * is the name of the terrain(s) that it's aliased to.
+	 *
+	 * Whether "underlying" means "only the types used in [movetype]" is determined
+	 * by the terrain.cfg file, rather than the .cpp code - in 1.14, the terrain.cfg
+	 * file uses only the [movetype] terrains in its alias lists.
+	 *
+	 * This may start with a t_translation::PLUS or t_translation::MINUS to
+	 * indicate whether the movement should be calculated as a best-of or
+	 * worst-of combination. These may also occur later in the list, however if
+	 * both PLUS and MINUS appear in the list then the values calculated are
+	 * implementation defined behavior.
+	 */
 	const t_translation::ter_list& underlying_mvt_terrain(const t_translation::terrain_code & terrain) const;
+	/**
+	 * The underlying defense type of the terrain. See the notes for underlying_mvt_terrain.
+	 */
 	const t_translation::ter_list& underlying_def_terrain(const t_translation::terrain_code & terrain) const;
+	/**
+	 * Unordered set of all terrains used in either underlying_mvt_terrain or
+	 * underlying_def_terrain. This does not include any PLUSes or MINUSes.
+	 *
+	 * May also include the aliasof and vision_alias terrains, however
+	 * vision_alias is deprecated and aliasof should probably match the
+	 * movement and defense terrains.
+	 */
 	const t_translation::ter_list& underlying_union_terrain(const t_translation::terrain_code & terrain) const;
 	/**
-	 * Get a formatted terrain name -- terrain (underlying, terrains)
+	 * Get a formatted terrain name -- terrain (underlying terrains)
 	 */
-	std::string get_terrain_string(const t_translation::terrain_code& terrain) const;
-	std::string get_terrain_editor_string(const t_translation::terrain_code& terrain) const;
-	std::string get_underlying_terrain_string(const t_translation::terrain_code& terrain) const;
+	t_string get_terrain_string(const t_translation::terrain_code& terrain) const;
+	t_string get_terrain_editor_string(const t_translation::terrain_code& terrain) const;
+	t_string get_underlying_terrain_string(const t_translation::terrain_code& terrain) const;
 
 	bool is_village(const t_translation::terrain_code & terrain) const
 		{ return get_terrain_info(terrain).is_village(); }
@@ -69,24 +120,33 @@ public:
 		};
 
 	/**
-	 * Tries to merge old and new terrain using the merge_settings config
+	 * Tries to find a new terrain which is the combination of old and new
+	 * terrain using the merge_settings. Here "merge" means to find the
+	 * best-fitting terrain code, it does not change any already-created
+	 * instance of terrain_data. Think of using the editor's
+	 * paint-with-one-layer functionality for the purpose of this.
+	 *
 	 * Relevant parameters are "layer" and "replace_conflicting"
 	 * "layer" specifies the layer that should be replaced (base or overlay, default is both).
 	 * If "replace_conflicting" is true the new terrain will replace the old one if merging failed
 	 * (using the default base if new terrain is an overlay terrain)
 	 * Will return the resulting terrain or NONE_TERRAIN if merging failed
 	 */
-	t_translation::terrain_code merge_terrains(const t_translation::terrain_code & old_t, const t_translation::terrain_code & new_t, const merge_mode mode, bool replace_if_failed = false);
+	t_translation::terrain_code merge_terrains(const t_translation::terrain_code & old_t, const t_translation::terrain_code & new_t, const merge_mode mode, bool replace_if_failed = false) const;
 
 	/**
-	 * Tries to find out if "terrain" can be created by combining two existing
-	 * terrains Will add the resulting terrain to the terrain list if
-	 * successful
+	 * Returns true if get_terrain_info(terrain) would succeed, or false if
+	 * get_terrain_info(terrain) would return a default-constructed instance.
+	 *
+	 * This has no connection to preferences::encountered_terrains().
+	 *
+	 * Implementation note: if necessary, will trigger the lazy-creation and
+	 * add the resulting terrain to the terrain list.
 	 */
-	bool try_merge_terrains(const t_translation::terrain_code & terrain);
+	bool is_known(const t_translation::terrain_code & terrain) const;
 
 private:
-	tcodeToTerrain_t::const_iterator find_or_merge(t_translation::terrain_code) const;
+	tcodeToTerrain_t::const_iterator find_or_create(t_translation::terrain_code) const;
 };
 
 typedef std::shared_ptr<terrain_type_data> ter_data_cache;


### PR DESCRIPTION
Change terrain_type_data's documentation and some methods to avoid exposing
implementation details, for example renaming try_merge_terrains to is_known.

Move the code to load all the [terrain_types] in to the terrain_type_data
class's own .cpp file, and out of terrain.cpp.

Add documentation about "underlying", and why worst(best(a,b),c,d) terrains don't work
The commented-out code for merging pluses and minuses in the middle of an alias
was commented out in 1.5's d2edbe118a5f49ca96268c6b5f6a4b2110df7cc2, but the
concept of pluses and minuses in the middle of an alias seems broken anyway
(see comments added to merge_alias_lists in this commit).

Descriptions are t_strings, avoid converting them to std::string and back.