### PR TITLE
Added tip of the day regarding changing difficulty level in a mid-campaign

### DIFF
--- a/data/tips.cfg
+++ b/data/tips.cfg
@@ -272,6 +272,11 @@
     # po: Translate the word "Flight" as in Wings of Victory
     source= _ "<i>― Vank of Galun’s Flight, 6YW</i>"
 [/tip]
+[tip]
+    text= _ "Did you know that you can change the difficulty level during a campaign? Select the <i>Change difficulty</i> option at the bottom of the <i>Load Game</i> screen when loading start-of-scenario save files."
+    # po: Translate "Change difficulty" and "Load Game" as in wesnoth-lib textdomain
+    source= _ "<i>― The Wesnoth Tactical Guide</i>"
+[/tip]
 #ifdef __UNUSED__
 [tip]
     text= _ "<i>Feral</i> units, such as Bats and wild animals, will avoid villages. Even if they occupy a village hex, they do not gain any defensive benefits from the village, although they will still be healed."


### PR DESCRIPTION
"The Wesnoth Tactical Guide" is chosen because it is also used for these tips:
- Read the Hotkeys list in the Preferences menu ...
- You can see how far enemy units can move by moving the mouse cursor over them ...
- Nearly every button and icon in the Wesnoth game has a tooltip ...
- You cannot undo a move that uncovers hexes hidden by fog or shroud ...