### PR TITLE
[Dwarves] Buff some level 2 units

### DIFF
--- a/data/core/units/dwarves/Lord.cfg
+++ b/data/core/units/dwarves/Lord.cfg
@@ -5,7 +5,7 @@
     race=dwarf
     image="units/dwarves/lord.png"
     profile="portraits/dwarves/lord.png"
-    hitpoints=76
+    hitpoints=74
     movement_type=dwarvishfoot
     movement=4
     experience=150
@@ -39,6 +39,8 @@
 
     [resistance]
         blade=60
+        pierce=70
+        impact=70
     [/resistance]
     [attack]
         name=battle axe

--- a/data/core/units/dwarves/Pathfinder.cfg
+++ b/data/core/units/dwarves/Pathfinder.cfg
@@ -5,7 +5,7 @@
     race=dwarf
     image=units/dwarves/pathfinder.png
     profile="portraits/dwarves/scout.png"
-    hitpoints=42
+    hitpoints=45
     movement_type=dwarvishfoot
     [resistance]
         blade=90

--- a/data/core/units/dwarves/Sentinel.cfg
+++ b/data/core/units/dwarves/Sentinel.cfg
@@ -40,7 +40,7 @@
         icon=attacks/spear.png
         type=pierce
         range=melee
-        damage=9
+        damage=10
         number=3
     [/attack]
     [attack]

--- a/data/core/units/dwarves/Stalwart.cfg
+++ b/data/core/units/dwarves/Stalwart.cfg
@@ -35,7 +35,7 @@
         icon=attacks/spear.png
         type=pierce
         range=melee
-        damage=7
+        damage=8
         number=3
     [/attack]
     [attack]

--- a/data/core/units/dwarves/Steelclad.cfg
+++ b/data/core/units/dwarves/Steelclad.cfg
@@ -6,7 +6,7 @@
     race=dwarf
     image="units/dwarves/steelclad.png"
     profile="portraits/dwarves/fighter.png"
-    hitpoints=56
+    hitpoints=55
     movement_type=dwarvishfoot
     movement=4
     experience=74
@@ -39,6 +39,8 @@
 
     [resistance]
         blade=70
+        pierce=70
+        impact=70
     [/resistance]
     [attack]
         name=battle axe

--- a/data/core/units/dwarves/Thunderguard.cfg
+++ b/data/core/units/dwarves/Thunderguard.cfg
@@ -6,7 +6,7 @@
     race=dwarf
     image="units/dwarves/thunderguard/thunderguard.png"
     profile="portraits/dwarves/thunderer.png"
-    hitpoints=44
+    hitpoints=47
     movement_type=dwarvishfoot
     movement=4
     experience=95


### PR DESCRIPTION
The counterpart to https://github.com/wesnoth/wesnoth/pull/4516, the steelclad/lord line was too strong, while other dwarvish level 2s are often too weak. Namely, Pathfinder and Thunderguard have too little HP (Pathfinder only has 42 and Thunderguard 44, compared to something like the Longbowman's 51, Pikeman/Swordsman 55). Additionally, the Stalwart and Sentinel do too little damage to justify their exp and costs (Stalwart has 7-3 melee pierce, the same as the level 1 Spearman,  but without even the firststrike special). Hopefully we can tweak their stats a bit to make them a bit better.

List of changes:
Pathfinder HP 42 -> 45
Thunderguard HP 44 -> 47
Stalwart Melee 7-3 -> 8-3
Sentinel Melee 9-3 -> 10-3

Tagging @soliton- and @Krogen2 for comments.