### PR TITLE
Corrected SotBE S11 objectives

### DIFF
--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg
@@ -22,7 +22,7 @@
                 show_turn_counter=yes
             [/objective]
             [objective]
-                description= _ "Enemies control any villages on the north side of the river when turns run out"
+                description= _ "You don't control all villages on the north side of the river when turns run out"
                 condition=lose
             [/objective]
             [objective]


### PR DESCRIPTION
Per comment from @Konrad22 
> Hey, I've got a small issue with SotBE S11. Or rather with the scenario objectives. The defeat condition is 'Enemies control any villages on the north side of the river when turns run out' At least, that's what it says. The actual defeat condition is 'You don't control all villages on the north side of the river when turns run out' (There is one leaderless enemy side, so those two sentences don't mean the same thing.)