### PR TITLE
Tutorial S02: Show "recruit the right units" when the player has gold

### DIFF
--- a/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
+++ b/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
@@ -552,7 +552,7 @@ A full list of abilities and weapons specials, along with traits, may be found i
                     caption= _ "The tutorial isn’t meant to be this difficult"
                     image=wesnoth-icon.png
                     message= _ "The orc on the island was supposed to move over the bridge, so that he could be attacked by several elves at once. Something’s broken the scripted event, which will make the scenario harder by leaving him in a defensive position.
-                    
+
 Please report the bug."
                 [/message]
             [/then]
@@ -816,17 +816,6 @@ Please report the bug."
     [/event]
 
     [event]
-        name=turn 12
-
-        [message]
-            speaker=narrator
-            caption= _ "Recruit the Right Units"
-            image=wesnoth-icon.png
-            message= _ "Remember to recruit troops useful for the situation. Archers are particularly effective against Grunts, Wolf Riders and the orcish leader."
-        [/message]
-    [/event]
-
-    [event]
         name=turn 18
 
         [message]
@@ -866,6 +855,13 @@ Please report the bug."
                 [message]
                     speaker=Galdrad
                     message= _ "Good idea!"
+                [/message]
+
+                [message]
+                    speaker=narrator
+                    caption= _ "Recruit the Right Units"
+                    image=wesnoth-icon.png
+                    message= _ "Remember to recruit troops useful for the situation. Archers are particularly effective against Grunts, Wolf Riders and the orcish leader."
                 [/message]
             [/then]
         [/if]


### PR DESCRIPTION
It's confusing when it pops up on turn 12, regardless of the game state. My
leader is normally on the other side of the river from my keep, and I always
wonder "what about my play triggered that?"

Move the message to be part of the "I now have enough gold to recruit more
units" hint.