### PR TITLE
Fix the MP lobby reloaded indicator always saying the game isn't reloaded.

### DIFF
--- a/src/game_initialization/lobby_data.cpp
+++ b/src/game_initialization/lobby_data.cpp
@@ -31,6 +31,7 @@
 #include "terrain/type_data.hpp"
 #include "wml_exception.hpp"
 #include "game_version.hpp"
+#include "mp_game_settings.hpp"
 
 #include <iterator>
 
@@ -213,7 +214,7 @@ game_info::game_info(const config& game, const std::vector<std::string>& install
 	, time_limit()
 	, vacant_slots()
 	, current_turn(0)
-	, reloaded(game["savegame"].to_bool())
+	, reloaded(game["savegame"].to_enum<mp_game_settings::SAVED_GAME_MODE>(mp_game_settings::SAVED_GAME_MODE::NONE) != mp_game_settings::SAVED_GAME_MODE::NONE)
 	, started(false)
 	, fog(game["mp_fog"].to_bool())
 	, shroud(game["mp_shroud"].to_bool())


### PR DESCRIPTION
Currently, the value of `game["savegame"]` is one of `mp_game_settings::SAVED_GAME_MODE`.  However, the `to_bool()` function doesn't recognize any of those values as being true, so a game is always shown in the MP lobby as not being a reload, even if it actually is.