### PR TITLE
Fix the add_completed_campaign() call for the tutorial

### DIFF
--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -678,6 +678,7 @@ void game_launcher::set_tutorial()
 	state_.clear();
 	state_.classification().campaign_type = game_classification::CAMPAIGN_TYPE::TUTORIAL;
 	state_.classification().campaign_define = "TUTORIAL";
+	state_.classification().campaign = "Tutorial";
 	state_.mp_settings().mp_era = "era_default";
 	state_.set_carryover_sides_start(
 		config {"next_scenario", "tutorial"}


### PR DESCRIPTION
When completing the tutorial, the preferences file's [completed_campaigns]
recorded that "" had been completed at difficulty NORMAL. This is an old
bug, unrelated to the other tutorial changes that I'm making, but would
cause problems if we want to change the UI based on whether the tutorial
has already been completed.