### PR TITLE
Fixed issue #4080

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -76,6 +76,7 @@
    * New predefined macros `{LEFT_BRACE}` and `{RIGHT_BRACE}` (PR#4432)
    * Weapon filtering `special=*` deprecated, replaced by new `special_id=*` and `special_type=*` (Issue#3915)
  ### Miscellaneous and bug fixes
+   * Fixed: Statistics dialog title shows empty parentheses (#Issue#4080)
    * Fixed :droid's arguments not all being optional (Issue#4308)
    * Ported the "expand-terrain-macros", "wmlflip", "wmlparser", "umc-dev/build/update_version",
      "wiki_grabber", "ai_test" and "unused_functions" tools to Python 3

--- a/data/core/about.cfg
+++ b/data/core/about.cfg
@@ -1060,6 +1060,9 @@
         name = "Aaron Winter (Byteron)"
     [/entry]
     [entry]
+        name = "Abhijay Sahay"
+    [/entry]
+    [entry]
         name = "Adam Leffew"
     [/entry]
     [entry]

--- a/src/gui/dialogs/statistics_dialog.cpp
+++ b/src/gui/dialogs/statistics_dialog.cpp
@@ -71,7 +71,11 @@ void statistics_dialog::pre_show(window& window)
 	// Set title
 	//
 	label& title = find_widget<label>(&window, "title", false);
-	title.set_label((formatter() << title.get_label() << " (" << current_team_.side_name() << ")").str());
+
+	// Show side name in parentheses if it is set, otherwise show nothing
+	std::string formatted_side_name = current_team_.side_name() == "" ? "" : "(" + current_team_.side_name() + ")";
+
+	title.set_label((formatter() << title.get_label() << formatted_side_name).str());
 
 	//
 	// Set up scenario menu


### PR DESCRIPTION
I added a simple check before printing side name in the statistics dialog. I could not find a way to get leader name, so I simply print nothing if side name is not set.