### PR TITLE
Added mushroom defense cap to mounted and several flying units

### DIFF
--- a/data/core/units.cfg
+++ b/data/core/units.cfg
@@ -643,7 +643,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             castle=60
             cave=80
             frozen=70
-            fungus=80
+            fungus=-80
         [/defense]
 
         [resistance]
@@ -784,7 +784,7 @@ The life span of the wose is unknown, although the most ancient members of this 
         [defense]
             {FLY_DEFENSE 50}
             cave=80
-            fungus=70
+            fungus=-70
         [/defense]
         {FLY_RESISTANCE}
     [/movetype]
@@ -1642,14 +1642,14 @@ The life span of the wose is unknown, although the most ancient members of this 
             swamp_water=80
             flat=60
             sand=60
-            forest=70
+            forest=-70
             hills=40
             mountains=60
             village=60
             castle=50
             cave=70
             frozen=70
-            fungus=70
+            fungus=-70
         [/defense]
         [resistance]
             blade=80


### PR DESCRIPTION
PR for https://github.com/wesnoth/wesnoth/issues/4454

Adding mushroom defense cap to human mounted units, dunefolk mounted units and several flying units (Gryphon, Wyvern and Roc)

I noticed that dunefolk mounted units don't have forest defense cap. I will communicate to Hejnewar (who was working on the Dunefolk rebalancing) regarding that.

P.S. Hejnewar shared an idea of adding mushroom defense cap to orcs. However, that is debatable, so I am not adding it here.