### PR TITLE
Fix Map size: 0x0 in multiplayer create game menu

### DIFF
--- a/src/gui/dialogs/multiplayer/mp_create_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.cpp
@@ -712,6 +712,10 @@ void mp_create_game::update_details(window& win)
 			const std::string map_data = !current_scenario->data()["map_data"].empty()
 				? current_scenario->data()["map_data"]
 				: filesystem::read_map(current_scenario->data()["map_file"]);
+			if (current_scenario->data()["map_data"].empty()) {
+				current_scenario->data()["map_data"] = map_data;
+				current_scenario->set_metadata();
+			}
 			find_widget<minimap>(&win, "minimap", false).set_map_data(map_data);
 
 			players.set_label(std::to_string(current_scenario->num_players()));


### PR DESCRIPTION
The multiplayer create game menu shows scenarios as having map size 0x0.

To reproduce this bug, select "Multiplayer" from main menu, then "Local Game".  After "OK" button pressed, select any scenario, and the map size is shown as "0x0".

This short fix loads the map data and collects metadata about it before displaying map size.