### PR TITLE
TRoW: Fixed Haldric's defense animations

### DIFF
--- a/data/campaigns/The_Rise_Of_Wesnoth/units/Noble_Commander.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/units/Noble_Commander.cfg
@@ -20,8 +20,15 @@
     description= _ "The rank of a noble Commander is held by those who lead battle groups into combat. Possessing leadership skills, they give lower-level units in adjacent hexes improved performance in combat. Commanders are best skilled with the sword, although they also carry a bow to use when necessary. If the Commander is lost, so is the battle."
     {NOTE_LEADERSHIP}
     die_sound={SOUND_LIST:HUMAN_DIE}
-    {DEFENSE_ANIM_RANGE "units/noble-commander-defend.png" "units/noble-commander.png" {SOUND_LIST:HUMAN_HIT} melee}
-    {DEFENSE_ANIM_RANGE "units/noble-commander-bow-defend.png" "units/noble-commander-bow.png" {SOUND_LIST:HUMAN_HIT} ranged}
+
+    # first defense animation is selected for sword and ruby of fire, second is used for bow only
+    {DEFENSE_ANIM "units/noble-commander-defend.png" "units/noble-commander.png" {SOUND_LIST:HUMAN_HIT}}
+    {DEFENSE_ANIM_FILTERED "units/noble-commander-bow-defend.png" "units/noble-commander-bow.png" {SOUND_LIST:HUMAN_HIT} (
+        [filter_second_attack]
+            name=bow
+        [/filter_second_attack]
+    )}
+
     [attack]
         name=sword
         #textdomain wesnoth-units

--- a/data/campaigns/The_Rise_Of_Wesnoth/units/Noble_Lord.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/units/Noble_Lord.cfg
@@ -21,8 +21,15 @@
     description= _ "The noble leaders of many troops, Lords are especially strong in melee combat, and also possess skill with the bow. Like Commanders, Lords possess leadership skills, and improve the fighting ability of all adjacent lower-level units."
     {NOTE_LEADERSHIP}
     die_sound={SOUND_LIST:HUMAN_DIE}
-    {DEFENSE_ANIM_RANGE "units/noble-lord-defend.png" "units/noble-lord.png" {SOUND_LIST:HUMAN_HIT} melee}
-    {DEFENSE_ANIM_RANGE "units/noble-lord-bow-defend.png" "units/noble-lord-bow.png" {SOUND_LIST:HUMAN_HIT} ranged}
+
+    # first defense animation is selected for sword and ruby of fire, second is used for bow only
+    {DEFENSE_ANIM "units/noble-lord-defend.png" "units/noble-lord.png" {SOUND_LIST:HUMAN_HIT}}
+    {DEFENSE_ANIM_FILTERED "units/noble-lord-bow-defend.png" "units/noble-lord-bow.png" {SOUND_LIST:HUMAN_HIT} (
+        [filter_second_attack]
+            name=bow
+        [/filter_second_attack]
+    )}
+
     [attack]
         name=sword
         #textdomain wesnoth-units


### PR DESCRIPTION
Fixes https://github.com/wesnoth/wesnoth/issues/4541

When sword or ruby of fire is used, second animation will not pass filter and first one will be selected. When bow is used, second animation earns additional point for filter matching (see https://wiki.wesnoth.org/AnimationWML#Generic_animation_filters_available_for_all_animations) and will be selected.