### PR TITLE
AI: add [filter_own] to all candidate actions

### DIFF
--- a/data/ai/lua/ca_castle_switch.lua
+++ b/data/ai/lua/ca_castle_switch.lua
@@ -26,7 +26,7 @@ end
 
 local ca_castle_switch = {}
 
-function ca_castle_switch:evaluation(cfg, data)
+function ca_castle_switch:evaluation(cfg, data, filter_own)
     local start_time, ca_name = wesnoth.get_time_stamp() / 1000., 'castle_switch'
     if AH.print_eval() then AH.print_ts('     - Evaluating castle_switch CA:') end
 
@@ -38,7 +38,8 @@ function ca_castle_switch:evaluation(cfg, data)
     local leader = wesnoth.units.find_on_map {
             side = wesnoth.current.side,
             canrecruit = 'yes',
-            formula = '(movement_left = total_movement) and (hitpoints = max_hitpoints)'
+            formula = '(movement_left = total_movement) and (hitpoints = max_hitpoints)',
+            { "and", filter_own }
         }[1]
     if not leader then
         -- CA is irrelevant if no leader or the leader may have moved from another CA
@@ -189,8 +190,12 @@ function ca_castle_switch:evaluation(cfg, data)
     return 0
 end
 
-function ca_castle_switch:execution(cfg, data)
-    local leader = wesnoth.units.find_on_map { side = wesnoth.current.side, canrecruit = 'yes' }[1]
+function ca_castle_switch:execution(cfg, data, filter_own)
+    local leader = wesnoth.units.find_on_map {
+        side = wesnoth.current.side,
+        canrecruit = 'yes',
+        { "and", filter_own }
+    }[1]
 
     if AH.print_exec() then AH.print_ts('   Executing castle_switch CA') end
     if AH.show_messages() then wesnoth.wml_actions.message { speaker = leader.id, message = 'Switching castles' } end

--- a/data/ai/lua/ca_grab_villages.lua
+++ b/data/ai/lua/ca_grab_villages.lua
@@ -8,12 +8,16 @@ local GV_unit, GV_village
 
 local ca_grab_villages = {}
 
-function ca_grab_villages:evaluation(cfg, data)
+function ca_grab_villages:evaluation(cfg, data, filter_own)
     local start_time, ca_name = wesnoth.get_time_stamp() / 1000., 'grab_villages'
     if AH.print_eval() then AH.print_ts('     - Evaluating grab_villages CA:') end
 
     -- Check if there are units with moves left
-    local units = AH.get_units_with_moves({ side = wesnoth.current.side, canrecruit = 'no' }, true)
+    local units = AH.get_units_with_moves({
+        side = wesnoth.current.side,
+        canrecruit = 'no',
+        { "and", filter_own }
+    }, true)
     if (not units[1]) then
         if AH.print_eval() then AH.done_eval_messages(start_time, ca_name) end
         return 0

--- a/data/ai/lua/ca_high_xp_attack.lua
+++ b/data/ai/lua/ca_high_xp_attack.lua
@@ -30,7 +30,7 @@ local XP_attack
 
 local ca_attack_highxp = {}
 
-function ca_attack_highxp:evaluation(cfg, data)
+function ca_attack_highxp:evaluation(cfg, data, filter_own)
     -- Note: (most of) the code below is set up to maximize speed. Do not
     -- "simplify" this unless you understand exactly what that means
 
@@ -38,7 +38,7 @@ function ca_attack_highxp:evaluation(cfg, data)
     local max_unit_level = 0
     local units = {}
     for _,unit in ipairs(attacks_aspect.own) do
-        if (unit.attacks_left > 0) and (#unit.attacks > 0) and (not unit.canrecruit) then
+        if (unit.attacks_left > 0) and (#unit.attacks > 0) and (not unit.canrecruit) and unit:matches(filter_own) then
             table.insert(units, unit)
 
             local level = unit.level

--- a/data/ai/lua/ca_move_to_any_enemy.lua
+++ b/data/ai/lua/ca_move_to_any_enemy.lua
@@ -9,13 +9,14 @@ local MTAE_unit, MTAE_destination
 
 local ca_move_to_any_enemy = {}
 
-function ca_move_to_any_enemy:evaluation(cfg, data)
+function ca_move_to_any_enemy:evaluation(cfg, data, filter_own)
     local start_time, ca_name = wesnoth.get_time_stamp() / 1000., 'move_to_any_enemy'
     if AH.print_eval() then AH.print_ts('     - Evaluating move_to_any_enemy CA:') end
 
     local units = AH.get_units_with_moves {
         side = wesnoth.current.side,
-        canrecruit = 'no'
+        canrecruit = 'no',
+        { "and", filter_own }
     }
 
     if (not units[1]) then

--- a/data/ai/lua/ca_move_to_any_enemy.lua
+++ b/data/ai/lua/ca_move_to_any_enemy.lua
@@ -33,6 +33,9 @@ function ca_move_to_any_enemy:evaluation(cfg, data)
 
             local x, y = wesnoth.find_vacant_tile(target.x, target.y)
             destination = AH.next_hop(unit, x, y)
+            if (destination[1] == unit.x) and (destination[2] == unit.y) then
+                destination = nil
+            end
 
             if destination then
                 break

--- a/data/ai/lua/ca_place_healers.lua
+++ b/data/ai/lua/ca_place_healers.lua
@@ -5,11 +5,11 @@ local HS = wesnoth.require "ai/micro_ais/cas/ca_healer_move.lua"
 
 local ca_place_healers = {}
 
-function ca_place_healers:evaluation(cfg, data)
+function ca_place_healers:evaluation(cfg, data, filter_own)
     local start_time, ca_name = wesnoth.get_time_stamp() / 1000., 'place_healers'
     if AH.print_eval() then AH.print_ts('     - Evaluating place_healers CA:') end
 
-    if HS:evaluation(cfg, data) > 0 then
+    if HS:evaluation({ { 'filter', filter_own } }, data) > 0 then
         if AH.print_eval() then AH.done_eval_messages(start_time, ca_name) end
         return 96000
     end

--- a/data/ai/lua/ca_recruit_rushers.lua
+++ b/data/ai/lua/ca_recruit_rushers.lua
@@ -34,9 +34,10 @@ wesnoth.require("ai/lua/generic_recruit_engine.lua").init(dummy_engine, params)
 
 local ca_recruit_rushers = {}
 
-function ca_recruit_rushers:evaluation(cfg, data)
+function ca_recruit_rushers:evaluation(cfg, data, filter_own)
     params.high_level_fraction = cfg.high_level_fraction
     params.randomness = cfg.randomness
+    params.filter_own = filter_own
     return dummy_engine:recruit_rushers_eval()
 end
 

--- a/data/ai/lua/ca_retreat_injured.lua
+++ b/data/ai/lua/ca_retreat_injured.lua
@@ -7,11 +7,14 @@ local retreat_unit, retreat_loc
 
 local ca_retreat_injured = {}
 
-function ca_retreat_injured:evaluation(cfg, data)
+function ca_retreat_injured:evaluation(cfg, data, filter_own)
     local start_time, ca_name = wesnoth.get_time_stamp() / 1000., 'retreat_injured'
     if AH.print_eval() then AH.print_ts('     - Evaluating retreat_injured CA:') end
 
-    local units = AH.get_units_with_moves({ side = wesnoth.current.side }, true)
+    local units = AH.get_units_with_moves({
+        side = wesnoth.current.side,
+        { "and", filter_own }
+    }, true)
     local unit, loc = R.retreat_injured_units(units)
     if unit then
         retreat_unit = unit

--- a/data/ai/lua/ca_spread_poison.lua
+++ b/data/ai/lua/ca_spread_poison.lua
@@ -7,7 +7,7 @@ local SP_attack
 
 local ca_spread_poison = {}
 
-function ca_spread_poison:evaluation(cfg, data)
+function ca_spread_poison:evaluation(cfg, data, filter_own)
     local start_time, ca_name = wesnoth.get_time_stamp() / 1000., 'spread_poison'
     if AH.print_eval() then AH.print_ts('     - Evaluating spread_poison CA:') end
 
@@ -21,7 +21,8 @@ function ca_spread_poison:evaluation(cfg, data)
                 } }
             } }
         } },
-        canrecruit = 'no'
+        canrecruit = 'no',
+        { "and", filter_own }
     }
     if (not poisoners[1]) then
         if AH.print_eval() then AH.done_eval_messages(start_time, ca_name) end

--- a/data/ai/lua/ca_village_hunt.lua
+++ b/data/ai/lua/ca_village_hunt.lua
@@ -6,7 +6,7 @@ local AH = wesnoth.require "ai/lua/ai_helper.lua"
 
 local ca_village_hunt = {}
 
-function ca_village_hunt:evaluation(cfg, data)
+function ca_village_hunt:evaluation(cfg, data, filter_own)
     local start_time, ca_name = wesnoth.get_time_stamp() / 1000., 'village_hunt'
     if AH.print_eval() then AH.print_ts('     - Evaluating village_hunt CA:') end
 
@@ -30,7 +30,11 @@ function ca_village_hunt:evaluation(cfg, data)
         return 0
     end
 
-    local units = AH.get_units_with_moves({ side = wesnoth.current.side, canrecruit = 'no' }, true)
+    local units = AH.get_units_with_moves({
+        side = wesnoth.current.side,
+        canrecruit = 'no',
+        { "and", filter_own }
+    }, true)
 
     if not units[1] then
         if AH.print_eval() then AH.done_eval_messages(start_time, ca_name) end
@@ -41,8 +45,12 @@ function ca_village_hunt:evaluation(cfg, data)
     return 30000
 end
 
-function ca_village_hunt:execution(cfg, data)
-    local unit = AH.get_units_with_moves({ side = wesnoth.current.side, canrecruit = 'no' }, true)[1]
+function ca_village_hunt:execution(cfg, data, filter_own)
+    local unit = AH.get_units_with_moves({
+        side = wesnoth.current.side,
+        canrecruit = 'no',
+        { "and", filter_own }
+    }, true)[1]
 
     if AH.print_exec() then AH.print_ts('   Executing village_hunt CA') end
 

--- a/data/ai/lua/generic_recruit_engine.lua
+++ b/data/ai/lua/generic_recruit_engine.lua
@@ -336,7 +336,11 @@ return {
 
         function do_recruit_eval(data)
             -- Check if leader is on keep
-            local leader = wesnoth.units.find_on_map { side = wesnoth.current.side, canrecruit = 'yes' }[1]
+            local leader = wesnoth.units.find_on_map {
+                side = wesnoth.current.side,
+                canrecruit = 'yes',
+                { "and", params.filter_own }
+            }[1]
 
             if (not leader) or (not wesnoth.get_terrain_info(wesnoth.get_terrain(leader.x, leader.y)).keep) then
                 return 0
@@ -566,7 +570,11 @@ return {
             end
 
             local recruit_type
-            local leader = wesnoth.units.find_on_map { side = wesnoth.current.side, canrecruit = 'yes' }[1]
+            local leader = wesnoth.units.find_on_map {
+                side = wesnoth.current.side,
+                canrecruit = 'yes',
+                { "and", params.filter_own }
+            }[1]
             repeat
                 recruit_data.recruit.best_hex, recruit_data.recruit.target_hex = ai_cas:find_best_recruit_hex(leader, recruit_data)
                 recruit_type = ai_cas:find_best_recruit(attack_type_count, unit_attack_type_count, recruit_effectiveness, recruit_vulnerability, attack_range_count, unit_attack_range_count, most_common_range_count)

--- a/src/ai/composite/aspect.hpp
+++ b/src/ai/composite/aspect.hpp
@@ -439,7 +439,8 @@ public:
 	{
 		this->valid_lua_ = true;
 		this->value_lua_.reset(new lua_object<T>);
-		handler_->handle(params_, true, this->value_lua_);
+		const config empty_cfg;
+		handler_->handle(params_, empty_cfg, true, this->value_lua_);
 	}
 
 	config to_config() const

--- a/src/ai/composite/goal.cpp
+++ b/src/ai/composite/goal.cpp
@@ -330,7 +330,8 @@ void lua_goal::add_targets(std::back_insert_iterator< std::vector< target >> tar
 {
 	std::shared_ptr<lua_object<std::vector<target>>> l_obj = std::make_shared<lua_object<std::vector<target>>>();
 	config c(cfg_.child_or_empty("args"));
-	handler_->handle(c, true, l_obj);
+	const config empty_cfg;
+	handler_->handle(c, empty_cfg, true, l_obj);
 	try {
 		std::vector < target > targets = *(l_obj->get());
 

--- a/src/ai/composite/rca.hpp
+++ b/src/ai/composite/rca.hpp
@@ -21,6 +21,7 @@
 
 #include "ai/composite/component.hpp"
 #include "ai/composite/contexts.hpp"
+#include "units/filter.hpp"
 
 //============================================================================
 namespace ai {
@@ -80,6 +81,18 @@ public:
 	 */
 	double get_max_score() const;
 
+
+	/**
+	 * Get the unit filter for allowed units for this candidate action
+	 */
+	std::shared_ptr<unit_filter> get_filter_own() const;
+
+
+	/**
+	 * Flag indicating whether unit may be used by this candidate action
+	 */
+	bool is_allowed_unit(const unit& u) const;
+
 	/**
 	 * Get the name of the candidate action (useful for debug purposes)
 	 */
@@ -123,6 +136,9 @@ private:
 
 
 	double max_score_;
+
+
+	std::shared_ptr<unit_filter> filter_own_;
 
 
 	std::string id_;

--- a/src/ai/default/aspect_attacks.cpp
+++ b/src/ai/default/aspect_attacks.cpp
@@ -439,7 +439,8 @@ aspect_attacks_lua::aspect_attacks_lua(readonly_context &context, const config &
 void aspect_attacks_lua::recalculate() const
 {
 	obj_.reset(new lua_object<aspect_attacks_lua_filter>);
-	handler_->handle(params_, true, obj_);
+	const config empty_cfg;
+	handler_->handle(params_, empty_cfg, true, obj_);
 	aspect_attacks_lua_filter filt = *obj_->get();
 	aspect_attacks_base::recalculate();
 	if(filt.lua) {

--- a/src/ai/default/ca.cpp
+++ b/src/ai/default/ca.cpp
@@ -85,6 +85,10 @@ double goto_phase::evaluate()
 		}
 		// end of passive_leader
 
+		if(!is_allowed_unit(*ui)){
+			continue;
+		}
+
 		const pathfind::shortest_path_calculator calc(*ui, current_team(), resources::gameboard->teams(), resources::gameboard->map());
 
 		const pathfind::teleport_map allowed_teleports = pathfind::get_teleport_locations(*ui, current_team());
@@ -161,6 +165,7 @@ combat_phase::~combat_phase()
 
 double combat_phase::evaluate()
 {
+	const unit_map &units_ = resources::gameboard->units();
 	std::vector<std::string> options = get_recruitment_pattern();
 
 	choice_rating_ = -1000.0;
@@ -191,6 +196,22 @@ double combat_phase::evaluate()
 			it != analysis.end(); ++it) {
 
 		if(skip_num > 0 && ((it - analysis.begin())%skip_num) && it->movements.size() > 1)
+			continue;
+
+		// This is somewhat inefficient. It would be faster to exclude these attacks
+		// in get_attacks() above, but the CA filter information is not available inside
+		// the attacks aspect code. Providing the filtering here is only done for consistency
+		// with other CAs though, the recommended method of filtering attacks is via
+		// 'filter_own' of the attacks aspect.
+		bool skip_attack = false;
+		for(std::size_t i = 0; i != it->movements.size(); ++i) {
+			const unit_map::const_iterator u = units_.find(it->movements[i].first);
+			if (!is_allowed_unit(*u)) {
+				skip_attack = true;
+				break;
+			}
+		}
+		if (skip_attack)
 			continue;
 
 		const double rating = it->rating(get_aggression(),*this);
@@ -288,7 +309,7 @@ double move_leader_to_goals_phase::evaluate()
 
 	const unit* leader = nullptr;
 	for (const unit_map::const_iterator& l_itor : leaders) {
-		if (!l_itor->incapacitated() && l_itor->movement_left() > 0) {
+		if (!l_itor->incapacitated() && l_itor->movement_left() > 0 && is_allowed_unit(*l_itor)) {
 			leader = &(*l_itor);
 			break;
 		}
@@ -413,7 +434,7 @@ double move_leader_to_keep_phase::evaluate()
 	int shortest_distance = 99999;
 
 	for (const unit_map::const_iterator& leader : leaders) {
-		if (leader->incapacitated() || leader->movement_left() == 0) {
+		if (leader->incapacitated() || leader->movement_left() == 0 || !is_allowed_unit(*leader)) {
 			continue;
 		}
 
@@ -620,7 +641,7 @@ void get_villages_phase::get_villages(
 		if(u_itor->can_recruit() && get_passive_leader()){
 			continue;
 		}
-		if(u_itor->side() == get_side() && u_itor->movement_left()) {
+		if(u_itor->side() == get_side() && u_itor->movement_left() && is_allowed_unit(*u_itor)) {
 			reachmap.emplace(u_itor->get_location(),	std::vector<map_location>());
 		}
 	}
@@ -732,7 +753,7 @@ void get_villages_phase::find_villages(
 		}
 
 		const unit_map::const_iterator u = resources::gameboard->units().find(j->second);
-		if (u == resources::gameboard->units().end() || u->get_state("guardian")) {
+		if (u == resources::gameboard->units().end() || u->get_state("guardian") || !is_allowed_unit(*u)) {
 			continue;
 		}
 
@@ -1340,7 +1361,7 @@ double get_healing_phase::evaluate()
 		if(u.side() == get_side() &&
 		   (u.max_hitpoints() - u.hitpoints() >= game_config::poison_amount/2
 		   || u.get_state(unit::STATE_POISONED)) &&
-		    !u.get_ability_bool("regenerate"))
+		    !u.get_ability_bool("regenerate") && is_allowed_unit(*u_it))
 		{
 			// Look for the village which is the least vulnerable to enemy attack.
 			typedef std::multimap<map_location,map_location>::const_iterator Itor;
@@ -1444,7 +1465,7 @@ double retreat_phase::evaluate()
 		    i->movement_left() == i->total_movement() &&
 		    //leaders.find(*i) == leaders.end() && //unit_map::const_iterator(i) != leader &&
 		    std::find(leaders.begin(), leaders.end(), i) == leaders.end() &&
-		    !i->incapacitated())
+		    !i->incapacitated() && is_allowed_unit(*i))
 		{
 			// This unit still has movement left, and is a candidate to retreat.
 			// We see the amount of power of each side on the situation,
@@ -1624,7 +1645,7 @@ void leader_shares_keep_phase::execute()
 
 	//check for each ai leader if he should move away from his keep
 	for (unit_map::unit_iterator &ai_leader : ai_leaders) {
-		if(!ai_leader.valid()) {
+		if(!ai_leader.valid() || !is_allowed_unit(*ai_leader)) {
 			//This can happen if wml killed or moved a leader during a movement events of another leader
 			continue;
 		}
@@ -1692,11 +1713,6 @@ void leader_shares_keep_phase::execute()
 			}
 		}
 		ai_leader->remove_movement_ai();
-	}
-	// re-get the AI leaders, in case an event did something
-	ai_leaders = resources::gameboard->units().find_leaders(get_side());
-	for(unit_map::unit_iterator &leader : ai_leaders) {
-		leader->remove_movement_ai();
 	}
 	//ERR_AI_TESTING_AI_DEFAULT << get_name() << ": evaluate - not yet implemented" << std::endl;
 }

--- a/src/ai/default/ca.cpp
+++ b/src/ai/default/ca.cpp
@@ -280,8 +280,21 @@ double move_leader_to_goals_phase::evaluate()
 		return BAD_SCORE;
 	}
 
-	const unit_map::iterator leader = resources::gameboard->units().find_leader(get_side());
-	if (!leader.valid() || leader->incapacitated()) {
+	const unit_map &units_ = resources::gameboard->units();
+	const std::vector<unit_map::const_iterator> leaders = units_.find_leaders(get_side());
+	if (leaders.empty()) {
+		return BAD_SCORE;
+	}
+
+	const unit* leader = nullptr;
+	for (const unit_map::const_iterator& l_itor : leaders) {
+		if (!l_itor->incapacitated() && l_itor->movement_left() > 0) {
+			leader = &(*l_itor);
+			break;
+		}
+	}
+
+	if (leader == nullptr) {
 		WRN_AI_TESTING_AI_DEFAULT << "Leader not found" << std::endl;
 		return BAD_SCORE;
 	}

--- a/src/ai/default/ca_move_to_targets.cpp
+++ b/src/ai/default/ca_move_to_targets.cpp
@@ -290,7 +290,7 @@ std::pair<map_location,map_location> move_to_targets_phase::choose_move(std::vec
 
 	//now find the first eligible remaining unit
 	for(u = units_.begin(); u != units_.end(); ++u) {
-		if (!(u->side() != get_side() || (u->can_recruit() && !get_leader_ignores_keep()) || u->movement_left() <= 0 || u->incapacitated())) {
+		if (!(u->side() != get_side() || (u->can_recruit() && !get_leader_ignores_keep()) || u->movement_left() <= 0 || u->incapacitated() || !is_allowed_unit(*u))) {
 			break;
 		}
 	}
@@ -393,7 +393,7 @@ std::pair<map_location,map_location> move_to_targets_phase::choose_move(std::vec
 		for(++u; u != units_.end(); ++u) {
 			if (u->side() != get_side() || (u->can_recruit() && !get_leader_ignores_keep()) ||
 			    u->movement_left() <= 0 || u->get_state("guardian") ||
-			    u->incapacitated())
+			    u->incapacitated() || !is_allowed_unit(*u))
 			{
 				continue;
 			}

--- a/src/ai/default/recruitment.cpp
+++ b/src/ai/default/recruitment.cpp
@@ -176,6 +176,12 @@ double recruitment::evaluate() {
 	const std::vector<unit_map::const_iterator> leaders = units.find_leaders(get_side());
 
 	for (const unit_map::const_iterator& leader : leaders) {
+		// Need to check this here, otherwise recruiting might be blacklisted
+		// if no allowed leader is on a keep yet
+		if (!is_allowed_unit(*leader)) {
+			continue;
+		}
+
 		if (leader == resources::gameboard->units().end()) {
 			return BAD_SCORE;
 		}
@@ -215,6 +221,10 @@ void recruitment::execute() {
 
 	for (const unit_map::const_iterator& leader : leaders) {
 		const map_location& keep = leader->get_location();
+		if (!is_allowed_unit(*leader)) {
+			LOG_AI_RECRUITMENT << "Leader " << leader->name() << " is not allowed recruiter. \n";
+			continue;
+		}
 		if (!resources::gameboard->map().is_keep(keep)) {
 			LOG_AI_RECRUITMENT << "Leader " << leader->name() << " is not on keep. \n";
 			continue;

--- a/src/ai/lua/core.cpp
+++ b/src/ai/lua/core.cpp
@@ -1104,7 +1104,7 @@ lua_ai_context::~lua_ai_context()
 	lua_pop(L, 1);
 }
 
-void lua_ai_action_handler::handle(const config &cfg, bool read_only, lua_object_ptr l_obj)
+void lua_ai_action_handler::handle(const config &cfg, const config &filter_own, bool read_only, lua_object_ptr l_obj)
 {
 	int initial_top = lua_gettop(L);//get the old stack size
 
@@ -1122,8 +1122,14 @@ void lua_ai_action_handler::handle(const config &cfg, bool read_only, lua_object
 	luaW_pushconfig(L, cfg);
 	lua_getfield(L, iState, "data");
 
+	int num = 3;
+	if (!filter_own.empty()) {
+		luaW_pushconfig(L, filter_own);
+		num=4;
+	}
+
 	// Call the function
-	luaW_pcall(L, 3, l_obj ? 1 : 0, true);
+	luaW_pcall(L, num, l_obj ? 1 : 0, true);
 	if (l_obj) {
 		l_obj->store(L, -1);
 	}

--- a/src/ai/lua/core.hpp
+++ b/src/ai/lua/core.hpp
@@ -78,7 +78,8 @@ private:
 	static lua_ai_action_handler* create(lua_State *L, char const *code, lua_ai_context &context);
 public:
 	~lua_ai_action_handler();
-	void handle(const config &cfg, bool read_only, lua_object_ptr l_obj);
+	//void handle(const config &cfg, bool read_only, lua_object_ptr l_obj);
+	void handle(const config &cfg, const config &filter_own, bool read_only, lua_object_ptr l_obj);
 	friend class ::game_lua_kernel;
 };
 


### PR DESCRIPTION
This allows restricting the CA to only a subset of the units. It is a first step toward solving Issue #2349, which calls for adding `[filter_own]` tags to all candidate actions. In my experience, it is one of the most serious shortcomings of the default AI. See #2349 for more information and additional comments.

So far, this is only implemented for the move-to-targets CA, as I want to see if there are comments before I add it to the other CAs as well.

`[filter_own]` is chosen as the tag name, because that's what is used for the only CA (combat) for which this exists already.