### PR TITLE
wip use ai advancement asepect also during [event]s

### DIFF
--- a/src/actions/advancement.cpp
+++ b/src/actions/advancement.cpp
@@ -111,9 +111,10 @@ namespace
 		const std::vector<std::string>& options = u->advances_to();
 		std::vector<config> mod_options = u->get_modification_advances();
 
+		assert(options.size() + mod_options.size() > 0);
 		if (choice >= options.size() + mod_options.size()) {
-			LOG_DP << "animate_unit_advancement suppressed: invalid option\n";
-			return false;
+			LOG_DP << "animate_unit_advancement: invalid option, using first option\n";
+			choice = 0;
 		}
 
 		// When the unit advances, it fades to white, and then switches

--- a/src/actions/advancement.hpp
+++ b/src/actions/advancement.hpp
@@ -23,7 +23,6 @@ class  team;
 class  unit;
 class  config;
 #include "units/types.hpp"
-#include "ai/lua/aspect_advancements.hpp"
 
 #include <string>
 #include <vector>
@@ -37,15 +36,13 @@ class  config;
 */
 struct advance_unit_params
 {
-	advance_unit_params(const map_location& loc) : loc_(loc), ai_advancements_(nullptr), force_dialog_(false), fire_events_(true), animate_(true) {}
-	advance_unit_params& ai_advancements(const ai::unit_advancements_aspect& value) {ai_advancements_ = &value; return *this;}
+	advance_unit_params(const map_location& loc) : loc_(loc), force_dialog_(false), fire_events_(true), animate_(true) {}
 	advance_unit_params& force_dialog(bool value) {force_dialog_ = value; return *this;}
 	advance_unit_params& fire_events(bool value) {fire_events_ = value; return *this;}
 	advance_unit_params& animate(bool value) {animate_ = value; return *this;}
 	friend void advance_unit_at(const advance_unit_params&);
 private:
 	map_location loc_;
-	const ai::unit_advancements_aspect* ai_advancements_;
 	bool force_dialog_;
 	bool fire_events_;
 	bool animate_;

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1552,19 +1552,18 @@ void attack_unit_and_advance(const map_location& attacker,
 		const map_location& defender,
 		int attack_with,
 		int defend_with,
-		bool update_display,
-		const ai::unit_advancements_aspect& ai_advancement)
+		bool update_display)
 {
 	attack_unit(attacker, defender, attack_with, defend_with, update_display);
 
 	unit_map::const_iterator atku = resources::gameboard->units().find(attacker);
 	if(atku != resources::gameboard->units().end()) {
-		advance_unit_at(advance_unit_params(attacker).ai_advancements(ai_advancement));
+		advance_unit_at(advance_unit_params(attacker));
 	}
 
 	unit_map::const_iterator defu = resources::gameboard->units().find(defender);
 	if(defu != resources::gameboard->units().end()) {
-		advance_unit_at(advance_unit_params(defender).ai_advancements(ai_advancement));
+		advance_unit_at(advance_unit_params(defender));
 	}
 }
 

--- a/src/actions/attack.hpp
+++ b/src/actions/attack.hpp
@@ -269,8 +269,7 @@ void attack_unit_and_advance(const map_location& attacker,
 		const map_location& defender,
 		int attack_with,
 		int defend_with,
-		bool update_display = true,
-		const ai::unit_advancements_aspect& ai_advancement = ai::unit_advancements_aspect());
+		bool update_display = true);
 
 /**
  * Tests if the unit at loc is currently affected by leadership.

--- a/src/ai/actions.hpp
+++ b/src/ai/actions.hpp
@@ -22,7 +22,6 @@
 #include "ai/game_info.hpp"
 
 #include "actions/move.hpp"
-#include "ai/lua/aspect_advancements.hpp"
 #include "units/ptr.hpp"
 
 namespace pathfind {
@@ -132,8 +131,7 @@ public:
 		const map_location& attacker_loc,
 		const map_location& defender_loc,
 		int attacker_weapon,
-		double aggression,
-		const unit_advancements_aspect& advancements = unit_advancements_aspect());
+		double aggression);
 
 	enum result {
 		E_EMPTY_ATTACKER = 1001,
@@ -159,7 +157,6 @@ private:
 	const map_location& defender_loc_;
 	int attacker_weapon_;
 	double aggression_;
-	const unit_advancements_aspect& advancements_;
 };
 
 class move_result : public action_result {
@@ -336,8 +333,7 @@ static attack_result_ptr execute_attack_action( side_number side,
 	const map_location& attacker_loc,
 	const map_location& defender_loc,
 	int attacker_weapon,
-	double aggression,
-	const unit_advancements_aspect& advancements = unit_advancements_aspect());
+	double aggression);
 
 
 /**

--- a/src/ai/contexts.cpp
+++ b/src/ai/contexts.cpp
@@ -109,16 +109,14 @@ team& readwrite_context_impl::current_team_w()
 attack_result_ptr readwrite_context_impl::execute_attack_action(const map_location& attacker_loc, const map_location& defender_loc, int attacker_weapon){
 	unit_map::iterator i = resources::gameboard->units().find(attacker_loc);
 	double m_aggression = i.valid() && i->can_recruit() ? get_leader_aggression() : get_aggression();
-	const unit_advancements_aspect& m_advancements = get_advancements();
-	return actions::execute_attack_action(get_side(),true,attacker_loc,defender_loc,attacker_weapon, m_aggression, m_advancements);
+	return actions::execute_attack_action(get_side(),true,attacker_loc,defender_loc,attacker_weapon, m_aggression);
 }
 
 
 attack_result_ptr readonly_context_impl::check_attack_action(const map_location& attacker_loc, const map_location& defender_loc, int attacker_weapon){
 	unit_map::iterator i = resources::gameboard->units().find(attacker_loc);
 	double m_aggression = i.valid() && i->can_recruit() ? get_leader_aggression() : get_aggression();
-	const unit_advancements_aspect& m_advancements = get_advancements();
-	return actions::execute_attack_action(get_side(),false,attacker_loc,defender_loc,attacker_weapon, m_aggression, m_advancements);
+	return actions::execute_attack_action(get_side(),false,attacker_loc,defender_loc,attacker_weapon, m_aggression);
 }
 
 

--- a/src/ai/lua/core.cpp
+++ b/src/ai/lua/core.cpp
@@ -227,8 +227,7 @@ static int ai_attack(lua_State *L, bool exec)
 		aggression = lua_tonumber(L, 4);
 	}
 
-	unit_advancements_aspect advancements = context.get_advancements();
-	ai::attack_result_ptr attack_result = ai::actions::execute_attack_action(side,exec,attacker,defender,attacker_weapon,aggression,advancements);
+	ai::attack_result_ptr attack_result = ai::actions::execute_attack_action(side,exec,attacker,defender,attacker_weapon,aggression);
 	return transform_ai_action(L,attack_result);
 }
 

--- a/src/ai/manager.cpp
+++ b/src/ai/manager.cpp
@@ -715,6 +715,10 @@ game_info& manager::get_ai_info()
 	return ai_info_;
 }
 
+const ai::unit_advancements_aspect& manager::get_advancement_aspect_for_side(side_number side)
+{
+	return get_active_ai_holder_for_side(side).get_ai_ref().get_advancements();
+}
 
 // =======================================================================
 // PROXY

--- a/src/ai/manager.hpp
+++ b/src/ai/manager.hpp
@@ -31,6 +31,7 @@
 #include <string>                       // for string
 
 class game_launcher;
+namespace ai { class unit_advancements_aspect; }  // lines 45-45
 namespace ai { class ai_composite; }  // lines 45-45
 namespace ai { class ai_context; }  // lines 42-42
 namespace ai { class component; }  // lines 43-43
@@ -417,6 +418,8 @@ public:
 	 * @return a reference to the AI-game info.
 	 */
 	game_info& get_ai_info();
+
+	const ai::unit_advancements_aspect& get_advancement_aspect_for_side(side_number side);
 
 
 	// =======================================================================


### PR DESCRIPTION
fixes #4605
previously advancements invoked by [event]s for example
by unstoring a unit with enough xp would alwas do a
purely random advancement even if they happend during
the ais own turn. Now the advancemt_aspect is considered
i don't really know how the code inside ai/ works so i
just took the easiert way to get a advancements_aspect
from the manager. In particular this leaves a TODO comment
about whether the advancemnts_aspect of advance_unit_at
(and thus of attack_and_advance) can not be removed or not
because i don't know whether the advancement aspect is
effectively a sinbgleton or not.