### PR TITLE
Changed failed replays to regular failure for the WML unit tests.

### DIFF
--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -513,12 +513,6 @@ game_launcher::unit_test_result game_launcher::unit_test()
 			case unit_test_result::TEST_PASS:
 				describe_result = "PASS TEST";
 				break;
-			case unit_test_result::TEST_FAIL_LOADING_REPLAY:
-				describe_result = "FAIL TEST (INVALID REPLAY)";
-				break;
-			case unit_test_result::TEST_FAIL_PLAYING_REPLAY:
-				describe_result = "FAIL TEST (ERRORED REPLAY)";
-				break;
 			default:
 				describe_result = "FAIL TEST";
 				break;
@@ -559,7 +553,7 @@ game_launcher::unit_test_result game_launcher::single_unit_test()
 
 	if (!load_game()) {
 		std::cerr << "Failed to load the replay!" << std::endl;
-		return unit_test_result::TEST_FAIL_LOADING_REPLAY; //failed to load replay
+		return unit_test_result::TEST_FAIL; //failed to load replay
 	}
 
 	try {
@@ -567,11 +561,11 @@ game_launcher::unit_test_result game_launcher::single_unit_test()
 		LEVEL_RESULT res = ccontroller.play_replay();
 		if (!(res == LEVEL_RESULT::VICTORY) || lg::broke_strict()) {
 			std::cerr << "Observed failure on replay" << std::endl;
-			return unit_test_result::TEST_FAIL_PLAYING_REPLAY;
+			return unit_test_result::TEST_FAIL;
 		}
 	} catch(const wml_exception& e) {
 		std::cerr << "WML Exception while playing replay: " << e.dev_message << std::endl;
-		return unit_test_result::TEST_FAIL_PLAYING_REPLAY;
+		return unit_test_result::TEST_FAIL;
 	}
 
 	return unit_test_result::TEST_PASS; //we passed, huzzah!

--- a/src/game_launcher.hpp
+++ b/src/game_launcher.hpp
@@ -64,8 +64,6 @@ public:
 	enum class unit_test_result : int {
 		TEST_PASS = 0,
 		TEST_FAIL = 1,
-		TEST_FAIL_LOADING_REPLAY = 3,
-		TEST_FAIL_PLAYING_REPLAY = 4,
 	};
 
 	bool init_video();

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -7,7 +7,7 @@
 1 test_assert_fail
 1 test_assert_fail_two
 2 empty_test
-4 break_replay_with_lua_random
+1 break_replay_with_lua_random
 0 fixed_lua_random_replay_with_sync_choice
 0 test_end_turn
 #


### PR DESCRIPTION
This changes "FAIL TEST (INVALID REPLAY)" and "FAIL TEST (ERRORED REPLAY)" into "FAIL TEST".  The INVALID REPLAY case isn't used anymore though, regardless.

---

Successful travis run is available [here](https://travis-ci.org/Pentarctagon/wesnoth/builds/616154542/), since master's isn't passing at the moment.