### PR TITLE
Separate unit test statuses for WML exceptions and strict warnings

### DIFF
--- a/data/test/scenarios/filter_this_unit.cfg
+++ b/data/test/scenarios/filter_this_unit.cfg
@@ -41,7 +41,7 @@
     [/event]
 )}
 
-{GENERIC_UNIT_TEST filter_this_unit_fai (
+{GENERIC_UNIT_TEST filter_this_unit_formula (
     [event]
         name=prestart
         [modify_unit]
@@ -59,7 +59,7 @@
     [/event]
 )}
 
-{GENERIC_UNIT_TEST filter_fai_unit (
+{GENERIC_UNIT_TEST filter_formula_unit (
     [event]
         name=prestart
         [modify_unit]
@@ -77,14 +77,19 @@
     [/event]
 )}
 
-{GENERIC_UNIT_TEST filter_fai_unit_error (
+# Tests what happens when an invalid formula is given to an SUF.
+# This test requires strict mode, the expected behavior is to log
+# a warning but not interrupt the WML.
+{GENERIC_UNIT_TEST filter_formula_unit_error (
     [event]
         name=prestart
         {RETURN (
-            [have_unit]
-                id=bob
-                formula="+ max_moves"
-            [/have_unit]
+            [not]
+                [have_unit]
+                    id=bob
+                    formula="+ max_moves"
+                [/have_unit]
+            [/not]
         )}
     [/event]
 )}

--- a/run_wml_tests
+++ b/run_wml_tests
@@ -17,6 +17,8 @@ class UnitTestResult(enum.Enum):
     TIMEOUT = 2
     FAIL_LOADING_REPLAY = 3
     FAIL_PLAYING_REPLAY = 4
+    FAIL_BROKE_STRICT = 5
+    FAIL_WML_EXCEPTION = 6
 
 class TestCase:
     """Represents a single line of the wml_test_schedule."""

--- a/src/commandline_options.cpp
+++ b/src/commandline_options.cpp
@@ -276,7 +276,7 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 	po::options_description testing_opts("Testing options");
 	testing_opts.add_options()
 		("test,t", po::value<std::string>()->implicit_value(std::string()), "runs the game in a small test scenario. If specified, scenario <arg> will be used instead.")
-		("unit,u", po::value<std::vector<std::string>>(), "runs a unit test scenario. The GUI is not shown and the exit code of the program reflects the victory / defeat conditions of the scenario.\n\t0 - PASS\n\t1 - FAIL\n\t3 - FAIL (INVALID REPLAY)\n\t4 - FAIL (ERRORED REPLAY)\n\tMultiple tests can be run by giving this option multiple times, in this case the test run will stop immediately after any test which doesn't PASS and the return code will be the status of the test that caused the stop.")
+		("unit,u", po::value<std::vector<std::string>>(), "runs a unit test scenario. The GUI is not shown and the exit code of the program reflects the victory / defeat conditions of the scenario.\n\t0 - PASS\n\t1 - FAIL\n\t3 - FAIL (INVALID REPLAY)\n\t4 - FAIL (ERRORED REPLAY)\n\t5 - FAIL (BROKE STRICT)\n\t6 - FAIL (WML EXCEPTION)\n\tMultiple tests can be run by giving this option multiple times, in this case the test run will stop immediately after any test which doesn't PASS and the return code will be the status of the test that caused the stop.")
 		("showgui", "don't run headlessly (for debugging a failing test)")
 		("log-strict", po::value<std::string>(), "sets the strict level of the logger. any messages sent to log domains of this level or more severe will cause the unit test to fail regardless of the victory result.")
 		("noreplaycheck", "don't try to validate replay of unit test.")

--- a/src/game_launcher.hpp
+++ b/src/game_launcher.hpp
@@ -64,8 +64,11 @@ public:
 	enum class unit_test_result : int {
 		TEST_PASS = 0,
 		TEST_FAIL = 1,
+		// 2 is reserved for timeouts
 		TEST_FAIL_LOADING_REPLAY = 3,
 		TEST_FAIL_PLAYING_REPLAY = 4,
+		TEST_FAIL_BROKE_STRICT = 5,
+		TEST_FAIL_WML_EXCEPTION = 6,
 	};
 
 	bool init_video();

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -14,7 +14,7 @@
 # Security test
 #
 0 cve_2018_1999023
-1 cve_2018_1999023_2
+5 cve_2018_1999023_2
 #
 # Test Check Victory (If this isn't working other tests may have dubious value)
 #
@@ -54,12 +54,12 @@
 0 unit_spawns_at_nearest_vacant_hex
 0 units_offmap_goto_recall
 0 test_move
-1 test_move_fail_1
-1 test_move_fail_2
-1 test_move_fail_3
-1 test_move_fail_4
-1 test_move_fail_5
-1 test_move_fail_6
+5 test_move_fail_1
+5 test_move_fail_2
+5 test_move_fail_3
+5 test_move_fail_4
+5 test_move_fail_5
+5 test_move_fail_6
 0 test_move_unit
 0 test_move_unit_in_circle
 0 sighted_events
@@ -175,9 +175,9 @@
 # Standard Unit Filter tests
 0 filter_this_unit_wml
 0 filter_this_unit_tl
-0 filter_this_unit_fai
-0 filter_fai_unit
-1 filter_fai_unit_error
+0 filter_this_unit_formula
+0 filter_formula_unit
+5 filter_formula_unit_error
 # Interrupt tag tests
 0 check_interrupts_break
 0 check_interrupts_return


### PR DESCRIPTION
This is part of working out whether a subset of the "fail" tests could be run in one Wesnoth instance. To run a test that returns TEST_FAIL_BROKE_STRICT with any other test would require a mechanism to reset lg::broke_strict()'s flag.

All tests that fail with an {ASSERT} will also set the lg::broke_strict() flag, the tests with the new status are only those that would pass without the strict flag.

In the SUF tests, change a test from fail-on-success to breaks-strict, rename the formula tests and add some comments. The rename is because "fai" is "Formula AI", an obsolete name for WFL.