### PR TITLE
Filter weapon in [filter student/opponent/etc] ,rework [filter_(secon…  …d_)weapon and fix sidebar show(pre 1.16 string)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -75,6 +75,7 @@
    * Support [set/clear_variable] inside [modify_unit/side]
    * Support [variables] in [modify_side], as in [modify_unit]
    * [filter_weapon] implemented in abilities used as weapons specials to be the same as true weapons specials (implement filter_weapon in [filter_student] instead of [filter_self])
+   * [leadership] can now, like the special weapons-based abilities, use all their options (active_on = (defense, offense, both), apply_to = self, opponent, etc.) as well as their filters ([filter_student / opponent , etc.])
  ### Packaging
    * The Wesnoth client now looks for the data/dist file when logging into the multiplayer server.
      This file should contain one of the following values based on where the package is for:

--- a/changelog.md
+++ b/changelog.md
@@ -74,6 +74,7 @@
    * [effect]apply_to=variation now supports heal_full
    * Support [set/clear_variable] inside [modify_unit/side]
    * Support [variables] in [modify_side], as in [modify_unit]
+   * [filter_weapon] implemented in abilities used as weapons specials to be the same as true weapons specials (implement filter_weapon in [filter_student] instead of [filter_self])
  ### Packaging
    * The Wesnoth client now looks for the data/dist file when logging into the multiplayer server.
      This file should contain one of the following values based on where the package is for:

--- a/data/campaigns/Heir_To_The_Throne/utils/abilities.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/abilities.cfg
@@ -6,9 +6,11 @@
         name= _ "initiative"
         description= _ "All adjacent friendly units will strike first in melee combat, even when defending."
         affect_self=no
-        [filter_second_weapon]
-            range=melee
-        [/filter_second_weapon]
+        [filter_opponent]
+            [filter_weapon]
+                range=melee
+            [/filter_weapon]
+        [/filter_opponent]
         [affect_adjacent]
         [/affect_adjacent]
     [/firststrike]

--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -327,6 +327,52 @@ Xu, Xu, Qxu, Qxu, Ql, Ql, Ql, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Gg, Gg, Gg, Gg, Gg
             type="White Mage"
             gender="female"
             generate_name=yes
+            [modifications]
+                [object]
+                    [effect]
+                        apply_to=new_ability
+                        [abilities]
+                            [leadership]
+                                id=magical_leadership
+                                value="(25 * (level - other.level))"
+                                cumulative=no
+                                name= _ "magical leadership"
+                                female_name= _ "female^magical leadership"
+                                description= _ "This unit can lead your own units that are next to it, making them fight better with magicals weapons.
+Adjacent own units of lower level will do more damage in battle. When a unit adjacent to, of a lower level than, and on the same side as a unit with Leadership engages in combat, its attacks do 25% more damage times the difference in their levels."
+                                affect_self=no
+                                [filter_weapon]
+                                    special_id=magical
+                                [/filter_weapon]
+                                [affect_adjacent]
+                                    [filter]
+                                        formula="level < other.level"
+                                    [/filter]
+                                [/affect_adjacent]
+                            [/leadership]
+                            [resistance]
+                                id=melee_steadfast
+                                add=20
+                                max_value=50
+                                # applies to any type if we leave it out
+                                #apply_to=blade,pierce,impact,fire,cold,arcane
+                                [filter_base_value]
+                                greater_than=0
+                                less_than=50
+                                [/filter_base_value]
+                                [filter_second_weapon]
+                                    range=melee
+                                [/filter_second_weapon]
+                                name= _ "steadfast"
+                                female_name= _ "female^steadfast"
+                                description= _ "This unit’s resistances are added to 20%, up to a maximum of 50%, when defending to melle attacks. Vulnerabilities are not affected."
+                                affect_self=yes
+                                active_on=defense
+                            [/resistance]
+                        [/abilities]
+                    [/effect]
+                [/object]
+            [/modifications]
         [/unit]
         [unit]
             # A unit with a cold attack
@@ -393,6 +439,60 @@ Xu, Xu, Qxu, Qxu, Ql, Ql, Ql, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Gg, Gg, Gg, Gg, Gg
             {IS_HERO}
             [modifications]
                 [object]
+                    [effect]
+                        apply_to=new_ability
+                        [abilities]
+                           [firststrike]
+                               id=initiative
+                               name= _ "initiative"
+                               description= _ "All adjacent friendly units will strike first in melee combat, even when defending."
+                               affect_self=no
+                               [filter_second_weapon]#don't must match here
+                                   [not]
+                                       range=melee
+                                   [/not]
+                               [/filter_second_weapon]
+                               [filter_opponent]
+                                   [filter_weapon]
+                                       range=melee
+                                   [/filter_weapon]
+                               [/filter_opponent]
+                               [affect_adjacent]
+                               [/affect_adjacent]
+                           [/firststrike]
+                           [chance_to_hit]
+                               id=marksman_leadership
+                               name= _ "cantor"
+                               female_name= _ "female^cantor"
+                               description= _ "This unit grants marksman to all ranged attacks of all adjacent allies."
+                               value=60
+                               cumulative=yes
+                               active_on=offense
+                               [filter_weapon]#don't match here
+                                   range=melee
+                               [/filter_weapon]
+                               [filter_second_weapon]
+                                   [not]
+                                       type=pierce
+                                   [/not]
+                               [/filter_second_weapon]
+                               [filter_student]
+                                   [filter_weapon]
+                                       range=ranged
+                                   [/filter_weapon]
+                               [/filter_student]
+                               [filter_opponent]
+                                   [filter_weapon]
+                                       type=pierce
+                                   [/filter_weapon]
+                               [/filter_opponent]
+                               affect_self=no
+                               affect_allies=yes
+                               [affect_adjacent]
+                               [/affect_adjacent]
+                           [/chance_to_hit]
+                        [/abilities]
+                    [/effect]
                     [effect]
                         apply_to=remove_attacks
                     [/effect]

--- a/data/schema/units/abilities.cfg
+++ b/data/schema/units/abilities.cfg
@@ -89,6 +89,7 @@
 	max=infinite
 	super="units/unit_type/abilities/~generic~"
 	{SIMPLE_KEY value f_int}
+    {FILTER_TAG "filter_student" unit {FILTER_TAG "filter_weapon" weapon ()}}
 	{FILTER_TAG "filter_weapon" weapon ()}
 	{FILTER_TAG "filter_second_weapon" weapon ()}
 [/tag]

--- a/data/schema/units/abilities.cfg
+++ b/data/schema/units/abilities.cfg
@@ -4,7 +4,7 @@
 		name={NAME}
 		max=infinite
 		super="units/unit_type/abilities/~generic~,units/unit_type/attack/specials/" + {NAME}
-		{FILTER_TAG "filter_student" unit ()}
+		{FILTER_TAG "filter_student" unit {FILTER_TAG "filter_weapon" weapon ()}}
 		{FILTER_TAG "filter_weapon" weapon ()}
 		{FILTER_TAG "filter_second_weapon" weapon ()}
 	[/tag]
@@ -80,6 +80,7 @@
 	name="resistance"
 	max=infinite
 	super="units/unit_type/abilities/~value~"
+    {FILTER_TAG "filter_student" unit {FILTER_TAG "filter_weapon" weapon ()}}
 	{FILTER_TAG "filter_weapon" weapon ()}
 	{FILTER_TAG "filter_second_weapon" weapon ()}
 [/tag]

--- a/data/schema/units/abilities.cfg
+++ b/data/schema/units/abilities.cfg
@@ -85,6 +85,15 @@
 	{FILTER_TAG "filter_second_weapon" weapon ()}
 [/tag]
 [tag]
+	name="leadership"
+	max=infinite
+	super="units/unit_type/abilities/~generic~, units/unit_type/attack/specials/~generic~"
+	{SIMPLE_KEY value f_int}
+	{FILTER_TAG "filter_student" unit {FILTER_TAG "filter_weapon" weapon ()}}
+	{FILTER_TAG "filter_weapon" weapon ()}
+	{FILTER_TAG "filter_second_weapon" weapon ()}
+[/tag]
+[tag]
 	name="illuminates"
 	max=infinite
 	super="units/unit_type/abilities/~generic~"
@@ -115,7 +124,6 @@
 		{DEFAULT_KEY pass_allied_units bool yes}
 	[/tag]
 [/tag]
-{BASED_ON_SPECIAL "leadership"}
 {BASED_ON_SPECIAL "attacks"}
 {BASED_ON_SPECIAL "chance_to_hit"}
 {BASED_ON_SPECIAL "damage"}

--- a/data/schema/units/abilities.cfg
+++ b/data/schema/units/abilities.cfg
@@ -80,7 +80,7 @@
 	name="resistance"
 	max=infinite
 	super="units/unit_type/abilities/~value~"
-    {FILTER_TAG "filter_student" unit {FILTER_TAG "filter_weapon" weapon ()}}
+	{FILTER_TAG "filter_student" unit {FILTER_TAG "filter_weapon" weapon ()}}
 	{FILTER_TAG "filter_weapon" weapon ()}
 	{FILTER_TAG "filter_second_weapon" weapon ()}
 [/tag]
@@ -89,7 +89,7 @@
 	max=infinite
 	super="units/unit_type/abilities/~generic~"
 	{SIMPLE_KEY value f_int}
-    {FILTER_TAG "filter_student" unit {FILTER_TAG "filter_weapon" weapon ()}}
+	{FILTER_TAG "filter_student" unit {FILTER_TAG "filter_weapon" weapon ()}}
 	{FILTER_TAG "filter_weapon" weapon ()}
 	{FILTER_TAG "filter_second_weapon" weapon ()}
 [/tag]

--- a/data/schema/units/abilities.cfg
+++ b/data/schema/units/abilities.cfg
@@ -85,15 +85,6 @@
 	{FILTER_TAG "filter_second_weapon" weapon ()}
 [/tag]
 [tag]
-	name="leadership"
-	max=infinite
-	super="units/unit_type/abilities/~generic~"
-	{SIMPLE_KEY value f_int}
-	{FILTER_TAG "filter_student" unit {FILTER_TAG "filter_weapon" weapon ()}}
-	{FILTER_TAG "filter_weapon" weapon ()}
-	{FILTER_TAG "filter_second_weapon" weapon ()}
-[/tag]
-[tag]
 	name="illuminates"
 	max=infinite
 	super="units/unit_type/abilities/~generic~"
@@ -124,6 +115,7 @@
 		{DEFAULT_KEY pass_allied_units bool yes}
 	[/tag]
 [/tag]
+{BASED_ON_SPECIAL "leadership"}
 {BASED_ON_SPECIAL "attacks"}
 {BASED_ON_SPECIAL "chance_to_hit"}
 {BASED_ON_SPECIAL "damage"}

--- a/data/schema/units/specials.cfg
+++ b/data/schema/units/specials.cfg
@@ -34,11 +34,6 @@
 	{FILTER_TAG "filter_base_value" base_value ()}
 [/tag]
 [tag]
-	name="leadership"
-	max=infinite
-	super="units/unit_type/attack/specials/~value~"
-[/tag]
-[tag]
 	name="attacks"
 	max=infinite
 	super="units/unit_type/attack/specials/~value~"

--- a/data/schema/units/specials.cfg
+++ b/data/schema/units/specials.cfg
@@ -34,6 +34,11 @@
 	{FILTER_TAG "filter_base_value" base_value ()}
 [/tag]
 [tag]
+	name="leadership"
+	max=infinite
+	super="units/unit_type/attack/specials/~value~"
+[/tag]
+[tag]
 	name="attacks"
 	max=infinite
 	super="units/unit_type/attack/specials/~value~"

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1760,28 +1760,32 @@ bool bool_leadership(const std::string& ability,const unit &un, unit_const_ptr u
 bool attack_type::bool_ability(const std::string& ability) const
 {
 	bool abil_bool= get_special_bool(ability);
-
-	if(leadership_affects_self(ability, *self_, self_loc_, is_attacker_)) {
-		abil_bool = get_special_bool(ability) || bool_leadership(ability, *self_, other_, self_loc_, other_loc_, is_attacker_, shared_from_this(), other_attack_);
+	if(self_){
+		if(leadership_affects_self(ability, *self_, self_loc_, is_attacker_)) {
+			abil_bool = get_special_bool(ability) || bool_leadership(ability, *self_, other_, self_loc_, other_loc_, is_attacker_, shared_from_this(), other_attack_);
+		}
 	}
-
-	if(other_ && leadership_affects_opponent(ability, *other_, other_loc_, !is_attacker_)) {
-		abil_bool = get_special_bool(ability) || bool_leadership(ability, *other_, self_, other_loc_, self_loc_, !is_attacker_, other_attack_, shared_from_this());
-	}
+    if(other_){
+	    if(leadership_affects_opponent(ability, *other_, other_loc_, !is_attacker_)) {
+		    abil_bool = get_special_bool(ability) || bool_leadership(ability, *other_, self_, other_loc_, self_loc_, !is_attacker_, other_attack_, shared_from_this());
+	    }
+    }
 	return abil_bool;
 }
 
 //emulate numerical special for self/adjacent and/or opponent.
 std::pair<int, bool> attack_type::combat_ability(const std::string& ability, int abil_value, bool backstab_pos) const
 {
-
-	if(leadership_affects_self(ability, *self_, self_loc_, is_attacker_)) {
-		return ability_leadership(ability, *self_, other_, self_loc_, other_loc_, is_attacker_, abil_value, backstab_pos, shared_from_this(), other_attack_);
-
-	}
-	if(other_ && leadership_affects_opponent(ability, *other_, other_loc_, !is_attacker_)) {
-		return ability_leadership(ability, *other_, self_, other_loc_,self_loc_, !is_attacker_, abil_value, backstab_pos, other_attack_, shared_from_this());
-	}
+    if(self_){
+	    if(leadership_affects_self(ability, *self_, self_loc_, is_attacker_)) {
+		    return ability_leadership(ability, *self_, other_, self_loc_, other_loc_, is_attacker_, abil_value, backstab_pos, shared_from_this(), other_attack_);
+	    }
+    }
+    if(other_){
+	    if(leadership_affects_opponent(ability, *other_, other_loc_, !is_attacker_)) {
+		    return ability_leadership(ability, *other_, self_, other_loc_,self_loc_, !is_attacker_, abil_value, backstab_pos, other_attack_, shared_from_this());
+	    }
+    }
 	return {abil_value, false};
 }
 //end of emulate weapon special functions.

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1760,7 +1760,6 @@ bool bool_leadership(const std::string& ability,const unit &un, unit_const_ptr u
 bool attack_type::bool_ability(const std::string& ability) const
 {
 	bool abil_bool= get_special_bool(ability);
-	const unit_map& units = display::get_singleton()->get_units();
 
 	if(leadership_affects_self(ability, *self_, self_loc_, is_attacker_)) {
 		abil_bool = get_special_bool(ability) || bool_leadership(ability, *self_, other_, self_loc_, other_loc_, is_attacker_, shared_from_this(), other_attack_);
@@ -1775,7 +1774,6 @@ bool attack_type::bool_ability(const std::string& ability) const
 //emulate numerical special for self/adjacent and/or opponent.
 std::pair<int, bool> attack_type::combat_ability(const std::string& ability, int abil_value, bool backstab_pos) const
 {
-	const unit_map& units = display::get_singleton()->get_units();
 
 	if(leadership_affects_self(ability, *self_, self_loc_, is_attacker_)) {
 		return ability_leadership(ability, *self_, other_, self_loc_, other_loc_, is_attacker_, abil_value, backstab_pos, shared_from_this(), other_attack_);

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1570,9 +1570,21 @@ void attack_unit_and_advance(const map_location& attacker,
 
 int under_leadership(const unit &u, const map_location& loc, const_attack_ptr weapon, const_attack_ptr opp_weapon)
 {
-	unit_ability_list abil = u.get_abilities("leadership", loc, weapon, opp_weapon);
-	unit_abilities::effect leader_effect(abil, 0, false);
-	return leader_effect.get_composite_value();
+	unit_ability_list abil = u.get_abilities("leadership", loc);
+	for(unit_ability_list::iterator i = abil.begin(); i != abil.end();) {
+        bool affect_weapon = !u.ability_affects_weapon(*i->first, weapon, false) || !u.ability_affects_weapon(*i->first, opp_weapon, true);
+        bool filter_student = !u.ability_filter_fighter("leadership", "filter_student" , *i->first, loc, weapon);
+		if(affect_weapon || filter_student) {
+			i = abil.erase(i);
+		} else {
+			++i;
+		}
+	}
+	if(!abil.empty()) {
+		unit_abilities::effect leader_effect(abil, 0, false);
+		return leader_effect.get_composite_value();
+	}
+	return 0;
 }
 
 //begin of weapon emulates function.
@@ -1592,40 +1604,61 @@ bool unit::abilities_filter_matches(const config& cfg, bool attacker, int res) c
 
 //functions for emulate weapon specials.
 //filter opponent and affect self/opponent/both option.
-bool unit::ability_filter_fighter(const std::string& ability, const std::string& filter_attacker , const config& cfg, const map_location& loc, const unit& u2) const
+bool unit::ability_filter_fighter(const std::string& ability, const std::string& filter_attacker , const config& cfg, const map_location& loc, const unit& u2, const_attack_ptr weapon) const
 {
 	const config &filter = cfg.child(filter_attacker);
 	if(!filter) {
 		return true;
 	}
+
+	if ( const config & filter_weapon = filter.child("filter_weapon") ) {
+		if ( !weapon || !weapon->matches_filter(filter_weapon))
+			return false;
+	}
 	return unit_filter(vconfig(filter)).set_use_flat_tod(ability == "illuminates").matches(*this, loc, u2);
 }
 
-static bool ability_apply_filter(const unit_map::const_iterator un, const unit_map::const_iterator up, const std::string& ability, const config& cfg, const map_location& loc, const map_location& opp_loc, bool attacker )
+bool unit::ability_filter_fighter(const std::string& ability, const std::string& filter_attacker , const config& cfg, const map_location& loc, const_attack_ptr weapon) const
 {
-	if(!up->ability_filter_fighter(ability, "filter_opponent", cfg, opp_loc, *un)){
+	const config &filter = cfg.child(filter_attacker);
+	if(!filter) {
 		return true;
 	}
-	if(!un->ability_filter_fighter(ability, "filter_student", cfg, loc, *up)){
-		return true;
+
+	if ( const config & filter_weapon = filter.child("filter_weapon") ) {
+		if ( !weapon || !weapon->matches_filter(filter_weapon))
+			return false;
 	}
-	if((attacker && !un->ability_filter_fighter(ability, "filter_attacker", cfg, loc, *up)) || (!attacker && !up->ability_filter_fighter(ability, "filter_attacker", cfg, opp_loc, *un))){
-		return true;
-	}
-	if((!attacker && !un->ability_filter_fighter(ability, "filter_defender", cfg, loc, *up)) || (attacker && !up->ability_filter_fighter(ability, "filter_defender", cfg, opp_loc, *un))){
+	return unit_filter(vconfig(filter)).set_use_flat_tod(ability == "illuminates").matches(*this, loc);
+}
+
+static bool ability_apply_filter(const unit &un, const unit &up, const std::string& ability, const config& cfg, const map_location& loc, const map_location& opp_loc, bool attacker, const_attack_ptr weapon, const_attack_ptr opp_weapon)
+{
+    bool filter_opponent = !up.ability_filter_fighter(ability, "filter_opponent", cfg, opp_loc, un, opp_weapon);
+    bool filter_student = !un.ability_filter_fighter(ability, "filter_student", cfg, loc, up, weapon);
+    bool filter_attacker = (attacker && !un.ability_filter_fighter(ability, "filter_attacker", cfg, loc, up, weapon)) || (!attacker && !up.ability_filter_fighter(ability, "filter_attacker", cfg, opp_loc, un, opp_weapon));
+    bool filter_defender = (!attacker && !un.ability_filter_fighter(ability, "filter_defender", cfg, loc, up, weapon)) || (attacker && !up.ability_filter_fighter(ability, "filter_defender", cfg, opp_loc, un, opp_weapon));
+	if(filter_student || filter_opponent || filter_attacker || filter_defender){
 		return true;
 	}
 	return false;
 }
 
-bool leadership_affects_self(const std::string& ability,const unit_map& units, const map_location& loc, bool attacker, const_attack_ptr weapon,const_attack_ptr opp_weapon)
+static bool ability_single_apply_filter(const unit &un, const std::string& ability, const config& cfg, const map_location& loc, bool attacker, const_attack_ptr weapon)
 {
-	const unit_map::const_iterator un = units.find(loc);
-	if(un == units.end()) {
-		return false;
+    bool filter_student = !un.ability_filter_fighter(ability, "filter_student", cfg, loc, weapon);
+    bool filter_attacker = (attacker && !un.ability_filter_fighter(ability, "filter_attacker", cfg, loc, weapon));
+    bool filter_defender = (!attacker && !un.ability_filter_fighter(ability, "filter_defender", cfg, loc, weapon));
+	if(filter_student || filter_attacker || filter_defender){
+		return true;
 	}
+	return false;
+}
 
-	unit_ability_list abil = un->get_abilities(ability, weapon, opp_weapon);
+bool leadership_affects_self(const std::string& ability, const unit &un, const map_location& loc, bool attacker)
+{
+
+	unit_ability_list abil = un.get_abilities(ability, loc);
 	for(unit_ability_list::iterator i = abil.begin(); i != abil.end();) {
 		const std::string& apply_to = (*i->first)["apply_to"];
 		if(apply_to.empty() || apply_to == "both" || apply_to == "self") {
@@ -1642,14 +1675,10 @@ bool leadership_affects_self(const std::string& ability,const unit_map& units, c
 	return false;
 }
 
-bool leadership_affects_opponent(const std::string& ability,const unit_map& units, const map_location& loc, bool attacker, const_attack_ptr weapon,const_attack_ptr opp_weapon)
+bool leadership_affects_opponent(const std::string& ability, const unit &un, const map_location& loc, bool attacker)
 {
-	const unit_map::const_iterator un = units.find(loc);
-	if(un == units.end()) {
-		return false;
-	}
 
-	unit_ability_list abil = un->get_abilities(ability, weapon, opp_weapon);
+	unit_ability_list abil = un.get_abilities(ability, loc);
 	for(unit_ability_list::iterator i = abil.begin(); i != abil.end();) {
 		const std::string& apply_to = (*i->first)["apply_to"];
 		if(apply_to == "both" || apply_to == "opponent") {
@@ -1667,27 +1696,25 @@ bool leadership_affects_opponent(const std::string& ability,const unit_map& unit
 }
 
 //sub function for emulate chance_to_hit,damage drains and attacks special.
-std::pair<int, bool> ability_leadership(const std::string& ability,const unit_map& units, const map_location& loc, const map_location& opp_loc, bool attacker, int abil_value, bool backstab_pos, const_attack_ptr weapon, const_attack_ptr opp_weapon)
+std::pair<int, bool> ability_leadership(const std::string& ability, const unit &un, unit_const_ptr up, const map_location& loc, const map_location& opp_loc, bool attacker, int abil_value, bool backstab_pos, const_attack_ptr weapon, const_attack_ptr opp_weapon)
 {
-	const unit_map::const_iterator un = units.find(loc);
-	const unit_map::const_iterator up = units.find(opp_loc);
-	if(un == units.end()) {
-		return {abil_value, false};
-	}
 
-	unit_ability_list abil = un->get_abilities(ability, weapon, opp_weapon);
+	unit_ability_list abil = un.get_abilities(ability , loc);
 	for(unit_ability_list::iterator i = abil.begin(); i != abil.end();) {
 		const config &filter = (*i->first).child("filter_opponent");
-		const config &filter_student = (*i->first).child("filter_student");
 		const config &filter_attacker = (*i->first).child("filter_attacker");
 		const config &filter_defender = (*i->first).child("filter_defender");
 		bool show_result = false;
-		if(up == units.end() && !filter_student && !filter && !filter_attacker && !filter_defender) {
-			show_result = un->abilities_filter_matches(*i->first, attacker, abil_value);
-		} else if(up == units.end() && (filter_student || filter || filter_attacker || filter_defender)) {
+		bool active_on_bool = un.abilities_filter_matches(*i->first, attacker, abil_value);
+		bool weapon_filter = !(un.ability_affects_weapon(*i->first, weapon, false) && un.ability_affects_weapon(*i->first, opp_weapon, true));
+		bool fighter_filter = ability_single_apply_filter(un, ability, *i->first, loc, attacker, weapon);
+		if(!up && !filter && !(filter_attacker && !attacker) && !(filter_defender && attacker)) {
+			show_result = !(!active_on_bool || fighter_filter || weapon_filter);
+		} else if(!up && (filter || (filter_attacker && !attacker) || (filter_defender && attacker))) {
 			return {abil_value, false};
 		} else {
-			show_result = !(!un->abilities_filter_matches(*i->first, attacker, abil_value) || ability_apply_filter(un, up, ability, *i->first, loc, opp_loc, attacker));
+			fighter_filter = ability_apply_filter(un, *up, ability, *i->first, loc, opp_loc, attacker, weapon, opp_weapon);
+			show_result = !(!active_on_bool || fighter_filter || weapon_filter);
 		}
 
 		if(!show_result) {
@@ -1705,18 +1732,19 @@ std::pair<int, bool> ability_leadership(const std::string& ability,const unit_ma
 }
 
 //sub function for wmulate boolean special(slow, poison...)
-bool bool_leadership(const std::string& ability,const unit_map& units, const map_location& loc, const map_location& opp_loc, bool attacker, const_attack_ptr weapon, const_attack_ptr opp_weapon)
+bool bool_leadership(const std::string& ability,const unit &un, unit_const_ptr up, const map_location& loc, const map_location& opp_loc, bool attacker, const_attack_ptr weapon, const_attack_ptr opp_weapon)
 {
-	const unit_map::const_iterator un = units.find(loc);
-	const unit_map::const_iterator up = units.find(opp_loc);
-	if(un == units.end() || up == units.end()) {
+	if(!up) {
 		return false;
 	}
 
-	unit_ability_list abil = un->get_abilities(ability, weapon, opp_weapon);
+	unit_ability_list abil = un.get_abilities(ability, loc);
 	for(unit_ability_list::iterator i = abil.begin(); i != abil.end();) {
 		const std::string& active_on = (*i->first)["active_on"];
-		if(!(active_on.empty() || (attacker && active_on == "offense") || (!attacker && active_on == "defense")) || ability_apply_filter(un, up, ability, *i->first, loc, opp_loc, attacker)) {
+		bool active_on_bool = !(active_on.empty() || (attacker && active_on == "offense") || (!attacker && active_on == "defense"));
+		bool fighter_filter = ability_apply_filter(un, *up, ability, *i->first, loc, opp_loc, attacker, weapon, opp_weapon);
+		bool weapon_filter = !(un.ability_affects_weapon(*i->first, weapon, false) && un.ability_affects_weapon(*i->first, opp_weapon, true));
+		if(active_on_bool || fighter_filter || weapon_filter) {
 			i = abil.erase(i);
 		} else {
 			++i;
@@ -1734,12 +1762,12 @@ bool attack_type::bool_ability(const std::string& ability) const
 	bool abil_bool= get_special_bool(ability);
 	const unit_map& units = display::get_singleton()->get_units();
 
-	if(leadership_affects_self(ability, units, self_loc_, is_attacker_, shared_from_this(), other_attack_)) {
-		abil_bool = get_special_bool(ability) || bool_leadership(ability, units, self_loc_, other_loc_, is_attacker_, shared_from_this(), other_attack_);
+	if(leadership_affects_self(ability, *self_, self_loc_, is_attacker_)) {
+		abil_bool = get_special_bool(ability) || bool_leadership(ability, *self_, other_, self_loc_, other_loc_, is_attacker_, shared_from_this(), other_attack_);
 	}
 
-	if(leadership_affects_opponent(ability, units, other_loc_, !is_attacker_, other_attack_, shared_from_this())) {
-		abil_bool = get_special_bool(ability) || bool_leadership(ability, units, other_loc_, self_loc_, !is_attacker_, other_attack_, shared_from_this());
+	if(other_ && leadership_affects_opponent(ability, *other_, other_loc_, !is_attacker_)) {
+		abil_bool = get_special_bool(ability) || bool_leadership(ability, *other_, self_, other_loc_, self_loc_, !is_attacker_, other_attack_, shared_from_this());
 	}
 	return abil_bool;
 }
@@ -1749,12 +1777,12 @@ std::pair<int, bool> attack_type::combat_ability(const std::string& ability, int
 {
 	const unit_map& units = display::get_singleton()->get_units();
 
-	if(leadership_affects_self(ability, units, self_loc_, is_attacker_, shared_from_this(), other_attack_)) {
-		return ability_leadership(ability, units, self_loc_, other_loc_, is_attacker_, abil_value, backstab_pos, shared_from_this(), other_attack_);
-	}
+	if(leadership_affects_self(ability, *self_, self_loc_, is_attacker_)) {
+		return ability_leadership(ability, *self_, other_, self_loc_, other_loc_, is_attacker_, abil_value, backstab_pos, shared_from_this(), other_attack_);
 
-	if(leadership_affects_opponent(ability, units, other_loc_, !is_attacker_, other_attack_, shared_from_this())) {
-		return ability_leadership(ability, units, other_loc_,self_loc_, !is_attacker_, abil_value, backstab_pos, other_attack_, shared_from_this());
+	}
+	if(other_ && leadership_affects_opponent(ability, *other_, other_loc_, !is_attacker_)) {
+		return ability_leadership(ability, *other_, self_, other_loc_,self_loc_, !is_attacker_, abil_value, backstab_pos, other_attack_, shared_from_this());
 	}
 	return {abil_value, false};
 }

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -199,7 +199,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 			resources::gameboard->units(), resources::gameboard->map(), u_loc, u.alignment(), u.is_fearless());
 
 	// Leadership bonus.
-	int leader_bonus = under_leadership(u, u_loc, weapon, opp_weapon);
+	int leader_bonus = weapon->combat_ability("leadership", 0, backstab_pos).first;
 	if(leader_bonus != 0) {
 		damage_multiplier += leader_bonus;
 	}
@@ -1566,25 +1566,6 @@ void attack_unit_and_advance(const map_location& attacker,
 	if(defu != resources::gameboard->units().end()) {
 		advance_unit_at(advance_unit_params(defender).ai_advancements(ai_advancement));
 	}
-}
-
-int under_leadership(const unit &u, const map_location& loc, const_attack_ptr weapon, const_attack_ptr opp_weapon)
-{
-	unit_ability_list abil = u.get_abilities("leadership", loc);
-	for(unit_ability_list::iterator i = abil.begin(); i != abil.end();) {
-        bool affect_weapon = !u.ability_affects_weapon(*i->first, weapon, false) || !u.ability_affects_weapon(*i->first, opp_weapon, true);
-        bool filter_student = !u.ability_filter_fighter("leadership", "filter_student" , *i->first, loc, weapon);
-		if(affect_weapon || filter_student) {
-			i = abil.erase(i);
-		} else {
-			++i;
-		}
-	}
-	if(!abil.empty()) {
-		unit_abilities::effect leader_effect(abil, 0, false);
-		return leader_effect.get_composite_value();
-	}
-	return 0;
 }
 
 //begin of weapon emulates function.

--- a/src/actions/attack.hpp
+++ b/src/actions/attack.hpp
@@ -279,10 +279,10 @@ void attack_unit_and_advance(const map_location& attacker,
  * Returns the bonus percentage (possibly 0 if there's no leader adjacent).
  */
 int under_leadership(const unit &u, const map_location& loc, const_attack_ptr weapon = nullptr, const_attack_ptr opp_weapon = nullptr);
-bool leadership_affects_self(const std::string& ability,const unit_map& units, const map_location& loc, bool attacker=true, const_attack_ptr weapon=nullptr,const_attack_ptr opp_weapon=nullptr);
-bool leadership_affects_opponent(const std::string& ability,const unit_map& units, const map_location& loc, bool attacker=true, const_attack_ptr weapon=nullptr,const_attack_ptr opp_weapon=nullptr);
-std::pair<int, bool> ability_leadership(const std::string& ability, const unit_map& units, const map_location& loc, const map_location& opp_loc, bool attacker=true, int abil_value=0, bool backstab_pos=false, const_attack_ptr weapon=nullptr, const_attack_ptr opp_weapon=nullptr);
-bool bool_leadership(const std::string& ability,const unit_map& units, const map_location& loc, const map_location& opp_loc, bool attacker=true, const_attack_ptr weapon=nullptr, const_attack_ptr opp_weapon=nullptr);
+bool leadership_affects_self(const std::string& ability, const unit &un, const map_location& loc, bool attacker=true);
+bool leadership_affects_opponent(const std::string& ability, const unit &un, const map_location& loc, bool attacker=true);
+std::pair<int, bool> ability_leadership(const std::string& ability, const unit &un, unit_const_ptr up, const map_location& loc, const map_location& opp_loc, bool attacker=true, int abil_value=0, bool backstab_pos=false, const_attack_ptr weapon=nullptr, const_attack_ptr opp_weapon=nullptr);
+bool bool_leadership(const std::string& ability, const unit &un, unit_const_ptr up,const map_location& loc, const map_location& opp_loc, bool attacker=true, const_attack_ptr weapon=nullptr, const_attack_ptr opp_weapon=nullptr);
 
 /**
  * Returns the amount that a unit's damage should be multiplied by

--- a/src/actions/attack.hpp
+++ b/src/actions/attack.hpp
@@ -278,7 +278,6 @@ void attack_unit_and_advance(const map_location& attacker,
  *
  * Returns the bonus percentage (possibly 0 if there's no leader adjacent).
  */
-int under_leadership(const unit &u, const map_location& loc, const_attack_ptr weapon = nullptr, const_attack_ptr opp_weapon = nullptr);
 bool leadership_affects_self(const std::string& ability, const unit &un, const map_location& loc, bool attacker=true);
 bool leadership_affects_opponent(const std::string& ability, const unit &un, const map_location& loc, bool attacker=true);
 std::pair<int, bool> ability_leadership(const std::string& ability, const unit &un, unit_const_ptr up, const map_location& loc, const map_location& opp_loc, bool attacker=true, int abil_value=0, bool backstab_pos=false, const_attack_ptr weapon=nullptr, const_attack_ptr opp_weapon=nullptr);

--- a/src/ai/default/aspect_attacks.cpp
+++ b/src/ai/default/aspect_attacks.cpp
@@ -259,7 +259,7 @@ void aspect_attacks_base::do_attack_analysis(
 				}
 			}
 
-			int best_leadership_bonus=0;
+			int best_leadership_bonus = 0;
 			for(const attack_type& a : unit_itor->attacks()) {
 				best_leadership_bonus= a.combat_ability("leadership", 0, backstab).first;
 			}

--- a/src/ai/default/aspect_attacks.cpp
+++ b/src/ai/default/aspect_attacks.cpp
@@ -259,7 +259,10 @@ void aspect_attacks_base::do_attack_analysis(
 				}
 			}
 
-			int best_leadership_bonus = under_leadership(*unit_itor, tiles[j]);
+			int best_leadership_bonus=0;
+			for(const attack_type& a : unit_itor->attacks()) {
+				best_leadership_bonus= a.combat_ability("leadership", 0, backstab).first;
+			}
 			double leadership_bonus = static_cast<double>(best_leadership_bonus+100)/100.0;
 			if (leadership_bonus > 1.1) {
 				LOG_AI << unit_itor->name() << " is getting leadership " << leadership_bonus << "\n";

--- a/src/gui/dialogs/attack_predictions.cpp
+++ b/src/gui/dialogs/attack_predictions.cpp
@@ -230,7 +230,7 @@ void attack_predictions::set_data(window& window, const combatant_data& attacker
 	}
 
 	// Leadership bonus.
-	const int leadership_bonus = under_leadership(attacker.unit_, attacker.unit_.get_location(), weapon, opp_weapon);
+	const int leadership_bonus = weapon->combat_ability("leadership", 0, attacker.stats_.backstab_pos).first;
 
 	if(leadership_bonus != 0) {
 		set_label_helper("leadership_modifier", utils::signed_percent(leadership_bonus));

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -767,7 +767,6 @@ static int attack_info(reports::context & rc, const attack_type &at, config &res
 		int base_damage = at.damage();
 		int specials_damage = at.modified_damage(false);
 		int damage_multiplier = 100;
-		const_attack_ptr weapon  = at.shared_from_this();
 		int tod_bonus = combat_modifier(get_visible_time_of_day_at(rc, hex), u.alignment(), u.is_fearless());
 		damage_multiplier += tod_bonus;
 		int leader_bonus = at.combat_ability("leadership").first;

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -770,7 +770,7 @@ static int attack_info(reports::context & rc, const attack_type &at, config &res
 		const_attack_ptr weapon  = at.shared_from_this();
 		int tod_bonus = combat_modifier(get_visible_time_of_day_at(rc, hex), u.alignment(), u.is_fearless());
 		damage_multiplier += tod_bonus;
-		int leader_bonus = under_leadership(u, hex, weapon);
+		int leader_bonus = at.combat_ability("leadership").first;
 		if (leader_bonus != 0)
 			damage_multiplier += leader_bonus;
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -181,16 +181,14 @@ bool unit::get_ability_bool(const std::string& tag_name, const map_location& loc
 	return false;
 }
 
-unit_ability_list unit::get_abilities(const std::string& tag_name, const map_location& loc, const_attack_ptr weapon, const_attack_ptr opp_weapon) const
+unit_ability_list unit::get_abilities(const std::string& tag_name, const map_location& loc) const
 {
 	unit_ability_list res(loc_);
 
 	for(const config& i : this->abilities_.child_range(tag_name)) {
 		if(ability_active(tag_name, i, loc)
-			&& ability_affects_self(tag_name, i, loc)
-			&& ability_affects_weapon(i, weapon, false)
-			&& ability_affects_weapon(i, opp_weapon, true)
-		) {
+			&& ability_affects_self(tag_name, i, loc))
+			{
 			res.emplace_back(&i, loc);
 		}
 	}
@@ -214,9 +212,8 @@ unit_ability_list unit::get_abilities(const std::string& tag_name, const map_loc
 		for(const config& j : it->abilities_.child_range(tag_name)) {
 			if(affects_side(j, side(), it->side())
 				&& it->ability_active(tag_name, j, adjacent[i])
-				&& ability_affects_adjacent(tag_name, j, i, loc, *it) && ability_affects_weapon(j, weapon, false)
-				&& ability_affects_weapon(j, opp_weapon, true)
-			) {
+				&& ability_affects_adjacent(tag_name, j, i, loc, *it))
+				{
 				res.emplace_back(&j, adjacent[i]);
 			}
 		}
@@ -447,6 +444,34 @@ bool unit::ability_affects_weapon(const config& cfg, const_attack_ptr weapon, bo
 	const std::string filter_tag_name = is_opp ? "filter_second_weapon" : "filter_weapon";
 	if(!cfg.has_child(filter_tag_name)) {
 		return true;
+	}
+	const config& filter_student_name= cfg.child("filter_student");
+	if(filter_student_name){
+        const config& filter_weapon_name= filter_student_name.child("filter_weapon");
+        if(filter_weapon_name && !is_opp){
+            return true;
+        }
+	}
+	const config& filter_opponent_name= cfg.child("filter_opponent");
+	if(filter_opponent_name){
+        const config& filter_weapon_name= filter_opponent_name.child("filter_weapon");
+        if(filter_weapon_name && is_opp){
+            return true;
+        }
+	}
+	const config& filter_attacker_name= cfg.child("filter_attacker");
+	if(filter_attacker_name){
+        const config& filter_weapon_name= filter_attacker_name.child("filter_weapon");
+        if(filter_weapon_name){
+            return true;
+        }
+	}
+	const config& filter_defender_name= cfg.child("filter_defender");
+	if(filter_defender_name){
+        const config& filter_weapon_name= filter_defender_name.child("filter_weapon");
+        if(filter_weapon_name){
+            return true;
+        }
 	}
 	const config& filter = cfg.child(filter_tag_name);
 	if(!weapon) {

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1681,9 +1681,11 @@ int unit::resistance_against(const std::string& damage_name,bool attacker,const 
 {
 	int res = movement_type_.resistance_against(damage_name);
 
-	unit_ability_list resistance_abilities = get_abilities("resistance",loc, weapon, opp_weapon);
+	unit_ability_list resistance_abilities = get_abilities("resistance", loc);
 	for(unit_ability_list::iterator i = resistance_abilities.begin(); i != resistance_abilities.end();) {
-		if(!resistance_filter_matches(*i->first, attacker, damage_name, 100-res)) {
+		bool affect_weapon = !ability_affects_weapon(*i->first, weapon, false) || !ability_affects_weapon(*i->first, opp_weapon, true);
+		bool filter_student = !ability_filter_fighter("resistance", "filter_student" , *i->first, loc, weapon);
+		if(!resistance_filter_matches(*i->first, attacker, damage_name, 100-res) || affect_weapon || filter_student) {
 			i = resistance_abilities.erase(i);
 		} else {
 			++i;

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1618,16 +1618,16 @@ public:
 	 * @param loc The location to use for resolving abilities
 	 * @return A list of active abilities, paired with the location they are active on
 	 */
-	unit_ability_list get_abilities(const std::string& tag_name, const map_location& loc, const_attack_ptr weapon = nullptr, const_attack_ptr opp_weapon = nullptr) const;
+	unit_ability_list get_abilities(const std::string& tag_name, const map_location& loc) const;
 
 	/**
 	 * Gets the unit's active abilities of a particular type.
 	 * @param tag_name The type of ability to check for
 	 * @return A list of active abilities, paired with the location they are active on
 	 */
-	unit_ability_list get_abilities(const std::string& tag_name, const_attack_ptr weapon = nullptr, const_attack_ptr opp_weapon = nullptr) const
+	unit_ability_list get_abilities(const std::string& tag_name) const
 	{
-		return get_abilities(tag_name, loc_, weapon, opp_weapon);
+		return get_abilities(tag_name, loc_);
 	}
 
 	/**
@@ -1678,7 +1678,9 @@ public:
 	void remove_ability_by_id(const std::string& ability);
 
 	bool abilities_filter_matches(const config& cfg, bool attacker, int res) const;
-	bool ability_filter_fighter(const std::string& ability, const std::string& filter_attacker , const config& cfg, const map_location& loc, const unit& u2) const;
+	bool ability_filter_fighter(const std::string& ability, const std::string& filter_attacker , const config& cfg, const map_location& loc, const unit& u2, const_attack_ptr weapon=nullptr) const;
+	bool ability_filter_fighter(const std::string& ability, const std::string& filter_attacker , const config& cfg, const map_location& loc, const_attack_ptr weapon=nullptr) const;
+	bool ability_affects_weapon(const config& cfg, const_attack_ptr weapon, bool is_opp) const;
 
 private:
 	/**
@@ -1706,8 +1708,6 @@ private:
 	 * @param loc The location on which to resolve the ability
 	 */
 	bool ability_affects_self(const std::string& ability, const config& cfg, const map_location& loc) const;
-
-	bool ability_affects_weapon(const config& cfg, const_attack_ptr weapon, bool is_opp) const;
 
 public:
 	/** Get the unit formula manager. */


### PR DESCRIPTION
this th 4th PR for resolve https://github.com/wesnoth/wesnoth/issues/4389, but also resolve https://github.com/wesnoth/wesnoth/pull/3642 for abilities used like specials.

i see what sidebar weapon don't follows mouseover when i use weapon abilities for "damage" or "attacks"