### PR TITLE
Remember tile_size/zoom factor between play sessions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -45,6 +45,7 @@
    * Hide the "Suppose Dead" key from the hotkeys list (it does nothing since 1.9.12)
    * Sidebar: In replays with "View: Full Map", show all enemy units in "Damage versus:" tooltip
    * Multiplayer Create Game screen now shows map previews for scenarios that use map_file=. (PR#4407)
+   * Remember zoom level between play sessions (#1518) and add zoom options to context menu (#1213)
  ### Lua API
    * Accessing wesnoth.theme_items.unit_status no longer prevents the unit
      status (poisoned/slowed/etc) from being shown in the sidebar. (Issue#4079)

--- a/data/game_config.cfg
+++ b/data/game_config.cfg
@@ -32,6 +32,8 @@
 
     hp_bar_scaling=0.6
     xp_bar_scaling=0.5
+
+	# zoom factors must be a sorted list of ascending multipliers
     zoom_levels = 0.25, 0.33333333333333333, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 3.0, 4.0
 
     #temporary disable hex brightening

--- a/data/themes/default.cfg
+++ b/data/themes/default.cfg
@@ -118,6 +118,8 @@
                 "wbexecuteaction,wbdeleteaction,wbbumpupaction,wbbumpdownaction,wbsupposedead," +
                 # Information
                 "describeterrain,describeunit,renameunit," +
+                # Zoom
+                "zoomin,zoomout,zoomdefault," +
                 # Debug commands
                 "createunit,changeside,killunit," +
                 # Labels

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -91,7 +91,6 @@ unsigned int display::last_zoom_ = SmallZoom;
 
 // Returns index of zoom_levels which is closest match to input zoom_level
 // Assumption: zoom_levels is a sorted vector of ascending tile sizes
-// (game_config is set-up this way as of October 2019 but there is no documentation stating it has to be so)
 int get_zoom_levels_index(unsigned int zoom_level)
 {
 	zoom_level = utils::clamp(zoom_level, MinZoom, MaxZoom);	// ensure zoom_level is within zoom_levels bounds

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2071,7 +2071,7 @@ bool display::set_zoom(unsigned int amount, const bool validate_value_and_set_in
 	return true;
 }
 
-void display::set_default_zoom()
+void display::toggle_default_zoom()
 {
 	if (zoom_ != DefaultZoom) {
 		last_zoom_ = zoom_;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -89,7 +89,7 @@ namespace {
 unsigned int display::zoom_ = DefaultZoom;
 unsigned int display::last_zoom_ = SmallZoom;
 
-// Returns index of zoom_levels which is closest match to input tile_size
+// Returns index of zoom_levels which is closest match to input zoom_level
 // Assumption: zoom_levels is a sorted vector of ascending tile sizes
 // (game_config is set-up this way as of October 2019 but there is no documentation stating it has to be so)
 int get_zoom_levels_index(unsigned int zoom_level)

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -233,6 +233,8 @@ display::display(const display_context * dc, std::weak_ptr<wb::manager> wb, repo
 
 	set_idle_anim_rate(preferences::idle_anim_rate());
 
+	if(preferences::tile_size() > 0)
+		zoom_ = preferences::tile_size();
 	zoom_index_ = std::distance(zoom_levels.begin(), std::find(zoom_levels.begin(), zoom_levels.end(), zoom_));
 
 	image::set_zoom(zoom_);
@@ -2045,6 +2047,7 @@ bool display::set_zoom(unsigned int amount, const bool validate_value_and_set_in
 		last_zoom_ = zoom_;
 	}
 
+	preferences::set_tile_size(zoom_);
 	image::set_zoom(zoom_);
 
 	labels().recalculate_labels();

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -635,7 +635,6 @@ public:
 
 private:
 	void read(const config& cfg);
-	bool validate_zoom_level_and_set_index(unsigned int &new_zoom, int &new_zoom_index);
 
 public:
 	/** Init the flag list and the team colors used by ~TC */

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -513,7 +513,7 @@ public:
 	static bool zoom_at_min();
 
 	/** Sets the zoom amount to the default. */
-	void set_default_zoom();
+	void toggle_default_zoom();
 
 	bool view_locked() const { return view_locked_; }
 

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -635,6 +635,7 @@ public:
 
 private:
 	void read(const config& cfg);
+	bool validate_zoom_level_and_set_index(unsigned int &new_zoom, int &new_zoom_index);
 
 public:
 	/** Init the flag list and the team colors used by ~TC */
@@ -646,6 +647,7 @@ public:
 	{
 		reports_object_ = &reports_object;
 	}
+
 private:
 	void init_flags_for_side_internal(std::size_t side, const std::string& side_color);
 

--- a/src/editor/controller/editor_controller.cpp
+++ b/src/editor/controller/editor_controller.cpp
@@ -695,7 +695,7 @@ bool editor_controller::do_execute_command(const hotkey::hotkey_command& cmd, in
 			toolkit_->set_mouseover_overlay(*gui_);
 			return true;
 		case HOTKEY_ZOOM_DEFAULT:
-			gui_->set_default_zoom();
+			gui_->toggle_default_zoom();
 			get_current_map_context().get_labels().recalculate_labels();
 			toolkit_->set_mouseover_overlay(*gui_);
 			return true;

--- a/src/hotkey/command_executor.cpp
+++ b/src/hotkey/command_executor.cpp
@@ -799,7 +799,7 @@ void command_executor_default::zoom_out()
 void command_executor_default::zoom_default()
 {
 	if(!get_display().view_locked()) {
-		get_display().set_default_zoom();
+		get_display().toggle_default_zoom();
 	}
 }
 

--- a/src/preferences/general.cpp
+++ b/src/preferences/general.cpp
@@ -602,12 +602,12 @@ void set_UI_volume(int vol)
 	sound::set_UI_volume(UI_volume());
 }
 
-int tile_size()
+unsigned int tile_size()
 {
-	return prefs["tile_size"];
+	return prefs["tile_size"].to_unsigned();
 }
 
-void set_tile_size(const int size)
+void set_tile_size(const unsigned int size)
 {
 	prefs["tile_size"] = size;
 }

--- a/src/preferences/general.cpp
+++ b/src/preferences/general.cpp
@@ -602,6 +602,16 @@ void set_UI_volume(int vol)
 	sound::set_UI_volume(UI_volume());
 }
 
+int tile_size()
+{
+	return prefs["tile_size"];
+}
+
+void set_tile_size(const int size)
+{
+	prefs["tile_size"] = size;
+}
+
 bool turn_bell()
 {
 	return get("turn_bell", true);

--- a/src/preferences/general.hpp
+++ b/src/preferences/general.hpp
@@ -141,8 +141,8 @@ namespace preferences {
 	bool stop_music_in_background();
 	void set_stop_music_in_background(bool ison);
 
-	int tile_size();
-	void set_tile_size(const int size);
+	unsigned int tile_size();
+	void set_tile_size(const unsigned int size);
 
 	bool turn_bell();
 	bool set_turn_bell(bool ison);

--- a/src/preferences/general.hpp
+++ b/src/preferences/general.hpp
@@ -141,6 +141,9 @@ namespace preferences {
 	bool stop_music_in_background();
 	void set_stop_music_in_background(bool ison);
 
+	int tile_size();
+	void set_tile_size(const int size);
+
 	bool turn_bell();
 	bool set_turn_bell(bool ison);
 


### PR DESCRIPTION
Resolves #1518

I don't know if this is the 'right' way to do things - there are a lot of places where preferences are set. There is a display preferences class and a display class, but also most things seem to be recorded in general preferences class. `tile_size` is referred to in `game_config.cpp` and the actual zooming is done inside the display class, using `game_config::tile_size` as the `DefaultZoom`. The default `tile_size` seems to be hard-coded to 72 in a few places.

Regardless, this seems to work for me.