### PR TITLE
Fixes a warning about scons builds with multiple threads.

### DIFF
--- a/packaging/flatpak/org.wesnoth.Wesnoth.json
+++ b/packaging/flatpak/org.wesnoth.Wesnoth.json
@@ -42,8 +42,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://download.sourceforge.net/scons/scons-3.0.1.tar.gz",
-                    "sha256": "24475e38d39c19683bc88054524df018fe6949d70fbd4c69e298d39a0269f173"
+                    "url": "http://download.sourceforge.net/scons/scons-3.0.2.tar.gz",
+                    "sha256": "d0afcf8f4c2ea5fa7af3c9321c0cb3ea1c83d137196be10c4cb2c79cc5dade01"
                 }
             ],
             "build-commands": [


### PR DESCRIPTION
Currently both on jenkins and locally building Wesnoth's flatpak gives the warning:

scons: warning: parallel builds are unsupported by this version of Python;
	ignoring -j or num_jobs option.

This is apparently due to an issue between scons 3.0.1 and python 3.7+, which was reported at https://github.com/SCons/scons/issues/3145, fixed in https://github.com/SCons/scons/pull/3150, and is therefore first included in scons 3.0.2.

---

As far as running a flatpak job on travis, it is technically possible and I have a working docker image for it, however it takes longer than the 50 minute limit we have on travis to build the boost libraries, scons, and then Wesnoth.