### PR TITLE
gui2/text_box: Add hover effect

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@
  ### User interface
    * "Core" type add-ons are now only accessible via hotkey.
    * Removed "Classic" in-game theme.
+   * Textboxes now have a hover effect.
  ### Units
    * Add mushroom defense cap to mounted and some flying units
    * Dwarvish Lord and Steelclad: reduce hitpoints by 3 and reduce impact and pierce resistance to 20%

--- a/data/gui/widget/text_box_default.cfg
+++ b/data/gui/widget/text_box_default.cfg
@@ -196,6 +196,20 @@
 
 		[/state_focused]
 
+		[state_hovered]
+
+			[draw]
+
+				{BACKGROUND_ENABLED}
+
+				{_GUI_DRAW_BORDER ({GUI__BORDER_COLOR_DARK}) }
+
+				{_GUI_DRAW_TEXT_OR_HINT ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__DEFAULT}) }
+
+			[/draw]
+
+		[/state_hovered]
+
 	[/resolution]
 
 #enddef

--- a/data/schema/gui.cfg
+++ b/data/schema/gui.cfg
@@ -776,6 +776,12 @@
                         max="1"
                         super="generic/state"
                     [/tag]
+                    [tag]
+                        name="state_hovered"
+                        min="0"
+                        max="1"
+                        super="generic/state"
+                    [/tag]
                     {DEFAULT_KEY "text_x_offset" f_unsigned ""}
                     {DEFAULT_KEY "text_y_offset" f_unsigned ""}
                 [/tag]

--- a/src/gui/widgets/text_box.cpp
+++ b/src/gui/widgets/text_box.cpp
@@ -435,6 +435,8 @@ text_box_definition::text_box_definition(const config& cfg)
  * @end{tag}{name="state_disabled"}
  * @begin{tag}{name="state_focused"}{min=0}{max=1}{super="generic/state"}
  * @end{tag}{name="state_focused"}
+ * @begin{tag}{name="state_hovered"}{min=0}{max=1}{super="generic/state"}
+ * @end{tag}{name="state_hovered"}
  * @end{tag}{name="resolution"}
  * @end{tag}{name="ext_box_definition"}
  * @end{parent}{name="gui/"}
@@ -448,6 +450,7 @@ text_box_definition::resolution::resolution(const config& cfg)
 	state.emplace_back(cfg.child("state_enabled"));
 	state.emplace_back(cfg.child("state_disabled"));
 	state.emplace_back(cfg.child("state_focused"));
+	state.emplace_back(cfg.child("state_hovered"));
 }
 
 // }---------- BUILDER -----------{

--- a/src/gui/widgets/text_box_base.cpp
+++ b/src/gui/widgets/text_box_base.cpp
@@ -61,6 +61,11 @@ text_box_base::text_box_base(const implementation::builder_styled_widget& builde
 	connect_signal<event::LOSE_KEYBOARD_FOCUS>(
 			std::bind(&text_box_base::signal_handler_lose_keyboard_focus, this, _2));
 
+	connect_signal<event::MOUSE_ENTER>(
+			std::bind(&text_box_base::signal_handler_mouse_enter, this, _2, _3));
+	connect_signal<event::MOUSE_LEAVE>(
+			std::bind(&text_box_base::signal_handler_mouse_leave, this, _2, _3));
+
 	toggle_cursor_timer(true);
 }
 
@@ -656,4 +661,27 @@ void text_box_base::signal_handler_lose_keyboard_focus(const event::ui_event eve
 	set_state(ENABLED);
 }
 
+void text_box_base::signal_handler_mouse_enter(const event::ui_event event,
+											   bool& handled)
+{
+	DBG_GUI_E << LOG_HEADER << ' ' << event << ".\n";
+
+	if(state_ != FOCUSED) {
+		set_state(HOVERED);
+	}
+
+	handled = true;
+}
+
+void text_box_base::signal_handler_mouse_leave(const event::ui_event event,
+											   bool& handled)
+{
+	DBG_GUI_E << LOG_HEADER << ' ' << event << ".\n";
+
+	if(state_ != FOCUSED) {
+		set_state(ENABLED);
+	}
+
+	handled = true;
+}
 } // namespace gui2

--- a/src/gui/widgets/text_box_base.hpp
+++ b/src/gui/widgets/text_box_base.hpp
@@ -276,6 +276,7 @@ public:
 		ENABLED,
 		DISABLED,
 		FOCUSED,
+		HOVERED,
 	};
 
 private:
@@ -517,6 +518,9 @@ private:
 
 	void signal_handler_receive_keyboard_focus(const event::ui_event event);
 	void signal_handler_lose_keyboard_focus(const event::ui_event event);
+
+	void signal_handler_mouse_enter(const event::ui_event event, bool& handled);
+	void signal_handler_mouse_leave(const event::ui_event event, bool& handled);
 };
 
 } // namespace gui2


### PR DESCRIPTION
This gives GUI2 textboxes (and password boxes since they are a subclass) a simple hover effect by extending the canvas definitions for the widget accordingly.