### PR TITLE
Fix [replace_map]map_file= when called in a prestart event

### DIFF
--- a/src/game_events/action_wml.cpp
+++ b/src/game_events/action_wml.cpp
@@ -553,38 +553,24 @@ namespace {
 	{
 		map_choice(const std::string& filename) : filename_(filename) {}
 		std::string filename_;
-		virtual config query_user(int /*side*/) const
+		virtual config query_user(int /*side*/) const override
 		{
-			//Do a regex check for the file format to prevent sending arbitrary files to other clients.
-			//Note: this allows only the new format.
-			static const std::string s_simple_terrain = R"""([A-Za-z\\|/]{1,4})""";
-			static const std::string s_terrain = s_simple_terrain + R"""((\^)""" + s_simple_terrain + ")?";
-			static const std::string s_sep = "(, |\\n)";
-			static const std::string s_prefix = R"""((\d+ )?)""";
-			static const std::string s_all = "(" + s_prefix + s_terrain + s_sep + ")+";
-			static const boost::regex r_all(s_all);
-
-			const std::string& mapfile = filesystem::get_wml_location(filename_);
-			std::string res = "";
-			if(filesystem::file_exists(mapfile)) {
-				res = filesystem::read_file(mapfile);
-			}
-			config retv;
-			if(boost::regex_match(res, r_all))
-			{
-				retv["map_data"] = res;
-			}
-			return retv;
+			std::string res = filesystem::read_map(filename_);
+			return config {"map_data", res};
 		}
-		virtual config random_choice(int /*side*/) const
+		virtual config random_choice(int /*side*/) const override
 		{
 			return config();
 		}
-		virtual std::string description() const
+		virtual std::string description() const override
 		{
 			return "Map Data";
 		}
-
+		virtual bool is_visible() const override
+		{
+			// Allow query_user() to be called during prestart events, as it doesn't show any UI.
+			return false;
+		}
 	};
 }
 


### PR DESCRIPTION
Fixes 8080271231adddb3a3e88297d5fc52d37e3de7d7's Eternal Night. The northern
parts of both 10 and 10a are the same, but 10a is extended southwards; this
caused some confusion thinking that the map-load hadn't changed anything.

The regexp code is removed, as @gfgtdf comments in #4633: "I'm quite sure that I
wrote that code but I don't remember why, I was probably just extra cautious.
In particular with the existence of wesnoth.read_file nowdays there is little
point in these checks."

Removing the regexp code allowed merging with the codepath for handling
[scenario]map_file=, which will allow the main issue of #4633 (searching other
folders for maps) to automatically affect [replace_map] too.