### PR TITLE
Make map_file= search for a maps directory in the [binary_path] (#4633)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -122,6 +122,7 @@
    * Added tool trackviewer, which has the animation-preview functions of trackplacer (PR #4574)
    * Removed the python2 trackplacer tool (issue #4365)
    * Made wmlscope recognize and analyze optional macro arguments
+   * Made `map_file=Example.map` support looking in the `[binary_path]`'s "maps/" directory (issue #4633)
 
 ## Version 1.15.2
  ### AI:

--- a/data/campaigns/Dead_Water/scenarios/01_Invasion.cfg
+++ b/data/campaigns/Dead_Water/scenarios/01_Invasion.cfg
@@ -34,7 +34,7 @@
 
 [scenario]
     name= _ "Invasion!"
-    map_file=campaigns/Dead_Water/maps/Home_1.map
+    map_file=Home_1.map
 
     id=01_Invasion
     next_scenario=02_Flight

--- a/data/campaigns/Dead_Water/scenarios/02_Flight.cfg
+++ b/data/campaigns/Dead_Water/scenarios/02_Flight.cfg
@@ -25,7 +25,7 @@
 
 [scenario]
     name= _ "Flight"
-    map_file=campaigns/Dead_Water/maps/Home_1.map
+    map_file=Home_1.map
 
     id=02_Flight
     next_scenario=03_Wolf_Coast

--- a/data/campaigns/Dead_Water/scenarios/03_Wolf_Coast.cfg
+++ b/data/campaigns/Dead_Water/scenarios/03_Wolf_Coast.cfg
@@ -11,7 +11,7 @@
 
 [scenario]
     name= _ "Wolf Coast"
-    map_file=campaigns/Dead_Water/maps/Wolf_Coast.map
+    map_file=Wolf_Coast.map
 
     id=03_Wolf_Coast
     next_scenario=04_Slavers

--- a/data/campaigns/Dead_Water/scenarios/04_Slavers.cfg
+++ b/data/campaigns/Dead_Water/scenarios/04_Slavers.cfg
@@ -31,7 +31,7 @@
 
 [scenario]
     name= _ "Slavers"
-    map_file=campaigns/Dead_Water/maps/Slavers.map
+    map_file=Slavers.map
 
     id=04_Slavers
     next_scenario=05_Tirigaz

--- a/data/campaigns/Dead_Water/scenarios/05_Tirigaz.cfg
+++ b/data/campaigns/Dead_Water/scenarios/05_Tirigaz.cfg
@@ -21,7 +21,7 @@
 
 [scenario]
     name= _ "Tirigaz"
-    map_file=campaigns/Dead_Water/maps/Tirigaz.map
+    map_file=Tirigaz.map
 
     id=05_Tirigaz
     next_scenario=06_Uncharted_Islands

--- a/data/campaigns/Dead_Water/scenarios/06_Uncharted_Islands.cfg
+++ b/data/campaigns/Dead_Water/scenarios/06_Uncharted_Islands.cfg
@@ -24,7 +24,7 @@
 
 [scenario]
     name= _ "Uncharted Islands"
-    map_file=campaigns/Dead_Water/maps/Uncharted_Islands.map
+    map_file=Uncharted_Islands.map
 
     id=06_Uncharted_Islands
     next_scenario=07_Bilheld

--- a/data/campaigns/Dead_Water/scenarios/07_Bilheld.cfg
+++ b/data/campaigns/Dead_Water/scenarios/07_Bilheld.cfg
@@ -22,7 +22,7 @@
 
 [scenario]
     name= _ "Bilheld"
-    map_file=campaigns/Dead_Water/maps/Bilheld.map
+    map_file=Bilheld.map
 
     id=07_Bilheld
     next_scenario=08_Talking_to_Tyegea

--- a/data/campaigns/Dead_Water/scenarios/08_Talking_to_Tyegea.cfg
+++ b/data/campaigns/Dead_Water/scenarios/08_Talking_to_Tyegea.cfg
@@ -5,7 +5,7 @@
 
 [scenario]
     name= _ "Talking to Tyegëa"
-    map_file=campaigns/Dead_Water/maps/Talking_To_Tyegea.map
+    map_file=Talking_To_Tyegea.map
 
     id=08_Talking_to_Tyegea
     next_scenario=09_The_Mage

--- a/data/campaigns/Dead_Water/scenarios/09_The_Mage.cfg
+++ b/data/campaigns/Dead_Water/scenarios/09_The_Mage.cfg
@@ -10,7 +10,7 @@
 
 [scenario]
     name= _ "The Mage"
-    map_file=campaigns/Dead_Water/maps/The_Mage.map
+    map_file=The_Mage.map
 
     id=09_The_Mage
     next_scenario=10_The_Flaming_Sword

--- a/data/campaigns/Dead_Water/scenarios/10_The_Flaming_Sword.cfg
+++ b/data/campaigns/Dead_Water/scenarios/10_The_Flaming_Sword.cfg
@@ -12,7 +12,7 @@
 
 [scenario]
     name= _ "The Flaming Sword"
-    map_file=campaigns/Dead_Water/maps/The_Flaming_Sword.map
+    map_file=The_Flaming_Sword.map
 
     id=10_The_Flaming_Sword
     next_scenario=11_Getting_Help

--- a/data/campaigns/Dead_Water/scenarios/11_Getting_Help.cfg
+++ b/data/campaigns/Dead_Water/scenarios/11_Getting_Help.cfg
@@ -2,7 +2,7 @@
 
 [scenario]
     name= _ "Getting Help"
-    map_file=campaigns/Dead_Water/maps/Talking_To_Tyegea.map
+    map_file=Talking_To_Tyegea.map
     theme=Cutscene_Minimal
 
     id=11_Getting_Help

--- a/data/campaigns/Dead_Water/scenarios/12_Revenge.cfg
+++ b/data/campaigns/Dead_Water/scenarios/12_Revenge.cfg
@@ -2,7 +2,7 @@
 
 [scenario]
     name= _ "Revenge"
-    map_file=campaigns/Dead_Water/maps/Home_2.map
+    map_file=Home_2.map
 
     id=12_Revenge
     next_scenario=13_Epilogue

--- a/data/campaigns/Dead_Water/scenarios/13_Epilogue.cfg
+++ b/data/campaigns/Dead_Water/scenarios/13_Epilogue.cfg
@@ -2,7 +2,7 @@
 
 [scenario]
     name= _ "Epilogue"
-    map_file=campaigns/Dead_Water/maps/Home_1.map
+    map_file=Home_1.map
     theme=Cutscene_Minimal
 
     id=13_Epilogue

--- a/data/campaigns/Descent_Into_Darkness/scenarios/01_Saving_Parthyn.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/01_Saving_Parthyn.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=01_Saving_Parthyn
     name= _ "Saving Parthyn"
-    map_file=campaigns/Descent_Into_Darkness/maps/01_Saving_Parthyn.map
+    map_file=01_Saving_Parthyn.map
     turns=13
     next_scenario=02_Peaceful_Valley
     victory_when_enemies_defeated=no

--- a/data/campaigns/Descent_Into_Darkness/scenarios/02_Peaceful_Valley.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/02_Peaceful_Valley.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=02_Peaceful_Valley
     name= _ "Peaceful Valley"
-    map_file=campaigns/Descent_Into_Darkness/maps/02_Peaceful_Valley.map
+    map_file=02_Peaceful_Valley.map
     victory_when_enemies_defeated=no
     {TURNS 19 17 15}
     next_scenario=03_A_Haunting_in_Winter

--- a/data/campaigns/Descent_Into_Darkness/scenarios/03_A_Haunting_in_Winter.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/03_A_Haunting_in_Winter.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=03_A_Haunting_in_Winter
     name= _ "A Haunting in Winter"
-    map_file=campaigns/Descent_Into_Darkness/maps/03_A_Haunting_in_Winter.map
+    map_file=03_A_Haunting_in_Winter.map
     victory_when_enemies_defeated=no
     turns=unlimited
     next_scenario=04_Spring_of_Reprisal

--- a/data/campaigns/Descent_Into_Darkness/scenarios/04_Spring_of_Reprisal.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/04_Spring_of_Reprisal.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=04_Spring_of_Reprisal
     name= _ "Spring of Reprisal"
-    map_file=campaigns/Descent_Into_Darkness/maps/04_Spring_of_Reprisal.map
+    map_file=04_Spring_of_Reprisal.map
     {TURNS 30 27 24}
     next_scenario=05_Schism
     victory_when_enemies_defeated=yes

--- a/data/campaigns/Descent_Into_Darkness/scenarios/05_Schism.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/05_Schism.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=05_Schism
     name= _ "Schism"
-    map_file=campaigns/Descent_Into_Darkness/maps/05_Schism.map
+    map_file=05_Schism.map
     victory_when_enemies_defeated=yes
     turns=37
     next_scenario=06_Return_to_Parthyn

--- a/data/campaigns/Descent_Into_Darkness/scenarios/06_Return_to_Parthyn.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/06_Return_to_Parthyn.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=06_Return_to_Parthyn
     name= _ "Return to Parthyn"
-    map_file=campaigns/Descent_Into_Darkness/maps/06_Return_to_Parthyn.map
+    map_file=06_Return_to_Parthyn.map
     {TURNS 19 18 17}
     victory_when_enemies_defeated=no
     next_scenario=07a_A_Small_Favor

--- a/data/campaigns/Descent_Into_Darkness/scenarios/07a_A_Small_Favor.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/07a_A_Small_Favor.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=07a_A_Small_Favor
     name= _ "A Small Favor — I"
-    map_file=campaigns/Descent_Into_Darkness/maps/07a_A_Small_Favor.map
+    map_file=07a_A_Small_Favor.map
     {TURNS 20 18 16}
     next_scenario=07b_A_Small_Favor2
     victory_when_enemies_defeated=no

--- a/data/campaigns/Descent_Into_Darkness/scenarios/07b_A_Small_Favor2.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/07b_A_Small_Favor2.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=07b_A_Small_Favor2
     name= _ "A Small Favor — II"
-    map_file=campaigns/Descent_Into_Darkness/maps/07b_A_Small_Favor2.map
+    map_file=07b_A_Small_Favor2.map
     {TURNS 25 22 19}
     next_scenario=07c_A_Small_Favor3
     victory_when_enemies_defeated=no

--- a/data/campaigns/Descent_Into_Darkness/scenarios/07c_A_Small_Favor3.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/07c_A_Small_Favor3.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=07c_A_Small_Favor3
     name= _ "A Small Favor — III"
-    map_file=campaigns/Descent_Into_Darkness/maps/07c_A_Small_Favor3.map
+    map_file=07c_A_Small_Favor3.map
     {TURNS 21 18 15}
     next_scenario=08_Alone_at_Last
     victory_when_enemies_defeated=no

--- a/data/campaigns/Descent_Into_Darkness/scenarios/08_Alone_at_Last.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/08_Alone_at_Last.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=08_Alone_at_Last
     name= _ "Alone at Last"
-    map_file=campaigns/Descent_Into_Darkness/maps/08_Alone_at_Last.map
+    map_file=08_Alone_at_Last.map
     {TURNS 35 32 29}
     next_scenario=09_Descent_into_Darkness
     victory_when_enemies_defeated=no

--- a/data/campaigns/Descent_Into_Darkness/scenarios/09_Descent_into_Darkness.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/09_Descent_into_Darkness.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=09_Descent_into_Darkness
     name= _ "Descent into Darkness"
-    map_file=campaigns/Descent_Into_Darkness/maps/09a_Descent_into_Darkness.map
+    map_file=09a_Descent_into_Darkness.map
     turns=unlimited
     next_scenario=10_Endless_Night
     victory_when_enemies_defeated=no
@@ -1616,7 +1616,7 @@
         [/message]
 
         [replace_map]
-            map_file=campaigns/Descent_Into_Darkness/maps/09_Descent_into_Darkness.map
+            map_file=09_Descent_into_Darkness.map
             expand=yes
             shrink=yes
         [/replace_map]

--- a/data/campaigns/Descent_Into_Darkness/scenarios/10_Endless_Night.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/10_Endless_Night.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=10_Endless_Night
     name= _ "Endless Night"
-    map_file=campaigns/Descent_Into_Darkness/maps/10_Endless_Night.map
+    map_file=10_Endless_Night.map
     turns=unlimited
     next_scenario=10_Endless_Night
     victory_when_enemies_defeated=yes
@@ -308,7 +308,7 @@
 
             [then]
                 [replace_map]
-                    map_file=campaigns/Descent_Into_Darkness/maps/10a_Endless_Night.map
+                    map_file=10a_Endless_Night.map
                     expand=yes
                     shrink=yes
                 [/replace_map]

--- a/data/campaigns/Eastern_Invasion/scenarios/01_The_Outpost.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/01_The_Outpost.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=01_The_Outpost
     name= _ "The Outpost"
-    map_file=campaigns/Eastern_Invasion/maps/01_The_Outpost.map
+    map_file=01_The_Outpost.map
     next_scenario=02_The_Escape_Tunnel
     turns=16
 

--- a/data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=02_The_Escape_Tunnel
     name= _ "The Escape Tunnel"
-    map_file=campaigns/Eastern_Invasion/maps/02_The_Escape_Tunnel.map
+    map_file=02_The_Escape_Tunnel.map
     {TURNS 26 24 22}
     next_scenario=03_An_Unexpected_Appearance
     victory_when_enemies_defeated=no

--- a/data/campaigns/Eastern_Invasion/scenarios/03_An_Unexpected_Appearance.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/03_An_Unexpected_Appearance.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=03_An_Unexpected_Appearance
     name= _ "An Unexpected Appearance"
-    map_file=campaigns/Eastern_Invasion/maps/03_An_Unexpected_Appearance.map
+    map_file=03_An_Unexpected_Appearance.map
     next_scenario=04a_An_Elven_Alliance
     {TURNS 20 18 16}
 

--- a/data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Alliance.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Alliance.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=04a_An_Elven_Alliance
     name= _ "An Elven Alliance"
-    map_file=campaigns/Eastern_Invasion/maps/04a_An_Elven_Alliance.map
+    map_file=04a_An_Elven_Alliance.map
     turns=18
     next_scenario=05_Northern_Outpost
 

--- a/data/campaigns/Eastern_Invasion/scenarios/04b_The_Undead_Border_Patrol.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/04b_The_Undead_Border_Patrol.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=04b_The_Undead_Border_Patrol
     name= _ "The Undead Border Patrol"
-    map_file=campaigns/Eastern_Invasion/maps/04b_The_Undead_Border_Patrol.map
+    map_file=04b_The_Undead_Border_Patrol.map
     turns=20
     next_scenario=05_Northern_Outpost
 

--- a/data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=04c_Mal-Ravanals_Capital
     name= _ "Mal-Ravanal’s Capital"
-    map_file=campaigns/Eastern_Invasion/maps/04c_Mal-Ravanals_Capital.map
+    map_file=04c_Mal-Ravanals_Capital.map
     turns=26
     next_scenario=05_Northern_Outpost
 

--- a/data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=05_Northern_Outpost
     name= _ "Northern Outpost"
-    map_file=campaigns/Eastern_Invasion/maps/05_Northern_Outpost.map
+    map_file=05_Northern_Outpost.map
     turns=20
     next_scenario=06_Two_Paths
     victory_when_enemies_defeated=no

--- a/data/campaigns/Eastern_Invasion/scenarios/06_Two_Paths.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/06_Two_Paths.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=06_Two_Paths
     name= _ "Two Paths"
-    map_file=campaigns/Eastern_Invasion/maps/06_Two_Paths.map
+    map_file=06_Two_Paths.map
     next_scenario=07a_The_Crossing
     {TURNS 18 17 16}
 

--- a/data/campaigns/Eastern_Invasion/scenarios/07a_The_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/07a_The_Crossing.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=07a_The_Crossing
     name= _ "The Crossing"
-    map_file=campaigns/Eastern_Invasion/maps/07a_The_Crossing.map
+    map_file=07a_The_Crossing.map
     turns=24
     next_scenario=08_Training_the_Ogres
 

--- a/data/campaigns/Eastern_Invasion/scenarios/07b_Undead_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/07b_Undead_Crossing.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=07b_Undead_Crossing
     name= _ "Undead Crossing"
-    map_file=campaigns/Eastern_Invasion/maps/07b_Undead_Crossing.map
+    map_file=07b_Undead_Crossing.map
     turns=21
     next_scenario=08_Training_the_Ogres
 

--- a/data/campaigns/Eastern_Invasion/scenarios/08_Training_the_Ogres.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/08_Training_the_Ogres.cfg
@@ -3,7 +3,7 @@
     id=08_Training_the_Ogres
     name= _ "Capturing the Ogres"
     next_scenario=09_Xenophobia
-    map_file=campaigns/Eastern_Invasion/maps/08_Training_the_Ogres.map
+    map_file=08_Training_the_Ogres.map
     victory_when_enemies_defeated=no
     turns=unlimited
     {NORTHERN_SCHEDULE}

--- a/data/campaigns/Eastern_Invasion/scenarios/09_Xenophobia.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Xenophobia.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=09_Xenophobia
     name= _ "Xenophobia"
-    map_file=campaigns/Eastern_Invasion/maps/09_Xenophobia.map
+    map_file=09_Xenophobia.map
     {TURNS 40 36 32}
     next_scenario=10_Lake_Vrug
 

--- a/data/campaigns/Eastern_Invasion/scenarios/10_Lake_Vrug.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/10_Lake_Vrug.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=10_Lake_Vrug
     name= _ "Lake Vrug"
-    map_file=campaigns/Eastern_Invasion/maps/10_Lake_Vrug.map
+    map_file=10_Lake_Vrug.map
     turns=30
 
     {DEFAULT_SCHEDULE_MORNING}

--- a/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
@@ -3,7 +3,7 @@
     id=11_Captured
     name= _ "Captured"
     next_scenario=12_Evacuation
-    map_file=campaigns/Eastern_Invasion/maps/11_Captured.map
+    map_file=11_Captured.map
     victory_when_enemies_defeated=no
     turns=unlimited
     {UNDERGROUND}

--- a/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=12_Evacuation
     name= _ "Evacuation"
-    map_file=campaigns/Eastern_Invasion/maps/12_Evacuation.map
+    map_file=12_Evacuation.map
     turns=12
     next_scenario=13_The_Drowned_Plains
 

--- a/data/campaigns/Eastern_Invasion/scenarios/13_The_Drowned_Plains.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/13_The_Drowned_Plains.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=13_The_Drowned_Plains
     name= _ "The Drowned Plains"
-    map_file=campaigns/Eastern_Invasion/maps/13_The_Drowned_Plains.map
+    map_file=13_The_Drowned_Plains.map
     {TURNS 28 26 24}
     next_scenario=14_Approaching_Weldyn
 

--- a/data/campaigns/Eastern_Invasion/scenarios/14_Approaching_Weldyn.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/14_Approaching_Weldyn.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=14_Approaching_Weldyn
     name= _ "Approaching Weldyn"
-    map_file=campaigns/Eastern_Invasion/maps/14_Approaching_Weldyn.map
+    map_file=14_Approaching_Weldyn.map
     turns=24
     next_scenario=15_The_Council
 

--- a/data/campaigns/Eastern_Invasion/scenarios/15_The_Council.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/15_The_Council.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=15_The_Council
     name= _ "The Council"
-    map_file=campaigns/Eastern_Invasion/maps/Throne_Room.map
+    map_file=Throne_Room.map
     theme=Cutscene_Minimal
     turns=1
     next_scenario=16_Weldyn_under_Attack

--- a/data/campaigns/Eastern_Invasion/scenarios/16_Weldyn_under_Attack.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/16_Weldyn_under_Attack.cfg
@@ -3,7 +3,7 @@
     id=16_Weldyn_under_Attack
     name= _ "Weldyn under Attack"
     next_scenario=17a_The_Duel
-    map_file=campaigns/Eastern_Invasion/maps/16_Weldyn_under_Attack.map
+    map_file=16_Weldyn_under_Attack.map
     turns=18
 
     {DUSK}

--- a/data/campaigns/Eastern_Invasion/scenarios/17a_The_Duel.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/17a_The_Duel.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=17a_The_Duel
     name= _ "The Duel"
-    map_file=campaigns/Eastern_Invasion/maps/17a_The_Duel.map
+    map_file=17a_The_Duel.map
     turns=unlimited
     next_scenario=18_Epilogue
 

--- a/data/campaigns/Eastern_Invasion/scenarios/17b_Weldyn_Besieged.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/17b_Weldyn_Besieged.cfg
@@ -7,7 +7,7 @@
 [scenario]
     id=17b_Weldyn_Besieged
     name= _ "Weldyn Besieged"
-    map_file=campaigns/Eastern_Invasion/maps/17b_Weldyn_Besieged.map
+    map_file=17b_Weldyn_Besieged.map
     turns=unlimited
     next_scenario=18_Epilogue
 

--- a/data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=18_Epilogue
     name= _ "Epilogue"
-    map_file=campaigns/Eastern_Invasion/maps/Throne_Room.map
+    map_file=Throne_Room.map
     theme=Cutscene_Minimal
     turns=1
     victory_when_enemies_defeated=no

--- a/data/campaigns/Heir_To_The_Throne/scenarios/01_The_Elves_Besieged.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/01_The_Elves_Besieged.cfg
@@ -4,7 +4,7 @@
     name= _ "The Elves Besieged"
     next_scenario=02_Blackwater_Port
     victory_when_enemies_defeated=no
-    map_file=campaigns/Heir_To_The_Throne/maps/01_The_Elves_Besieged.map
+    map_file=01_The_Elves_Besieged.map
     {TURNS 16 14 12}
     {DEFAULT_SCHEDULE}
 

--- a/data/campaigns/Heir_To_The_Throne/scenarios/02_Blackwater_Port.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/02_Blackwater_Port.cfg
@@ -3,7 +3,7 @@
     id=02_Blackwater_Port
     name= _ "scenario name^Blackwater Port"
     next_scenario=03_The_Isle_of_Alduin
-    map_file=campaigns/Heir_To_The_Throne/maps/02_Blackwater_Port.map
+    map_file=02_Blackwater_Port.map
     {DEFAULT_SCHEDULE}
     {TURNS 12 12 9}
 

--- a/data/campaigns/Heir_To_The_Throne/scenarios/03_The_Isle_of_Alduin.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/03_The_Isle_of_Alduin.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=03_The_Isle_of_Alduin
     name= _ "The Isle of Alduin"
-    map_file=campaigns/Heir_To_The_Throne/maps/03_The_Isle_of_Alduin.map
+    map_file=03_The_Isle_of_Alduin.map
     {TURNS 34 24 21}
 
     {DEFAULT_SCHEDULE_AFTERNOON}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/04_The_Bay_of_Pearls.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/04_The_Bay_of_Pearls.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=04_The_Bay_of_Pearls
     name= _ "The Bay of Pearls"
-    map_file=campaigns/Heir_To_The_Throne/maps/04_The_Bay_of_Pearls.map
+    map_file=04_The_Bay_of_Pearls.map
     {TURNS 27 24 21}
 
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/05a_Muff_Malal_Peninsula.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/05a_Muff_Malal_Peninsula.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=05a_Muff_Malals_Peninsula
     name= _ "Muff Malal’s Peninsula"
-    map_file=campaigns/Heir_To_The_Throne/maps/05a_Muff_Malal_Peninsula.map
+    map_file=05a_Muff_Malal_Peninsula.map
     {TURNS 27 24 21}
 
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/05b_Isle_of_the_Damned.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/05b_Isle_of_the_Damned.cfg
@@ -3,7 +3,7 @@
     id=05b_Isle_of_the_Damned
     next_scenario=06_The_Siege_of_Elensefar
     name= _ "Isle of the Damned"
-    map_file=campaigns/Heir_To_The_Throne/maps/05b_Isle_of_the_Damned.map
+    map_file=05b_Isle_of_the_Damned.map
     {TURNS 28 26 24}
 
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/06_The_Siege_of_Elensefar.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/06_The_Siege_of_Elensefar.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=06_The_Siege_of_Elensefar
     name= _ "The Siege of Elensefar"
-    map_file=campaigns/Heir_To_The_Throne/maps/06_The_Siege_of_Elensefar.map
+    map_file=06_The_Siege_of_Elensefar.map
     {TURNS 40 32 29}
 
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/07_Crossroads.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/07_Crossroads.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=07_Crossroads
     name= _ "Crossroads"
-    map_file=campaigns/Heir_To_The_Throne/maps/07_Crossroads.map
+    map_file=07_Crossroads.map
     {TURNS 37 34 31}
 
     next_scenario=08_The_Princess_of_Wesnoth

--- a/data/campaigns/Heir_To_The_Throne/scenarios/08_The_Princess_of_Wesnoth.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/08_The_Princess_of_Wesnoth.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=08_The_Princess_of_Wesnoth
     name= _ "The Princess of Wesnoth"
-    map_file=campaigns/Heir_To_The_Throne/maps/08_The_Princess_of_Wesnoth.map
+    map_file=08_The_Princess_of_Wesnoth.map
     {TURNS 31 28 25}
 
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/09_The_Valley_of_Death.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/09_The_Valley_of_Death.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=09_The_Valley_of_Death
     name= _ "The Valley of Death — The Princess’s Revenge"
-    map_file=campaigns/Heir_To_The_Throne/maps/09_The_Valley_of_Death.map
+    map_file=09_The_Valley_of_Death.map
     turns=12
 
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/10_Gryphon_Mountain.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/10_Gryphon_Mountain.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=10_Gryphon_Mountain
     name= _ "Gryphon Mountain"
-    map_file=campaigns/Heir_To_The_Throne/maps/10_Gryphon_Mountain.map
+    map_file=10_Gryphon_Mountain.map
     {TURNS 27 24 21}
 
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/11_The_Ford_of_Abez.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/11_The_Ford_of_Abez.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=11_The_Ford_of_Abez
     name= _ "The Ford of Abez"
-    map_file=campaigns/Heir_To_The_Throne/maps/11_The_Ford_of_Abez.map
+    map_file=11_The_Ford_of_Abez.map
     {TURNS 27 24 21}
 
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/12_Northern_Winter.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/12_Northern_Winter.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=12_Northern_Winter
     name= _ "Northern Winter"
-    map_file=campaigns/Heir_To_The_Throne/maps/12_Northern_Winter.map
+    map_file=12_Northern_Winter.map
 
     {TURNS 50 40 40}
     [event]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/13_The_Dwarven_Doors.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/13_The_Dwarven_Doors.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=13_The_Dwarven_Doors
     name= _ "The Dwarven Doors"
-    map_file=campaigns/Heir_To_The_Throne/maps/13_The_Dwarven_Doors.map
+    map_file=13_The_Dwarven_Doors.map
     {TURNS 26 20 15}
     victory_when_enemies_defeated=no
 

--- a/data/campaigns/Heir_To_The_Throne/scenarios/14_Plunging_Into_the_Darkness.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/14_Plunging_Into_the_Darkness.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=14_Plunging_into_the_Darkness
     name= _ "Plunging into the Darkness"
-    map_file=campaigns/Heir_To_The_Throne/maps/14_Plunging_Into_the_Darkness.map
+    map_file=14_Plunging_Into_the_Darkness.map
     victory_when_enemies_defeated=no
     turns=unlimited
 

--- a/data/campaigns/Heir_To_The_Throne/scenarios/15_The_Lost_General.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/15_The_Lost_General.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=15_The_Lost_General
     name= _ "The Lost General"
-    map_file=campaigns/Heir_To_The_Throne/maps/15_The_Lost_General.map
+    map_file=15_The_Lost_General.map
     {TURNS 64 60 54}
 
     {UNDERGROUND}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/16_Hasty_Alliance.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/16_Hasty_Alliance.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=16_Hasty_Alliance
     name= _ "Hasty Alliance"
-    map_file=campaigns/Heir_To_The_Throne/maps/16_Hasty_Alliance.map
+    map_file=16_Hasty_Alliance.map
     {TURNS 33 30 27}
 
     {DEEP_UNDERGROUND}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/18_A_Choice_Must_Be_Made.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/18_A_Choice_Must_Be_Made.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=18_A_Choice_Must_Be_Made
     name= _ "A Choice Must Be Made"
-    map_file=campaigns/Heir_To_The_Throne/maps/18_A_Choice_Must_Be_Made.map
+    map_file=18_A_Choice_Must_Be_Made.map
     {TURNS 33 30 27}
 
     next_scenario=19a_Snow_Plains

--- a/data/campaigns/Heir_To_The_Throne/scenarios/19a_Snow_Plains.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/19a_Snow_Plains.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=19a_Snow_Plains
     name= _ "Snow Plains"
-    map_file=campaigns/Heir_To_The_Throne/maps/19a_Snow_Plains.map
+    map_file=19a_Snow_Plains.map
     {TURNS 43 40 37}
 
     next_scenario="20a_North_Elves"

--- a/data/campaigns/Heir_To_The_Throne/scenarios/19b_Swamp_Of_Dread.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/19b_Swamp_Of_Dread.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=19b_Swamp_Of_Dread
     name= _ "Swamp Of Dread"
-    map_file=campaigns/Heir_To_The_Throne/maps/19b_Swamp_Of_Dread.map
+    map_file=19b_Swamp_Of_Dread.map
     {TURNS 33 30 27}
 
     next_scenario=20a_North_Elves

--- a/data/campaigns/Heir_To_The_Throne/scenarios/19c_Cliffs_of_Thoria.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/19c_Cliffs_of_Thoria.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=19c_Cliffs_of_Thoria
     name= _ "The Cliffs of Thoria"
-    map_file=campaigns/Heir_To_The_Throne/maps/19c_Cliffs_of_Thoria.map
+    map_file=19c_Cliffs_of_Thoria.map
     {TURNS 55 50 45}
 
     next_scenario="20b_Underground_Channels"

--- a/data/campaigns/Heir_To_The_Throne/scenarios/20a_North_Elves.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/20a_North_Elves.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=20a_North_Elves
     name= _ "Home of the North Elves"
-    map_file=campaigns/Heir_To_The_Throne/maps/20a_North_Elves.map
+    map_file=20a_North_Elves.map
     {TURNS 21 18 15}
 
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/20b_Underground_Channels.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/20b_Underground_Channels.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=20b_Underground_Channels
     name= _ "Underground Channels"
-    map_file=campaigns/Heir_To_The_Throne/maps/20b_Underground_Channels.map
+    map_file=20b_Underground_Channels.map
     {TURNS 80 70 60}
 
     next_scenario="21_Elven_Council"

--- a/data/campaigns/Heir_To_The_Throne/scenarios/21_Elven_Council.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/21_Elven_Council.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=21_Elven_Council
     name= _ "The Elven Council"
-    map_file=campaigns/Heir_To_The_Throne/maps/21_Elven_Council.map
+    map_file=21_Elven_Council.map
 
     turns=1
     theme=Cutscene_Minimal

--- a/data/campaigns/Heir_To_The_Throne/scenarios/22_Return_to_Wesnoth.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/22_Return_to_Wesnoth.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=22_Return_to_Wesnoth
     name= _ "Return to Wesnoth"
-    map_file=campaigns/Heir_To_The_Throne/maps/22_Return_to_Wesnoth.map
+    map_file=22_Return_to_Wesnoth.map
     {TURNS 31 28 25}
 
     next_scenario=23_Test_of_the_Clans

--- a/data/campaigns/Heir_To_The_Throne/scenarios/23_Test_of_the_Clans.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/23_Test_of_the_Clans.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=23_Test_of_the_Clans
     name= _ "Test of the Clan"
-    map_file=campaigns/Heir_To_The_Throne/maps/23_Test_of_the_Clans.map
+    map_file=23_Test_of_the_Clans.map
     {TURNS 53 50 47}
 
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/24_Battle_for_Wesnoth.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/24_Battle_for_Wesnoth.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=24_Battle_for_Wesnoth
     name= _ "The Battle for Wesnoth"
-    map_file=campaigns/Heir_To_The_Throne/maps/24_Battle_for_Wesnoth.map
+    map_file=24_Battle_for_Wesnoth.map
     turns=60
 
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/Liberty/scenarios/01_The_Raid.cfg
+++ b/data/campaigns/Liberty/scenarios/01_The_Raid.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=01_The_Raid
     name= _ "The Raid"
-    map_file=campaigns/Liberty/maps/01_The_Raid.map
+    map_file=01_The_Raid.map
     {TURNS 19 17 15}
 
     next_scenario=02_Civil_Disobedience

--- a/data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg
+++ b/data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg
@@ -3,7 +3,7 @@
     id=02_Civil_Disobedience
     name= _ "Civil Disobedience"
     next_scenario=03_A_Strategy_of_Hope
-    map_file=campaigns/Liberty/maps/02_Civil_Disobedience.map
+    map_file=02_Civil_Disobedience.map
     {TURNS 14 13 12}
     {DEFAULT_SCHEDULE_AFTERNOON}
 

--- a/data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg
+++ b/data/campaigns/Liberty/scenarios/03_A_Strategy_Of_Hope.cfg
@@ -4,7 +4,7 @@
     name= _ "A Strategy of Hope"
     next_scenario=04_Unlawful_Orders
     victory_when_enemies_defeated=yes
-    map_file=campaigns/Liberty/maps/03_Strategy_of_Hope.map
+    map_file=03_Strategy_of_Hope.map
     {TURNS 28 25 22}
     {DEFAULT_SCHEDULE}
 

--- a/data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg
+++ b/data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg
@@ -4,7 +4,7 @@
     name= _ "Unlawful Orders"
     next_scenario=05_Hide_and_Seek
     victory_when_enemies_defeated=yes
-    map_file=campaigns/Liberty/maps/04_Unlawful_Orders.map
+    map_file=04_Unlawful_Orders.map
     {TURNS 30 22 16}
     {DEFAULT_SCHEDULE}
 

--- a/data/campaigns/Liberty/scenarios/05_Hide_and_Seek.cfg
+++ b/data/campaigns/Liberty/scenarios/05_Hide_and_Seek.cfg
@@ -4,7 +4,7 @@
     next_scenario=06_The_Hunters
     victory_when_enemies_defeated=no
     name= _ "Hide and Seek"
-    map_file=campaigns/Liberty/maps/05_Hide_and_Seek.map
+    map_file=05_Hide_and_Seek.map
     {TURNS 34 30 26}
 
     [time]

--- a/data/campaigns/Liberty/scenarios/06_The_Hunters.cfg
+++ b/data/campaigns/Liberty/scenarios/06_The_Hunters.cfg
@@ -4,7 +4,7 @@
     name= _ "The Hunters"
     victory_when_enemies_defeated=no
     next_scenario=07_Glory
-    map_file=campaigns/Liberty/maps/06_The_Hunters.map
+    map_file=06_The_Hunters.map
     turns=27
     {FIRST_WATCH}
     {FIRST_WATCH}

--- a/data/campaigns/Liberty/scenarios/07_Glory.cfg
+++ b/data/campaigns/Liberty/scenarios/07_Glory.cfg
@@ -4,7 +4,7 @@
     name= _ "Glory"
     next_scenario=08_Epilogue
     victory_when_enemies_defeated=no
-    map_file=campaigns/Liberty/maps/07_Glory.map
+    map_file=07_Glory.map
     {TURNS 48 45 40}
     {DEFAULT_SCHEDULE_AFTERNOON}
 

--- a/data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=01_Breaking_the_Chains
     name= _ "Breaking the Chains"
-    map_file=campaigns/Northern_Rebirth/maps/01_Breaking_the_Chains.map
+    map_file=01_Breaking_the_Chains.map
     {TURNS 41 31 26}
     next_scenario=02_01_Infested_Caves
 

--- a/data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=02_01_Infested_Caves
     name= _ "Infested Caves"
-    map_file=campaigns/Northern_Rebirth/maps/02_01_Infested_Caves.map
+    map_file=02_01_Infested_Caves.map
     {TURNS 55 50 45}
     next_scenario=02_02_Meeting_With_Dwarves
 

--- a/data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=02_02_Meeting_With_Dwarves
     name= _ "Meeting With Dwarves"
-    map_file=campaigns/Northern_Rebirth/maps/02_02_Meeting_With_Dwarves.map
+    map_file=02_02_Meeting_With_Dwarves.map
     next_scenario=03_To_the_Mines
     theme=Cutscene_Minimal
 

--- a/data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=03_To_the_Mines
     name= _ "To the Mines"
-    map_file=campaigns/Northern_Rebirth/maps/03_To_the_Mines.map
+    map_file=03_To_the_Mines.map
     {TURNS 36 30 24}
     next_scenario=04_Clearing_the_Mines
 

--- a/data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=04_Clearing_the_Mines
     name= _ "Clearing the Mines"
-    map_file=campaigns/Northern_Rebirth/maps/04_Clearing_the_Mines.map
+    map_file=04_Clearing_the_Mines.map
     {TURNS 65 55 45}
     next_scenario=05a_01_The_Pursuit
 

--- a/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=05a_01_The_Pursuit
     name= _ "The Pursuit"
-    map_file=campaigns/Northern_Rebirth/maps/05a_01_The_Pursuit.map
+    map_file=05a_01_The_Pursuit.map
     turns=unlimited
     next_scenario=05a_02_Dealings
     victory_when_enemies_defeated=no

--- a/data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=05a_02_Dealings
     name= _ "Dealings"
-    map_file=campaigns/Northern_Rebirth/maps/05a_02_Dealings.map
+    map_file=05a_02_Dealings.map
     next_scenario=06a_Old_Friend
     theme=Cutscene_Minimal
 

--- a/data/campaigns/Northern_Rebirth/scenarios/05b_Compelled.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/05b_Compelled.cfg
@@ -24,7 +24,7 @@
         [/part]
     [/story]
 
-    map_file=campaigns/Northern_Rebirth/maps/05b_Compelled.map
+    map_file=05b_Compelled.map
 
     {TURNS 39 35 31}
 

--- a/data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=06a_Old_Friend
     name= _ "Old Friend"
-    map_file=campaigns/Northern_Rebirth/maps/06a_Old_Friend.map
+    map_file=06a_Old_Friend.map
     turns=18
     next_scenario=07a_Settling_Disputes
 

--- a/data/campaigns/Northern_Rebirth/scenarios/06b_Slave_of_the_Undead.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/06b_Slave_of_the_Undead.cfg
@@ -38,7 +38,7 @@
         [/part]
     [/story]
 
-    map_file=campaigns/Northern_Rebirth/maps/06b_Slave_of_the_Undead.map
+    map_file=06b_Slave_of_the_Undead.map
 
     {TURNS 41 38 35}
     {UNDERGROUND}

--- a/data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=07a_Settling_Disputes
     name= _ "Settling Disputes"
-    map_file=campaigns/Northern_Rebirth/maps/07a_Settling_Disputes.map
+    map_file=07a_Settling_Disputes.map
     {TURNS 25 20 15}
     next_scenario=08a_Elvish_Princess
 

--- a/data/campaigns/Northern_Rebirth/scenarios/07b_Protecting_the_Master.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/07b_Protecting_the_Master.cfg
@@ -27,7 +27,7 @@
         [/part]
     [/story]
 
-    map_file=campaigns/Northern_Rebirth/maps/07b_Protecting_the_Master.map
+    map_file=07b_Protecting_the_Master.map
 
     [event]
         name=prestart

--- a/data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=08a_Elvish_Princess
     name= _ "Elvish Princess"
-    map_file=campaigns/Northern_Rebirth/maps/08a_Elvish_Princess.map
+    map_file=08a_Elvish_Princess.map
     {TURNS 21 18 15}
     next_scenario=09a_Introductions
     victory_when_enemies_defeated=no

--- a/data/campaigns/Northern_Rebirth/scenarios/08b_Ray_of_Hope.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/08b_Ray_of_Hope.cfg
@@ -131,7 +131,7 @@
         [/part]
     [/story]
 
-    map_file=campaigns/Northern_Rebirth/maps/08b_Ray_of_Hope.map
+    map_file=08b_Ray_of_Hope.map
 
     [side]
         type=Peasant

--- a/data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=09a_Introductions
     name= _ "Introductions"
-    map_file=campaigns/Northern_Rebirth/maps/09a_Introductions.map
+    map_file=09a_Introductions.map
     {TURNS 21 18 15}
     next_scenario=10a_Stolen_Gold
     victory_when_enemies_defeated=no

--- a/data/campaigns/Northern_Rebirth/scenarios/09b_Judgment.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/09b_Judgment.cfg
@@ -6,7 +6,7 @@
     turns=unlimited
     next_scenario=null    # Next was to be called 10b_New_Life
     victory_when_enemies_defeated=no
-    map_file=campaigns/Northern_Rebirth/maps/09b_Judgment.map
+    map_file=09b_Judgment.map
     theme=Cutscene_Minimal
 
     [story]

--- a/data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=10a_Stolen_Gold
     name= _ "Stolen Gold"
-    map_file=campaigns/Northern_Rebirth/maps/10a_Stolen_Gold.map
+    map_file=10a_Stolen_Gold.map
     turns=36
     next_scenario=11a_The_Eastern_Flank
     victory_when_enemies_defeated=yes

--- a/data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=11a_The_Eastern_Flank
     name= _ "The Eastern Flank"
-    map_file=campaigns/Northern_Rebirth/maps/11a_The_Eastern_Flank.map
+    map_file=11a_The_Eastern_Flank.map
     {TURNS 53 50 47}
     next_scenario=12a_Get_the_Gold
 

--- a/data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=12a_Get_the_Gold
     name= _ "Get the Gold"
-    map_file=campaigns/Northern_Rebirth/maps/12a_Get_the_Gold.map
+    map_file=12a_Get_the_Gold.map
     {TURNS 35 30 25}
     next_scenario=13a_Showdown
 

--- a/data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=13a_Showdown
     name= _ "Showdown"
-    map_file=campaigns/Northern_Rebirth/maps/13a_Showdown.map
+    map_file=13a_Showdown.map
     {DEFAULT_SCHEDULE}
     turns=unlimited
     next_scenario=14a_Epilogue

--- a/data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/14a_Epilogue.cfg
@@ -4,7 +4,7 @@
 
     id=14a_Epilogue
     name= _ "Epilogue"
-    map_file=campaigns/Northern_Rebirth/maps/14a_Epilogue.map
+    map_file=14a_Epilogue.map
     {DEFAULT_SCHEDULE}
     next_scenario=null
     {INTRO_AND_SCENARIO_MUSIC "elf-land.ogg" "battle-epic.ogg"}

--- a/data/campaigns/Sceptre_of_Fire/scenarios/1_A_Bargain_is_Struck.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/1_A_Bargain_is_Struck.cfg
@@ -3,7 +3,7 @@
     name= _ "A Bargain is Struck"
     id=1_A_Bargain_is_Struck
     turns=24
-    map_file=campaigns/Sceptre_of_Fire/maps/1_A_Bargain_is_Struck.map
+    map_file=1_A_Bargain_is_Struck.map
     next_scenario=2_Closing_the_Gates
 
     {SCENARIO_MUSIC knolls.ogg}

--- a/data/campaigns/Sceptre_of_Fire/scenarios/2_Closing_the_Gates.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/2_Closing_the_Gates.cfg
@@ -3,7 +3,7 @@
     name= _ "Closing the Gates"
     id=2_Closing_the_Gates
     turns=15
-    map_file=campaigns/Sceptre_of_Fire/maps/2_Closing_the_Gates.map
+    map_file=2_Closing_the_Gates.map
     next_scenario=2t_In_the_Dwarven_City
     victory_when_enemies_defeated=no
 

--- a/data/campaigns/Sceptre_of_Fire/scenarios/2p5_Reaching_the_Runecrafter.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/2p5_Reaching_the_Runecrafter.cfg
@@ -3,7 +3,7 @@
     name= _ "Reaching the Runecrafter"
     id=2p5_Reaching_the_Runecrafter
     turns=15
-    map_file=campaigns/Sceptre_of_Fire/maps/2p5_Reaching_the_Runecrafter.map
+    map_file=2p5_Reaching_the_Runecrafter.map
     next_scenario=3_Searching_for_the_Runecrafter
     victory_when_enemies_defeated=no
 

--- a/data/campaigns/Sceptre_of_Fire/scenarios/2t_In_the_Dwarven_City.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/2t_In_the_Dwarven_City.cfg
@@ -3,7 +3,7 @@
     name= _ "In the Dwarven City"
     id=2t_In_the_Dwarven_City
     turns=1
-    map_file=campaigns/Sceptre_of_Fire/maps/2t_In_the_Dwarven_City.map
+    map_file=2t_In_the_Dwarven_City.map
     next_scenario=2p5_Reaching_the_Runecrafter
     theme=Cutscene_Minimal
 

--- a/data/campaigns/Sceptre_of_Fire/scenarios/3_Searching_for_the_Runecrafter.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/3_Searching_for_the_Runecrafter.cfg
@@ -3,7 +3,7 @@
     name= _ "Searching for the Runecrafter"
     id=3_Searching_for_the_Runecrafter
     turns=20
-    map_file=campaigns/Sceptre_of_Fire/maps/3_Searching_for_the_Runecrafter.map
+    map_file=3_Searching_for_the_Runecrafter.map
     next_scenario=3t_The_Council_Regathers
     victory_when_enemies_defeated=no
 

--- a/data/campaigns/Sceptre_of_Fire/scenarios/3t_The_Council_Regathers.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/3t_The_Council_Regathers.cfg
@@ -3,7 +3,7 @@
     name= _ "The Council Regathers"
     id=3t_The_Council_Regathers
     turns=1
-    map_file=campaigns/Sceptre_of_Fire/maps/3t_The_Council_Regathers.map
+    map_file=3t_The_Council_Regathers.map
     next_scenario=4_Gathering_Materials
     theme=Cutscene_Minimal
 

--- a/data/campaigns/Sceptre_of_Fire/scenarios/4t_The_Jeweler.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/4t_The_Jeweler.cfg
@@ -3,7 +3,7 @@
     name= _ "The Jeweler"
     id=4t_The_Jeweler
     turns=1
-    map_file=campaigns/Sceptre_of_Fire/maps/4t_The_Jeweler.map
+    map_file=4t_The_Jeweler.map
     next_scenario=5_Hills_of_the_Shorbear_Clan
     theme=Cutscene_Minimal
 

--- a/data/campaigns/Sceptre_of_Fire/scenarios/5_Hills_of_the_Shorbear_Clan.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/5_Hills_of_the_Shorbear_Clan.cfg
@@ -3,7 +3,7 @@
     name= _ "Hills of the Shorbear Clan"
     id=5_Hills_of_the_Shorbear_Clan
     turns=24
-    map_file=campaigns/Sceptre_of_Fire/maps/5_Hills_of_the_Shorbear_Clan.map
+    map_file=5_Hills_of_the_Shorbear_Clan.map
     next_scenario=6_Towards_the_Caves
 
     # the music will change in the end of the opening dialogue

--- a/data/campaigns/Sceptre_of_Fire/scenarios/6_Towards_the_Caves.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/6_Towards_the_Caves.cfg
@@ -3,7 +3,7 @@
     name= _ "Towards the Caves"
     id=6_Towards_the_Caves
     turns=12
-    map_file=campaigns/Sceptre_of_Fire/maps/6_Towards_the_Caves.map
+    map_file=6_Towards_the_Caves.map
     next_scenario=7_Outriding_the_Outriders
 
     {SCENARIO_MUSIC breaking_the_chains.ogg}

--- a/data/campaigns/Sceptre_of_Fire/scenarios/7_Outriding_the_Outriders.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/7_Outriding_the_Outriders.cfg
@@ -3,7 +3,7 @@
     name= _ "Outriding the Outriders"
     id=7_Outriding_the_Outriders
     turns=12
-    map_file=campaigns/Sceptre_of_Fire/maps/7_Outriding_the_Outriders.map
+    map_file=7_Outriding_the_Outriders.map
     next_scenario=8_The_Dragon
     victory_when_enemies_defeated=no
 

--- a/data/campaigns/Sceptre_of_Fire/scenarios/8_The_Dragon.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/8_The_Dragon.cfg
@@ -3,7 +3,7 @@
     name= _ "The Dragon"
     id=8_The_Dragon
     turns=unlimited
-    map_file=campaigns/Sceptre_of_Fire/maps/8_The_Dragon.map
+    map_file=8_The_Dragon.map
     next_scenario=9_Caverns_of_Flame
 
     victory_when_enemies_defeated=no

--- a/data/campaigns/Sceptre_of_Fire/scenarios/9_Caverns_of_Flame.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/9_Caverns_of_Flame.cfg
@@ -2,7 +2,7 @@
 [scenario]
     name= _ "Caverns of Flame"
     id=9_Caverns_of_Flame
-    map_file=campaigns/Sceptre_of_Fire/maps/9_Caverns_of_Flame.map
+    map_file=9_Caverns_of_Flame.map
     next_scenario=Epilogue
     turns=unlimited
     victory_when_enemies_defeated=no

--- a/data/campaigns/Sceptre_of_Fire/scenarios/Epilogue.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/Epilogue.cfg
@@ -3,7 +3,7 @@
     name= _ "Epilogue"
     id=Epilogue
     turns=1
-    map_file=campaigns/Sceptre_of_Fire/maps/Epilogue.map
+    map_file=Epilogue.map
     theme=Cutscene_Minimal
     disallow_recall=yes
 

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg
@@ -20,7 +20,7 @@
 
 [scenario]
     name= _ "Slipping Away"
-    map_file=campaigns/Secrets_of_the_Ancients/maps/01_Slipping_Away.map
+    map_file=01_Slipping_Away.map
 
     id=01_Slipping_Away
     next_scenario=02_Dark_Business

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg
@@ -9,7 +9,7 @@
 
 [scenario]
     name= _ "Dark Business"
-    map_file=campaigns/Secrets_of_the_Ancients/maps/02_Dark_Business.map
+    map_file=02_Dark_Business.map
 
     id=02_Dark_Business
     next_scenario=03_Bandits

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/03_Bandits.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/03_Bandits.cfg
@@ -4,7 +4,7 @@
 
 [scenario]
     name= _ "Bandits"
-    map_file=campaigns/Secrets_of_the_Ancients/maps/03_Bandits.map
+    map_file=03_Bandits.map
 
     id=03_Bandits
     next_scenario=04_Becalmed

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg
@@ -11,7 +11,7 @@
 
 [scenario]
     name= _ "Becalmed"
-    map_file=campaigns/Secrets_of_the_Ancients/maps/04_Becalmed.map
+    map_file=04_Becalmed.map
 
     id=04_Becalmed
     next_scenario=05_Blackwater

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/05_Blackwater.cfg
@@ -11,7 +11,7 @@
 
 [scenario]
     name= _ "Blackwater"
-    map_file=campaigns/Secrets_of_the_Ancients/maps/05_Blackwater.map
+    map_file=05_Blackwater.map
 
     id=05_Blackwater
     next_scenario=06_Following_the_Shadow

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/06_Following_the_Shadow.cfg
@@ -8,7 +8,7 @@
 
 [scenario]
     name= _ "Following the Shadow"
-    map_file=campaigns/Secrets_of_the_Ancients/maps/06_Following_the_Shadow.map
+    map_file=06_Following_the_Shadow.map
 
     id=06_Following_the_Shadow
     next_scenario=07_Meeting_of_the_Minds

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg
@@ -2,7 +2,7 @@
 
 [scenario]
     name= _ "Meeting of the Minds"
-    map_file=campaigns/Secrets_of_the_Ancients/maps/07_Meeting_of_the_Minds.map
+    map_file=07_Meeting_of_the_Minds.map
     theme=Cutscene_Minimal
 
     [story]

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg
@@ -11,7 +11,7 @@
 
 [scenario]
     name= _ "Carcyn"  # The name of the city and its most prominent citizen
-    map_file=campaigns/Secrets_of_the_Ancients/maps/08_Carcyn.map
+    map_file=08_Carcyn.map
 
     id=08_Carcyn
     next_scenario=09_Training_Session

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/09_Training_Session.cfg
@@ -11,7 +11,7 @@
 
 [scenario]
     name= _ "Training Session"
-    map_file=campaigns/Secrets_of_the_Ancients/maps/09_Training_Session.map
+    map_file=09_Training_Session.map
 
     id=09_Training_Session
     next_scenario=10_Merfolk_Revenge

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/10_Merfolk_Revenge.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/10_Merfolk_Revenge.cfg
@@ -11,7 +11,7 @@
 
 [scenario]
     name= _ "Merfolk Revenge"
-    map_file=campaigns/Secrets_of_the_Ancients/maps/10_Merfolk_Revenge.map
+    map_file=10_Merfolk_Revenge.map
 
     id=10_Merfolk_Revenge
     next_scenario=11_Battleground

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg
@@ -8,7 +8,7 @@
 
 [scenario]
     name= _ "Battleground"
-    map_file=campaigns/Secrets_of_the_Ancients/maps/11_Battleground.map
+    map_file=11_Battleground.map
 
     id=11_Battleground
     next_scenario=12_Walking_Trees

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/12_Walking_Trees.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/12_Walking_Trees.cfg
@@ -7,7 +7,7 @@
 
 [scenario]
     name= _ "Walking Trees"
-    map_file=campaigns/Secrets_of_the_Ancients/maps/12_Walking_Trees.map
+    map_file=12_Walking_Trees.map
 
     id=12_Walking_Trees
     next_scenario=13_Together_Again

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg
@@ -2,7 +2,7 @@
 
 [scenario]
     name= _ "Together Again"
-    map_file=campaigns/Secrets_of_the_Ancients/maps/13_Together_Again.map
+    map_file=13_Together_Again.map
     theme=Cutscene_Minimal
 
     id=13_Together_Again

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg
@@ -6,7 +6,7 @@
 
 [scenario]
     name= _ "Entering the Northlands"
-    map_file=campaigns/Secrets_of_the_Ancients/maps/14_Entering_the_Northlands.map
+    map_file=14_Entering_the_Northlands.map
 
     id=14_Entering_the_Northlands
     next_scenario=15_Mountain_Pass

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg
@@ -7,7 +7,7 @@
 
 [scenario]
     name= _ "Mountain Pass"
-    map_file=campaigns/Secrets_of_the_Ancients/maps/15_Mountain_Pass.map
+    map_file=15_Mountain_Pass.map
 
     id=15_Mountain_Pass
     next_scenario=16_The_Mage

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg
@@ -11,7 +11,7 @@
 
 [scenario]
     name= _ "The Mage"
-    map_file=campaigns/Secrets_of_the_Ancients/maps/16_The_Mage.map
+    map_file=16_The_Mage.map
 
     id=16_The_Mage
     next_scenario=17_Mortality

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg
@@ -4,7 +4,7 @@
 
 [scenario]
     name= _ "Mortality"
-    map_file=campaigns/Secrets_of_the_Ancients/maps/17_Mortality.map
+    map_file=17_Mortality.map
     theme=Cutscene_Minimal
 
     id=17_Mortality

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/18_Abandoned_Outpost.cfg
@@ -16,7 +16,7 @@
 
 [scenario]
     name= _ "Abandoned Outpost"
-    map_file=campaigns/Secrets_of_the_Ancients/maps/18_Abandoned_Outpost.map
+    map_file=18_Abandoned_Outpost.map
 
     id=18_Abandoned_Outpost
     next_scenario=19_Lava_and_Stone

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/19_Lava_and_Stone.cfg
@@ -2,7 +2,7 @@
 
 [scenario]
     name= _ "Lava and Stone"
-    map_file=campaigns/Secrets_of_the_Ancients/maps/19_Lava_and_Stone.map
+    map_file=19_Lava_and_Stone.map
 
     id=19_Lava_and_Stone
     next_scenario=20_North_Knalga

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/20_North_Knalga.cfg
@@ -7,7 +7,7 @@
 
 [scenario]
     name= _ "North Knalga"
-    map_file=campaigns/Secrets_of_the_Ancients/maps/20_North_Knalga.map
+    map_file=20_North_Knalga.map
 
     id=20_North_Knalga
     next_scenario=21_Against_the_World

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg
@@ -12,7 +12,7 @@
 
 [scenario]
     name= _ "Against the World"
-    map_file=campaigns/Secrets_of_the_Ancients/maps/21_Against_the_World.map
+    map_file=21_Against_the_World.map
 
     id=21_Against_the_World
     next_scenario=22_Epilogue

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/01_End_of_Peace.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=01_End_of_Peace
     name= _ "End of Peace"
-    map_file=campaigns/Son_Of_The_Black_Eye/maps/01_End_of_Peace.map
+    map_file=01_End_of_Peace.map
 
     {TURNS 28 24 22}
 

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/02_The_Human_Army.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/02_The_Human_Army.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=02_The_Human_Army
     name= _ "The Human Army"
-    map_file=campaigns/Son_Of_The_Black_Eye/maps/01_End_of_Peace.map
+    map_file=01_End_of_Peace.map
 
     turns=18
 

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=03_Toward_Mountains_of_Haag
     name= _ "Toward Mountains of Haag"
-    map_file=campaigns/Son_Of_The_Black_Eye/maps/03_Toward_Mountains_of_Haag.map
+    map_file=03_Toward_Mountains_of_Haag.map
 
     {TURNS 27 24 20}
 

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=04_The_Siege_of_Barag_Gor
     name= _ "The Siege of Barag Gór"
-    map_file=campaigns/Son_Of_The_Black_Eye/maps/04_The_Siege_of_Barag_Gor.map
+    map_file=04_The_Siege_of_Barag_Gor.map
     turns=24
     victory_when_enemies_defeated=yes
 

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/05_To_the_Harbor_of_Tirigaz.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/05_To_the_Harbor_of_Tirigaz.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=05_To_the_Harbor_of_Tirigaz
     name= _ "To the Harbor of Tirigaz"
-    map_file=campaigns/Son_Of_The_Black_Eye/maps/05_To_the_Harbor_of_Tirigaz.map
+    map_file=05_To_the_Harbor_of_Tirigaz.map
 
     turns=20
     {SCENARIO_MUSIC "underground.ogg"}

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/06_Black_Flag.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/06_Black_Flag.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=06_Black_Flag
     name= _ "Black Flag"
-    map_file=campaigns/Son_Of_The_Black_Eye/maps/06_Black_Flag.map
+    map_file=06_Black_Flag.map
     {TURNS 26 24 22}
 
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/07_The_Desert_of_Death.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/07_The_Desert_of_Death.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=07_The_Desert_of_Death
     name= _ "The Desert of Death"
-    map_file=campaigns/Son_Of_The_Black_Eye/maps/07_The_Desert_of_Death.map
+    map_file=07_The_Desert_of_Death.map
     {TURNS 26 24 22}
 
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/08_Silent_Forest.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/08_Silent_Forest.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=08_Silent_Forest
     name= _ "Silent Forest"
-    map_file=campaigns/Son_Of_The_Black_Eye/maps/08_Silent_Forest.map
+    map_file=08_Silent_Forest.map
     {TURNS 30 28 26}
 
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=09_Shan_Taum_the_Smug
     name= _ "Shan Taum the Smug"
-    map_file=campaigns/Son_Of_The_Black_Eye/maps/09_Shan_Taum_the_Smug.map
+    map_file=09_Shan_Taum_the_Smug.map
     turns=20
 
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg
@@ -10,7 +10,7 @@
 [scenario]
     id=10_Saving_Inarix
     name= _ "Saving Inarix"
-    map_file=campaigns/Son_Of_The_Black_Eye/maps/10_Saving_Inarix.map
+    map_file=10_Saving_Inarix.map
     turns=16
 
     {DEFAULT_SCHEDULE_AFTERNOON}

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=11_Clash_of_Armies
     name= _ "Clash of Armies"
-    map_file=campaigns/Son_Of_The_Black_Eye/maps/11_Clash_of_Armies.map
+    map_file=11_Clash_of_Armies.map
     turns=24
 
     {DEFAULT_SCHEDULE_SECOND_WATCH}

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=12_Giving_Some_Back
     name= _ "Giving Some Back"
-    map_file=campaigns/Son_Of_The_Black_Eye/maps/12_Giving_Some_Back.map
+    map_file=12_Giving_Some_Back.map
     turns=18
 
     {SCENARIO_MUSIC "the_city_falls.ogg"}

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/13_The_Dwarvish_Stand.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/13_The_Dwarvish_Stand.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=13_The_Dwarvish_Stand
     name= _ "The Dwarvish Stand"
-    map_file=campaigns/Son_Of_The_Black_Eye/maps/13_The_Dwarvish_Stand.map
+    map_file=13_The_Dwarvish_Stand.map
     {TURNS 28 24 22}
 
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/14_Back_Home.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/14_Back_Home.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=14_Back_Home
     name= _ "Back Home"
-    map_file=campaigns/Son_Of_The_Black_Eye/maps/14_Back_Home.map
+    map_file=14_Back_Home.map
     turns=24
 
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=15_Civil_War
     name= _ "Civil War"
-    map_file=campaigns/Son_Of_The_Black_Eye/maps/15_Civil_War.map
+    map_file=15_Civil_War.map
 
     turns=30
 

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=16_The_Coward
     name= _ "The Coward"
-    map_file=campaigns/Son_Of_The_Black_Eye/maps/16_The_Coward.map
+    map_file=16_The_Coward.map
 
     turns=22
 

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=17_The_Human_Attack
     name= _ "The Human Attack"
-    map_file=campaigns/Son_Of_The_Black_Eye/maps/17_The_Human_Attack.map
+    map_file=17_The_Human_Attack.map
 
     turns=25
 

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=18_Northern_Alliance
     name= _ "Northern Alliance"
-    map_file=campaigns/Son_Of_The_Black_Eye/maps/18_Northern_Alliance.map
+    map_file=18_Northern_Alliance.map
 
     turns=unlimited
 

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/19_Epilogue.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/19_Epilogue.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=19_Epilogue
     name= _ "Epilogue"
-    map_file=campaigns/Son_Of_The_Black_Eye/maps/18_Northern_Alliance.map
+    map_file=18_Northern_Alliance.map
 
     turns=unlimited
 

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/01_At_the_East_Gate.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=01_At_the_East_Gate
     name= _ "At the East Gate"
-    map_file=campaigns/The_Hammer_of_Thursagan/maps/01_At_the_East_Gate.map
+    map_file=01_At_the_East_Gate.map
     {TURNS 32 30 28}
     next_scenario=02_Reclaiming_the_Past
 

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=02_Reclaiming_the_Past
     name= _ "Reclaiming the Past"
-    map_file=campaigns/The_Hammer_of_Thursagan/maps/02_Reclaiming_the_Past.map
+    map_file=02_Reclaiming_the_Past.map
     turns=unlimited
     next_scenario=03_Strange_Allies
     victory_when_enemies_defeated=no

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/03_Strange_Allies.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=03_Strange_Allies
     name= _ "Strange Allies"
-    map_file=campaigns/The_Hammer_of_Thursagan/maps/03_Strange_Allies.map
+    map_file=03_Strange_Allies.map
     {TURNS 30 28 24}
     next_scenario=04_High_Pass
     victory_when_enemies_defeated=yes

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=04_High_Pass
     name= _ "High Pass"
-    map_file=campaigns/The_Hammer_of_Thursagan/maps/04_High_Pass.map
+    map_file=04_High_Pass.map
     {TURNS 22 20 18}
     next_scenario=05_Fear
     victory_when_enemies_defeated=no

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/05_Fear.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=05_Fear
     name= _ "Fear"
-    map_file=campaigns/The_Hammer_of_Thursagan/maps/05_Fear.map
+    map_file=05_Fear.map
     {TURNS 26 23 20}
     next_scenario=06_Forbidden_Forest
     victory_when_enemies_defeated=no

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=06_Forbidden_Forest
     name= _ "Forbidden Forest"
-    map_file=campaigns/The_Hammer_of_Thursagan/maps/06_Forbidden_Forest.map
+    map_file=06_Forbidden_Forest.map
     {TURNS 40 34 28}
     next_scenario=07_The_Siege_of_Kal_Kartha
     victory_when_enemies_defeated=no

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/07_The_Siege_of_Kal_Kartha.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=07_The_Siege_of_Kal_Kartha
     name= _ "The Siege of Kal Kartha"
-    map_file=campaigns/The_Hammer_of_Thursagan/maps/07_The_Siege_of_Kal_Kartha.map
+    map_file=07_The_Siege_of_Kal_Kartha.map
     turns=35
     next_scenario=08_The_Court_of_Karrag
     victory_when_enemies_defeated=yes

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Court_of_Karrag.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=08_The_Court_of_Karrag
     name= _ "The Court of Karrag"
-    map_file=campaigns/The_Hammer_of_Thursagan/maps/08_The_Court_of_Karrag.map
+    map_file=08_The_Court_of_Karrag.map
     turns=12
     next_scenario=09_The_Underlevels
     victory_when_enemies_defeated=yes

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=09_The_Underlevels
     name= _ "The Underlevels"
-    map_file=campaigns/The_Hammer_of_Thursagan/maps/09_The_Underlevels.map
+    map_file=09_The_Underlevels.map
     turns=65
     next_scenario=10_Epilogue
     victory_when_enemies_defeated=yes

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/10_Epilogue.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=10_Epilogue
     name= _ "Epilogue"
-    map_file=campaigns/The_Hammer_of_Thursagan/maps/10_Epilogue.map
+    map_file=10_Epilogue.map
     turns=unlimited
     victory_when_enemies_defeated=no
     theme=Cutscene_Minimal

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/01_A_Summer_of_Storms.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/01_A_Summer_of_Storms.cfg
@@ -3,7 +3,7 @@
     id=01_A_Summer_of_Storms
     name= _ "A Summer of Storms"
     next_scenario=02_The_Fall
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/01_A_Summer_of_Storms.map
+    map_file=01_A_Summer_of_Storms.map
     {TURNS 31 28 25}
     {DEFAULT_SCHEDULE}
 

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/02_The_Fall.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/02_The_Fall.cfg
@@ -3,7 +3,7 @@
     id=02_The_Fall
     name= _ "The Fall"
     next_scenario=03_A_Harrowing_Escape
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/02_The_Fall.map
+    map_file=02_The_Fall.map
     {TURNS 23 20 17}
     {DEFAULT_SCHEDULE}
 

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/03_A_Harrowing_Escape.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/03_A_Harrowing_Escape.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=03_A_Harrowing_Escape
     name= _ "A Harrowing Escape"
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/03_A_Harrowing_Escape.map
+    map_file=03_A_Harrowing_Escape.map
     next_scenario=04a_The_Swamp_of_Esten
     {TURNS 48 45 42}
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/04a_The_Swamp_of_Esten.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/04a_The_Swamp_of_Esten.cfg
@@ -3,7 +3,7 @@
     id=04a_The_Swamp_of_Esten
     name= _ "The Swamp of Esten"
     next_scenario=05_The_Oldwood
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/04a_The_Swamp_of_Esten.map
+    map_file=04a_The_Swamp_of_Esten.map
     {TURNS 39 36 33}
     {DEFAULT_SCHEDULE}
 

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/04b_The_Midlands.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/04b_The_Midlands.cfg
@@ -3,7 +3,7 @@
     id=04b_The_Midlands
     name= _ "The Midlands"
     next_scenario=05_The_Oldwood
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/04b_The_Midlands.map
+    map_file=04b_The_Midlands.map
     {TURNS 45 42 39}
     {DEFAULT_SCHEDULE}
 

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/05_The_Oldwood.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/05_The_Oldwood.cfg
@@ -3,7 +3,7 @@
     id=05_The_Oldwood
     name= _ "The Oldwood"
     next_scenario=06_Temple_in_the_Deep
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/05_The_Oldwood.map
+    map_file=05_The_Oldwood.map
     {TURNS 35 32 29}
     {DEFAULT_SCHEDULE}
 

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/06_Temple_in_the_Deep.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/06_Temple_in_the_Deep.cfg
@@ -4,7 +4,7 @@
     name= _ "Temple in the Deep"
     next_scenario=07_Return_to_Oldwood
     victory_when_enemies_defeated=no
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/06_Temple_in_the_Deep.map
+    map_file=06_Temple_in_the_Deep.map
     {TURNS 37 34 31}
     {UNDERGROUND}
 

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/07_Return_to_Oldwood.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/07_Return_to_Oldwood.cfg
@@ -3,7 +3,7 @@
     id=07_Return_to_Oldwood
     next_scenario=08_Clearwater_Port
     name= _ "Return to Oldwood"
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/05_The_Oldwood.map
+    map_file=05_The_Oldwood.map
     victory_when_enemies_defeated=no
     turns=1
     theme=Cutscene_Minimal

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/08_Clearwater_Port.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/08_Clearwater_Port.cfg
@@ -4,7 +4,7 @@
     name= _ "Clearwater Port"
     next_scenario=09_Fallen_Lich_Point
     victory_when_enemies_defeated=no
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/08_Clearwater_Port.map
+    map_file=08_Clearwater_Port.map
 
     turns=32
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/09_Fallen_Lich_Point.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/09_Fallen_Lich_Point.cfg
@@ -4,7 +4,7 @@
     name= _ "Fallen Lich Point"
     next_scenario=10_Sewer_of_Southbay
     victory_when_enemies_defeated=no
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/09_Fallen_Lich_Point.map
+    map_file=09_Fallen_Lich_Point.map
     {TURNS 39 36 33}
     {DEFAULT_SCHEDULE}
 

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/10_Sewer_of_Southbay.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/10_Sewer_of_Southbay.cfg
@@ -5,7 +5,7 @@
     name= _ "Sewer of Southbay"
     next_scenario=11_Southbay_in_Winter
     victory_when_enemies_defeated=no
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/10_Sewer_of_Southbay.map
+    map_file=10_Sewer_of_Southbay.map
 
     {TURNS 39 36 33}
     {UNDERGROUND}

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/11_Southbay_in_Winter.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/11_Southbay_in_Winter.cfg
@@ -3,7 +3,7 @@
     id=11_Southbay_in_Winter
     name= _ "Southbay in Winter"
     next_scenario=12_A_Final_Spring
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/11_Southbay_in_Winter.map
+    map_file=11_Southbay_in_Winter.map
     turns=1
     theme=Cutscene_Minimal
 

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/12_A_Final_Spring.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/12_A_Final_Spring.cfg
@@ -3,7 +3,7 @@
     id=12_A_Final_Spring
     name= _ "A Final Spring"
     next_scenario=13_Peoples_in_Decline
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/12_A_Final_Spring.map
+    map_file=12_A_Final_Spring.map
     {TURNS 39 36 33}
 
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/13_Peoples_in_Decline.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/13_Peoples_in_Decline.cfg
@@ -3,7 +3,7 @@
     id=13_Peoples_in_Decline
     name= _ "Peoples in Decline"
     next_scenario=14_Rough_Landing
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/13_Peoples_in_Decline.map
+    map_file=13_Peoples_in_Decline.map
     {TURNS 39 36 33}
     {DEFAULT_SCHEDULE}
 

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/14_Rough_Landing.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/14_Rough_Landing.cfg
@@ -3,7 +3,7 @@
     id=14_Rough_Landing
     name= _ "Rough Landing"
     next_scenario=15_A_New_Land
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/14_Rough_Landing.map
+    map_file=14_Rough_Landing.map
 
     {TURNS 35 32 29}
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/15_A_New_Land.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/15_A_New_Land.cfg
@@ -3,7 +3,7 @@
     id=15_A_New_Land
     name= _ "A New Land"
     next_scenario=16_The_Kalian
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/15_A_New_Land.map
+    map_file=15_A_New_Land.map
 
     victory_when_enemies_defeated=no
     turns=unlimited

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/16_The_Kalian.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/16_The_Kalian.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=16_The_Kalian
     name= _ "The Ka’lian"
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/16_The_Kalian.map
+    map_file=16_The_Kalian.map
     next_scenario=18_A_Spy_in_the_Woods
     theme=Cutscene_Minimal
 

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/17a_The_Dragon.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/17a_The_Dragon.cfg
@@ -4,7 +4,7 @@
     name= _ "The Dragon"
     next_scenario=16_The_Kalian
     victory_when_enemies_defeated=no
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/17a_The_Dragon.map
+    map_file=17a_The_Dragon.map
 
     {TURNS 39 36 33}
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/17b_Lizard_Beach.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/17b_Lizard_Beach.cfg
@@ -3,7 +3,7 @@
     id=17b_Lizard_Beach
     name= _ "Lizard Beach"
     next_scenario=16_The_Kalian
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/17b_Lizard_Beach.map
+    map_file=17b_Lizard_Beach.map
 
     {TURNS 35 32 29}
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/17c_Troll_Hole.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/17c_Troll_Hole.cfg
@@ -3,7 +3,7 @@
     id=17c_Troll_Hole
     name= _ "Troll Hole"
     next_scenario=16_The_Kalian
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/17c_Troll_Hole.map
+    map_file=17c_Troll_Hole.map
 
     {TURNS 39 36 33}
     {UNDERGROUND}

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/17d_Cursed_Isle.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/17d_Cursed_Isle.cfg
@@ -4,7 +4,7 @@
     name= _ "Cursed Isle"
     next_scenario=16_The_Kalian
     victory_when_enemies_defeated=no
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/17d_Cursed_Isle.map
+    map_file=17d_Cursed_Isle.map
 
     {TURNS 37 34 31}
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/18_A_Spy_in_the_Woods.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/18_A_Spy_in_the_Woods.cfg
@@ -3,7 +3,7 @@
     id=18_A_Spy_in_the_Woods
     name= _ "A Spy in the Woods"
     next_scenario=19_The_Vanguard
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/16_The_Kalian.map
+    map_file=16_The_Kalian.map
     turns=1
     theme=Cutscene_Minimal
 

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/19_The_Vanguard.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/19_The_Vanguard.cfg
@@ -3,7 +3,7 @@
     id=19_The_Vanguard
     name= _ "The Vanguard"
     next_scenario=20_Return_of_the_Fleet
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/19_The_Vanguard.map
+    map_file=19_The_Vanguard.map
 
     {TURNS 41 38 35}
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/20_Return_of_the_Fleet.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/20_Return_of_the_Fleet.cfg
@@ -3,7 +3,7 @@
     id=20_Return_of_the_Fleet
     name= _ "Return of the Fleet"
     next_scenario=21_The_Plan
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/20_Return_of_the_Fleet.map
+    map_file=20_Return_of_the_Fleet.map
 
     {TURNS 45 42 39}
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/21_The_Plan.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/21_The_Plan.cfg
@@ -3,7 +3,7 @@
     id=21_The_Plan
     name= _ "The Plan"
     next_scenario=22_The_Rise_of_Wesnoth
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/21_The_Plan.map
+    map_file=21_The_Plan.map
     turns=1
     theme=Cutscene_Minimal
 

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/22_The_Rise_of_Wesnoth.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/22_The_Rise_of_Wesnoth.cfg
@@ -4,7 +4,7 @@
     name= _ "The Rise of Wesnoth"
     next_scenario=23_Epilogue
     victory_when_enemies_defeated=no
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/22_The_Rise_of_Wesnoth.map
+    map_file=22_The_Rise_of_Wesnoth.map
 
     {TURNS 45 42 39}
     {DEFAULT_SCHEDULE}

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/23_Epilogue.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/23_Epilogue.cfg
@@ -3,7 +3,7 @@
     id=23_Epilogue
     name= _ "Epilogue"
     next_scenario=null
-    map_file=campaigns/The_Rise_Of_Wesnoth/maps/21_The_Plan.map
+    map_file=21_The_Plan.map
     turns=1
     theme=Cutscene_Minimal
 

--- a/data/campaigns/The_South_Guard/scenarios/01_Born_to_the_Banner.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/01_Born_to_the_Banner.cfg
@@ -9,7 +9,7 @@
     {EXTRA_SCENARIO_MUSIC battle.ogg}
     {EXTRA_SCENARIO_MUSIC knolls.ogg}
 
-    map_file=campaigns/The_South_Guard/maps/01_Born_to_the_Banner.map
+    map_file=01_Born_to_the_Banner.map
 
     {campaigns/The_South_Guard/utils/sg_deaths.cfg}
     {campaigns/The_South_Guard/utils/sg_help.cfg}

--- a/data/campaigns/The_South_Guard/scenarios/02_Proven_by_the_Sword.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/02_Proven_by_the_Sword.cfg
@@ -9,7 +9,7 @@
     {EXTRA_SCENARIO_MUSIC the_city_falls.ogg}
     {EXTRA_SCENARIO_MUSIC casualties_of_war.ogg}
 
-    map_file=campaigns/The_South_Guard/maps/02_Proven_by_the_Sword.map
+    map_file=02_Proven_by_the_Sword.map
 
     {campaigns/The_South_Guard/utils/sg_deaths.cfg}
     {campaigns/The_South_Guard/utils/sg_help.cfg}

--- a/data/campaigns/The_South_Guard/scenarios/03_A_Desparate_Errand.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/03_A_Desparate_Errand.cfg
@@ -9,7 +9,7 @@
     {EXTRA_SCENARIO_MUSIC traveling_minstrels.ogg}
     {EXTRA_SCENARIO_MUSIC legends_of_the_north.ogg}
 
-    map_file=campaigns/The_South_Guard/maps/03_A_Desperate_Errand.map
+    map_file=03_A_Desperate_Errand.map
 
     {campaigns/The_South_Guard/utils/sg_deaths.cfg}
 

--- a/data/campaigns/The_South_Guard/scenarios/04_Vale_of_Tears.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/04_Vale_of_Tears.cfg
@@ -9,7 +9,7 @@
     {EXTRA_SCENARIO_MUSIC knolls.ogg}
     {EXTRA_SCENARIO_MUSIC nunc_dimittis.ogg}
 
-    map_file=campaigns/The_South_Guard/maps/04_Vale_of_Tears.map
+    map_file=04_Vale_of_Tears.map
 
     {campaigns/The_South_Guard/utils/sg_deaths.cfg}
 

--- a/data/campaigns/The_South_Guard/scenarios/05_Choice_In_The_Fog.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/05_Choice_In_The_Fog.cfg
@@ -10,7 +10,7 @@
     {EXTRA_SCENARIO_MUSIC northerners.ogg}
     {EXTRA_SCENARIO_MUSIC heroes_rite.ogg}
 
-    map_file=campaigns/The_South_Guard/maps/05_Choice_in_the_Fog.map
+    map_file=05_Choice_in_the_Fog.map
 
     {campaigns/The_South_Guard/utils/sg_deaths.cfg}
 

--- a/data/campaigns/The_South_Guard/scenarios/06a_Into_the_Depths.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/06a_Into_the_Depths.cfg
@@ -10,7 +10,7 @@
     {EXTRA_SCENARIO_MUSIC knalgan_theme.ogg}
     {EXTRA_SCENARIO_MUSIC underground.ogg}
 
-    map_file=campaigns/The_South_Guard/maps/06a_Into_the_Depths.map
+    map_file=06a_Into_the_Depths.map
 
 #define SG_DEATHS_LAST_LEVEL
 #enddef

--- a/data/campaigns/The_South_Guard/scenarios/06b_The_Long_March.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/06b_The_Long_March.cfg
@@ -13,7 +13,7 @@
     # forest will be picked when the scenario starts. When editing the map, make
     # sure not to create any dead ends in the roads, and preferably also make
     # sure to not have sets of three dirt hexes all adjacent to each other.
-    map_file=campaigns/The_South_Guard/maps/06b_The_Long_March.map
+    map_file=06b_The_Long_March.map
 
     {campaigns/The_South_Guard/utils/sg_deaths.cfg}
 

--- a/data/campaigns/The_South_Guard/scenarios/07a_Return_to_Kerlath.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/07a_Return_to_Kerlath.cfg
@@ -2,7 +2,7 @@
 [scenario]
     id=07a_Return_to_Kerlath
     name= _ "Return to Kerlath"
-    map_file=campaigns/The_South_Guard/maps/07a_Return_to_Kerlath.map
+    map_file=07a_Return_to_Kerlath.map
     next_scenario=08a_Vengeance
     {TURNS 22 20 18}
     victory_when_enemies_defeated=no

--- a/data/campaigns/The_South_Guard/scenarios/07b_Pebbles_in_the_Flood.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/07b_Pebbles_in_the_Flood.cfg
@@ -9,7 +9,7 @@
     {EXTRA_SCENARIO_MUSIC the_king_is_dead.ogg}
     {EXTRA_SCENARIO_MUSIC nunc_dimittis.ogg}
 
-    map_file=campaigns/The_South_Guard/maps/07b_Pebbles_in_the_Flood.map
+    map_file=07b_Pebbles_in_the_Flood.map
 
     {campaigns/The_South_Guard/utils/sg_help.cfg}
 

--- a/data/campaigns/The_South_Guard/scenarios/08a_Vengeance.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/08a_Vengeance.cfg
@@ -7,7 +7,7 @@
 
     {SCENARIO_MUSIC nunc_dimittis.ogg}
 
-    map_file=campaigns/The_South_Guard/maps/08a_Vengeance.map
+    map_file=08a_Vengeance.map
 
 #define SG_DEATHS_LAST_LEVEL
 #enddef

--- a/data/campaigns/The_South_Guard/scenarios/08b_The_Tides_of_War.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/08b_The_Tides_of_War.cfg
@@ -10,7 +10,7 @@
     {EXTRA_SCENARIO_MUSIC siege_of_laurelmor.ogg}
     {EXTRA_SCENARIO_MUSIC vengeful.ogg}
 
-    map_file=campaigns/The_South_Guard/maps/08b_The_Tides_of_War.map
+    map_file=08b_The_Tides_of_War.map
 
 #define SG_DEATHS_LAST_LEVEL
 #enddef

--- a/data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=01_Rooting_Out_a_Mage
     name=_ "Rooting Out a Mage"
-    map_file=campaigns/Two_Brothers/maps/01_Rooting_Out_a_Mage.map
+    map_file=01_Rooting_Out_a_Mage.map
     turns=18
     next_scenario=02_The_Chase
 

--- a/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=02_The_Chase
     name= _ "The Chase"
-    map_file=campaigns/Two_Brothers/maps/02_The_Chase.map
+    map_file=02_The_Chase.map
     next_scenario=03_Guarded_Castle
 #ifdef EASY
     turns=28

--- a/data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=03_Guarded_Castle
     name= _ "Guarded Castle"
-    map_file=campaigns/Two_Brothers/maps/03_Guarded_Castle.map
+    map_file=03_Guarded_Castle.map
 #ifdef EASY
     turns=30
 #else

--- a/data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=04_Return_to_the_Village
     name= _ "Return to the Village"
-    map_file=campaigns/Two_Brothers/maps/04_Return_to_the_Village.map
+    map_file=04_Return_to_the_Village.map
 #ifdef EASY
     turns=26
 #else

--- a/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
+++ b/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
@@ -6,7 +6,7 @@
     # po: welcoming new players. Please keep the friendly fun feeling!
     # po: If you have any questions, ask in the forums or in the #wesnoth-dev channel on the Freenode IRC network.
     name= _ "Wesnoth Tutorial — Part I"
-    map_file=campaigns/tutorial/maps/01_Tutorial_part_1.map
+    map_file=01_Tutorial_part_1.map
     next_scenario=2_Tutorial
     victory_when_enemies_defeated=no
     experience_modifier=100

--- a/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
+++ b/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
@@ -3,7 +3,7 @@
 [scenario]
     id=2_Tutorial
     name= _ "Wesnoth Tutorial — Part II"
-    map_file=campaigns/tutorial/maps/02_Tutorial_part_2.map
+    map_file=02_Tutorial_part_2.map
     turns=36
     experience_modifier=100
 

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -1428,6 +1428,7 @@ std::string get_binary_file_location(const std::string& type, const std::string&
 		return std::string();
 	}
 
+	std::string result;
 	for(const std::string& bp : get_binary_paths(type)) {
 		bfs::path bpath(bp);
 		bpath /= filename;
@@ -1436,12 +1437,17 @@ std::string get_binary_file_location(const std::string& type, const std::string&
 
 		if(file_exists(bpath)) {
 			DBG_FS << "  found at '" << bpath.string() << "'\n";
-			return bpath.string();
+			if(result.empty()) {
+				result = bpath.string();
+			} else {
+				WRN_FS << "Conflicting files in binary_path: '" << sanitize_path(result)
+					   << "' and '" << sanitize_path(bpath.string()) << "'\n";
+			}
 		}
 	}
 
 	DBG_FS << "  not found\n";
-	return std::string();
+	return result;
 }
 
 std::string get_binary_dir_location(const std::string& type, const std::string& filename)

--- a/src/filesystem_common.cpp
+++ b/src/filesystem_common.cpp
@@ -139,11 +139,14 @@ std::string read_map(const std::string& name)
 {
 	std::string res;
 	std::string map_location = get_wml_location(name);
+	if(map_location.empty()) {
+		// If this is an add-on or campaign that's set the [binary_path] for its image directory,
+		// automatically check for a sibling maps directory.
+		map_location = get_binary_file_location("maps", name);
+	}
 	if(!map_location.empty()) {
 		res = read_file(map_location);
 	}
-
-	// TODO: might be nice to have automatic detection of the maps/ directory?
 
 	if(res.empty()) {
 		res = read_file(get_user_data_dir() + "/editor/maps/" + name);

--- a/src/tests/test_filesystem.cpp
+++ b/src/tests/test_filesystem.cpp
@@ -142,6 +142,9 @@ BOOST_AUTO_TEST_CASE( test_fs_binary_path )
 {
 	BOOST_CHECK_EQUAL( get_binary_dir_location("images", "."), gamedata + "/images/." );
 
+	// This test depends on get_binary_file_location() deterministically choosing
+	// which order to search the [binary_path] entries, as there are four "images"
+	// directories that could match.
 	BOOST_CHECK_EQUAL( get_binary_file_location("images", "././././././"),
 	                   gamedata + "/images/././././././" );
 


### PR DESCRIPTION
For both [scenario]map_file= and [replace_map]map_file=, this allows both of
these to have the same effect:

* map_file=campaigns/Heir_To_The_Throne/maps/01_The_Elves_Besieged.map
* map_file=01_The_Elves_Besieged.map

This allows a lot of copies of the campaign/add-on's name to be omitted. Thus
it's no longer necessary to change every scenario's .cfg file to rename an
add-on, or to move a campaign between UMC and mainline.

This makes [binary_path] a misnomer, as it now also handles a text-based type
of file, however that's going to be the correct path for campaigns or add-ons
that use the standard layout with images/, maps/, scenarios/, etc.

This commit has the change itself, in filesystem_common.cpp, and the updates
for most of the campaigns. DM, LoW, UtBS and WoV are omitted from this, as they
all use a macro to do the same effect:

 #define MEMOIRS_MAP NAME
-    map_file=campaigns/Delfadors_Memoirs/maps/{NAME}
+    map_file={NAME}
 #enddef

There are several comments on a previous version of this: https://github.com/stevecotton/wesnoth/commit/96e8077a5a02b58e7ea0e980225b55cbece66a59