### PR TITLE
Filter weapon in [filter student/opponent/etc] ,rework [filter_(secon… …d_)weapon and adding [swarm],[heal_on_hit] and plague to abilities used like specials(pre1.16 string)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -106,6 +106,9 @@
    * [effect]apply_to=variation now supports heal_full
    * Support [set/clear_variable] inside [modify_unit/side]
    * Support [variables] in [modify_side], as in [modify_unit]
+   * [filter_weapon] implemented in abilities used as weapons specials to be the same as true weapons specials (implement filter_weapon in [filter_student] instead of [filter_self])
+   * [leadership] can now, like the special weapons-based abilities, use all their options (active_on = (defense, offense, both), apply_to = self, opponent, etc.) as well as their filters ([filter_student / opponent , etc.])
+   * All special weapons can be used in [abilities] now (this was not the case yet for [heal_on_hit], [plague] and [swarm])
  ### Packaging
    * The Wesnoth client now looks for the data/dist file when logging into the multiplayer server.
      This file should contain one of the following values based on where the package is for:

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-## Version 1.15.2+dev 
+## Version 1.15.2+dev
  ### AI
    * Merge most of Experimental AI candidate actions (CAs) into default AI
      * CAs merged: castle switch, retreat injured, spread poison, place healers, move to any enemy

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-## Version 1.15.2+dev
+## Version 1.15.2+dev 
  ### AI
    * Merge most of Experimental AI candidate actions (CAs) into default AI
      * CAs merged: castle switch, retreat injured, spread poison, place healers, move to any enemy

--- a/data/campaigns/Heir_To_The_Throne/utils/abilities.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/abilities.cfg
@@ -6,9 +6,11 @@
         name= _ "initiative"
         description= _ "All adjacent friendly units will strike first in melee combat, even when defending."
         affect_self=no
-        [filter_second_weapon]
-            range=melee
-        [/filter_second_weapon]
+        [filter_opponent]
+            [filter_weapon]
+                range=melee
+            [/filter_weapon]
+        [/filter_opponent]
         [affect_adjacent]
         [/affect_adjacent]
     [/firststrike]

--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -408,9 +408,6 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
                                 [filter_student]
                                     [filter_weapon]
                                         range=melee
-                                        [not]
-                                            special_type_active=plague
-                                        [/not]
                                 [/filter_weapon]
                                 [/filter_student]
                                 [affect_adjacent]

--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -327,6 +327,52 @@ Xu, Xu, Qxu, Qxu, Ql, Ql, Ql, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Gg, Gg, Gg, Gg, Gg
             type="White Mage"
             gender="female"
             generate_name=yes
+            [modifications]
+                [object]
+                    [effect]
+                        apply_to=new_ability
+                        [abilities]
+                            [leadership]
+                                id=magical_leadership
+                                value="(25 * (level - other.level))"
+                                cumulative=no
+                                name= _ "magical leadership"
+                                female_name= _ "female^magical leadership"
+                                description= _ "This unit can lead your own units that are next to it, making them fight better with magicals weapons.
+Adjacent own units of lower level will do more damage in battle. When a unit adjacent to, of a lower level than, and on the same side as a unit with Leadership engages in combat, its attacks do 25% more damage times the difference in their levels."
+                                affect_self=no
+                                [filter_weapon]
+                                    special_id=magical
+                                [/filter_weapon]
+                                [affect_adjacent]
+                                    [filter]
+                                        formula="level < other.level"
+                                    [/filter]
+                                [/affect_adjacent]
+                            [/leadership]
+                            [resistance]
+                                id=melee_steadfast
+                                add=20
+                                max_value=50
+                                # applies to any type if we leave it out
+                                #apply_to=blade,pierce,impact,fire,cold,arcane
+                                [filter_base_value]
+                                greater_than=0
+                                less_than=50
+                                [/filter_base_value]
+                                [filter_second_weapon]
+                                    range=melee
+                                [/filter_second_weapon]
+                                name= _ "steadfast"
+                                female_name= _ "female^steadfast"
+                                description= _ "This unit’s resistances are added to 20%, up to a maximum of 50%, when defending to melle attacks. Vulnerabilities are not affected."
+                                affect_self=yes
+                                active_on=defense
+                            [/resistance]
+                        [/abilities]
+                    [/effect]
+                [/object]
+            [/modifications]
         [/unit]
         [unit]
             # A unit with a cold attack
@@ -352,6 +398,24 @@ Xu, Xu, Qxu, Qxu, Ql, Ql, Ql, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Gg, Gg, Gg, Gg, Gg
                                 description= "darkens and stuff"
                                 affect_self=yes
                             [/illuminates]
+                            [plague]
+                                id=plague
+                                name= _ "plague"
+                                description= _ "When a unit is killed by a Plague attack, that unit is replaced with a Walking Corpse on the same side as the unit with the Plague attack. This doesn’t work on Undead or units in villages."
+                                type=Walking Corpse
+                                affect_self=no
+                                affect_allies=yes
+                                [filter_student]
+                                    [filter_weapon]
+                                        range=melee
+                                        [not]
+                                            special_type_active=plague
+                                        [/not]
+                                [/filter_weapon]
+                                [/filter_student]
+                                [affect_adjacent]
+                                [/affect_adjacent]
+                            [/plague]
                         [/abilities]
                     [/effect]
                     [effect]
@@ -393,6 +457,60 @@ Xu, Xu, Qxu, Qxu, Ql, Ql, Ql, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Gg, Gg, Gg, Gg, Gg
             {IS_HERO}
             [modifications]
                 [object]
+                    [effect]
+                        apply_to=new_ability
+                        [abilities]
+                           [firststrike]
+                               id=initiative
+                               name= _ "initiative"
+                               description= _ "All adjacent friendly units will strike first in melee combat, even when defending."
+                               affect_self=no
+                               [filter_second_weapon]#don't must match here
+                                   [not]
+                                       range=melee
+                                   [/not]
+                               [/filter_second_weapon]
+                               [filter_opponent]
+                                   [filter_weapon]
+                                       range=melee
+                                   [/filter_weapon]
+                               [/filter_opponent]
+                               [affect_adjacent]
+                               [/affect_adjacent]
+                           [/firststrike]
+                           [chance_to_hit]
+                               id=marksman_leadership
+                               name= _ "cantor"
+                               female_name= _ "female^cantor"
+                               description= _ "This unit grants marksman to all ranged attacks of all adjacent allies."
+                               value=60
+                               cumulative=yes
+                               active_on=offense
+                               [filter_weapon]#don't match here
+                                   range=melee
+                               [/filter_weapon]
+                               [filter_second_weapon]
+                                   [not]
+                                       type=pierce
+                                   [/not]
+                               [/filter_second_weapon]
+                               [filter_student]
+                                   [filter_weapon]
+                                       range=ranged
+                                   [/filter_weapon]
+                               [/filter_student]
+                               [filter_opponent]
+                                   [filter_weapon]
+                                       type=pierce
+                                   [/filter_weapon]
+                               [/filter_opponent]
+                               affect_self=no
+                               affect_allies=yes
+                               [affect_adjacent]
+                               [/affect_adjacent]
+                           [/chance_to_hit]
+                        [/abilities]
+                    [/effect]
                     [effect]
                         apply_to=remove_attacks
                     [/effect]

--- a/data/schema/units/abilities.cfg
+++ b/data/schema/units/abilities.cfg
@@ -4,7 +4,7 @@
 		name={NAME}
 		max=infinite
 		super="units/unit_type/abilities/~generic~,units/unit_type/attack/specials/" + {NAME}
-		{FILTER_TAG "filter_student" unit ()}
+		{FILTER_TAG "filter_student" unit {FILTER_TAG "filter_weapon" weapon ()}}
 		{FILTER_TAG "filter_weapon" weapon ()}
 		{FILTER_TAG "filter_second_weapon" weapon ()}
 	[/tag]
@@ -86,8 +86,9 @@
 [tag]
 	name="leadership"
 	max=infinite
-	super="units/unit_type/abilities/~generic~"
+	super="units/unit_type/abilities/~generic~, units/unit_type/attack/specials/~generic~"
 	{SIMPLE_KEY value f_int}
+	{FILTER_TAG "filter_student" unit {FILTER_TAG "filter_weapon" weapon ()}}
 	{FILTER_TAG "filter_weapon" weapon ()}
 	{FILTER_TAG "filter_second_weapon" weapon ()}
 [/tag]
@@ -123,10 +124,13 @@
 	[/tag]
 [/tag]
 {BASED_ON_SPECIAL "attacks"}
+{BASED_ON_SPECIAL "swarm"}
 {BASED_ON_SPECIAL "chance_to_hit"}
 {BASED_ON_SPECIAL "damage"}
 {BASED_ON_SPECIAL "drains"}
+{BASED_ON_SPECIAL "heal_on_hit"}
 {BASED_ON_SPECIAL "berserk"}
+{BASED_ON_SPECIAL "plague"}
 {BASED_ON_SPECIAL "firststrike"}
 {BASED_ON_SPECIAL "poison"}
 {BASED_ON_SPECIAL "slow"}

--- a/data/test/scenarios/swarm_disables_upgrades_with_abilities.cfg
+++ b/data/test/scenarios/swarm_disables_upgrades_with_abilities.cfg
@@ -1,0 +1,129 @@
+# This unit test defines a WML object based implementation of the "unupgradable" ability
+# https://github.com/ProditorMagnus/Ageless-for-1-14/blob/52c1eaf31722bb58046a1b459d4f29daa8d88487/data/general_data/weapon_specials/unupgradable.cfg
+# and checks that it works. What is being tested here is that
+# [swarm] with swarm_attacks_max=swarm_attacks_min prevents strike changes
+# - through [attacks]
+# - through [effect] increase_attacks
+
+{GENERIC_UNIT_TEST "swarm_disables_upgrades" (
+    [event]
+        name=start
+        [modify_unit]
+            [filter]
+            [/filter]
+            max_hitpoints=100
+            hitpoints=100
+            attacks_left=1
+        [/modify_unit]
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [swarm]
+                        swarm_attacks_max=1
+                        swarm_attacks_min=1
+                    [/swarm]
+                    [attacks]
+                        value=10
+                    [/attacks]
+                    [attacks]
+                        add=13
+                    [/attacks]
+                    [damage]
+                        value=1
+                    [/damage]
+                    [chance_to_hit]
+                        value=100
+                    [/chance_to_hit]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=bob
+            [/filter]
+        [/object]
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [attacks]
+                        value=10
+                    [/attacks]
+                    [damage]
+                        value=1
+                    [/damage]
+                    [chance_to_hit]
+                        value=100
+                    [/chance_to_hit]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+        [object]
+            silent=yes
+            [filter]
+                id=bob
+            [/filter]
+            [effect]
+                apply_to=attack
+                increase_attacks=12
+            [/effect]
+        [/object]
+
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=a
+            kill=yes
+        [/store_unit]
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=b
+        [/store_unit]
+        [unstore_unit]
+            variable=a
+            find_vacant=yes
+            x,y=$b.x,$b.y
+        [/unstore_unit]
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=a
+        [/store_unit]
+
+        [do_command]
+            [attack]
+                weapon=0
+                defender_weapon=0
+                [source]
+                    x,y=$a.x,$a.y
+                [/source]
+                [destination]
+                    x,y=$b.x,$b.y
+                [/destination]
+            [/attack]
+        [/do_command]
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=a
+        [/store_unit]
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=b
+        [/store_unit]
+        {ASSERT ({VARIABLE_CONDITIONAL a.hitpoints equals 99})}
+        {ASSERT ({VARIABLE_CONDITIONAL b.hitpoints equals 90})}
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/swarm_disables_upgrades_with_abilities.cfg
+++ b/data/test/scenarios/swarm_disables_upgrades_with_abilities.cfg
@@ -6,6 +6,26 @@
 # - through [effect] increase_attacks
 
 {GENERIC_UNIT_TEST "swarm_disables_upgrades_with_abilities" (
+#define FILTER_BOB
+[filter_student]
+    [filter_weapon]
+        type=blade
+    [/filter_weapon]
+[/filter_student]
+[filter_opponent]
+    race=elf
+[/filter_opponent]
+#enddef
+#define FILTER_ALICE
+[filter_student]
+    [filter_weapon]
+        type=blade,pierce
+    [/filter_weapon]
+[/filter_student]
+[filter_opponent]
+    race=orc
+[/filter_opponent]
+#enddef
     [event]
         name=start
         [modify_unit]
@@ -23,18 +43,23 @@
                     [swarm]
                         swarm_attacks_max=1
                         swarm_attacks_min=1
+                        {FILTER_BOB}
                     [/swarm]
                     [attacks]
                         value=10
+                        {FILTER_BOB}
                     [/attacks]
                     [attacks]
                         add=13
+                        {FILTER_BOB}
                     [/attacks]
                     [damage]
                         value=1
+                        {FILTER_BOB}
                     [/damage]
                     [chance_to_hit]
                         value=100
+                        {FILTER_BOB}
                     [/chance_to_hit]
                 [/abilities]
             [/effect]
@@ -49,12 +74,15 @@
                 [abilities]
                     [attacks]
                         value=10
+                        {FILTER_ALICE}
                     [/attacks]
                     [damage]
                         value=1
+                        {FILTER_ALICE}
                     [/damage]
                     [chance_to_hit]
                         value=100
+                        {FILTER_ALICE}
                     [/chance_to_hit]
                 [/abilities]
             [/effect]

--- a/data/test/scenarios/swarm_disables_upgrades_with_abilities.cfg
+++ b/data/test/scenarios/swarm_disables_upgrades_with_abilities.cfg
@@ -5,7 +5,7 @@
 # - through [attacks]
 # - through [effect] increase_attacks
 
-{GENERIC_UNIT_TEST "swarm_disables_upgrades" (
+{GENERIC_UNIT_TEST "swarm_disables_upgrades_with_abilities" (
     [event]
         name=start
         [modify_unit]

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -238,7 +238,6 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 	unit_abilities::effect heal_on_hit_effects(heal_on_hit_specials, 0, backstab_pos);
 	drain_constant += heal_on_hit_effects.get_composite_value();
 	drain_constant += weapon->combat_ability("heal_on_hit", drain_constant, backstab_pos).first;
-	}
 
 	drains = drain_constant || drain_percent;
 

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -144,9 +144,10 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 	poisons = !opp.get_state("unpoisonable") && weapon->bool_ability("poison") && !opp.get_state(unit::STATE_POISONED);
 	backstab_pos = is_attacker && backstab_check(u_loc, opp_loc, units, resources::gameboard->teams());
 	rounds = weapon->get_specials("berserk").highest("value", 1).first;
-	if(!weapon->list_ability("berserk").empty()) {
-		rounds = weapon->list_ability("berserk").highest("value", 1).first;
-	}
+	int alt_rounds = weapon->list_ability("berserk").highest("value", 1).first;
+		if(alt_rounds > 0 && alt_rounds != 1){
+			rounds = alt_rounds;
+		}
 	firststrike = weapon->bool_ability("firststrike");
 
 	{
@@ -157,7 +158,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 
 	// Handle plague.
 	unit_ability_list plague_specials = weapon->get_specials("plague");
-	if(!weapon->list_ability("plague").empty()){
+	if(!weapon->list_ability("plague").empty()){//here if conditionnal is necessary
 		plague_specials = weapon->list_ability("plague");
 	}
 	plagues = !opp.get_state("unplagueable") && !plague_specials.empty() &&
@@ -226,7 +227,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 			unit_abilities::effect drain_percent_effects(drain_specials, 50, backstab_pos);
 			drain_percent = drain_percent_effects.get_composite_value();
 		}
-		if (weapon->combat_ability("drains", 50, backstab_pos).second) {
+		if (weapon->combat_ability("drains", 50, backstab_pos).second) {//here 'if' conditionnal is necessary
 			drain_percent = weapon->combat_ability("drains", 50, backstab_pos).first;
 		}
 	}
@@ -235,8 +236,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 	unit_ability_list heal_on_hit_specials = weapon->get_specials("heal_on_hit");
 	unit_abilities::effect heal_on_hit_effects(heal_on_hit_specials, 0, backstab_pos);
 	drain_constant += heal_on_hit_effects.get_composite_value();
-	if (weapon->combat_ability("heal_on_hit", 0, backstab_pos).second) {
-		drain_constant += weapon->combat_ability("heal_on_hit", 0, backstab_pos).first;
+	drain_constant += weapon->combat_ability("heal_on_hit", drain_constant, backstab_pos).first;
 	}
 
 	drains = drain_constant || drain_percent;

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -158,8 +158,9 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 
 	// Handle plague.
 	unit_ability_list plague_specials = weapon->get_specials("plague");
-	if(!weapon->list_ability("plague").empty()){//here if conditionnal is necessary
-		plague_specials = weapon->list_ability("plague");
+	unit_ability_list alt_plague_specials = weapon->list_ability("plague");
+	if(!alt_plague_specials.empty()){
+		plague_specials = alt_plague_specials;
 	}
 	plagues = !opp.get_state("unplagueable") && !plague_specials.empty() &&
 		opp.undead_variation() != "null" && !resources::gameboard->map().is_village(opp_loc);

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1561,18 +1561,6 @@ void attack_unit_and_advance(const map_location& attacker,
 	}
 }
 
-int attack_type::under_leadership() const
-{
-    unit_ability_list abil(self_loc_);
-    abil = list_ability("leadership");
-
-    if(!abil.empty()) {
-		unit_abilities::effect leader_effect(abil, 0, false);
-		return leader_effect.get_composite_value();
-	}
-	return 0;
-}
-
 int combat_modifier(const unit_map& units,
 		const gamemap& map,
 		const map_location& loc,

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -144,10 +144,10 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 	poisons = !opp.get_state("unpoisonable") && weapon->bool_ability("poison") && !opp.get_state(unit::STATE_POISONED);
 	backstab_pos = is_attacker && backstab_check(u_loc, opp_loc, units, resources::gameboard->teams());
 	rounds = weapon->get_specials("berserk").highest("value", 1).first;
-	int alt_rounds = weapon->list_ability("berserk").highest("value", 1).first;
-		if(alt_rounds > 0 && alt_rounds != 1){
-			rounds = alt_rounds;
-		}
+	unit_ability_list berserk_specials = weapon->list_ability("berserk");
+	if(!berserk_specials.empty()){
+		rounds = berserk_specials.highest("value", 1).first;
+	}
 	firststrike = weapon->bool_ability("firststrike");
 
 	{

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -159,7 +159,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 	// Handle plague.
 	unit_ability_list plague_specials = weapon->get_specials("plague");
 	unit_ability_list alt_plague_specials = weapon->list_ability("plague");
-	if(!alt_plague_specials.empty()){
+	if(!alt_plague_specials.empty() && plague_specials.empty()){
 		plague_specials = alt_plague_specials;
 	}
 	plagues = !opp.get_state("unplagueable") && !plague_specials.empty() &&

--- a/src/actions/attack.hpp
+++ b/src/actions/attack.hpp
@@ -272,14 +272,16 @@ void attack_unit_and_advance(const map_location& attacker,
 		bool update_display = true);
 
 /**
- * Tests if the unit at loc is currently affected by leadership.
- * (i.e. has a higher-level unit with the 'leadership' ability next to it).
- *
- * Returns the bonus percentage (possibly 0 if there's no leader adjacent).
+ * Test if the unit is affected and/or if is his opponent.
+ * 
  */
 bool leadership_affects_self(const std::string& ability, const unit &un, const map_location& loc, bool attacker=true);
 bool leadership_affects_opponent(const std::string& ability, const unit &un, const map_location& loc, bool attacker=true);
-unit_ability_list list_leadership(const std::string& ability,unit_const_ptr un, unit_const_ptr up, const map_location& loc, const map_location& opp_loc, bool attacker=true, const_attack_ptr weapon=nullptr, const_attack_ptr opp_weapon=nullptr);
+/**
+  * return an ability list if conditional matches(filters and active_on)
+  * un is the unit affected by leadership and up his opponent
+  */
+unit_ability_list list_leadership(const std::string& ability, unit_const_ptr un, unit_const_ptr up, const map_location& loc, const map_location& opp_loc, bool attacker=true, const_attack_ptr weapon=nullptr, const_attack_ptr opp_weapon=nullptr);
 
 /**
  * Returns the amount that a unit's damage should be multiplied by

--- a/src/actions/attack.hpp
+++ b/src/actions/attack.hpp
@@ -277,11 +277,9 @@ void attack_unit_and_advance(const map_location& attacker,
  *
  * Returns the bonus percentage (possibly 0 if there's no leader adjacent).
  */
-int under_leadership(const unit &u, const map_location& loc, const_attack_ptr weapon = nullptr, const_attack_ptr opp_weapon = nullptr);
-bool leadership_affects_self(const std::string& ability,const unit_map& units, const map_location& loc, bool attacker=true, const_attack_ptr weapon=nullptr,const_attack_ptr opp_weapon=nullptr);
-bool leadership_affects_opponent(const std::string& ability,const unit_map& units, const map_location& loc, bool attacker=true, const_attack_ptr weapon=nullptr,const_attack_ptr opp_weapon=nullptr);
-std::pair<int, bool> ability_leadership(const std::string& ability, const unit_map& units, const map_location& loc, const map_location& opp_loc, bool attacker=true, int abil_value=0, bool backstab_pos=false, const_attack_ptr weapon=nullptr, const_attack_ptr opp_weapon=nullptr);
-bool bool_leadership(const std::string& ability,const unit_map& units, const map_location& loc, const map_location& opp_loc, bool attacker=true, const_attack_ptr weapon=nullptr, const_attack_ptr opp_weapon=nullptr);
+bool leadership_affects_self(const std::string& ability, const unit &un, const map_location& loc, bool attacker=true);
+bool leadership_affects_opponent(const std::string& ability, const unit &un, const map_location& loc, bool attacker=true);
+unit_ability_list list_leadership(const std::string& ability,unit_const_ptr un, unit_const_ptr up, const map_location& loc, const map_location& opp_loc, bool attacker=true, const_attack_ptr weapon=nullptr, const_attack_ptr opp_weapon=nullptr);
 
 /**
  * Returns the amount that a unit's damage should be multiplied by

--- a/src/ai/default/aspect_attacks.cpp
+++ b/src/ai/default/aspect_attacks.cpp
@@ -259,9 +259,9 @@ void aspect_attacks_base::do_attack_analysis(
 				}
 			}
 
-			int best_leadership_bonus=0;
+			int best_leadership_bonus = 0;
 			for(const attack_type& a : unit_itor->attacks()) {
-				best_leadership_bonus= a.combat_ability("leadership", 0, backstab).first;
+				best_leadership_bonus= a.under_leadership();
 			}
 			double leadership_bonus = static_cast<double>(best_leadership_bonus+100)/100.0;
 			if (leadership_bonus > 1.1) {

--- a/src/ai/default/aspect_attacks.cpp
+++ b/src/ai/default/aspect_attacks.cpp
@@ -259,7 +259,10 @@ void aspect_attacks_base::do_attack_analysis(
 				}
 			}
 
-			int best_leadership_bonus = under_leadership(*unit_itor, tiles[j]);
+			int best_leadership_bonus=0;
+			for(const attack_type& a : unit_itor->attacks()) {
+				best_leadership_bonus= a.combat_ability("leadership", 0, backstab).first;
+			}
 			double leadership_bonus = static_cast<double>(best_leadership_bonus+100)/100.0;
 			if (leadership_bonus > 1.1) {
 				LOG_AI << unit_itor->name() << " is getting leadership " << leadership_bonus << "\n";

--- a/src/gui/dialogs/attack_predictions.cpp
+++ b/src/gui/dialogs/attack_predictions.cpp
@@ -230,7 +230,7 @@ void attack_predictions::set_data(window& window, const combatant_data& attacker
 	}
 
 	// Leadership bonus.
-	const int leadership_bonus = weapon->combat_ability("leadership", 0, attacker.stats_.backstab_pos).first;
+	const int leadership_bonus = weapon->under_leadership();
 
 	if(leadership_bonus != 0) {
 		set_label_helper("leadership_modifier", utils::signed_percent(leadership_bonus));

--- a/src/gui/dialogs/attack_predictions.cpp
+++ b/src/gui/dialogs/attack_predictions.cpp
@@ -230,7 +230,7 @@ void attack_predictions::set_data(window& window, const combatant_data& attacker
 	}
 
 	// Leadership bonus.
-	const int leadership_bonus = under_leadership(attacker.unit_, attacker.unit_.get_location(), weapon, opp_weapon);
+	const int leadership_bonus = weapon->combat_ability("leadership", 0, attacker.stats_.backstab_pos).first;
 
 	if(leadership_bonus != 0) {
 		set_label_helper("leadership_modifier", utils::signed_percent(leadership_bonus));

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -769,7 +769,7 @@ static int attack_info(reports::context & rc, const attack_type &at, config &res
 		int damage_multiplier = 100;
 		int tod_bonus = combat_modifier(get_visible_time_of_day_at(rc, hex), u.alignment(), u.is_fearless());
 		damage_multiplier += tod_bonus;
-		int leader_bonus = at.combat_ability("leadership").first;
+		int leader_bonus = at.under_leadership();
 		if (leader_bonus != 0)
 			damage_multiplier += leader_bonus;
 

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -767,10 +767,9 @@ static int attack_info(reports::context & rc, const attack_type &at, config &res
 		int base_damage = at.damage();
 		int specials_damage = at.modified_damage(false);
 		int damage_multiplier = 100;
-		const_attack_ptr weapon  = at.shared_from_this();
 		int tod_bonus = combat_modifier(get_visible_time_of_day_at(rc, hex), u.alignment(), u.is_fearless());
 		damage_multiplier += tod_bonus;
-		int leader_bonus = under_leadership(u, hex, weapon);
+		int leader_bonus = at.combat_ability("leadership").first;
 		if (leader_bonus != 0)
 			damage_multiplier += leader_bonus;
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1143,12 +1143,9 @@ unit_ability_list attack_type::list_ability(const std::string& ability) const
 			abil_list = list_leadership(ability, other, self, other_loc_, self_loc_, !is_attacker_, other_attack_, shared_from_this());
 		}
 	}
-
-	if(shared_from_this()){
-		for(const config& i : specials_.child_range(ability)) {
-			if(!get_specials(ability).empty()) {
-				abil_list.emplace_back(&i, self_loc_);
-			}
+	for(const config& i : specials_.child_range(ability)) {
+		if(!get_specials(ability).empty()) {
+			abil_list.emplace_back(&i, self_loc_);
 		}
 	}
 	if(other_attack_){

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1143,18 +1143,20 @@ unit_ability_list attack_type::list_ability(const std::string& ability) const
 			abil_list = list_leadership(ability, other, self, other_loc_, self_loc_, !is_attacker_, other_attack_, shared_from_this());
 		}
 	}
-	for(const config& i : specials_.child_range(ability)) {
-		if(!get_specials(ability).empty()) {
-			abil_list.emplace_back(&i, self_loc_);
-		}
-	}
-	if(other_attack_){
-		for(const config& j : other_attack_->specials_.child_range(ability)) {
+	if(!abil_list.empty()){	
+		for(const config& i : specials_.child_range(ability)) {
 			if(!get_specials(ability).empty()) {
-				abil_list.emplace_back(&j, other_loc_);
+				abil_list.emplace_back(&i, self_loc_);
 			}
 		}
-	}
+		if(other_attack_){
+			for(const config& j : other_attack_->specials_.child_range(ability)) {
+				if(!get_specials(ability).empty()) {
+					abil_list.emplace_back(&j, other_loc_);
+				}
+			}
+		}
+	} else { abil_list = get_specials(ability);}
 	return abil_list;
 }
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1143,22 +1143,21 @@ unit_ability_list attack_type::list_ability(const std::string& ability) const
 			abil_list = list_leadership(ability, other, self, other_loc_, self_loc_, !is_attacker_, other_attack_, shared_from_this());
 		}
 	}
-	if(!abil_list.empty()){
-		if(shared_from_this()){
-			for(const config& i : specials_.child_range(ability)) {
-				if(!get_specials(ability).empty()) {
-					abil_list.emplace_back(&i, self_loc_);
-				}
+
+	if(shared_from_this()){
+		for(const config& i : specials_.child_range(ability)) {
+			if(!get_specials(ability).empty()) {
+				abil_list.emplace_back(&i, self_loc_);
 			}
 		}
-		if(other_attack_){
-			for(const config& j : other_attack_->specials_.child_range(ability)) {
-				if(!other_attack_->get_specials(ability).empty()) {
-					abil_list.emplace_back(&j, other_loc_);
-				}
+	}
+	if(other_attack_){
+		for(const config& j : other_attack_->specials_.child_range(ability)) {
+			if(!get_specials(ability).empty()) {
+				abil_list.emplace_back(&j, other_loc_);
 			}
 		}
-	} else { abil_list = get_specials(ability);}
+	}
 	return abil_list;
 }
 
@@ -1202,6 +1201,18 @@ bool attack_type::bool_ability(const std::string& ability) const
 		abil_bool = true;
 	}
 	return abil_bool;
+}
+
+int attack_type::under_leadership() const
+{
+    unit_ability_list abil(self_loc_);
+    abil = list_ability("leadership");
+
+    if(!abil.empty()) {
+		unit_abilities::effect leader_effect(abil, 0, false);
+		return leader_effect.get_composite_value();
+	}
+	return 0;
 }
 //end of emulate weapon special functions.
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1101,7 +1101,7 @@ unit_ability_list list_leadership(const std::string& ability, unit_const_ptr un,
 	unit_ability_list abiln (loc);
 	unit_ability_list abil = (*un).get_abilities(ability, loc);
 	for(unit_ability_list::iterator i = abil.begin(); i != abil.end();) {
-        const config &filter = (*i->first).child("filter_opponent");
+		const config &filter = (*i->first).child("filter_opponent");
 		const config &filter_attacker = (*i->first).child("filter_attacker");
 		const config &filter_defender = (*i->first).child("filter_defender");
 		bool fighter_filter = ability_apply_filter(un, up, ability, *i->first, loc, opp_loc, attacker, weapon, opp_weapon);

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1051,8 +1051,7 @@ static bool ability_apply_filter(unit_const_ptr un, unit_const_ptr up, const std
 	return false;
 }
 
-//The two functions below are used to manage the application of the ability to the unit (master or student),
-// to his enemy, or either to the attacker or to the defender.
+
 bool leadership_affects_self(const std::string& ability, const unit &un, const map_location& loc, bool attacker)
 {
 	unit_ability_list abil = un.get_abilities(ability, loc);
@@ -1091,11 +1090,6 @@ bool leadership_affects_opponent(const std::string& ability, const unit &un, con
 	return false;
 }
 
-//This sub-function establishes the list of capacities according
-//to the name of the capacity, activation in attack and / or defense,
-//filters ([filter_student, opponent, etc ..])
-//or the old filter of attack ([filter (_second) _weapon]), list used to determine
-//if the capacity exists and is active
 unit_ability_list list_leadership(const std::string& ability, unit_const_ptr un, unit_const_ptr up, const map_location& loc, const map_location& opp_loc, bool attacker, const_attack_ptr weapon, const_attack_ptr opp_weapon)
 {
 	unit_ability_list abiln (loc);
@@ -1121,10 +1115,6 @@ unit_ability_list list_leadership(const std::string& ability, unit_const_ptr un,
 	return abil;
 }
 
-//This function uses the previous sub-function to apply it
-//either to the unit (master or student) or to its enemy (or both)
-//and can be used independently or inside the boolean functions or
-//to return a value that follow.
 unit_ability_list attack_type::list_ability(const std::string& ability) const
 {
 	const unit_map& units = display::get_singleton()->get_units();
@@ -1162,8 +1152,6 @@ unit_ability_list attack_type::list_ability(const std::string& ability) const
 	return abil_list;
 }
 
-//bool_ability is used to manage the capacities and weapon like poison, slow or 
-//petrification types as well as for the drain
 bool attack_type::bool_ability(const std::string& ability) const
 {
 	bool abil_bool= get_special_bool(ability);
@@ -1175,9 +1163,6 @@ bool attack_type::bool_ability(const std::string& ability) const
 	return abil_bool;
 }
 
-//combat_ability returns a numeric value to emulate the luck_to_hit, damage and attack abilities,
-//but is also used for leadership, the boolean value is used for the drain ability which must be managed independently
-//of the special weapon
 std::pair<int, bool> attack_type::combat_ability(const std::string& ability, int abil_value, bool backstab_pos) const
 {
 	unit_ability_list abil(self_loc_);

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -967,9 +967,7 @@ void attack_type::modified_attacks(bool is_backstab, unsigned & min_attacks,
 	unit_abilities::effect attacks_effect(get_specials("attacks"),
 	                                      num_attacks(), is_backstab);
 	int attacks_value = attacks_effect.get_composite_value();
-	if ( combat_ability("attacks", attacks_value, is_backstab).second ) {
-		attacks_value = combat_ability("attacks", attacks_value, is_backstab).first;
-	}
+	attacks_value = combat_ability("attacks", attacks_value, is_backstab).first;
 
 	if ( attacks_value < 0 ) {
 		attacks_value = num_attacks();
@@ -978,6 +976,10 @@ void attack_type::modified_attacks(bool is_backstab, unsigned & min_attacks,
 
 	// Apply [swarm].
 	unit_ability_list swarm_specials = get_specials("swarm");
+	unit_ability_list alt_swarm_specials = list_ability("swarm");
+	if(!alt_swarm_specials.empty()){
+            swarm_specials = alt_swarm_specials;    
+	}
 	if ( !swarm_specials.empty() ) {
 		min_attacks = std::max<int>(0, swarm_specials.highest("swarm_attacks_min").first);
 		max_attacks = std::max<int>(0, swarm_specials.highest("swarm_attacks_max", attacks_value).first);
@@ -994,9 +996,7 @@ int attack_type::modified_damage(bool is_backstab) const
 {
 	unit_abilities::effect dmg_effect(get_specials("damage"), damage(), is_backstab);
 	int damage_value = dmg_effect.get_composite_value();
-	if ( combat_ability("damage", damage_value, is_backstab).second ) {
-		damage_value = combat_ability("damage", damage_value, is_backstab).first;
-	}
+	damage_value = combat_ability("damage", damage_value, is_backstab).first;
 	return damage_value;
 }
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1143,22 +1143,11 @@ unit_ability_list attack_type::list_ability(const std::string& ability) const
 			abil_list = list_leadership(ability, other, self, other_loc_, self_loc_, !is_attacker_, other_attack_, shared_from_this());
 		}
 	}
-	if(!abil_list.empty()){
-		if(shared_from_this()){
-			for(const config& i : specials_.child_range(ability)) {
-				if(special_active(i, AFFECT_SELF, ability)) {
-					abil_list.emplace_back(&i, self_loc_);
-				}
-			}
-		}
-		if(other_attack_){
-			for(const config& j : other_attack_->specials_.child_range(ability)) {
-				if(other_attack_->special_active(j, AFFECT_OTHER, ability)) {
-					abil_list.emplace_back(&j, other_loc_);
-				}
-			}
-		}
-	} else {abil_list = get_specials(ability);}	
+	for(const config& i : specials_.child_range(ability)) {
+        if(!get_specials(ability).empty()) {
+            abil_list.emplace_back(&i, self_loc_);
+            }
+    }	
 	return abil_list;
 }
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1143,20 +1143,22 @@ unit_ability_list attack_type::list_ability(const std::string& ability) const
 			abil_list = list_leadership(ability, other, self, other_loc_, self_loc_, !is_attacker_, other_attack_, shared_from_this());
 		}
 	}
-	if(shared_from_this()){
-		for(const config& i : specials_.child_range(ability)) {
-			if(!get_specials(ability).empty()) {
-				abil_list.emplace_back(&i, self_loc_);
+	if(!abil_list.empty()){
+		if(shared_from_this()){
+			for(const config& i : specials_.child_range(ability)) {
+				if(!get_specials(ability).empty()) {
+					abil_list.emplace_back(&i, self_loc_);
+				}
 			}
 		}
-	}
-	if(other_attack_){
-		for(const config& j : other_attack_->specials_.child_range(ability)) {
-			if(!other_attack_->get_specials(ability).empty()) {
-				abil_list.emplace_back(&j, other_loc_);
+		if(other_attack_){
+			for(const config& j : other_attack_->specials_.child_range(ability)) {
+				if(!other_attack_->get_specials(ability).empty()) {
+					abil_list.emplace_back(&j, other_loc_);
+				}
 			}
 		}
-	}
+	} else { abil_list = get_specials(ability);}
 	return abil_list;
 }
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1140,14 +1140,20 @@ unit_ability_list attack_type::list_ability(const std::string& ability) const
 	temporary_facing other_facing(other, other_loc_.get_relative_dir(self_loc_));
 	unit_ability_list abil_list(self_loc_);
 	if(self){
-		if(leadership_affects_self(ability, *self, self_loc_, is_attacker_)) {
+		if(shared_from_this() && leadership_affects_self(ability, *self, self_loc_, is_attacker_)) {
 			abil_list = list_leadership(ability, self, other, self_loc_, other_loc_, is_attacker_, shared_from_this(), other_attack_);
 			for(const config& i : specials_.child_range(ability)) {
 				if(special_active(i, AFFECT_SELF, ability)) {
 					abil_list.emplace_back(&i, self_loc_);
 				}
 			}
-		}
+			if(other_attack_){
+				for(const config& j : other_attack_->specials_.child_range(ability)) {
+					if(other_attack_->special_active(j, AFFECT_OTHER, ability)) {
+						abil_list.emplace_back(&j, other_loc_);
+					}
+				}
+			}
 	}
 	if(other){
 		if(other_attack_ && leadership_affects_opponent(ability, *other, other_loc_, !is_attacker_)) {
@@ -1155,6 +1161,13 @@ unit_ability_list attack_type::list_ability(const std::string& ability) const
 			for(const config& i : other_attack_->specials_.child_range(ability)) {
 				if(other_attack_->special_active(i, AFFECT_OTHER, ability)) {
 					abil_list.emplace_back(&i, other_loc_);
+				}
+			}
+			if(shared_from_this()){
+				for(const config& j : specials_.child_range(ability)) {
+					if(special_active(j, AFFECT_SELF, ability)) {
+						abil_list.emplace_back(&j, self_loc_);
+					}
 				}
 			}
 		}

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1143,11 +1143,20 @@ unit_ability_list attack_type::list_ability(const std::string& ability) const
 			abil_list = list_leadership(ability, other, self, other_loc_, self_loc_, !is_attacker_, other_attack_, shared_from_this());
 		}
 	}
-	for(const config& i : specials_.child_range(ability)) {
-        if(!get_specials(ability).empty()) {
-            abil_list.emplace_back(&i, self_loc_);
-            }
-    }	
+	if(shared_from_this()){
+		for(const config& i : specials_.child_range(ability)) {
+			if(!get_specials(ability).empty()) {
+				abil_list.emplace_back(&i, self_loc_);
+			}
+		}
+	}
+	if(other_attack_){
+		for(const config& j : other_attack_->specials_.child_range(ability)) {
+			if(!other_attack_->get_specials(ability).empty()) {
+				abil_list.emplace_back(&j, other_loc_);
+			}
+		}
+	}
 	return abil_list;
 }
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1140,38 +1140,29 @@ unit_ability_list attack_type::list_ability(const std::string& ability) const
 	temporary_facing other_facing(other, other_loc_.get_relative_dir(self_loc_));
 	unit_ability_list abil_list(self_loc_);
 	if(self){
-		if(shared_from_this() && leadership_affects_self(ability, *self, self_loc_, is_attacker_)) {
+		if(leadership_affects_self(ability, *self, self_loc_, is_attacker_)) {
 			abil_list = list_leadership(ability, self, other, self_loc_, other_loc_, is_attacker_, shared_from_this(), other_attack_);
-			for(const config& i : specials_.child_range(ability)) {
-				if(special_active(i, AFFECT_SELF, ability)) {
-					abil_list.emplace_back(&i, self_loc_);
-				}
-			}
-			if(other_attack_){
-				for(const config& j : other_attack_->specials_.child_range(ability)) {
-					if(other_attack_->special_active(j, AFFECT_OTHER, ability)) {
-						abil_list.emplace_back(&j, other_loc_);
-					}
-				}
-			}
+		}
 	}
 	if(other){
-		if(other_attack_ && leadership_affects_opponent(ability, *other, other_loc_, !is_attacker_)) {
+		if(leadership_affects_opponent(ability, *other, other_loc_, !is_attacker_)) {
 			abil_list = list_leadership(ability, other, self, other_loc_, self_loc_, !is_attacker_, other_attack_, shared_from_this());
-			for(const config& i : other_attack_->specials_.child_range(ability)) {
-				if(other_attack_->special_active(i, AFFECT_OTHER, ability)) {
-					abil_list.emplace_back(&i, other_loc_);
-				}
-			}
-			if(shared_from_this()){
-				for(const config& j : specials_.child_range(ability)) {
-					if(special_active(j, AFFECT_SELF, ability)) {
-						abil_list.emplace_back(&j, self_loc_);
-					}
-				}
+		}
+	}
+	if(shared_from_this()){
+		for(const config& i : specials_.child_range(ability)) {
+			if(special_active(i, AFFECT_SELF, ability)) {
+				abil_list.emplace_back(&i, self_loc_);
 			}
 		}
 	}
+	if(other_attack_){
+		for(const config& j : other_attack_->specials_.child_range(ability)) {
+			if(other_attack_->special_active(j, AFFECT_OTHER, ability)) {
+				abil_list.emplace_back(&j, other_loc_);
+			}
+		}
+	}	
 	return abil_list;
 }
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1142,11 +1142,21 @@ unit_ability_list attack_type::list_ability(const std::string& ability) const
 	if(self){
 		if(leadership_affects_self(ability, *self, self_loc_, is_attacker_)) {
 			abil_list = list_leadership(ability, self, other, self_loc_, other_loc_, is_attacker_, shared_from_this(), other_attack_);
+			for(const config& i : specials_.child_range(ability)) {
+				if(special_active(i, AFFECT_SELF, ability)) {
+					abil_list.emplace_back(&i, self_loc_);
+				}
+			}
 		}
 	}
 	if(other){
-		if(leadership_affects_opponent(ability, *other, other_loc_, !is_attacker_)) {
+		if(other_attack_ && leadership_affects_opponent(ability, *other, other_loc_, !is_attacker_)) {
 			abil_list = list_leadership(ability, other, self, other_loc_, self_loc_, !is_attacker_, other_attack_, shared_from_this());
+			for(const config& i : other_attack_->specials_.child_range(ability)) {
+				if(other_attack_->special_active(i, AFFECT_OTHER, ability)) {
+					abil_list.emplace_back(&i, other_loc_);
+				}
+			}
 		}
 	}
 	return abil_list;

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1010,12 +1010,12 @@ int attack_type::modified_damage(bool is_backstab) const
 //special weapons ([filter_self] is replaced by [filter_student])
 static bool ability_filter_fighter(const std::string& ability,
 				   const std::string & filter_attacker,
-				   const config& cfg,
-				   const map_location & loc,
+				   const config& cfg, const map_location & loc,
 				   unit_const_ptr & u,
 				   unit_const_ptr & u2,
 				   const_attack_ptr weapon)
 {
+	
 	if (!loc.valid()){
 		return true;
 	}
@@ -1036,19 +1036,18 @@ static bool ability_filter_fighter(const std::string& ability,
 	if (!u2) {
 		return unit_filter(vconfig(filter)).set_use_flat_tod(ability == "illuminates").matches(*u, loc);
 	}
-	
 	return unit_filter(vconfig(filter)).set_use_flat_tod(ability == "illuminates").matches(*u, loc, *u2);
 }
 
 static bool ability_apply_filter(unit_const_ptr un, unit_const_ptr up, const std::string& ability, const config& cfg, const map_location& loc, const map_location& opp_loc, bool attacker, const_attack_ptr weapon, const_attack_ptr opp_weapon)
 {
-    bool filter_opponent = !ability_filter_fighter(ability, "filter_opponent", cfg, opp_loc, up, un, opp_weapon);
-    bool filter_student = !ability_filter_fighter(ability, "filter_student", cfg, loc, un, up, weapon);
-    bool filter_attacker = (attacker && !ability_filter_fighter(ability, "filter_attacker", cfg, loc, un, up, weapon)) || (!attacker && !ability_filter_fighter(ability, "filter_attacker", cfg, opp_loc, up, un, opp_weapon));
-    bool filter_defender = (!attacker && !ability_filter_fighter(ability, "filter_defender", cfg, loc,un, up, weapon)) || (attacker && !ability_filter_fighter(ability, "filter_defender", cfg, opp_loc, up, un, opp_weapon));
-    if(filter_student || filter_opponent || filter_attacker || filter_defender){
-	    return true;
-    }
+	bool filter_opponent = !ability_filter_fighter(ability, "filter_opponent", cfg, opp_loc, up, un, opp_weapon);
+	bool filter_student = !ability_filter_fighter(ability, "filter_student", cfg, loc, un, up, weapon);
+	bool filter_attacker = (attacker && !ability_filter_fighter(ability, "filter_attacker", cfg, loc, un, up, weapon)) || (!attacker && !ability_filter_fighter(ability, "filter_attacker", cfg, opp_loc, up, un, opp_weapon));
+	bool filter_defender = (!attacker && !ability_filter_fighter(ability, "filter_defender", cfg, loc,un, up, weapon)) || (attacker && !ability_filter_fighter(ability, "filter_defender", cfg, opp_loc, up, un, opp_weapon));
+	if(filter_student || filter_opponent || filter_attacker || filter_defender){
+		return true;
+	}
 	return false;
 }
 
@@ -1120,7 +1119,6 @@ unit_ability_list list_leadership(const std::string& ability, unit_const_ptr un,
 		}
 	}
 	return abil;
-
 }
 
 //This function uses the previous sub-function to apply it
@@ -1129,7 +1127,6 @@ unit_ability_list list_leadership(const std::string& ability, unit_const_ptr un,
 //to return a value that follow.
 unit_ability_list attack_type::list_ability(const std::string& ability) const
 {
-
 	const unit_map& units = display::get_singleton()->get_units();
 
 	unit_const_ptr self = self_;
@@ -1183,10 +1180,10 @@ bool attack_type::bool_ability(const std::string& ability) const
 //of the special weapon
 std::pair<int, bool> attack_type::combat_ability(const std::string& ability, int abil_value, bool backstab_pos) const
 {
-    unit_ability_list abil(self_loc_);
-    abil = list_ability(ability);
-
-    if(!abil.empty()) {
+	unit_ability_list abil(self_loc_);
+	abil = list_ability(ability);
+	
+	if(!abil.empty()) {
 		unit_abilities::effect leader_effect(abil, abil_value, backstab_pos);
 		return {leader_effect.get_composite_value(), true};
 	}

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1166,7 +1166,38 @@ bool attack_type::bool_ability(const std::string& ability) const
 {
 	bool abil_bool = get_special_bool(ability);
 	unit_ability_list abil(self_loc_);
-	abil = list_ability(ability);
+	const unit_map& units = display::get_singleton()->get_units();
+
+	unit_const_ptr self = self_;
+	unit_const_ptr other = other_;
+
+	if(self == nullptr) {
+		unit_map::const_iterator it = units.find(self_loc_);
+		if(it.valid()) {
+			self = it.get_shared_ptr().get();
+		}
+	}
+	if(other == nullptr) {
+		unit_map::const_iterator it = units.find(other_loc_);
+		if(it.valid()) {
+			other = it.get_shared_ptr().get();
+		}
+	}
+
+	// Make sure they're facing each other.
+	temporary_facing self_facing(self, self_loc_.get_relative_dir(other_loc_));
+	temporary_facing other_facing(other, other_loc_.get_relative_dir(self_loc_));
+	unit_ability_list abil_list(self_loc_);
+	if(self){
+		if(leadership_affects_self(ability, *self, self_loc_, is_attacker_)) {
+			abil = list_leadership(ability, self, other, self_loc_, other_loc_, is_attacker_, shared_from_this(), other_attack_);
+		}
+	}
+	if(other){
+		if(leadership_affects_opponent(ability, *other, other_loc_, !is_attacker_)) {
+			abil = list_leadership(ability, other, self, other_loc_, self_loc_, !is_attacker_, other_attack_, shared_from_this());
+		}
+	}
 	if(!abil.empty()) {
 		abil_bool = true;
 	}

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -991,7 +991,6 @@ int attack_type::modified_damage(bool is_backstab) const
 {
 	unit_abilities::effect dmg_effect(list_ability("damage"), damage(), is_backstab);
 	int damage_value = dmg_effect.get_composite_value();
-
 	return damage_value;
 }
 
@@ -1165,25 +1164,13 @@ unit_ability_list attack_type::list_ability(const std::string& ability) const
 
 bool attack_type::bool_ability(const std::string& ability) const
 {
-	bool abil_bool= get_special_bool(ability);
+	bool abil_bool = get_special_bool(ability);
 	unit_ability_list abil(self_loc_);
 	abil = list_ability(ability);
 	if(!abil.empty()) {
 		abil_bool = true;
 	}
 	return abil_bool;
-}
-
-std::pair<int, bool> attack_type::combat_ability(const std::string& ability, int abil_value, bool backstab_pos) const
-{
-	unit_ability_list abil(self_loc_);
-	abil = list_ability(ability);
-	
-	if(!abil.empty()) {
-		unit_abilities::effect leader_effect(abil, abil_value, backstab_pos);
-		return {leader_effect.get_composite_value(), true};
-	}
-	return {abil_value, false};
 }
 //end of emulate weapon special functions.
 

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -66,9 +66,6 @@ public:
 	void set_defense_weight(double value) { defense_weight_ = value; set_changed(true); }
 	void set_specials(config value) { specials_ = value; set_changed(true); }
 
-	// In action/attack.cpp
-	int under_leadership() const;
-
 
 	// In unit_abilities.cpp:
 
@@ -86,10 +83,12 @@ public:
 	                      unsigned & max_attacks) const;
 	/// Returns the damage per attack of this weapon, considering specials.
 	int modified_damage(bool is_backstab) const;
-	/// Returns list for weapon like abilities
+	/// Returns list for weapon like abilities, ability value is tag_name.
 	unit_ability_list list_ability(const std::string& ability) const;
 	///return an boolean value for abilities like poison slow firstrike or petrifies
 	bool bool_ability(const std::string& ability) const;
+	/// return leader_bonus for units affected by [leadership] ability
+	int under_leadership() const;
 
 	// In unit_types.cpp:
 

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -87,6 +87,7 @@ public:
 	                      unsigned & max_attacks) const;
 	/// Returns the damage per attack of this weapon, considering specials.
 	int modified_damage(bool is_backstab) const;
+	unit_ability_list list_ability(const std::string& ability) const;
 
 	// In unit_types.cpp:
 

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -66,10 +66,6 @@ public:
 	void set_defense_weight(double value) { defense_weight_ = value; set_changed(true); }
 	void set_specials(config value) { specials_ = value; set_changed(true); }
 
-	// In action/attack.cpp
-	std::pair<int, bool> combat_ability(const std::string& ability, int abil_value = 0, bool backstab_pos = false) const;
-	bool bool_ability(const std::string& ability) const;
-
 
 	// In unit_abilities.cpp:
 
@@ -87,7 +83,12 @@ public:
 	                      unsigned & max_attacks) const;
 	/// Returns the damage per attack of this weapon, considering specials.
 	int modified_damage(bool is_backstab) const;
+	/// Returns list for weapon like abilities
 	unit_ability_list list_ability(const std::string& ability) const;
+	///return an numerical value for abilite like weapon like chance_to_hit, damage but also for leadership
+	std::pair<int, bool> combat_ability(const std::string& ability, int abil_value = 0, bool backstab_pos = false) const;
+	///return an boolean value for abilities like poison slow firstrike or petrifies
+	bool bool_ability(const std::string& ability) const;
 
 	// In unit_types.cpp:
 

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -68,6 +68,8 @@ public:
 
 	// In action/attack.cpp
 	int under_leadership() const;
+
+
 	// In unit_abilities.cpp:
 
 	/// @return True iff the special @a special is active.

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -66,7 +66,8 @@ public:
 	void set_defense_weight(double value) { defense_weight_ = value; set_changed(true); }
 	void set_specials(config value) { specials_ = value; set_changed(true); }
 
-
+	// In action/attack.cpp
+	int under_leadership() const;
 	// In unit_abilities.cpp:
 
 	/// @return True iff the special @a special is active.
@@ -85,8 +86,6 @@ public:
 	int modified_damage(bool is_backstab) const;
 	/// Returns list for weapon like abilities
 	unit_ability_list list_ability(const std::string& ability) const;
-	///return an numerical value for abilite like weapon like chance_to_hit, damage but also for leadership
-	std::pair<int, bool> combat_ability(const std::string& ability, int abil_value = 0, bool backstab_pos = false) const;
 	///return an boolean value for abilities like poison slow firstrike or petrifies
 	bool bool_ability(const std::string& ability) const;
 

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1681,9 +1681,10 @@ int unit::resistance_against(const std::string& damage_name,bool attacker,const 
 {
 	int res = movement_type_.resistance_against(damage_name);
 
-	unit_ability_list resistance_abilities = get_abilities("resistance",loc, weapon, opp_weapon);
+	unit_ability_list resistance_abilities = get_abilities("resistance",loc);
 	for(unit_ability_list::iterator i = resistance_abilities.begin(); i != resistance_abilities.end();) {
-		if(!resistance_filter_matches(*i->first, attacker, damage_name, 100-res)) {
+		bool affect_weapon = !ability_affects_weapon(*i->first, weapon, false) || !ability_affects_weapon(*i->first, opp_weapon, true);
+		if(!resistance_filter_matches(*i->first, attacker, damage_name, 100-res) || affect_weapon) {
 			i = resistance_abilities.erase(i);
 		} else {
 			++i;

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1618,16 +1618,16 @@ public:
 	 * @param loc The location to use for resolving abilities
 	 * @return A list of active abilities, paired with the location they are active on
 	 */
-	unit_ability_list get_abilities(const std::string& tag_name, const map_location& loc, const_attack_ptr weapon = nullptr, const_attack_ptr opp_weapon = nullptr) const;
+	unit_ability_list get_abilities(const std::string& tag_name, const map_location& loc) const;
 
 	/**
 	 * Gets the unit's active abilities of a particular type.
 	 * @param tag_name The type of ability to check for
 	 * @return A list of active abilities, paired with the location they are active on
 	 */
-	unit_ability_list get_abilities(const std::string& tag_name, const_attack_ptr weapon = nullptr, const_attack_ptr opp_weapon = nullptr) const
+	unit_ability_list get_abilities(const std::string& tag_name) const
 	{
-		return get_abilities(tag_name, loc_, weapon, opp_weapon);
+		return get_abilities(tag_name, loc_);
 	}
 
 	/**

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1676,7 +1676,7 @@ public:
 	 * @param ability The type of ability (tag name) to remove.
 	 */
 	void remove_ability_by_id(const std::string& ability);
-
+	///filters the weapons that condition the use of abilities for combat (leadership, resistance or abilities used like specials)
 	bool ability_affects_weapon(const config& cfg, const_attack_ptr weapon, bool is_opp) const;
 
 private:

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1677,8 +1677,7 @@ public:
 	 */
 	void remove_ability_by_id(const std::string& ability);
 
-	bool abilities_filter_matches(const config& cfg, bool attacker, int res) const;
-	bool ability_filter_fighter(const std::string& ability, const std::string& filter_attacker , const config& cfg, const map_location& loc, const unit& u2) const;
+	bool ability_affects_weapon(const config& cfg, const_attack_ptr weapon, bool is_opp) const;
 
 private:
 	/**
@@ -1706,8 +1705,6 @@ private:
 	 * @param loc The location on which to resolve the ability
 	 */
 	bool ability_affects_self(const std::string& ability, const config& cfg, const map_location& loc) const;
-
-	bool ability_affects_weapon(const config& cfg, const_attack_ptr weapon, bool is_opp) const;
 
 public:
 	/** Get the unit formula manager. */

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -155,6 +155,7 @@
 0 test_berzerk_firststrike
 0 feeding
 0 swarm_disables_upgrades
+0 swarm_disables_upgrades_with_abilities
 #
 # Deterministic unit facing tests
 0 recruit_facing_enemy_one


### PR DESCRIPTION
This PR resolves https://github.com/wesnoth/wesnoth/issues/4629 with the addition of the latest special weapons to abilities,
https://github.com/wesnoth/wesnoth/issues/4475 (the display bug in the combat prediction window) and https://github.com/wesnoth/wesnoth/issues/4389.

