### PR TITLE
Dunefolk usage attributes and recruitment patterns

### DIFF
--- a/data/core/units/dunefolk/Alchemist.cfg
+++ b/data/core/units/dunefolk/Alchemist.cfg
@@ -18,7 +18,7 @@ units/dunefolk/herbalist/#enddef
     advances_to=null
     {AMLA_DEFAULT}
     cost=27
-    usage=fighter
+    usage=mixed fighter
     [abilities]
         {ABILITY_REGENERATES}
     [/abilities]

--- a/data/core/units/dunefolk/Apothecary.cfg
+++ b/data/core/units/dunefolk/Apothecary.cfg
@@ -21,7 +21,7 @@ units/dunefolk/herbalist/#enddef
     alignment=liminal
     advances_to=Dune Luminary
     cost=27
-    usage=fighter
+    usage=healer
     description= _ "Even in the absence of battle, infection and injury are common plights in the harsh desert sands. Dunefolk healers, in particular, require vast knowledge of herbs and medicine in comparison with healers of other races; the lack of magic combined with the meager plantlife in the desert results in great difficulty in treating the plethora of ailments and poisons that plague the dune peoples. Apothecaries are typically more knowledgeable and well-traveled compared to their less experienced brethren, but the title is usually applied to those who undertake the complex task of tending to valuable medicinal plants. The Dunefolk have no means of healing without the necessary materials, and thus Apothecaries possess a special role in supporting the remedial arts of their kind."
     {NOTE_EXTRA_HEAL}
     {NOTE_SELF_HEAL}

--- a/data/core/units/dunefolk/Captain.cfg
+++ b/data/core/units/dunefolk/Captain.cfg
@@ -22,7 +22,7 @@ units/dunefolk/soldier/#enddef
     alignment=liminal
     advances_to=Dune Warmaster
     cost=30
-    usage=mixed fighter
+    usage=fighter
     [abilities]
         {ABILITY_LEADERSHIP}
     [/abilities]

--- a/data/core/units/dunefolk/Firetrooper.cfg
+++ b/data/core/units/dunefolk/Firetrooper.cfg
@@ -18,7 +18,7 @@ units/dunefolk/burner/#enddef
     advances_to=null
     {AMLA_DEFAULT}
     cost=50
-    usage=fighter
+    usage=mixed fighter
     description= _ "By refining Sanbaar sap through a very specific distillation process, it becomes possible to produce exceedingly flammable naphtha which burns even more violently than the sap it was derived from. Such a substance is, of course, extremely dangerous due to its highly combustible nature. Even Scorchers will shy away from its use since the potential for self injury is very high, but a few daring souls choose to use pure naphtha as their weapon of choice. The resulting destruction is more than enough to justify the use of such a hazardous chemical."
     die_sound={SOUND_LIST:HUMAN_DIE}
     [standing_anim]

--- a/data/core/units/dunefolk/Luminary.cfg
+++ b/data/core/units/dunefolk/Luminary.cfg
@@ -21,7 +21,7 @@ units/dunefolk/herbalist/#enddef
     alignment=liminal
     {AMLA_DEFAULT}
     cost=53
-    usage=fighter
+    usage=healer
     description= _ "On the surface, it is not entirely clear what distinguishes a Luminary from other healers among the Dunefolk. Certainly, a Luminary may be marginally more knowledgeable, well-traveled, or skilled in combat compared to Herbalists or Apothecaries, but the difference is usually modest at best. Nevertheless, ‘Luminary’ is a formal title granted to the highest order of Dunefolk healers and grants these men both the greatest esteem and the greatest envy.
 
 There is some speculation that a secret order exists among the Luminaries. These so called ‘Eminents’ hoard a great deal of forbidden knowledge and advise many Dunefolk leaders from the shadows. Such a thing has never been proven, but the fact remains that some Luminaries seem to hold much more influence than their abilities should afford."

--- a/data/core/units/dunefolk/Marauder.cfg
+++ b/data/core/units/dunefolk/Marauder.cfg
@@ -17,7 +17,7 @@ units/dunefolk/rider/#enddef
     advances_to=null
     {AMLA_DEFAULT}
     cost=52
-    usage=fighter
+    usage=scout
     description= _ "Some find themselves well suited to the life of a Raider and may even form their own clans with like-minded individuals. Ever roaming the deserts for unwary travelers or vulnerable caravans, these horsemen make their livelihood off of scavenging and pilfering. Having no particular specialty, Marauders are neither the strongest warriors, nor the most dextrous archers; nevertheless, they are among the most dangerous enemies out in the desert due to their sheer maneuverability. A coordinated Marauder attack can wipe out even medium-sized camps before any response is possible, and against stronger foes, guerrilla tactics may allow them to prevail where brute force does not. For this reason, they are sometimes hired by small armies or wealthier caravans as a deterrent to unwanted raids."
     die_sound=horse-die.ogg
     {DEFENSE_ANIM "{PATH_TEMP}marauder.png" "{PATH_TEMP}marauder.png" {SOUND_LIST:HORSE_HIT} }

--- a/data/core/units/dunefolk/Raider.cfg
+++ b/data/core/units/dunefolk/Raider.cfg
@@ -16,7 +16,7 @@ units/dunefolk/rider/#enddef
     alignment=chaotic
     advances_to=Dune Marauder
     cost=34
-    usage=archer
+    usage=scout
     description= _ "Though rarely found in organized armies, Raiders are a staple among the nomadic Dunefolk, who regularly ambush rival caravans and camps at night. In these scenarios, raw power is of little concern. The greatest importance is placed on speed—striking quickly, spreading as much chaos with their torches in the shortest time possible, allows these riders to get in and out of the blitz without any fear of counterattack. Raiders are the fastest of the Dunefolk, capable of outpacing nearly anything they might encounter in the sandy deserts."
     die_sound={SOUND_LIST:HUMAN_DIE}
     {DEFENSE_ANIM "{PATH_TEMP}raider.png" "{PATH_TEMP}raider.png" {SOUND_LIST:HUMAN_HIT} }

--- a/data/core/units/dunefolk/Rider.cfg
+++ b/data/core/units/dunefolk/Rider.cfg
@@ -16,7 +16,7 @@ units/dunefolk/rider/#enddef
     alignment=liminal
     advances_to=Dune Raider,Dune Horse Archer,Dune Sunderer
     cost=18
-    usage=archer
+    usage=scout
     description= _ "The Dunefolk are prominent horse breeders who raise many different varieties of mounts to fulfill various purposes. Those who are used for hard labor are bred for power, while those for journeys or caravans are bred for endurance. For warfare, a mix of traits is usually best, though the ability to easily and rapidly traverse sand is of utmost importance. The riders of these horses primarily function as scouts and messengers, or occasionally as supporting forces for weakened lines. The crucial trait of maneuverability is what allows these horsemen to be so effective and versatile out on the rolling dunes."
     die_sound=horse-die.ogg
     {DEFENSE_ANIM "{PATH_TEMP}rider.png" "{PATH_TEMP}rider.png" {SOUND_LIST:HORSE_HIT} }

--- a/data/core/units/dunefolk/Scorcher.cfg
+++ b/data/core/units/dunefolk/Scorcher.cfg
@@ -18,7 +18,7 @@ units/dunefolk/burner/#enddef
     alignment=lawful
     advances_to=Dune Firetrooper
     cost=23
-    usage=fighter
+    usage=archer
     description= _ "The Scorcher’s name is derived not from the destruction they wreak on adversarial formations, but on their own singed appearance. By experimenting endlessly with their equipment, most Scorchers inevitably overstep their bounds and are seared by the highly volatile Sanbaar sap that soaks their weapons. Bearing their burns as a mark of pride in their work, these archers relish igniting great swaths of flame on the battlefield, though this sometimes results in unintended friendly fire as well."
     die_sound={SOUND_LIST:HUMAN_DIE}
     {DEFENSE_ANIM "{PATH_TEMP}scorcher.png" "{PATH_TEMP}scorcher.png" {SOUND_LIST:HUMAN_HIT} }

--- a/data/core/units/dunefolk/Skirmisher.cfg
+++ b/data/core/units/dunefolk/Skirmisher.cfg
@@ -18,7 +18,7 @@ units/dunefolk/skirmisher/#enddef
     alignment=lawful
     advances_to=Dune Strider
     cost=16
-    usage=mixed fighter
+    usage=fighter
     description= _ "Born and raised out on the open sands, Dune Skirmishers are accustomed to the harsh, arid desert heat and inhospitable terrain. Compared to even other Dunefolk, Skirmishers are unnaturally agile on the unstable dunes, allowing them to safeguard their herds and hunt the barrens with ease. When applied to battle, the same agility allows them to both slip through enemy lines and avoid all manner of attack. These skills make Skirmishers effective saboteurs, capable of cutting of escape routes and supply lines, assassinating key units, or pincering an enemy formation into a disadvantageous position."
     {NOTE_SKIRMISHER}
     {NOTE_FIRSTSTRIKE}

--- a/data/core/units/dunefolk/Warmaster.cfg
+++ b/data/core/units/dunefolk/Warmaster.cfg
@@ -23,7 +23,7 @@ units/dunefolk/soldier/#enddef
     advances_to=null
     {AMLA_DEFAULT}
     cost=56
-    usage=mixed fighter
+    usage=fighter
     [abilities]
         {ABILITY_LEADERSHIP}
     [/abilities]

--- a/data/core/units/nagas/Dirkfang.cfg
+++ b/data/core/units/nagas/Dirkfang.cfg
@@ -14,7 +14,7 @@
     alignment=liminal
     advances_to=Naga Ophidian,Naga Ringcaster
     cost=15
-    usage=fighter
+    usage=mixed fighter
     description= _ "In contrast to the heavily melee-focused style of their northern brethren, young Naga of the southern tribes prefer to carry small bows, with which they used to pepper their prey with arrows. While finishing off any water-based enemies usually must be done at close range, softening foes with ranged attacks is usually much less dangerous than rushing headlong directly into the fray. Sometimes viewed as cowardly by more proper Naga warriors, these fighters are nonetheless effective when it comes time to engage in warfare."
     die_sound=naga-die.ogg
     {DEFENSE_ANIM "units/nagas/dirkfang.png" "units/nagas/dirkfang.png" {SOUND_LIST:NAGA_HIT} }

--- a/data/core/units/nagas/Ringcaster.cfg
+++ b/data/core/units/nagas/Ringcaster.cfg
@@ -13,7 +13,7 @@
     alignment=liminal
     advances_to=Naga Zephyr
     cost=24
-    usage=fighter
+    usage=archer
     description= _ "The blade ring, or chakram, is the signature weapon of the southern Naga and their renowned Ringcasters. These nagas choose their tools with great care: the process of forging a chakram underwater is quite tricky and usually results in weapons with a fair bit of variance. Each Ringcaster picks a specific set of chakrams that suits them, whether it be rings with high uniformity for faster spinning, blades with a slight bit of wobble for unpredictability, or lopsided rings for curved trajectories. As different as each blade ring is coming out of the forge, each Ringcaster has a different fighting style to which their tools are tailored."
     die_sound=naga-die.ogg
     {DEFENSE_ANIM "units/nagas/ringcaster.png" "units/nagas/ringcaster.png" {SOUND_LIST:NAGA_HIT} }

--- a/data/core/units/nagas/Zephyr.cfg
+++ b/data/core/units/nagas/Zephyr.cfg
@@ -14,7 +14,7 @@
     advances_to=null
     {AMLA_DEFAULT}
     cost=50
-    usage=fighter
+    usage=archer
     description= _ "The Southern Naga commonly recount a curious story about the Wind Spirit, Zefra and the aetherial chakram:
 
 In the distant past, there was a chakram wielder who was possessed of legendary skill. It is said that he could cleave the very seas with a flurry of blades, fell a hundred foes before a single could reach him, and deflect a thousand arrows without being struck. Called by the name of Xylrix, tempest, he was a warrior whose arrogance was as great as his talent. He was always more than willing to boast his prowess to any and all who would watch him. Then one day, while flaunting himself to a band of young Nagini, he chose a sacred Allnai tree as his target.

--- a/data/multiplayer/factions/dunefolk-aoh.cfg
+++ b/data/multiplayer/factions/dunefolk-aoh.cfg
@@ -14,6 +14,6 @@
 "+_"The <bold>text='Dunefolk'</bold> are a faction of humans from the deserts and hills of the southern lands. The Dunefolk specialize in using terrain features to coordinate attacks at dawn or dusk. Their ranks boast lawful and liminal units, healers, high-accuracy melee fighters, and fearsome horse-mounted archers. While Dunefolk units tend to be more expensive than those of the Loyalist faction, they make up for this with high mobility — especially on hilly terrains."
     # wmllint: markcheck on
     [ai]
-        recruitment_pattern=fighter,fighter,fighter,mixed fighter,mixed fighter,archer,archer,scout
+        recruitment_pattern=fighter,fighter,mixed fighter,mixed fighter,archer,healer,scout
     [/ai]
 [/multiplayer_side]

--- a/data/multiplayer/factions/dunefolk-default.cfg
+++ b/data/multiplayer/factions/dunefolk-default.cfg
@@ -14,6 +14,6 @@
 "+_"The <bold>text='Dunefolk'</bold> are a faction of humans from the deserts and hills of the southern lands. The Dunefolk specialize in using terrain features to coordinate attacks at dawn or dusk. Their ranks boast lawful and liminal units, healers, high-accuracy melee fighters, and fearsome horse-mounted archers. While Dunefolk units tend to be more expensive than those of the Loyalist faction, they make up for this with high mobility — especially on hilly terrains."
     # wmllint: markcheck on
     [ai]
-        recruitment_pattern=fighter,fighter,fighter,mixed fighter,mixed fighter,archer,archer,scout
+        recruitment_pattern=fighter,fighter,mixed fighter,mixed fighter,archer,healer,scout
     [/ai]
 [/multiplayer_side]


### PR DESCRIPTION
Hello,
the usage attributes for AI recruitment of some dunefolk units are odd. Additionally, the current recruitment_pattern includes scout but does not include healer, while the Dune Herbalist has usage=healer and no dunefolk unit has usage=scout at the moment.

More details on the values that the proposed new usage attributes are based on can be found below.

I do not know if the suggested new recruitment_pattern is optimal, but it includes all occurring usage attributes, with weights according to the number of default era recruits of that type (2:2:1:1:1). In the few simple AI versus AI tests I did, the win ratio against other factions was quite okay.


Details:
each entry: level, id (ratio melee damage/ranged damage, some relevant abilities and weapon specials)

total: 33 (counting Paragon)
default recruits: 7
aoh recruits: 20

fighter
total: 13 (counting Paragon)
default recruits: 2
aoh recruits: 7
1 Soldier (22/0=inf)
_2 Captain (27/0=inf)
__3 Warmaster (36/0=inf)
_2 Spearguard (32/0=inf)
__3 Spearmaster (46/0=inf)
_2 Swordsman (30/0=inf)
__3 Blademaster (45/0=inf)
___4 Paragon (52/0=inf)
1 Skirmisher (16/6=2.667)
_2 Sunderer (33/15=2.2)
__3 Cataphract (42/18=2.333)
_2 Ophidian (24/12=2)
__3 Dervish (40/18=2.222)

mixed fighter
total: 8
default recruits: 2
aoh recruits: 5
1 Dirkfang (12/12=1)
1 Rover (12/15=0.8)
_2 Explorer (24/24=1)
__3 Wayfarer (32/32=1)
_2 Strider (24/14=1.714, ranged slows)
__3 Harrier (32/18=1.778, ranged slows)
_2 Alchemist (27/14=1.929, ranged poison)
__3 Firetrooper (27/36=0.75)

archer
total: 6
default recruits: 1
aoh recruits: 4
_2 Horse Archer (14/28=0.5)
__3 Windbolt (20/40=0.5)
_2 Ringcaster (12/24=0.5)
__3 Zephyr (18/35=0.514)
1 Burner (12/21=0.571)
_2 Scorcher (18/27=0.667)

healer
total: 3
default recruits: 1
aoh recruits: 2
1 Herbalist (12/0=inf, heals +4)
_2 Apothecary (24/0=inf, heals +8)
__3 Luminary (36/0=inf, cures, heals +8)

scout
total: 3
default recruits: 1
aoh recruits: 2
1 Rider (10/15=0.667)
_2 Raider (24/21=1.143)
__3 Marauder (33/30=1.1)