### PR TITLE
Help for the ^Uf mushrooms terrains + display carets to the user (#4359)

### DIFF
--- a/data/core/terrain.cfg
+++ b/data/core/terrain.cfg
@@ -942,25 +942,39 @@ Most units receive 20 to 40% defense in sand."
     symbol_image=forest/mushrooms-tile
     id=fungus_grove_old
     name= _ "Mushroom Grove"
-    editor_name= _ "Mushroom Grove"
+    editor_name= _ "Non-mixed Mushroom Grove"
     string=^Uf
     aliasof=Tt
     default_base=Uu
     editor_group=cave, forest
     hidden=yes # deprecated, only kept around so old maps still work
+#ifdef EDITOR
+    # po: this hint is only shown in the map editor, the ^Uf, ^Tf and Tb are all terrain codes and should be left as-is
+    help_topic_text= _ "editor^The overlays '^Uf' and '^Ufi' are deprecated because, although the graphics show an overlay with another terrain underneath, the movement and defense stats are purely fungus terrain, ignoring the underlying terrain. The recommended replacements are '^Tf' and '^Tfi' which look the same but have the stats implied by the graphics. For hexes where the stats of purely fungus are wanted, 'Tb' is a mushroom base terrain, which can be used with or without '^Tf' on top."
+#else
+    # po: this is only shown when the player opens the help by asking for the terrain description of a old mushroom terrain (^Uf or ^Ufi)
+    help_topic_text= _ "Dwarven tales describe different types of mushrooms — with some types the difficulty of walking on the spongy floor has no relation to the ground underneath, even when the ground underneath is still visible. This terrain’s defense and movement costs are purely based on the unit’s stats for <italic>text='Fungus'</italic>."
+#endif
 [/terrain_type]
 
 [terrain_type]
     symbol_image=forest/mushrooms-beam-tile
     id=fungus_beam_old
     name= _ "Mushroom Grove"
-    editor_name= _ "Lit Mushroom Grove"
+    editor_name= _ "Lit Non-mixed Mushroom Grove"
     string=^Ufi
     default_base=Uu
     aliasof=Tt
     light=25
     editor_group=cave
     hidden=yes # deprecated, only kept around so old maps still work
+#ifdef EDITOR
+    # po: this hint is only shown in the map editor, the ^Uf, ^Tf and Tb are all terrain codes and should be left as-is
+    help_topic_text= _ "editor^The overlays '^Uf' and '^Ufi' are deprecated because, although the graphics show an overlay with another terrain underneath, the movement and defense stats are purely fungus terrain, ignoring the underlying terrain. The recommended replacements are '^Tf' and '^Tfi' which look the same but have the stats implied by the graphics. For hexes where the stats of purely fungus are wanted, 'Tb' is a mushroom base terrain, which can be used with or without '^Tf' on top."
+#else
+    # po: this is only shown when the player opens the help by asking for the terrain description of a old mushroom terrain (^Uf or ^Ufi)
+    help_topic_text= _ "Dwarven tales describe different types of mushrooms — with some types the difficulty of walking on the spongy floor has no relation to the ground underneath, even when the ground underneath is still visible. This terrain’s defense and movement costs are purely based on the unit’s stats for <italic>text='Fungus'</italic>."
+#endif
 [/terrain_type]
 
 [terrain_type]

--- a/src/gettext.cpp
+++ b/src/gettext.cpp
@@ -405,7 +405,7 @@ std::string dsgettext (const char * domainname, const char *msgid)
 {
 	std::string msgval = dgettext (domainname, msgid);
 	if (msgval == msgid) {
-		const char* firsthat = std::strrchr (msgid, '^');
+		const char* firsthat = std::strchr (msgid, '^');
 		if (firsthat == nullptr)
 			msgval = msgid;
 		else
@@ -420,7 +420,7 @@ std::string dsngettext (const char * domainname, const char *singular, const cha
 	std::lock_guard<std::mutex> lock(get_mutex());
 	std::string msgval = bl::dngettext(domainname, singular, plural, n, get_manager().get_locale());
 	if (msgval == singular) {
-		const char* firsthat = std::strrchr (singular, '^');
+		const char* firsthat = std::strchr (singular, '^');
 		if (firsthat == nullptr)
 			msgval = singular;
 		else


### PR DESCRIPTION
Two commits, which I've put in the same PR because the new mushroom text will be the first text displaying carets to the user. Will happily merge just the .cpp change if the prose needs more work.

Allow translatable strings to display carets to the user (#4359)
---

Treat `editor^The overlays '^Uf' and '^Ufi' are deprecated because ...` as a having translation hint `editor`, and show "The overlays ..." to the user. This disallows using carets inside the translation hint itself.

Code already reviewed in the discussion in #4359.

Help for the ^Uf mushrooms terrains, including an editor-only hint
---

As the terrain is hidden in help, these hints can only be seen by using the "Terrain Description" command on a ^Uf or ^Ufi mushroom hex, and then switching to the overlay's own page.

A hint for players about how these mushrooms behave, and an editor-only hint about replacing the ^Uf mushroom terrains with ^Tf.