### PR TITLE
Restore co-ordinates to classic theme

### DIFF
--- a/data/themes/classic.cfg
+++ b/data/themes/classic.cfg
@@ -359,6 +359,7 @@
             # so that the long strings don't get cut off as easily.
             [panel]
                 id=terrain-panel
+                ref=status-income
                 rect="+0,=,1024,="
                 xanchor=left
                 yanchor=fixed
@@ -371,7 +372,7 @@
                 id=status-position
                 font_size={DEFAULT_FONT_SMALL}
                 ref=terrain-panel
-                rect="=+15,=,+95,="
+                rect="=+115,=,+95,="
                 xanchor=fixed
                 yanchor=fixed
             [/position]
@@ -379,7 +380,7 @@
                 id=status-terrain
                 font_size={DEFAULT_FONT_SMALL}
                 ref=terrain-panel
-                rect="=+115,=,=-24,="
+                rect="=+215,=,=-24,="
                 xanchor=left
                 yanchor=fixed
             [/terrain]


### PR DESCRIPTION
Resolves #4053.

Classic theme lost co-ordinates since at least 1.14.6 - apparently due to work on the battery indicator. Tested to work with both battery and no battery indicator, as well as SP and MP.

No need for master, so I understand, because classic theme is supposed to be dropped in 1.15 (it doesn't look like it has been yet, though).

I don't know how classic theme used to look so it probably doesn't match how it used to be before the battery indicator was added.