### PR TITLE
[1.14] Log a warning if a file is found in more than one [binary_path]

### DIFF
--- a/src/filesystem_boost.cpp
+++ b/src/filesystem_boost.cpp
@@ -1356,6 +1356,7 @@ std::string get_binary_file_location(const std::string& type, const std::string&
 		return std::string();
 	}
 
+	std::string result;
 	for(const std::string& bp : get_binary_paths(type)) {
 		bfs::path bpath(bp);
 		bpath /= filename;
@@ -1364,12 +1365,17 @@ std::string get_binary_file_location(const std::string& type, const std::string&
 
 		if(file_exists(bpath)) {
 			DBG_FS << "  found at '" << bpath.string() << "'\n";
-			return bpath.string();
+			if(result.empty()) {
+				result = bpath.string();
+			} else {
+				WRN_FS << "Conflicting files in binary_path: '" << sanitize_path(result)
+					   << "' and '" << sanitize_path(bpath.string()) << "'\n";
+			}
 		}
 	}
 
 	DBG_FS << "  not found\n";
-	return std::string();
+	return result;
 }
 
 std::string get_binary_dir_location(const std::string& type, const std::string& filename)

--- a/src/tests/test_filesystem.cpp
+++ b/src/tests/test_filesystem.cpp
@@ -142,6 +142,9 @@ BOOST_AUTO_TEST_CASE( test_fs_binary_path )
 {
 	BOOST_CHECK_EQUAL( get_binary_dir_location("images", "."), gamedata + "/images/." );
 
+	// This test depends on get_binary_file_location() deterministically choosing
+	// which order to search the [binary_path] entries, as there are four "images"
+	// directories that could match.
 	BOOST_CHECK_EQUAL( get_binary_file_location("images", "././././././"),
 	                   gamedata + "/images/././././././" );
 


### PR DESCRIPTION
The Boost-based C++ unit tests generate three messages about duplicates,
however as those tests don't run in strict mode this doesn't cause a
failure (and it's not the only warning-level message in those tests).

The 1.15 version of this will be in PR #4654 .

Example output:
```
20191221 17:18:31 warning filesystem: Conflicting files in binary_path: '/home/USER/.local/share/wesnoth/1.14/data/add-ons/Desert_Map-Pack/images/maps/background.jpg' and '/home/USER/development/other-source/wesnoth/branch_1_14/data/core/images/maps/background.jpg'
```