### PR TITLE
Changes to deprecation logging and deprecate --userdata-dir=relative-path

### DIFF
--- a/src/deprecation.cpp
+++ b/src/deprecation.cpp
@@ -24,7 +24,7 @@
 // 0 would mean log errors only.
 // 1 would mean log errors and warnings.
 // and so on and so on.
-static lg::log_domain log_deprecate("deprecation", -1);
+static lg::log_domain log_deprecate("deprecation", 0);
 
 std::string deprecated_message(
 		const std::string& elem_name, DEP_LEVEL level, const version_info& version, const std::string& detail)

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -21,6 +21,7 @@
 #include "filesystem.hpp"
 
 #include "config.hpp"
+#include "deprecation.hpp"
 #include "game_config.hpp"
 #include "gettext.hpp"
 #include "log.hpp"
@@ -620,6 +621,17 @@ void set_user_data_dir(std::string newprefdir)
 	} else {
 		if(newprefdir.empty()) {
 			newprefdir = "Wesnoth" + get_version_path_suffix();
+		} else {
+#ifdef PREFERENCES_DIR
+			if (newprefdir != PREFERENCES_DIR)
+#endif
+			{
+				// TRANSLATORS: translate the part inside <...> only
+				deprecated_message(_("--userdata-dir=<relative path that doesn't start with a period>"),
+					DEP_LEVEL::FOR_REMOVAL,
+					{1, 17, 0},
+					_("Use an absolute path, or a relative path that starts with a period and a backslash"));
+			}
 		}
 
 		PWSTR docs_path = nullptr;
@@ -681,6 +693,11 @@ void set_user_data_dir(std::string newprefdir)
 		if(newprefdir[0] == '/') {
 			user_data_dir = newprefdir;
 		} else {
+			// TRANSLATORS: translate the part inside <...> only
+			deprecated_message(_("--userdata-dir=<relative path>"),
+				DEP_LEVEL::FOR_REMOVAL,
+				{1, 17, 0},
+				_("Use absolute paths. Relative paths are deprecated because they are interpreted relative to $HOME"));
 			user_data_dir = home / newprefdir;
 		}
 	}
@@ -695,6 +712,11 @@ void set_user_data_dir(std::string newprefdir)
 	if(newprefdir[0] == '/') {
 		user_data_dir = newprefdir;
 	} else {
+		// TRANSLATORS: translate the part inside <...> only
+		deprecated_message(_("--userdata-dir=<relative path>"),
+			DEP_LEVEL::FOR_REMOVAL,
+			{1, 17, 0},
+			_("Use absolute paths. Relative paths are deprecated because they are interpreted relative to $HOME"));
 		user_data_dir = home / newprefdir;
 	}
 #endif

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -362,6 +362,17 @@ static int process_command_args(const commandline_options& cmdline_opts)
 {
 	// Options that don't change behavior based on any others should be checked alphabetically below.
 
+	if(cmdline_opts.log) {
+		for(const auto& log_pair : cmdline_opts.log.get()) {
+			const std::string log_domain = log_pair.second;
+			const int severity = log_pair.first;
+			if(!lg::set_log_domain_severity(log_domain, severity)) {
+				std::cerr << "unknown log domain: " << log_domain << '\n';
+				return 2;
+			}
+		}
+	}
+
 	if(cmdline_opts.userconfig_dir) {
 		filesystem::set_user_config_dir(*cmdline_opts.userconfig_dir);
 	}
@@ -451,17 +462,6 @@ static int process_command_args(const commandline_options& cmdline_opts)
 	if(cmdline_opts.help) {
 		std::cout << cmdline_opts;
 		return 0;
-	}
-
-	if(cmdline_opts.log) {
-		for(const auto& log_pair : cmdline_opts.log.get()) {
-			const std::string log_domain = log_pair.second;
-			const int severity = log_pair.first;
-			if(!lg::set_log_domain_severity(log_domain, severity)) {
-				std::cerr << "unknown log domain: " << log_domain << '\n';
-				return 2;
-			}
-		}
 	}
 
 	if(cmdline_opts.logdomains) {


### PR DESCRIPTION
See individual commit messages for details.

I'd like to backport the wesnoth.cpp and deprecated.cpp parts. I'm not sure if I should backport the filesystem.cpp changes too.

The filesystem.cpp part is for issue #2000.