### PR TITLE
recruit dialog: Gray out units that will not be able to be recruited

### DIFF
--- a/src/actions/create.cpp
+++ b/src/actions/create.cpp
@@ -475,7 +475,7 @@ std::string find_recruit_location(const int side, map_location& recruit_location
 
 	case RECRUIT_NO_ABLE_LEADER:
 		LOG_NG << "No leader is able to recruit '" << unit_type << "' on side " << side << ".\n";
-		return _("None of your leaders are able to recruit that unit.");
+		return _("None of your leaders are able to recruit this unit.");
 
 	case RECRUIT_NO_KEEP_LEADER:
 		LOG_NG << "No leader able to recruit '" << unit_type << "' is on a keep.\n";

--- a/src/gui/dialogs/unit_recruit.cpp
+++ b/src/gui/dialogs/unit_recruit.cpp
@@ -134,28 +134,15 @@ void unit_recruit::pre_show(window& window)
 		std::string	image_string = recruit->image() + "~RC(" + recruit->flag_rgb() + ">"
 			+ team_.color() + ")";
 
-		int wb_gold = 0;
-		if(resources::controller) {
-			if(const std::shared_ptr<wb::manager>& whiteb = resources::controller->get_whiteboard()) {
-				wb::future_map future; // So gold takes into account planned spending
-				wb_gold = whiteb->get_spent_gold_for(team_.side());
-			}
-		}
-
-		/// TODO: The name is historical. This is false whenever the unit is not recruitable, not just for gold issues.
-		const bool can_afford = (error.empty() && recruit->cost() <= team_.gold() - wb_gold);
+		/// TODO: The name is historical. This is false whenever the unit is not recruitable.
+		const bool can_afford = error.empty();
 
 		const std::string cost_string = std::to_string(recruit->cost());
 
 		column["use_markup"] = "true";
 		if(!error.empty()) {
-			column["tooltip"] = error;
-		} else if(!can_afford) {
 			// Just set the tooltip on every single element in this row.
-			if(wb_gold > 0)
-				column["tooltip"] = _("This unit cannot be recruited because you will not have enough gold at this point in your plan.");
-			else
-				column["tooltip"] = _("This unit cannot be recruited because you do not have enough gold.");
+			column["tooltip"] = error;
 		}
 
 		column["label"] = image_string + (can_afford ? "" : "~GS()");

--- a/src/gui/dialogs/unit_recruit.cpp
+++ b/src/gui/dialogs/unit_recruit.cpp
@@ -42,7 +42,7 @@ namespace dialogs
 
 REGISTER_DIALOG(unit_recruit)
 
-unit_recruit::unit_recruit(std::map<const unit_type*, std::string>& recruit_map, team& team)
+unit_recruit::unit_recruit(std::map<const unit_type*, t_string>& recruit_map, team& team)
 	: recruit_list_()
 	, recruit_map_(recruit_map)
 	, team_(team)
@@ -127,7 +127,7 @@ void unit_recruit::pre_show(window& window)
 
 	for(const auto& recruit : recruit_list_)
 	{
-		const std::string& error = recruit_map_[recruit];
+		const t_string& error = recruit_map_[recruit];
 		std::map<std::string, string_map> row_data;
 		string_map column;
 

--- a/src/gui/dialogs/unit_recruit.cpp
+++ b/src/gui/dialogs/unit_recruit.cpp
@@ -60,9 +60,9 @@ unit_recruit::unit_recruit(std::map<const unit_type*, std::string>& recruit_map,
 
 static const color_t inactive_row_color(0x96, 0x96, 0x96);
 
-static inline std::string can_afford_unit(const std::string& text, const bool can_afford)
+static inline std::string gray_if_unrecruitable(const std::string& text, const bool is_recruitable)
 {
-	return can_afford ? text : font::span_color(inactive_row_color, text);
+	return is_recruitable ? text : font::span_color(inactive_row_color, text);
 }
 
 // Compare unit_create::filter_text_change
@@ -134,8 +134,7 @@ void unit_recruit::pre_show(window& window)
 		std::string	image_string = recruit->image() + "~RC(" + recruit->flag_rgb() + ">"
 			+ team_.color() + ")";
 
-		/// TODO: The name is historical. This is false whenever the unit is not recruitable.
-		const bool can_afford = error.empty();
+		const bool is_recruitable = error.empty();
 
 		const std::string cost_string = std::to_string(recruit->cost());
 
@@ -145,17 +144,17 @@ void unit_recruit::pre_show(window& window)
 			column["tooltip"] = error;
 		}
 
-		column["label"] = image_string + (can_afford ? "" : "~GS()");
+		column["label"] = image_string + (is_recruitable ? "" : "~GS()");
 		row_data.emplace("unit_image", column);
 
-		column["label"] = can_afford_unit(recruit->type_name(), can_afford);
+		column["label"] = gray_if_unrecruitable(recruit->type_name(), is_recruitable);
 		row_data.emplace("unit_type", column);
 
-		column["label"] = can_afford_unit(cost_string, can_afford);
+		column["label"] = gray_if_unrecruitable(cost_string, is_recruitable);
 		row_data.emplace("unit_cost", column);
 
 		grid& grid = list.add_row(row_data);
-		if(!can_afford) {
+		if(!is_recruitable) {
 			image *gold_icon = dynamic_cast<image*>(grid.find("gold_icon", false));
 			assert(gold_icon);
 			gold_icon->set_image(gold_icon->get_image() + "~GS()");

--- a/src/gui/dialogs/unit_recruit.hpp
+++ b/src/gui/dialogs/unit_recruit.hpp
@@ -27,7 +27,9 @@ namespace dialogs
 class unit_recruit : public modal_dialog
 {
 public:
-	unit_recruit(std::vector<const unit_type*>& recruit_list, team& team);
+	/// @param recruit_list maps unit typs to strings. The strings are ""
+	/// if the unit can be recalled and an error message string otherwise.
+	unit_recruit(std::map<const unit_type*, std::string>& recruit_map, team& team);
 
 	const unit_type *get_selected_unit_type() const
 	{
@@ -47,7 +49,9 @@ private:
 
 	void show_help();
 
-	std::vector<const unit_type*>& recruit_list_;
+	/// A vector of unit types in the order listed. Used by unit_recruit::post_show.
+	std::vector<const unit_type*> recruit_list_;
+	std::map<const unit_type*, std::string>& recruit_map_;
 
 	team& team_;
 

--- a/src/gui/dialogs/unit_recruit.hpp
+++ b/src/gui/dialogs/unit_recruit.hpp
@@ -27,7 +27,7 @@ namespace dialogs
 class unit_recruit : public modal_dialog
 {
 public:
-	/// @param recruit_list maps unit typs to strings. The strings are ""
+	/// @param recruit_map maps unit typs to strings. The strings are ""
 	/// if the unit can be recalled and an error message string otherwise.
 	unit_recruit(std::map<const unit_type*, std::string>& recruit_map, team& team);
 
@@ -49,7 +49,7 @@ private:
 
 	void show_help();
 
-	/// A vector of unit types in the order listed. Used by unit_recruit::post_show.
+	/// A vector of unit types in the order listed in the UI. Used by unit_recruit::post_show.
 	std::vector<const unit_type*> recruit_list_;
 	std::map<const unit_type*, std::string>& recruit_map_;
 

--- a/src/gui/dialogs/unit_recruit.hpp
+++ b/src/gui/dialogs/unit_recruit.hpp
@@ -29,7 +29,7 @@ class unit_recruit : public modal_dialog
 public:
 	/// @param recruit_map maps unit typs to strings. The strings are ""
 	/// if the unit can be recalled and an error message string otherwise.
-	unit_recruit(std::map<const unit_type*, std::string>& recruit_map, team& team);
+	unit_recruit(std::map<const unit_type*, t_string>& recruit_map, team& team);
 
 	const unit_type *get_selected_unit_type() const
 	{
@@ -51,7 +51,7 @@ private:
 
 	/// A vector of unit types in the order listed in the UI. Used by unit_recruit::post_show.
 	std::vector<const unit_type*> recruit_list_;
-	std::map<const unit_type*, std::string>& recruit_map_;
+	std::map<const unit_type*, t_string>& recruit_map_;
 
 	team& team_;
 

--- a/src/gui/dialogs/unit_recruit.hpp
+++ b/src/gui/dialogs/unit_recruit.hpp
@@ -29,9 +29,9 @@ class unit_recruit : public modal_dialog
 public:
 	unit_recruit(std::vector<const unit_type*>& recruit_list, team& team);
 
-	int get_selected_index() const
+	const unit_type *get_selected_unit_type() const
 	{
-		return selected_index_;
+		return selected_index_ < 0 ? nullptr : recruit_list_[selected_index_];
 	}
 
 private:

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -255,7 +255,7 @@ bool menu_handler::has_friends() const
 
 void menu_handler::recruit(int side_num, const map_location& last_hex)
 {
-	std::map<const unit_type*, std::string> sample_units;
+	std::map<const unit_type*, t_string> sample_units;
 
 	std::set<std::string> recruits = actions::get_recruits(side_num, last_hex);
 
@@ -301,7 +301,7 @@ void menu_handler::repeat_recruit(int side_num, const map_location& last_hex)
 // TODO: Return multiple strings here, in case more than one error applies? For
 // example, if you start AOI S5 with 0GP and recruit a Mage, two reasons apply,
 // leader not on keep (extrarecruit=Mage) and not enough gold.
-std::string menu_handler::can_recruit(const std::string& name, int side_num, map_location& loc, map_location& recruited_from)
+t_string menu_handler::can_recruit(const std::string& name, int side_num, map_location& loc, map_location& recruited_from)
 {
 	team& current_team = board().get_team(side_num);
 

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -296,55 +296,64 @@ void menu_handler::repeat_recruit(int side_num, const map_location& last_hex)
 	}
 }
 
-bool menu_handler::do_recruit(const std::string& name, int side_num, map_location& loc)
+std::string menu_handler::can_recruit(const std::string& name, int side_num, map_location& loc, map_location& recruited_from)
 {
 	team& current_team = board().get_team(side_num);
 
-	// search for the unit to be recruited in recruits
-	if(!utils::contains(actions::get_recruits(side_num, loc), name)) {
-		gui2::show_transient_message("", VGETTEXT("You cannot recruit a $unit_type_name at this time",
-				utils::string_map { { "unit_type_name", u_type->type_name() }}));
-		return false;
+	const unit_type* u_type = unit_types.find(name);
+	if(u_type == nullptr) {
+		return _("Internal error. Please report this as a bug! Details:\n")
+			+ "menu_handler::can_recruit: u_type == nullptr for " + name;
 	}
 
-	const unit_type* u_type = unit_types.find(name);
-	assert(u_type);
+	// search for the unit to be recruited in recruits
+	if(!utils::contains(actions::get_recruits(side_num, loc), name)) {
+		return VGETTEXT("You cannot recruit a $unit_type_name at this time.",
+				utils::string_map { { "unit_type_name", u_type->type_name() }});
+	}
 
 	if(u_type->cost() > current_team.gold() - (pc_.get_whiteboard()
 			? pc_.get_whiteboard()->get_spent_gold_for(side_num)
 			: 0))
 	{
-		gui2::show_transient_message("", _("You do not have enough gold to recruit that unit."));
-		return false;
+		return _("You do not have enough gold to recruit that unit.");
 	}
 
 	current_team.last_recruit(name);
 	const events::command_disabler disable_commands;
 
-	map_location recruited_from = map_location::null_location();
-
-	std::string msg;
 	{
 		wb::future_map_if_active future; /* start planned unit map scope if in planning mode */
-		msg = actions::find_recruit_location(side_num, loc, recruited_from, name);
+		std::string msg = actions::find_recruit_location(side_num, loc, recruited_from, name);
+		if(!msg.empty()) {
+			return msg;
+		}
 	} // end planned unit map scope
 
-	if(!msg.empty()) {
-		gui2::show_transient_message("", msg);
-		return false;
-	}
+	return "";
+}
 
-	if(!pc_.get_whiteboard() || !pc_.get_whiteboard()->save_recruit(name, side_num, loc)) {
+bool menu_handler::do_recruit(const std::string& name, int side_num, map_location& loc)
+{
+	map_location recruited_from = map_location::null_location();
+	const std::string res = can_recruit(name, side_num, loc, recruited_from);
+	team& current_team = board().get_team(side_num);
+
+	if(res.empty() && (!pc_.get_whiteboard() || !pc_.get_whiteboard()->save_recruit(name, side_num, loc))) {
 		// MP_COUNTDOWN grant time bonus for recruiting
 		current_team.set_action_bonus_count(1 + current_team.action_bonus_count());
 
 		// Do the recruiting.
 
-		synced_context::run_and_throw("recruit", replay_helper::get_recruit(u_type->id(), loc, recruited_from));
+		synced_context::run_and_throw("recruit", replay_helper::get_recruit(name, loc, recruited_from));
 		return true;
+	} else if(res.empty()) {
+		return false;
+	} else {
+		gui2::show_transient_message("", res);
+		return false;
 	}
 
-	return false;
 }
 
 void menu_handler::recall(int side_num, const map_location& last_hex)

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -278,12 +278,12 @@ void menu_handler::recruit(int side_num, const map_location& last_hex)
 
 	if(dlg.show()) {
 		map_location recruit_hex = last_hex;
-		int index = dlg.get_selected_index();
-		if (index < 0) {
+		const unit_type *type = dlg.get_selected_unit_type();
+		if (!type) {
 			gui2::show_transient_message("", _("No unit recruited."));
 			return;
 		}
-		do_recruit(sample_units[index]->id(), side_num, recruit_hex);
+		do_recruit(type->id(), side_num, recruit_hex);
 	}
 }
 

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -255,7 +255,7 @@ bool menu_handler::has_friends() const
 
 void menu_handler::recruit(int side_num, const map_location& last_hex)
 {
-	std::vector<const unit_type*> sample_units;
+	std::map<const unit_type*, std::string> sample_units;
 
 	std::set<std::string> recruits = actions::get_recruits(side_num, last_hex);
 
@@ -266,7 +266,9 @@ void menu_handler::recruit(int side_num, const map_location& last_hex)
 			return;
 		}
 
-		sample_units.push_back(type);
+		map_location ignored;
+		map_location recruit_hex = last_hex;
+		sample_units[type] = (can_recruit(type->id(), side_num, recruit_hex, ignored));
 	}
 
 	if(sample_units.empty()) {
@@ -316,7 +318,7 @@ std::string menu_handler::can_recruit(const std::string& name, int side_num, map
 			? pc_.get_whiteboard()->get_spent_gold_for(side_num)
 			: 0))
 	{
-		return _("You do not have enough gold to recruit that unit.");
+		return _("You do not have enough gold to recruit this unit.");
 	}
 
 	current_team.last_recruit(name);

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -302,6 +302,8 @@ bool menu_handler::do_recruit(const std::string& name, int side_num, map_locatio
 
 	// search for the unit to be recruited in recruits
 	if(!utils::contains(actions::get_recruits(side_num, loc), name)) {
+		gui2::show_transient_message("", VGETTEXT("You cannot recruit a $unit_type_name at this time",
+				utils::string_map { { "unit_type_name", u_type->type_name() }}));
 		return false;
 	}
 

--- a/src/menu_events.hpp
+++ b/src/menu_events.hpp
@@ -108,6 +108,8 @@ public:
 			int side_num,
 			mouse_handler& mousehandler);
 
+	///@return If the recruit is possible, an empty string and set @a recruited_from; otherwise, return an error message string.
+	std::string can_recruit(const std::string& name, int side_num, map_location& target_hex, map_location& recruited_from);
 	///@return Whether or not the recruit was successful
 	bool do_recruit(const std::string& name, int side_num, map_location& target_hex);
 	void do_speak();

--- a/src/menu_events.hpp
+++ b/src/menu_events.hpp
@@ -29,6 +29,7 @@ class game_board;
 class play_controller;
 class team;
 class unit_map;
+class t_string;
 
 namespace events
 {
@@ -109,7 +110,7 @@ public:
 			mouse_handler& mousehandler);
 
 	///@return If the recruit is possible, an empty string and set @a recruited_from; otherwise, return an error message string.
-	std::string can_recruit(const std::string& name, int side_num, map_location& target_hex, map_location& recruited_from);
+	t_string can_recruit(const std::string& name, int side_num, map_location& target_hex, map_location& recruited_from);
 	///@return Whether or not the recruit was successful
 	bool do_recruit(const std::string& name, int side_num, map_location& target_hex);
 	void do_speak();


### PR DESCRIPTION
Fixes #4443. This doesn't add or remove any units to the recruit dialog, it simply makes units that will fail to be recruited be listed in gray.

See the individual commits for details.