### PR TITLE
adding resistance_anim to shema validation

### DIFF
--- a/data/schema/units/animations.cfg
+++ b/data/schema/units/animations.cfg
@@ -148,7 +148,7 @@
 	super="units/unit_type/$animation"
 [/tag]
 [tag]
-	name="helping_anim"
+	name="resistance_anim"
 	max=infinite
 	super="units/unit_type/$animation"
 [/tag]

--- a/data/schema/units/animations.cfg
+++ b/data/schema/units/animations.cfg
@@ -148,6 +148,11 @@
 	super="units/unit_type/$animation"
 [/tag]
 [tag]
+	name="resistance"
+	max=infinite
+	super="units/unit_type/$animation"
+[/tag]
+[tag]
 	name="recruit_anim"
 	max=infinite
 	super="units/unit_type/$animation"

--- a/data/schema/units/animations.cfg
+++ b/data/schema/units/animations.cfg
@@ -148,7 +148,7 @@
 	super="units/unit_type/$animation"
 [/tag]
 [tag]
-	name="resistance"
+	name="resist_anim"
 	max=infinite
 	super="units/unit_type/$animation"
 [/tag]

--- a/data/schema/units/animations.cfg
+++ b/data/schema/units/animations.cfg
@@ -148,7 +148,7 @@
 	super="units/unit_type/$animation"
 [/tag]
 [tag]
-	name="resist_anim"
+	name="helping_anim"
 	max=infinite
 	super="units/unit_type/$animation"
 [/tag]

--- a/src/units/udisplay.cpp
+++ b/src/units/udisplay.cpp
@@ -675,7 +675,7 @@ void unit_attack(display * disp, game_board & board,
 		unit_map::const_iterator helper = board.units().find(ability.second);
 		assert(helper.valid());
 		helper->set_facing(ability.second.get_relative_dir(b));
-		animator.add_animation(&*helper, "resist_anim", ability.second,
+		animator.add_animation(&*helper, "helping", ability.second,
 			def->get_location(), damage, true,  "", {0,0,0},
 			hit_type, attack.shared_from_this(), secondary_attack, swing);
 	}

--- a/src/units/udisplay.cpp
+++ b/src/units/udisplay.cpp
@@ -675,7 +675,7 @@ void unit_attack(display * disp, game_board & board,
 		unit_map::const_iterator helper = board.units().find(ability.second);
 		assert(helper.valid());
 		helper->set_facing(ability.second.get_relative_dir(b));
-		animator.add_animation(&*helper, "resistance", ability.second,
+		animator.add_animation(&*helper, "resist_anim", ability.second,
 			def->get_location(), damage, true,  "", {0,0,0},
 			hit_type, attack.shared_from_this(), secondary_attack, swing);
 	}

--- a/src/units/udisplay.cpp
+++ b/src/units/udisplay.cpp
@@ -675,7 +675,7 @@ void unit_attack(display * disp, game_board & board,
 		unit_map::const_iterator helper = board.units().find(ability.second);
 		assert(helper.valid());
 		helper->set_facing(ability.second.get_relative_dir(b));
-		animator.add_animation(&*helper, "helping", ability.second,
+		animator.add_animation(&*helper, "resistance", ability.second,
 			def->get_location(), damage, true,  "", {0,0,0},
 			hit_type, attack.shared_from_this(), secondary_attack, swing);
 	}


### PR DESCRIPTION
If a day, a resistance abilities applied to adjacent unit is added in the core, with a proper animation, it can be validated.