### PR TITLE
Add a separate toggle for if a replay should be public.

### DIFF
--- a/data/gui/window/mp_create_game.cfg
+++ b/data/gui/window/mp_create_game.cfg
@@ -941,6 +941,10 @@
 {_GUI_MP_CREATE_MAIN_TOGGLE "strict_sync" _"Strict Synchronization" _"Stricter checks for out-of-sync errors"}
 #enddef
 
+#define _GUI_MP_CREATE_PRIVATE_TOGGLE
+{_GUI_MP_CREATE_MAIN_TOGGLE "private_replay" _"Private Replay" _"Whether the replay will be publicly available"}
+#enddef
+
 #define _GUI_MP_CREATE_MAIN_OPTIONS
 [row]
 	grow_factor = 0
@@ -1083,3 +1087,4 @@
 #undef _GUI_MP_CREATE_OBSERVER_TOGGLE
 #undef _GUI_MP_CREATE_REGISTERED_TOGGLE
 #undef _GUI_MP_CREATE_SYNC_TOGGLE
+#undef _GUI_MP_CREATE_PRIVATE_TOGGLE

--- a/data/gui/window/mp_create_game/default_resolution.cfg
+++ b/data/gui/window/mp_create_game/default_resolution.cfg
@@ -322,6 +322,9 @@
 																{_GUI_MP_CREATE_SYNC_TOGGLE}
 															[/row]
 
+															[row]
+																{_GUI_MP_CREATE_PRIVATE_TOGGLE}
+															[/row]
 														[/grid]
 
 													[/column]

--- a/data/gui/window/mp_create_game/small_resolution.cfg
+++ b/data/gui/window/mp_create_game/small_resolution.cfg
@@ -95,6 +95,12 @@
 											[/row]
 
 											[row]
+
+												{_GUI_MP_CREATE_PRIVATE_TOGGLE}
+
+											[/row]
+
+											[row]
 												grow_factor = 0
 
 												[column]

--- a/data/gui/window/mp_create_game/tiny_resolution.cfg
+++ b/data/gui/window/mp_create_game/tiny_resolution.cfg
@@ -267,6 +267,9 @@
 								horizontal_grow = true
 								vertical_grow = true
 								[grid]
+									[row]
+										{_GUI_MP_CREATE_PRIVATE_TOGGLE}
+									[/row]
 									{_GUI_MP_CREATE_MAP_SETTINGS}
 								[/grid]
 							[/column]

--- a/src/game_initialization/configure_engine.hpp
+++ b/src/game_initialization/configure_engine.hpp
@@ -225,6 +225,11 @@ public:
 		parameters_.registered_users_only = val;
 	}
 
+	void set_private_replay(bool val)
+	{
+		parameters_.private_replay = val;
+	}
+
 	void set_oos_debug(bool val)
 	{
 		state_.classification().oos_debug = val;

--- a/src/game_initialization/lobby_data.cpp
+++ b/src/game_initialization/lobby_data.cpp
@@ -198,6 +198,7 @@ game_info::game_info(const config& game, const std::vector<std::string>& install
 	, shuffle_sides(game["shuffle_sides"].to_bool(true))
 	, use_map_settings(game["mp_use_map_settings"].to_bool())
 	, registered_users_only(game["registered_users_only"].to_bool())
+	, private_replay(game["private_replay"].to_bool())
 	, verified(true)
 	, password_required(game["password"].to_bool())
 	, have_era(true)

--- a/src/game_initialization/lobby_data.hpp
+++ b/src/game_initialization/lobby_data.hpp
@@ -171,6 +171,7 @@ struct game_info
 	bool shuffle_sides;
 	bool use_map_settings;
 	bool registered_users_only;
+	bool private_replay;
 	bool verified;
 	bool password_required;
 	bool have_era;

--- a/src/gui/dialogs/multiplayer/mp_create_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.cpp
@@ -84,6 +84,7 @@ mp_create_game::mp_create_game(const config& cfg, saved_game& state, bool local_
 	, observers_(register_bool("observers", true, prefs::allow_observers, prefs::set_allow_observers))
 	, registered_users_(register_bool("registered_users", true, prefs::registered_users_only, prefs::set_registered_users_only))
 	, strict_sync_(register_bool("strict_sync", true))
+	, private_replay_(register_bool("private_replay", true))
 	, turns_(register_integer("turn_count", true, prefs::turns, prefs::set_turns))
 	, gold_(register_integer("village_gold", true, prefs::village_gold, prefs::set_village_gold))
 	, support_(register_integer("village_support", true, prefs::village_support, prefs::set_village_support))
@@ -319,6 +320,7 @@ void mp_create_game::pre_show(window& win)
 
 		observers_->widget_set_enabled(win, false, false);
 		strict_sync_->widget_set_enabled(win, false, false);
+		private_replay_->widget_set_enabled(win, false, false);
 	}
 
 	//
@@ -380,6 +382,7 @@ void mp_create_game::pre_show(window& win)
 		UPDATE_ATTRIBUTE(observers, to_bool);
 		UPDATE_ATTRIBUTE(registered_users, to_bool);
 		UPDATE_ATTRIBUTE(strict_sync, to_bool);
+		UPDATE_ATTRIBUTE(private_replay, to_bool);
 		UPDATE_ATTRIBUTE(shuffle_sides, to_bool);
 	}, true);
 
@@ -930,6 +933,7 @@ void mp_create_game::post_show(window& window)
 
 		config_engine_->set_allow_observers(observers_->get_widget_value(window));
 		config_engine_->set_registered_users_only(registered_users_->get_widget_value(window));
+		config_engine_->set_private_replay(private_replay_->get_widget_value(window));
 		config_engine_->set_oos_debug(strict_sync_->get_widget_value(window));
 		config_engine_->set_shuffle_sides(shuffle_sides_->get_widget_value(window));
 

--- a/src/gui/dialogs/multiplayer/mp_create_game.hpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.hpp
@@ -102,6 +102,7 @@ private:
 	field_bool* observers_;
 	field_bool* registered_users_;
 	field_bool* strict_sync_;
+	field_bool* private_replay_;
 
 	field_integer* turns_;
 	field_integer* gold_;

--- a/src/mp_game_settings.cpp
+++ b/src/mp_game_settings.cpp
@@ -128,6 +128,7 @@ config mp_game_settings::to_config() const
 	cfg["mp_random_start_time"] = random_start_time;
 	cfg["observer"] = allow_observers;
 	cfg["registered_users_only"] = registered_users_only;
+	cfg["private_replay"] = private_replay;
 	cfg["shuffle_sides"] = shuffle_sides;
 	cfg["random_faction_mode"] = random_faction_mode;
 	cfg["savegame"] = saved_game;

--- a/src/mp_game_settings.hpp
+++ b/src/mp_game_settings.hpp
@@ -58,6 +58,7 @@ struct mp_game_settings
 	bool shroud_game;
 	bool allow_observers;
 	bool registered_users_only;
+	bool private_replay;
 	bool shuffle_sides;
 
 	MAKE_ENUM(SAVED_GAME_MODE,

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -1619,8 +1619,8 @@ void server::handle_player_in_game(socket_ptr socket, std::shared_ptr<simple_wml
 		g.start_game(socket);
 
 		if(user_handler_) {
-			const simple_wml::node& multiplayer = *g.level().root().child("multiplayer");
-			user_handler_->db_update_game_start(uuid_, g.id(), multiplayer["mp_scenario"].to_string(), multiplayer["mp_era"].to_string(), g.is_reload(), multiplayer["observer"].to_bool(), multiplayer["observer"].to_bool(), g.has_password());
+			const simple_wml::node& m = *g.level().root().child("multiplayer");
+			user_handler_->db_update_game_start(uuid_, g.id(), m["mp_scenario"].to_string(), m["mp_era"].to_string(), g.is_reload(), m["observer"].to_bool(), !m["private_replay"].to_bool(), g.has_password());
 
 			const simple_wml::node::child_list& sides = g.get_sides_list();
 			for(unsigned side_index = 0; side_index < sides.size(); ++side_index) {
@@ -1640,7 +1640,7 @@ void server::handle_player_in_game(socket_ptr socket, std::shared_ptr<simple_wml
 				user_handler_->db_insert_game_player_info(uuid_, g.id(), side["player_id"].to_string(), side["side"].to_int(), side["is_host"].to_bool(), side["faction"].to_string(), version, source, side["current_player"].to_string());
 			}
 
-			const std::string mods = multiplayer["active_mods"].to_string();
+			const std::string mods = m["active_mods"].to_string();
 			if(mods != "") {
 				for(const std::string mod : utils::split(mods, ',')){
 					user_handler_->db_insert_modification_info(uuid_, g.id(), mod);


### PR DESCRIPTION
This makes it possible for a game to allow observers but have the replay not be public.

---

This resolves the second part of #3909