### PR TITLE
Experimental AI: make AI recruit higher level units

### DIFF
--- a/data/ai/lua/ca_recruit_rushers.lua
+++ b/data/ai/lua/ca_recruit_rushers.lua
@@ -35,6 +35,7 @@ wesnoth.require("ai/lua/generic_recruit_engine.lua").init(dummy_engine, params)
 local ca_recruit_rushers = {}
 
 function ca_recruit_rushers:evaluation(cfg, data)
+    params.high_level_fraction = cfg.high_level_fraction
     return dummy_engine:recruit_rushers_eval()
 end
 

--- a/data/ai/lua/ca_recruit_rushers.lua
+++ b/data/ai/lua/ca_recruit_rushers.lua
@@ -36,6 +36,7 @@ local ca_recruit_rushers = {}
 
 function ca_recruit_rushers:evaluation(cfg, data)
     params.high_level_fraction = cfg.high_level_fraction
+    params.randomness = cfg.randomness
     return dummy_engine:recruit_rushers_eval()
 end
 

--- a/data/ai/lua/generic_recruit_engine.lua
+++ b/data/ai/lua/generic_recruit_engine.lua
@@ -804,7 +804,15 @@ return {
             if (min_recruit_level < 1) then min_recruit_level = 1 end
             local unit_deficit = {}
             for i=min_recruit_level+1,max_recruit_level do
-                unit_deficit[i] = high_level_fraction ^ (i - min_recruit_level) * #all_units - (level_count[i] or 0)
+                -- If no non-leader units are on the map yet, we set up the situation as if there were
+                -- one of each level. This is in order to get the situation for the first recruit right.
+                local n_units = #all_units
+                local n_units_this_level = level_count[i] or 0
+                if (n_units == 0) then
+                    n_units = max_recruit_level - min_recruit_level
+                    n_units_this_level = 1
+                end
+                unit_deficit[i] = high_level_fraction ^ (i - min_recruit_level) * n_units - n_units_this_level
             end
 
             for i, recruit_id in ipairs(wesnoth.sides[wesnoth.current.side].recruit) do

--- a/data/ai/lua/generic_recruit_engine.lua
+++ b/data/ai/lua/generic_recruit_engine.lua
@@ -785,7 +785,7 @@ return {
             local randomness = params.randomness or 0.1
 
             -- Bonus for higher-level units, as unit cost is penalized otherwise
-            local high_level_fraction = 0.33
+            local high_level_fraction = params.high_level_fraction or 0
             local all_units = AH.get_live_units {
                 side = wesnoth.current.side,
                 { "not", { canrecruit = "yes" }}

--- a/data/ai/micro_ais/cas/ca_recruit_rushers.lua
+++ b/data/ai/micro_ais/cas/ca_recruit_rushers.lua
@@ -9,6 +9,7 @@ wesnoth.require("ai/lua/generic_recruit_engine.lua").init(internal_recruit_cas, 
 local ca_recruit_rushers = {}
 
 function ca_recruit_rushers:evaluation(cfg)
+    internal_params.high_level_fraction = cfg.high_level_fraction
     internal_params.randomness = cfg.randomness
     internal_params.score_function = function() return cfg.ca_score end
     return internal_recruit_cas:recruit_rushers_eval()

--- a/data/ai/micro_ais/mai-defs/recruiting.lua
+++ b/data/ai/micro_ais/mai-defs/recruiting.lua
@@ -18,7 +18,7 @@ local function handle_default_recruitment(cfg)
 end
 
 function wesnoth.micro_ais.recruit_rushers(cfg)
-	local optional_keys = { "randomness" }
+	local optional_keys = { "high_level_fraction", "randomness" }
 	local CA_parms = {
 		ai_id = 'mai_rusher_recruit',
 		{ ca_id = "move", location = 'ca_recruit_rushers.lua', score = cfg.ca_score or 180000 }

--- a/data/core/macros/ai.cfg
+++ b/data/core/macros/ai.cfg
@@ -590,3 +590,75 @@
         [/candidate_action]
     [/stage]
 #enddef
+
+#define CUSTOMIZABLE_EXPERIMENTAL_AI ARGS
+    # Use the Experimental AI with custom parameter setting
+    # Put this into the [side][ai] tag.
+    # Does not work in [modify_side][ai] or [modify_ai] at the moment.
+    [stage]
+        id=main_loop
+        name=ai_default_rca::candidate_action_evaluation_loop
+        {AI_CA_GOTO}
+        #{AI_CA_RECRUITMENT}
+        {AI_CA_MOVE_LEADER_TO_GOALS}
+        {AI_CA_MOVE_LEADER_TO_KEEP}
+        {AI_CA_HIGH_XP_ATTACK}
+        {AI_CA_COMBAT}
+        {AI_CA_HEALING}
+        {AI_CA_VILLAGES}
+        {AI_CA_RETREAT}
+        {AI_CA_MOVE_TO_TARGETS}
+        {AI_CA_LEADER_SHARES_KEEP}
+        [candidate_action]
+            engine=lua
+            name=recruit_rushers
+            max_score=300000
+            location="ai/lua/ca_recruit_rushers.lua"
+            [args]
+                {ARGS}
+            [/args]
+        [/candidate_action]
+        [candidate_action]
+            engine=lua
+            name=switch_castle
+            max_score=290000
+            location="ai/lua/ca_castle_switch.lua"
+        [/candidate_action]
+        [candidate_action]
+            engine=lua
+            name=retreat_injured
+            max_score=205000
+            location="ai/lua/ca_retreat_injured.lua"
+        [/candidate_action]
+        [candidate_action]
+            engine=lua
+            name=grab_villages
+            max_score=200000
+            location="ai/lua/ca_grab_villages.lua"
+        [/candidate_action]
+        [candidate_action]
+            engine=lua
+            name=spread_poison
+            max_score=190000
+            location="ai/lua/ca_spread_poison.lua"
+        [/candidate_action]
+        [candidate_action]
+            engine=lua
+            name=place_healers
+            max_score=95000
+            location="ai/lua/ca_place_healers.lua"
+        [/candidate_action]
+        [candidate_action]
+            engine=lua
+            name=village_hunt
+            max_score=30000
+            location="ai/lua/ca_village_hunt.lua"
+        [/candidate_action]
+        [candidate_action]
+            engine=lua
+            name=move_to_any_enemy
+            max_score=1
+            location="ai/lua/ca_move_to_any_enemy.lua"
+        [/candidate_action]
+    [/stage]
+#enddef


### PR DESCRIPTION
The ExpAI recruits almost no higher level units. In the scenarios I tested with default era units, there's maybe one L2 unit recruited every dozen or so recruits.  Yet, it's reasonable to assume that if scenario designers give the AI higher level units to recruit, they expect that to happen not just sporadically.

The reason why almost no L2s or higher are recruited might be partially because unit cost is not as well balanced for the higher level units.  But mostly it happens because cost is penalized by the ExpAI recruiting.  This is in order "to avoid recruiting many expensive units -- there is a requirement for bodies in order to block movement" as per a comment in the code. I don't want to change that, as it would mess up the recruiting ratios of L1 units of different cost, so instead I am adding a bonus for higher level units that increases as the high-to-low-level units ratio decreases.  A few comments on that:

- The code tries to recruit so that the ratio of level i+1 to level i units is _approximately_ `high_level_fraction`.  The evaluation could be set up so that that this ratio is exact, but I actually think it is better to make it an approximate ratio, it adds a bit variety and unpredictability.
- `high_level_fraction` could be made a configurable parameter.  The current value of 0.33 is chosen because having 1 L2 for every 2 L1 units "sounds about right", but this is clearly somewhat dependent on the scenario.  I don't currently know how to do that when setting up the ExpAI using `ai_algorithm=` though (I do know how to do it when it is set up as rush recruiting Micro AI), but I am sure I can figure it out.
- The factor 0.25 in the equation for the bonus is chosen because in my tests this was roughly the average rating difference between L1 and L2 units of the same advancement tree.  The exact value does not matter all that much though because of the square on `unit_deficit`.
- I only start the bonus at L2 units.  There's no such bonus for the relative ratio of L1s to L0s, as those are handled pretty well already (likely because their cost is balanced better in the default era).

@sevu You brought this up.  Any comments?
@Alarantalara Pinging you in case you are still around and interested in following this.