### PR TITLE
wip support [time_area] with no specific timezone

### DIFF
--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -722,21 +722,6 @@ const team& play_controller::current_team() const
 	return gamestate().board_.get_team(current_side());
 }
 
-/// @returns: the number n in [min, min+mod ) so that (n - num) is a multiple of mod.
-static int modulo(int num, int mod, int min)
-{
-	assert(mod > 0);
-	int n = (num - min) % mod;
-	if (n < 0)
-		n += mod;
-	//n is now in [0, mod)
-	n = n + min;
-	return n;
-	// the following properties are easy to verify:
-	//  1) For all m: modulo(num, mod, min) == modulo(num + mod*m, mod, min)
-	//  2) For all 0 <= m < mod: modulo(min + m, mod, min) == min + m
-}
-
 bool play_controller::is_team_visible(int team_num, bool observer) const
 {
 	const team& t = gamestate().board_.get_team(team_num);

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -3788,6 +3788,11 @@ int game_lua_kernel::intf_set_time_of_day(lua_State * L)
 			return luaL_argerror(L, 1, "invalid time of day ID");
 		}
 	}
+
+	if(new_time == 0 && num_times == 0) {
+		//ignore this case, because we don't want code like set_current_time(get_current_time()) to fail if num_times is 0.
+		return 0;
+	}
 	if(new_time < 0 || new_time >= num_times) {
 		return luaL_argerror(L, 1, "invalid time of day index");
 	}

--- a/src/time_of_day.cpp
+++ b/src/time_of_day.cpp
@@ -72,10 +72,4 @@ void time_of_day::parse_times(const config& cfg, std::vector<time_of_day>& times
 	for(const config &t : cfg.child_range("time")) {
 		times.push_back(time_of_day(t));
 	}
-
-	if(times.empty())
-	{
-		// Make sure we have at least default time
-		times.push_back(time_of_day());
-	}
 }

--- a/src/tod_manager.cpp
+++ b/src/tod_manager.cpp
@@ -62,29 +62,6 @@ tod_manager::tod_manager(const config& scenario_cfg):
 
 }
 
-tod_manager& tod_manager::operator=(const tod_manager& manager)
-{
-	if(this == &manager) {
-		return *this;
-	}
-
-	currentTime_ = manager.currentTime_;
-	times_ = manager.times_;
-	areas_ = manager.areas_;
-	liminal_bonus_ = manager.liminal_bonus_;
-
-	turn_ = manager.turn_;
-	num_turns_ = manager.num_turns_;
-
-	has_turn_event_fired_ = manager.has_turn_event_fired_;
-	has_tod_bonus_changed_= manager.has_tod_bonus_changed_;
-	has_cfg_liminal_bonus_ = manager.has_cfg_liminal_bonus_;
-
-	random_tod_ = manager.random_tod_;
-
-	return *this;
-}
-
 void tod_manager::resolve_random(randomness::rng& r)
 {
 	//process the random_start_time string, which can be boolean yes/no true/false or a
@@ -180,7 +157,8 @@ const time_of_day& tod_manager::get_previous_time_of_day() const
 	return get_time_of_day_turn(times_, turn_ - 1, currentTime_);
 }
 
-int tod_manager::get_current_area_time(int index) const {
+int tod_manager::get_current_area_time(int index) const
+{
 	assert(index < static_cast<int>(areas_.size()) );
 	return areas_[index].currentTime;
 }
@@ -344,7 +322,8 @@ void tod_manager::replace_local_schedule(const std::vector<time_of_day>& schedul
 	area.currentTime = 0;
 }
 
-void tod_manager::set_area_id(int area_index, const std::string& id) {
+void tod_manager::set_area_id(int area_index, const std::string& id) 
+{
 	assert(area_index < static_cast<int>(areas_.size()));
 	areas_[area_index].id = id;
 }
@@ -361,8 +340,9 @@ std::vector<std::string> tod_manager::get_area_ids() const
 const std::set<map_location>& tod_manager::get_area_by_id(const std::string& id) const
 {
 	for (const area_time_of_day& area : areas_) {
-		if (area.id == id)
+		if (area.id == id) {
 			return area.hexes;
+		}
 	}
 	static const std::set<map_location> res;
 	return res;
@@ -480,8 +460,9 @@ void tod_manager::set_turn(const int num, game_data* vars, const bool increase_l
 		set_number_of_turns(new_turn);
 	}
 	turn_ = new_turn;
-	if (vars)
+	if (vars) {
 		vars->get_variable("turn_number") = new_turn;
+	}
 }
 
 void tod_manager::set_turn_by_wml(const int num, game_data* vars, const bool increase_limit_if_needed)
@@ -521,6 +502,7 @@ int tod_manager::calculate_time_index_at_turn(
 
 void tod_manager::set_current_time(int time)
 {
+	time = fix_time_index(times_.size(), time);
 	if (!times_.empty() && times_[time].lawful_bonus != times_[currentTime_].lawful_bonus) {
 		has_tod_bonus_changed_ = true;
 	}
@@ -536,18 +518,15 @@ void tod_manager::set_current_time(int time, int area_index)
 void tod_manager::set_current_time(int time, const std::string& area_id)
 {
 	for (area_time_of_day& area : areas_) {
-		if (area.id == area_id)
+		if (area.id == area_id) {
 			set_current_time(time, area);
+		}
 	}
 }
 
 void tod_manager::set_current_time(int time, area_time_of_day& area)
 {
-	if(time == 0 && area.times.empty()) {
-		//this case is okay, don't fail from the assertion below.
-		return;
-	}
-	assert(time < static_cast<int>(area.times.size()) );
+	time = fix_time_index(area.times.size(), time);
 	if (area.times[time].lawful_bonus != area.times[area.currentTime].lawful_bonus) {
 		has_tod_bonus_changed_ = true;
 	}

--- a/src/tod_manager.hpp
+++ b/src/tod_manager.hpp
@@ -195,11 +195,19 @@ class tod_manager
 		 * for_turn_number: for which current turn
 		 * current_time: the main or time area's current time
 		 */
-		int calculate_current_time(
-			const int number_of_times,
-			const int for_turn_number,
-			const int current_time,
-			const bool only_to_allowed_range = false) const;
+		static int fix_time_index(
+			int number_of_times,
+			int time);
+		/**
+		 * Computes for the main time or a time area the index of its times where we're currently at.
+		 * number_of_times: size of that main time or time area's times vector
+		 * for_turn_number: for which current turn
+		 * current_time: the main or time area's current time
+		 */
+		int calculate_time_index_at_turn(
+			int number_of_times,
+			int for_turn_number,
+			int current_time) const;
 		/**
 		 * Computes the maximum absolute value of lawful_bonus in the schedule.
 		 */
@@ -210,7 +218,6 @@ class tod_manager
 		 * and all time areas.
 		 */
 		void set_new_current_times(const int new_current_turn_number);
-
 
 		struct area_time_of_day {
 			area_time_of_day() :

--- a/src/tod_manager.hpp
+++ b/src/tod_manager.hpp
@@ -33,7 +33,7 @@ class tod_manager
 	public:
 	explicit tod_manager(const config& scenario_cfg = config());
 		~tod_manager() {}
-		tod_manager& operator=(const tod_manager& manager);
+		tod_manager& operator=(const tod_manager& manager) = default;
 
 		config to_config() const;
 		/**

--- a/src/utils/math.hpp
+++ b/src/utils/math.hpp
@@ -26,6 +26,7 @@
 #include <limits>
 #include <vector>
 #include <algorithm>
+#include <cassert>
 
 template<typename T>
 inline bool is_even(T num) { return num % 2 == 0; }
@@ -50,6 +51,25 @@ inline int bounded_add(int base, int increment, int max_sum, int min_sum = 0)
 	} else {
 		return std::max(base + increment, std::min(base, min_sum));
 	}
+}
+
+
+/** 
+ * @returns: the number n in [min, min+mod ) so that (n - num) is a multiple of mod.
+ */
+template<typename T>
+inline T modulo(T num, int mod, T min = 0)
+{
+	assert(mod > 0);
+	T n = (num - min) % mod;
+	if (n < 0)
+		n += mod;
+	//n is now in [0, mod)
+	n = n + min;
+	return n;
+	// the following properties are easy to verify:
+	//  1) For all m: modulo(num, mod, min) == modulo(num + mod*m, mod, min)
+	//  2) For all 0 <= m < mod: modulo(min + m, mod, min) == min + m
 }
 
 /**


### PR DESCRIPTION
now the c++ code does no longer add a dummy time when
there are no times defines for an [time_area]. this is
in particular useful when one wants to define areas in
the map editor that is then used ingame for exampel in
filters.
We should consider renamaing [time_area] to just [area]
[time_area]s that dont define their own times are now
ignored during tod calculation.