### PR TITLE
Orcish Ruler: Fix grammar in description

### DIFF
--- a/data/core/units/orcs/Ruler.cfg
+++ b/data/core/units/orcs/Ruler.cfg
@@ -15,7 +15,7 @@
     advances_to=Orcish Sovereign
     cost=35
     usage=mixed fighter
-    description= _ "Any orc who can keep a large tribe from feuding and in-fighting is often unusually intelligent and commanding, and is inevitably very strong as well. They are skilled with both sword and crossbow, but their real talent lies in their rare ability to rally other orcs to battle, to give orders that are followed not out of fear, but loyalty."
+    description= _ "Any orc who can keep a large tribe from feuding and in-fighting is often unusually intelligent and commanding, and is inevitably very strong as well. They are skilled with both sword and crossbow, but their real talent lies in their rare ability to rally other orcs to battle, to give orders that are followed out of not fear, but loyalty."
     {NOTE_LEADERSHIP}
     die_sound={SOUND_LIST:ORC_DIE}
     {DEFENSE_ANIM_RANGE "units/orcs/ruler-defend-2.png" "units/orcs/ruler-defend-1.png" {SOUND_LIST:ORC_HIT} melee}


### PR DESCRIPTION
In the construct "not X, but Y", it's not valid to have a preposition in X but not in Y.

@CelticMinstrel @Vultraz I revisited this and checked with @nemaara and I think that the existing text is incorrect after all.