### PR TITLE
Make a unit respond to mouse-clicks after end_unit_turn (fixes #4466)

### DIFF
--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -997,6 +997,12 @@ void menu_handler::end_unit_turn(mouse_handler& mousehandler, int side_num)
 		if(un->user_end_turn()) {
 			mousehandler.cycle_units(false);
 		}
+
+		// If cycle_units hasn't found a new unit to cycle to then the original unit is still selected, but
+		// in a state where left-clicking on it does nothing. Make it respond to mouse clicks again.
+		if(un == units().find(mousehandler.get_selected_hex())) {
+			mousehandler.deselect_hex();
+		}
 	}
 }
 


### PR DESCRIPTION
This was an edge-case when the player had only one unit, logged as #4466.

This change looks fairly straightforward, will merge it tomorrow if it doesn't have any comments.