### PR TITLE
wmlxgettext: support double quotes in raw strings (fixes #4484)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -91,6 +91,7 @@
      * On windows, relative paths that start with `.\` are not deprecated
    * Removed incomplete joystick support.
    * Removed option to disable unit and item halos.
+   * Added support to wmlxgettext for double-quote characters in translatable raw strings
 
 ## Version 1.15.1
  ### Editor

--- a/data/tools/pywmlx/state/machine.py
+++ b/data/tools/pywmlx/state/machine.py
@@ -248,11 +248,13 @@ class PendingLuaString:
 
 
 class PendingWmlString:
-    def __init__(self, lineno, wmlstring, ismultiline, istranslatable):
+    def __init__(self, lineno, wmlstring, ismultiline, istranslatable, israw):
+        """The israw argument indicates a << >> delimited string"""
         self.lineno = lineno
         self.wmlstring = wmlstring.replace('\\', r'\\')
         self.ismultiline = ismultiline
         self.istranslatable = istranslatable
+        self.israw = israw
 
     def addline(self, value):
         self.wmlstring = self.wmlstring + '\n' + value.replace('\\', r'\\')
@@ -275,7 +277,10 @@ class PendingWmlString:
                 # so, using "if errcode != 1"
                 # we will add the translatable string ONLY if it is NOT empty
                 _linenosub += 1
-                self.wmlstring = re.sub('""', r'\"', self.wmlstring)
+                if self.israw:
+                    self.wmlstring = re.sub('"', r'\"', self.wmlstring)
+                else:
+                    self.wmlstring = re.sub('""', r'\"', self.wmlstring)
                 pywmlx.nodemanip.addNodeSentence(self.wmlstring,
                                              ismultiline=self.ismultiline,
                                              lineno=self.lineno,

--- a/data/tools/pywmlx/state/wml_states.py
+++ b/data/tools/pywmlx/state/wml_states.py
@@ -169,7 +169,7 @@ class WmlStr02:
                    'please report a bug if you encounter this error message')
         pywmlx.state.machine._pending_wmlstring = (
             pywmlx.state.machine.PendingWmlString(
-                lineno, loc_string, loc_multiline, loc_translatable
+                lineno, loc_string, loc_multiline, loc_translatable, israw=True
             )
         )
         return (xline, _nextstate)
@@ -249,7 +249,7 @@ class WmlStr01:
             xline = xline [ match.end(): ]
         pywmlx.state.machine._pending_wmlstring = (
             pywmlx.state.machine.PendingWmlString(
-                lineno, match.group(2), loc_multiline, loc_translatable
+                lineno, match.group(2), loc_multiline, loc_translatable, israw=False
             )
         )
         return (xline, _nextstate)


### PR DESCRIPTION
This adds support for _<<map="{maps/01_First_Map.map}">>.

@AncientLich , please would you review?