### PR TITLE
Log a console error message when a parse_error closes the help

### DIFF
--- a/src/help/help.cpp
+++ b/src/help/help.cpp
@@ -50,8 +50,7 @@ static lg::log_domain log_display("display");
 #define WRN_DP LOG_STREAM(warn, log_display)
 
 static lg::log_domain log_help("help");
-#define WRN_HP LOG_STREAM(warn, log_help)
-#define DBG_HP LOG_STREAM(debug, log_help)
+#define ERR_HELP LOG_STREAM(err, log_help)
 
 namespace help {
 
@@ -234,11 +233,12 @@ void show_help(const section &toplevel_sec,
 			CVideo::delay(10);
 		}
 	}
-	catch (parse_error& /*e*/) {
-		// Disabled due to issue #2587
+	catch (const parse_error& e) {
+		ERR_HELP << _("Parse error when parsing help text:") << " " << e.message << std::endl;
 #if 0
+		// Displaying in the UI is disabled due to issue #2587
 		std::stringstream msg;
-		msg << _("Parse error when parsing help text: ") << "'" << e.message << "'";
+		msg << _("Parse error when parsing help text:") << " '" << e.message << "'";
 		gui2::show_transient_message("", msg.str());
 #endif
 	}


### PR DESCRIPTION
Related to issue #4507, which is asking for better handling of the parse_error.
This commit doesn't improve the handling, but it will hopefully avoid anyone
spending time debugging to work out what text triggered #4507.