### PR TITLE
Campaigns Menu: Make descriptions and abbreviations search terms

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,8 @@
    * Dwarvish Lord and Steelclad: reduce hitpoints by 3 and reduce impact and pierce resistance to 20%
  ### User interface
    * The load-game dialog can now see the directories used by Wesnoth 1.14, 1.12, etc.
+   * The search box in the Campaigns menu now takes campaign abbreviations and descriptions (in the current language)
+     into account.
  ### Lua API
  ### WML engine
  ### Packaging

--- a/src/gui/dialogs/campaign_selection.cpp
+++ b/src/gui/dialogs/campaign_selection.cpp
@@ -163,7 +163,9 @@ void campaign_selection::sort_campaigns(window& window, campaign_selection::CAMP
 		for(unsigned i = 0; i < levels.size(); ++i) {
 			bool found = false;
 			for(const auto& word : last_search_words_) {
-				found = translation::ci_search(levels[i]->name(), word);
+				found = translation::ci_search(levels[i]->name(), word) ||
+				        translation::ci_search(levels[i]->description(), word) ||
+				        translation::ci_search(levels[i]->data()["abbrev"], word);
 
 				if(!found) {
 					break;


### PR DESCRIPTION
This should extend the dialog's usefulness in a way that is more or less consistent with the Add-ons Manager's search function. Although one issue is that abbreviations are often found floating around in their English form ("HttT") instead of the various localized versions ("HaT").