### PR TITLE
Support running multiple expected-to-pass unit tests

### DIFF
--- a/src/commandline_options.cpp
+++ b/src/commandline_options.cpp
@@ -276,7 +276,7 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 	po::options_description testing_opts("Testing options");
 	testing_opts.add_options()
 		("test,t", po::value<std::string>()->implicit_value(std::string()), "runs the game in a small test scenario. If specified, scenario <arg> will be used instead.")
-		("unit,u", po::value<std::string>()->implicit_value(std::string()), "runs a unit test scenario. Works like test, except that the exit code of the program reflects the victory / defeat conditions of the scenario.\n\t0 - PASS\n\t1 - FAIL\n\t3 - FAIL (INVALID REPLAY)\n\t4 - FAIL (ERRORED REPLAY)")
+		("unit,u", po::value<std::vector<std::string>>(), "runs a unit test scenario. Works like test, except that the exit code of the program reflects the victory / defeat conditions of the scenario.\n\t0 - PASS\n\t1 - FAIL\n\t3 - FAIL (INVALID REPLAY)\n\t4 - FAIL (ERRORED REPLAY)")
 		("showgui", "don't run headlessly (for debugging a failing test)")
 		("log-strict", po::value<std::string>(), "sets the strict level of the logger. any messages sent to log domains of this level or more severe will cause the unit test to fail regardless of the victory result.")
 		("noreplaycheck", "don't try to validate replay of unit test.")
@@ -495,7 +495,7 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 		test = vm["test"].as<std::string>();
 	if (vm.count("unit"))
 	{
-		unit_test = vm["unit"].as<std::string>();
+		unit_test = vm["unit"].as<std::vector<std::string>>();
 		headless_unit_test = true;
 	}
 	if (vm.count("showgui"))

--- a/src/commandline_options.cpp
+++ b/src/commandline_options.cpp
@@ -276,7 +276,7 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 	po::options_description testing_opts("Testing options");
 	testing_opts.add_options()
 		("test,t", po::value<std::string>()->implicit_value(std::string()), "runs the game in a small test scenario. If specified, scenario <arg> will be used instead.")
-		("unit,u", po::value<std::vector<std::string>>(), "runs a unit test scenario. Works like test, except that the exit code of the program reflects the victory / defeat conditions of the scenario.\n\t0 - PASS\n\t1 - FAIL\n\t3 - FAIL (INVALID REPLAY)\n\t4 - FAIL (ERRORED REPLAY)")
+		("unit,u", po::value<std::vector<std::string>>(), "runs a unit test scenario. The GUI is not shown and the exit code of the program reflects the victory / defeat conditions of the scenario.\n\t0 - PASS\n\t1 - FAIL\n\t3 - FAIL (INVALID REPLAY)\n\t4 - FAIL (ERRORED REPLAY)\n\tMultiple tests can be run by giving this option multiple times, in this case the test run will stop immediately after any test which doesn't PASS and the return code will be the status of the test that caused the stop.")
 		("showgui", "don't run headlessly (for debugging a failing test)")
 		("log-strict", po::value<std::string>(), "sets the strict level of the logger. any messages sent to log domains of this level or more severe will cause the unit test to fail regardless of the victory result.")
 		("noreplaycheck", "don't try to validate replay of unit test.")

--- a/src/commandline_options.hpp
+++ b/src/commandline_options.hpp
@@ -186,7 +186,7 @@ public:
 	/// Non-empty if --test was given on the command line. Goes directly into test mode, into a scenario, if specified.
 	boost::optional<std::string> test;
 	/// Non-empty if --unit was given on the command line. Goes directly into unit test mode, into a scenario, if specified.
-	boost::optional<std::string> unit_test;
+	std::vector<std::string> unit_test;
 	/// True if --unit is used and --showgui is not present.
 	bool headless_unit_test;
 	/// True if --noreplaycheck was given on the command line. Dependent on --unit.

--- a/src/game_launcher.hpp
+++ b/src/game_launcher.hpp
@@ -57,6 +57,17 @@ public:
 
 	enum mp_selection {MP_CONNECT, MP_HOST, MP_LOCAL};
 
+	/**
+	 * Status code after running a unit test, should match the run_wml_tests
+	 * script and the documentation for the --unit_test command-line option.
+	 */
+	enum class unit_test_result : int {
+		TEST_PASS = 0,
+		TEST_FAIL = 1,
+		TEST_FAIL_LOADING_REPLAY = 3,
+		TEST_FAIL_PLAYING_REPLAY = 4,
+	};
+
 	bool init_video();
 	bool init_language();
 	bool init_lua_script();
@@ -64,7 +75,8 @@ public:
 	bool play_test();
 	bool play_screenshot_mode();
 	bool play_render_image_mode();
-	int unit_test();
+	/// Runs unit tests specified on the command line
+	unit_test_result unit_test();
 
 	bool is_loading() const;
 	void clear_loaded_game();
@@ -105,6 +117,10 @@ private:
 
 	editor::EXIT_STATUS start_editor(const std::string& filename);
 
+	/// Internal to the implementation of unit_test(). If a single instance of
+	/// Wesnoth is running multiple unit tests, this gets called once per test.
+	unit_test_result single_unit_test();
+
 	const commandline_options& cmdline_opts_;
 	//Never null.
 	const std::unique_ptr<CVideo> video_;
@@ -117,7 +133,7 @@ private:
 	sound::music_thinker music_thinker_;
 	sound::music_muter music_muter_;
 
-	std::string test_scenario_;
+	std::vector<std::string> test_scenarios_;
 
 	std::string screenshot_map_, screenshot_filename_;
 

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -827,13 +827,8 @@ static int do_gameloop(const std::vector<std::string>& args)
 		plugins.play_slice();
 		plugins.play_slice();
 
-		if(cmdline_opts.unit_test) {
-			int worker_result = game->unit_test();
-			std::cerr << ((worker_result == 0) ? "PASS TEST " : "FAIL TEST ")
-					  << ((worker_result == 3) ? "(INVALID REPLAY)" : "")
-					  << ((worker_result == 4) ? "(ERRORED REPLAY)" : "") << ": " << *cmdline_opts.unit_test
-					  << std::endl;
-			return worker_result;
+		if(!cmdline_opts.unit_test.empty()) {
+			return static_cast<int>(game->unit_test());
 		}
 
 		if(game->play_test() == false) {


### PR DESCRIPTION
The C++ part of issue #4535

This allows batching all of the tests that are expected to return status zero,
which is currently 161 tests, and running the batch with a single instance of
Wesnoth.  It doesn't include the changes to the run_wml_tests script to use
this new feature (and I'd welcome someone else refactoring that script).

Timing on my PC:
* 4 seconds to run a single test on a debug build
* 90 seconds to run the whole batch of 161 on a debug build
* 1.2 seconds to run a single test on a release build
* 31.2 seconds to run the whole batch of 161 on a release build

I feel it's hacking more complexity on top of the wesnoth.cpp / game_launcher.cpp / commandline_options.cpp / title_screen.cpp spaghetti, but faster testing means people are more likely to run the tests.

The main output is still that Wesnoth returns the status code of the last test run - if all the tests pass then the final status code returned is zero. It will also print `PASS TEST: test_name` for each individual test.

Example of a fail on test 3 of a set of 4 - the run stops after the failed test, and the status is returned.
```
steve@lisar:~$ wesnoth-main.dev.debug -u test_assert -u test_assert -u test_assert_fail -u test_assert
Battle for Wesnoth v1.15.2+dev
... paths ...

Checking lua scripts... ok
PASS TEST: test_assert
PASS TEST: test_assert
FAIL TEST: test_assert_fail
steve@lisar:~$ echo $?
1
steve@lisar:~$ 
```