### PR TITLE
Backport unit test framework changes (fixes #4471)

### DIFF
--- a/data/test/scenarios/filter_this_unit.cfg
+++ b/data/test/scenarios/filter_this_unit.cfg
@@ -41,7 +41,7 @@
     [/event]
 )}
 
-{GENERIC_UNIT_TEST filter_this_unit_fai (
+{GENERIC_UNIT_TEST filter_this_unit_formula (
     [event]
         name=prestart
         [modify_unit]
@@ -59,7 +59,7 @@
     [/event]
 )}
 
-{GENERIC_UNIT_TEST filter_fai_unit (
+{GENERIC_UNIT_TEST filter_formula_unit (
     [event]
         name=prestart
         [modify_unit]
@@ -77,14 +77,19 @@
     [/event]
 )}
 
-{GENERIC_UNIT_TEST filter_fai_unit_error (
+# Tests what happens when an invalid formula is given to an SUF.
+# This test requires strict mode, the expected behavior is to log
+# a warning but not interrupt the WML.
+{GENERIC_UNIT_TEST filter_formula_unit_error (
     [event]
         name=prestart
         {RETURN (
-            [have_unit]
-                id=bob
-                formula="+ max_moves"
-            [/have_unit]
+            [not]
+                [have_unit]
+                    id=bob
+                    formula="+ max_moves"
+                [/have_unit]
+            [/not]
         )}
     [/event]
 )}

--- a/doc/man/wesnoth.6
+++ b/doc/man/wesnoth.6
@@ -500,9 +500,7 @@ and 1 indicates that the test failed. An exit status of 3 indicates that the tes
 replay file. An exit status of 4 indicates that the test passed, but the replay produced errors. These latter
 two are only returned if
 .B --noreplaycheck
-is not passed. An exit status of 2 indicates that the test timed out, when used with the deprecated
-.B --timeout
-option.
+is not passed.
 .
 .SH AUTHOR
 .

--- a/run_wml_tests
+++ b/run_wml_tests
@@ -1,384 +1,241 @@
-#!/bin/bash
-#This script runs a sequence of wml unit test scenarios.
-#Use -h to get help with usage.
+#!/usr/bin/env python3
+# encoding: utf-8
+"""
+This script runs a sequence of wml unit test scenarios.
+"""
 
-usage()
-{
-  echo "Usage:" $0 "[OPTIONS] [EXTRA-ARGS]"
-  echo "Executes a series of wml unit test scenarios found in a file."
-  echo
-  echo -e "Options:"
-  echo -e "\t-h\tShows this help."
-  echo -e "\t-v\tVerbose mode."
-  echo -e "\t-w\tVery verbose mode. (Debug script.)"
-  echo -e "\t-c\tClean mode. (Don't load any add-ons. Used for mainline tests.)"
-  echo -e "\t-a arg\tAdditional arguments to go to wesnoth."
-  echo -e "\t-t arg\tNew timer value to use, instead of 10s as default."
-  echo -e "\t  \t0s means no timer, and also skips tests that expect timeout."
-  echo -e "\t-s\tDisable strict mode. By default, we run wesnoth with option"
-  echo -e "\t  \t'--log-strict=warning' to ensure errors result in a failed test."
-  echo -e "\t-d\tRun wesnoth-debug binary instead of wesnoth."
-  echo -e "\t-g\tIf we encounter a crash, generate a backtrace using gdb. Must have gdb installed for this option."
-  echo -e "\t-p arg\tPath to wesnoth binary. By default assume it is with this script."
-  if [ $(uname) = "Darwin" ]; then
-    echo -e "\t  \tThe special value xcode searches in XCode's DerivedProducts directory."
-  fi
-  echo -e "\t-l arg\tLoads list of tests from the given file."
-  echo -e "\t  \tBy default, the file is wml_test_schedule."
-  echo
-  echo "Each line in the list of tests should be formatted:"
-  echo -e "\n\t<expected return code> <name of unit test scenario>\n"
-  echo "Lines beginning # are treated as comments."
-  echo "Expected return codes:"
-  for i in `seq 0 4`;
-  do
-    get_code_string $i
-    echo -e "\t" $i "-" $CodeString
-  done
-  echo
-  echo "Extra arguments besides these options are saved and passed on to wesnoth."
-}
+import argparse, enum, os, re, subprocess, sys
 
-get_code_string()
-{
-  case ${1} in
-  0)
-    CodeString="PASS"
-    ;;
-  1)
-    CodeString="FAIL"
-    ;;
-  2)
-    CodeString="FAIL (TIMEOUT)"
-    ;;
-  3)
-    CodeString="FAIL (INVALID REPLAY)"
-    ;;
-  4)
-    CodeString="FAIL (ERRORED REPLAY)"
-    ;;
-  124)
-    CodeString="FAIL (TIMEOUT, by TERM signal)"
-    ;;
-  137)
-    CodeString="FAIL (TIMEOUT, by KILL signal)"
-    ;;
-  134)
-    CodeString="FAIL (ASSERTION FAILURE ? ? ?)"
-    ;;
-  139)
-    CodeString="FAIL (SEGFAULT ? ? ?)"
-    ;;
-  *)
-    CodeString="FAIL (? ? ?)"
-    ;;
-  esac
-}
+class UnexpectedTestStatusException(Exception):
+    """Exception raised when a unit test doesn't return the expected result."""
+    pass
 
-check_errs()
-{
-  # Argument 1 is the name of the test.
-  # Argument 2 is the wesnoth error code for the test.
-  # Argument 3 is the expected error code.
-  if [ "${2}" -eq 124 -a "${3}" -eq 2 ]; then
-    if [ "$Verbose" -ge 2 ]; then
-      echo "Caught return code 124 from timeout"
-      echo "This signal means that the unix timeout utility killed wesnoth with TERM."
-      echo "Since we expected timeout, the test passes."
-    fi
-    return 0
-  elif [ "${2}" -eq 137 -a "${3}" -eq 2 ]; then
-    if [ "$Verbose" -ge 2 ]; then
-      echo "Caught return code 137 from timeout"
-      echo "This signal means that the unix timeout utility killed wesnoth with KILL."
-      echo "Since we expected timeout, the test passes."
-    fi
-    return 0
-  elif [ "${2}" -ne "${3}" ]; then
-    echo "${1}" ":"
-    get_code_string ${2}
-    printf '%-55s %3d - %s\n' "  Observed result :" "${2}" "$CodeString"
-    get_code_string ${3}
-    printf '%-55s %3d - %s\n' "  Expected result :" "${3}" "$CodeString"
-    if [ "$Verbose" -ge 2 -a -f "error.log" ]; then
-      echo ""
-      echo "Found error.log:"
-      cat error.log
-    fi
-    return 1
-  fi
-  return 0
-}
+class UnitTestResult(enum.Enum):
+    """Enum corresponding to game_launcher.hpp's unit_test_result"""
+    PASS = 0
+    FAIL = 1
+    TIMEOUT = 2
+    FAIL_LOADING_REPLAY = 3
+    FAIL_PLAYING_REPLAY = 4
+    FAIL_BROKE_STRICT = 5
+    FAIL_WML_EXCEPTION = 6
 
-handle_error_log()
-{
-  if [ -f "error.log" ]; then
-    if [ "${1}" -ne 0 ]; then
-      if [ -f "errors.log" ]; then
-        echo -e "\n--- next unit test ---\n" >> errors.log
-        cat error.log >> errors.log
-      else
-        cp error.log errors.log
-      fi
-    fi
+class TestCase:
+    """Represents a single line of the wml_test_schedule."""
+    def __init__(self, status, name):
+        self.status = status
+        self.name = name
 
-    rm error.log
-  fi
-}
+    def __str__(self):
+        return "TestCase<{status}, {name}>".format(status=self.status, name=self.name)
 
-run_test()
-{
-  # Argument 1 is the expected error code
-  # Argument 2 is the name of the test scenario
-  # Argument 3 (optional) overrides strict mode (0 to disable, 1 to enable)
+class TestListParser:
+    """Each line in the list of tests should be formatted:
+        <expected return code><space><name of unit test scenario>
 
-  preopts=""
-  binary="$BinPath"
-  opts="-u$2 "
+    For example:
+        0 test_functionality
 
-  timer=$basetimer
+    Lines beginning # are treated as comments.
+    """
+    def __init__(self, options):
+        self.verbose = options.verbose
+        self.filename = options.list
 
-  if [ "$DebugMode" -eq 1 ]; then
-    binary+="wesnoth-debug "
-  else
-    binary+="wesnoth "
-  fi
+    def get(self):
+        status_name_re = re.compile(r"^(\d+) ([\w-]+)$")
+        test_list = []
+        for line in open(self.filename, mode="rt"):
+            line = line.strip()
+            if line == "" or line.startswith("#"):
+                continue
 
-  # Use validcache on tests that aren't the first test.
-  if [ "$FirstTest" -eq 1 ]; then
-    ((timer *= 2))
-  else
-    opts+="--validcache "
-  fi
+            x = status_name_re.match(line)
+            if x is None:
+                print("Could not parse test list file: ", line)
 
-  # Add a timeout using unix timeout utility
-  if [ $timer -gt 0 ]; then
-    # Some versions might not support the --kill-after option
-    timeout --kill-after=5 1 true
-    # Exit code of timeout is 125 if the command itself fails, like if we passed a bad argument
-    if [ $? -ne 125 ]; then
-      timer1=$((timer+1))
-      preopts+="timeout --kill-after=$timer1 $timer "
-    else
-      preopts+="timeout $timer "
-    fi
-  elif [ $1 -eq 2 ]; then
-    # If timeout is disabled, skip tests that expect it
-    return 100
-  fi
+            t = TestCase(UnitTestResult(int(x.groups()[0])), x.groups()[1])
+            if self.verbose > 1:
+                print(t)
+            test_list.append(t)
+        return test_list
 
-  strict_mode=$3
-  if [ -z "$strict_mode" ]; then
-    strict_mode=$StrictMode
-  fi
+def get_output_filename(args):
+    for i,arg in enumerate(args):
+        if arg == "-u":
+            return "test-output-"+args[i+1]
+    raise RuntimeError("No -u option found!")
 
-  # If running strict, then set strict level to "warning"
-  if [ "$strict_mode" -eq 1 ]; then
-    opts+="--log-strict=warning "
-  fi
+def run_with_rerun_for_sdl_video(args, timeout):
+    """A wrapper for subprocess.run with a workaround for the issue of travis+18.04
+    intermittently failing to initialise SDL.
+    """
+    # Sanity check on the number of retries. It's a rare failure, a single retry would probably
+    # be enough.
+    sdl_retries = 0
+    while sdl_retries < 10:
+        # For compatibility with Ubuntu 16.04 LTS, this has to run on Python3.5,
+        # so the capture_output argument is not available.
+        filename = get_output_filename(args)
+        res = subprocess.run(args, timeout=timeout, stdout=open(filename, "w"), stderr=subprocess.STDOUT)
+        retry = False
+        with open(filename, "r") as output:
+            if "Could not initialize SDL_video" in output.read():
+                retry = True
+        if not retry:
+        	  return res
+        sdl_retries += 1
+        print("Could not initialise SDL_video error, attempt", sdl_retries)
 
-  # If running clean mode, then pass "--noaddons"
-  if [ "$CleanMode" -eq 1 ]; then
-    opts+="--noaddons "
-  fi
+class WesnothRunner:
+    def __init__(self, options):
+        self.verbose = options.verbose
+        if options.path is None:
+            path = os.path.split(os.path.realpath(sys.argv[0]))[0]
+        elif options.path in ["XCode", "xcode", "Xcode"]:
+            import glob
+            path_list = []
+            for build in ["Debug", "Release"]:
+                pattern = os.path.join("~/Library/Developer/XCode/DerivedData/Wesnoth*",
+                    build, "Build/Products/Release/Wesnoth.app/Contents/MacOS/")
+                path_list.extend(glob.glob(os.path.expanduser(pattern)))
+            if len(path_list) == 0:
+                raise FileNotFoundError("Couldn't find your xcode build dir")
+            if len(path_list) > 1:
+                # seems better than choosing one at random
+                raise RuntimeError("Found more than one xcode build dir")
+            path = path_list[0]
+        else:
+            path = options.path
+        path += "/wesnoth"
+        if options.debug_bin:
+            path += "-debug"
+        self.common_args = [path]
+        if options.strict_mode:
+            self.common_args.append("--log-strict=warning")
+        if options.clean:
+            self.common_args.append("--noaddons")
+        if options.additional_arg is not None:
+            self.common_args.extend(options.additional_arg)
+        self.timeout = options.timeout
+        self.batch_timeout = options.batch_timeout
+        if self.verbose > 1:
+            print("Options that will be used for all Wesnoth instances:", repr(self.common_args))
 
-  # Assemble command
-  command="$preopts"
-  command+="$binary"
-  command+="$opts"
-  command+="$extra_opts"
-  if [ "$Verbose" -eq 1 ]; then
-    echo "$command"
-  elif [ "$Verbose" -eq 2 ]; then
-    echo "$command" "2> error.log"
-  fi
-  $command 2> error.log
-  error_code="$?"
-  if check_errs $2 $error_code $1; then
-    FirstTest=0 #Only start using validcache flag when at least one test has passed without error
-    handle_error_log 0
-    return 0
-  else
-    # If we got a code of value at least 128, and it wasn't KILL timeout, it means we segfaulted / failed assertion etc. most likely, so run gdb to get a backtrace
-    if [ "$GdbBacktraceMode" -eq 1 -a "$error_code" -ge 128 -a "$error_code" -ne 137 ]; then
-        echo -e "\n* Launching gdb for a backtrace...\n" >>error.log
-        gdb -q -batch -ex start -ex continue -ex bt -ex quit --args $binary $opts $extra_opts >>error.log
-    fi
+    def run_tests(self, test_list):
+        """Run all of the tests in a single instance of Wesnoth"""
+        if len(test_list) == 0:
+            raise ValueError("Running an empty test list")
+        if len(test_list) > 1:
+            for test in test_list:
+                if test.status != UnitTestResult.PASS:
+                    raise NotImplementedError("run_tests doesn't yet support batching tests with non-zero statuses")
+        expected_result = test_list[0].status
+        args = self.common_args.copy()
+        for test in test_list:
+            args.append("-u")
+            args.append(test.name)
+        if self.timeout == 0:
+            timeout = None
+        else:
+            if len(test_list) == 1:
+                timeout = self.timeout
+            else:
+                timeout = self.batch_timeout
+        if len(test_list) == 1:
+            print("Running test", test_list[0].name)
+        else:
+            print("Running {count} tests ({names})".format(count=len(test_list),
+                names=", ".join([test.name for test in test_list])))
+        if self.verbose > 1:
+            print(repr(args))
+        try:
+            res = run_with_rerun_for_sdl_video(args, timeout)
+        except subprocess.TimeoutExpired as e:
+            print("Timed out (killed by Python timeout implementation)")
+            res = subprocess.CompletedProcess(args, UnitTestResult.TIMEOUT.value)
+        if self.verbose > 1:
+            print("Result:", res.returncode)
+        if res.returncode < 0:
+            print("Wesnoth exited because of signal", -res.returncode)
+            if options.backtrace:
+                print("Launching GDB for a backtrace...")
+                gdb_args = ["gdb", "-q", "-batch", "-ex", "start", "-ex", "continue", "-ex", "bt", "-ex", "quit", "--args"]
+                gdb_args.extend(args)
+                subprocess.run(gdb_args, timeout=240)
+            raise UnexpectedTestStatusException()
+        if res.returncode != expected_result.value:
+            with open(get_output_filename(args), "r") as output:
+                for line in output.readlines():
+                	print(line)
+            print("Failure, Wesnoth returned", res.returncode, "but we expected", expected_result.value)
+            raise UnexpectedTestStatusException()
 
-    handle_error_log 1
-    return 1
-  fi
-}
+def test_batcher(test_list):
+    """A generator function that collects tests into batches which a single
+    instance of Wesnoth can run.
+    """
+    expected_to_pass = []
+    for test in test_list:
+        if test.status == UnitTestResult.PASS:
+            expected_to_pass.append(test)
+        else:
+            yield [test]
+    yield expected_to_pass
 
+if __name__ == '__main__':
+    ap = argparse.ArgumentParser()
+    # The options that are mandatory to support (because they're used in the Travis script)
+    # are the one-letter forms of verbose, clean, timeout and backtrace.
+    ap.add_argument("-v", "--verbose", action="count", default=0,
+        help="Verbose mode. Use -v twice for very verbose mode.")
+    ap.add_argument("-c", "--clean", action="store_true",
+        help="Clean mode. (Don't load any add-ons. Used for mainline tests.)")
+    ap.add_argument("-a", "--additional_arg", action="append",
+        help="Additional arguments to go to wesnoth. For options that start with a hyphen, '--add_argument --data-dir' will give an error, use '--add_argument=--data-dir' instead.")
+    ap.add_argument("-t", "--timeout", type=int, default=10,
+        help="New timer value to use, instead of 10s as default. The value 0 means no timer, and also skips tests that expect timeout.")
+    ap.add_argument("-bt", "--batch-timeout", type=int, default=300,
+        help="New timer value to use for batched tests, instead of 300s as default.")
+    ap.add_argument("-s", "--no-strict", dest="strict_mode", action="store_false",
+        help="Disable strict mode. By default, we run wesnoth with the option --log-strict=warning to ensure errors result in a failed test.")
+    ap.add_argument("-d", "--debug_bin", action="store_true",
+        help="Run wesnoth-debug binary instead of wesnoth.")
+    ap.add_argument("-g", "--backtrace", action="store_true",
+        help="If we encounter a crash, generate a backtrace using gdb. Must have gdb installed for this option.")
+    ap.add_argument("-p", "--path", metavar="dir",
+        help="Path to wesnoth binary. By default assume it is with this script.")
+    ap.add_argument("-l", "--list", metavar="filename",
+        help="Loads list of tests from the given file.",
+    default="wml_test_schedule")
 
-### Main Script Starts Here ###
+    # Workaround for argparse not accepting option values that start with a hyphen,
+    # for example "-a --user-data-dir". https://bugs.python.org/issue9334
+    # New callers can use "-a=--user-data-dir", but compatibility with the old version
+    # of run_wml_tests needs support for "-a --user-data-dir".
+    try:
+        while True:
+            i = sys.argv.index("-a")
+            sys.argv[i] = "=".join(["-a", sys.argv.pop(i + 1)])
+    except IndexError:
+        pass
+    except ValueError:
+        pass
 
-Verbose=0
-UnixTimeout=0
-CleanMode=0
-LoadFile="wml_test_schedule"
-BinPath="./"
-StrictMode=1
-DebugMode=0
-GdbBacktraceMode=0
-extra_opts=""
-basetimer=10
-export OMP_WAIT_POLICY=PASSIVE
+    options = ap.parse_args()
 
-while getopts ":hvwcusdgp:l:a:t:" Option
-do
-  case $Option in
-    h )
-      usage
-      exit 0;
-      ;;
-    v )
-      if [ "$Verbose" -lt 1 ]; then
-        Verbose=1
-      fi
-      ;;
-    w )
-      if [ "$Verbose" -lt 2 ]; then
-        Verbose=2
-      fi
-      ;;
-    c )
-      CleanMode=1
-      ;;
-    u )
-      UnixTimeout=1
-      ;;
-    s )
-      StrictMode=0
-      ;;
-    d )
-      DebugMode=1
-      ;;
-    g )
-      GdbBacktraceMode=1
-      ;;
-    p )
-      if [ "$OPTARG" = "XCode" -o "$OPTARG" = "xcode" -o "$OPTARG" = "Xcode" ]; then
-        # Find it in XCode's build dir
-        path_list=( ~/Library/Developer/XCode/DerivedData/Wesnoth*/Build/Products/{Debug,Release}/Wesnoth.app/Contents/MacOS/ )
-        BinPath="${path_list[0]}"
-      else
-        BinPath="$OPTARG"
-      fi
-      ;;
-    l )
-      LoadFile="$OPTARG"
-      ;;
-    a )
-      extra_opts+=" $OPTARG"
-      ;;
-    t )
-      echo "Replacing default timer of 10 with" "$OPTARG" "seconds."
-      basetimer="$OPTARG"
-      ;;
-  esac
-done
-shift $(($OPTIND - 1))
+    if options.verbose > 1:
+        print(repr(options))
 
-extra_opts+="$*"
+    test_list = TestListParser(options).get()
+    runner = WesnothRunner(options)
 
-# Make sure the binary exists
-if [ "$DebugMode" -eq 1 ]; then
-  if [ ! -x "$BinPath/wesnoth-debug" ]; then
-    echo "Wesnoth binary not found at $BinPath/wesnoth-debug"
-    exit 1
-  fi
-else
-  if [ ! -x "$BinPath/wesnoth" ]; then
-    echo "Wesnoth binary not found at $BinPath/wesnoth"
-    exit 1
-  fi
-fi
+    a_test_failed = False
+    for batch in test_batcher(test_list):
+        try:
+            runner.run_tests(batch)
+        except UnexpectedTestStatusException:
+            a_test_failed = True
 
-if [ "$Verbose" -ge 2 ]; then
-  if [ "${#extra_opts}" -ge 0 ]; then
-    echo "Found additional arguments to wesnoth: " "$extra_opts"
-  fi
-  if [ "$UnixTimeout" -eq 1 ]; then
-    echo "Wesnoth built-in timeout was disabled. This script was updated, and -u is now unnecessary and has no effect."
-  fi
-fi
-
-# Disable timeouts if the timeout utility is missing
-if [ ! $(which timeout) ]; then
-  echo 'timeout not found; skipping timeout tests'
-  basetimer=0
-fi
-
-echo "Getting tests from" "$LoadFile" "..."
-
-old_IFS=$IFS
-IFS=$'\n'
-schedule=($(cat $LoadFile)) # array
-IFS=$old_IFS
-
-NumTests=0
-NumComments=0
-
-for line in "${schedule[@]}"
-do
-    if [[ "$line" =~ \#.* ]]; then
-      NumComments=$((NumComments+1))
-    else
-      NumTests=$((NumTests+1))
-    fi
-done
-
-echo "Running" $NumTests "test scenarios."
-
-if [ -f "errors.log" ]; then
-  rm errors.log
-fi
-
-AllPassed=1
-FirstTest=1
-TotalPassed=0
-
-for line in "${schedule[@]}"
-do
-    if [[ "$line" =~ \#.* ]]; then
-      if [ "$Verbose" -ge 2 ]; then
-        echo "comment:" $line
-      fi
-    else
-      if [ "$Verbose" -eq 0 ]; then
-        echo -n "."
-      fi
-      if run_test $line; then #note: don't put run_test inside a pipe implicitly by using ! or something, this will cause the FirstTest variable not to work properly
-        if [ "$Verbose" -ge 2 ]; then
-          echo "good"
-        elif [ "$Verbose" -eq 0 ]; then
-          echo -ne '\b:'
-        fi
-        TotalPassed=$((TotalPassed+1))
-      elif [ $? -ne 100 ]; then
-        if [ "$Verbose" -eq 0 ]; then
-          echo -ne '\b!'
-        fi
-        AllPassed=0
-      fi
-    fi
-done
-
-if [ "$Verbose" -eq 0 ]; then
-  echo ''
-fi
-
-if [ "$AllPassed" -eq 0 ]; then
-  if [ "$StrictMode" -eq 1 ]; then
-    echo "$TotalPassed" "out of" "$NumTests" "tests were correct."
-  else
-    echo "$TotalPassed" "out of" "$NumTests" "tests were correct. (However, some tests may expect to be running in strict mode, and not fail as expected otherwise.)"
-  fi
-  echo "Not all tests gave the correct result."
-  echo "Check errors.log for error reports."
-  exit 2
-else
-  echo "All tests gave the correct result."
-  exit 0
-fi
+    if a_test_failed:
+        sys.exit(1)

--- a/src/commandline_options.cpp
+++ b/src/commandline_options.cpp
@@ -259,9 +259,8 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 	po::options_description testing_opts("Testing options");
 	testing_opts.add_options()
 		("test,t", po::value<std::string>()->implicit_value(std::string()), "runs the game in a small test scenario. If specified, scenario <arg> will be used instead.")
-		("unit,u", po::value<std::string>()->implicit_value(std::string()), "runs a unit test scenario. Works like test, except that the exit code of the program reflects the victory / defeat conditions of the scenario.\n\t0 - PASS\n\t1 - FAIL\n\t2 - FAIL (TIMEOUT)\n\t3 - FAIL (INVALID REPLAY)\n\t4 - FAIL (ERRORED REPLAY)")
+		("unit,u", po::value<std::string>()->implicit_value(std::string()), "runs a unit test scenario. Works like test, except that the exit code of the program reflects the victory / defeat conditions of the scenario.\n\t0 - PASS\n\t1 - FAIL\n\t3 - FAIL (INVALID REPLAY)\n\t4 - FAIL (ERRORED REPLAY)")
 		("showgui", "don't run headlessly (for debugging a failing test)")
-		("timeout", po::value<unsigned int>(), "sets a timeout (milliseconds) for the unit test. (DEPRECATED)")
 		("log-strict", po::value<std::string>(), "sets the strict level of the logger. any messages sent to log domains of this level or more severe will cause the unit test to fail regardless of the victory result.")
 		("noreplaycheck", "don't try to validate replay of unit test.")
 		("mp-test", "load the test mp scenarios.")
@@ -460,8 +459,6 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 	}
 	if (vm.count("showgui"))
 		headless_unit_test = false;
-	if (vm.count("timeout"))
-		timeout = vm["timeout"].as<unsigned int>();
 	if (vm.count("noreplaycheck"))
 		noreplaycheck = true;
 	if (vm.count("turns"))

--- a/src/commandline_options.cpp
+++ b/src/commandline_options.cpp
@@ -259,7 +259,7 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 	po::options_description testing_opts("Testing options");
 	testing_opts.add_options()
 		("test,t", po::value<std::string>()->implicit_value(std::string()), "runs the game in a small test scenario. If specified, scenario <arg> will be used instead.")
-		("unit,u", po::value<std::vector<std::string>>(), "runs a unit test scenario. The GUI is not shown and the exit code of the program reflects the victory / defeat conditions of the scenario.\n\t0 - PASS\n\t1 - FAIL\n\t3 - FAIL (INVALID REPLAY)\n\t4 - FAIL (ERRORED REPLAY)\n\tMultiple tests can be run by giving this option multiple times, in this case the test run will stop immediately after any test which doesn't PASS and the return code will be the status of the test that caused the stop.")
+		("unit,u", po::value<std::vector<std::string>>(), "runs a unit test scenario. The GUI is not shown and the exit code of the program reflects the victory / defeat conditions of the scenario.\n\t0 - PASS\n\t1 - FAIL\n\t3 - FAIL (INVALID REPLAY)\n\t4 - FAIL (ERRORED REPLAY)\n\t5 - FAIL (BROKE STRICT)\n\t6 - FAIL (WML EXCEPTION)\n\tMultiple tests can be run by giving this option multiple times, in this case the test run will stop immediately after any test which doesn't PASS and the return code will be the status of the test that caused the stop.")
 		("showgui", "don't run headlessly (for debugging a failing test)")
 		("log-strict", po::value<std::string>(), "sets the strict level of the logger. any messages sent to log domains of this level or more severe will cause the unit test to fail regardless of the victory result.")
 		("noreplaycheck", "don't try to validate replay of unit test.")

--- a/src/commandline_options.cpp
+++ b/src/commandline_options.cpp
@@ -259,7 +259,7 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 	po::options_description testing_opts("Testing options");
 	testing_opts.add_options()
 		("test,t", po::value<std::string>()->implicit_value(std::string()), "runs the game in a small test scenario. If specified, scenario <arg> will be used instead.")
-		("unit,u", po::value<std::string>()->implicit_value(std::string()), "runs a unit test scenario. Works like test, except that the exit code of the program reflects the victory / defeat conditions of the scenario.\n\t0 - PASS\n\t1 - FAIL\n\t3 - FAIL (INVALID REPLAY)\n\t4 - FAIL (ERRORED REPLAY)")
+		("unit,u", po::value<std::vector<std::string>>(), "runs a unit test scenario. The GUI is not shown and the exit code of the program reflects the victory / defeat conditions of the scenario.\n\t0 - PASS\n\t1 - FAIL\n\t3 - FAIL (INVALID REPLAY)\n\t4 - FAIL (ERRORED REPLAY)\n\tMultiple tests can be run by giving this option multiple times, in this case the test run will stop immediately after any test which doesn't PASS and the return code will be the status of the test that caused the stop.")
 		("showgui", "don't run headlessly (for debugging a failing test)")
 		("log-strict", po::value<std::string>(), "sets the strict level of the logger. any messages sent to log domains of this level or more severe will cause the unit test to fail regardless of the victory result.")
 		("noreplaycheck", "don't try to validate replay of unit test.")
@@ -454,7 +454,7 @@ commandline_options::commandline_options (const std::vector<std::string>& args) 
 		test = vm["test"].as<std::string>();
 	if (vm.count("unit"))
 	{
-		unit_test = vm["unit"].as<std::string>();
+		unit_test = vm["unit"].as<std::vector<std::string>>();
 		headless_unit_test = true;
 	}
 	if (vm.count("showgui"))

--- a/src/commandline_options.hpp
+++ b/src/commandline_options.hpp
@@ -189,8 +189,6 @@ public:
 	boost::optional<std::string> unit_test;
 	/// True if --unit is used and --showgui is not present.
 	bool headless_unit_test;
-	/// Non-empty if --timeout was given on the command line. Dependent on --unit.
-	boost::optional<unsigned int> timeout;
 	/// True if --noreplaycheck was given on the command line. Dependent on --unit.
 	bool noreplaycheck;
 	/// True if --mp-test was given on the command line.

--- a/src/commandline_options.hpp
+++ b/src/commandline_options.hpp
@@ -186,7 +186,7 @@ public:
 	/// Non-empty if --test was given on the command line. Goes directly into test mode, into a scenario, if specified.
 	boost::optional<std::string> test;
 	/// Non-empty if --unit was given on the command line. Goes directly into unit test mode, into a scenario, if specified.
-	boost::optional<std::string> unit_test;
+	std::vector<std::string> unit_test;
 	/// True if --unit is used and --showgui is not present.
 	bool headless_unit_test;
 	/// True if --noreplaycheck was given on the command line. Dependent on --unit.

--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -541,6 +541,12 @@ game_launcher::unit_test_result game_launcher::unit_test()
 			case unit_test_result::TEST_FAIL_PLAYING_REPLAY:
 				describe_result = "FAIL TEST (ERRORED REPLAY)";
 				break;
+			case unit_test_result::TEST_FAIL_BROKE_STRICT:
+				describe_result = "FAIL TEST (BROKE STRICT)";
+				break;
+			case unit_test_result::TEST_FAIL_WML_EXCEPTION:
+				describe_result = "FAIL TEST (WML EXCEPTION)";
+				break;
 			default:
 				describe_result = "FAIL TEST";
 				break;
@@ -561,12 +567,17 @@ game_launcher::unit_test_result game_launcher::single_unit_test()
 	try {
 		campaign_controller ccontroller(state_, game_config_manager::get()->terrain_types(), true);
 		LEVEL_RESULT res = ccontroller.play_game();
-		if (!(res == LEVEL_RESULT::VICTORY) || lg::broke_strict()) {
+		if (res != LEVEL_RESULT::VICTORY) {
 			return unit_test_result::TEST_FAIL;
+		}
+		if (lg::broke_strict()) {
+			// Test for LEVEL_RESULT::VICTORY before this, as the warning printed by
+			// a failing ASSERT will also set broke_strict()'s flag.
+			return unit_test_result::TEST_FAIL_BROKE_STRICT;
 		}
 	} catch(const wml_exception& e) {
 		std::cerr << "Caught WML Exception:" << e.dev_message << std::endl;
-		return unit_test_result::TEST_FAIL;
+		return unit_test_result::TEST_FAIL_WML_EXCEPTION;
 	}
 
 	savegame::clean_saves(state_.classification().label);

--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -111,7 +111,7 @@ game_launcher::game_launcher(const commandline_options& cmdline_opts, const char
 	hotkey_manager_(),
 	music_thinker_(),
 	music_muter_(),
-	test_scenario_("test"),
+	test_scenarios_{"test"},
 	screenshot_map_(),
 	screenshot_filename_(),
 	state_(),
@@ -253,14 +253,11 @@ game_launcher::game_launcher(const commandline_options& cmdline_opts, const char
 	if (cmdline_opts_.test)
 	{
 		if (!cmdline_opts_.test->empty())
-			test_scenario_ = *cmdline_opts_.test;
+			test_scenarios_ = {*cmdline_opts_.test};
 	}
-	if (cmdline_opts_.unit_test)
+	if (!cmdline_opts_.unit_test.empty())
 	{
-		if (!cmdline_opts_.unit_test->empty()) {
-			test_scenario_ = *cmdline_opts_.unit_test;
-		}
-
+		test_scenarios_ = cmdline_opts_.unit_test;
 	}
 	if (cmdline_opts_.windowed)
 		video().set_fullscreen(false);
@@ -476,6 +473,9 @@ void game_launcher::set_test(const std::string& id)
 
 bool game_launcher::play_test()
 {
+	// This first_time variable was added in 70f3c80a3e2 so that using the GUI
+	// menu to load a game works. That seems to have edge-cases, for example if
+	// you try to load a game a second time then Wesnoth exits.
 	static bool first_time = true;
 
 	if(!cmdline_opts_.test) {
@@ -486,8 +486,15 @@ bool game_launcher::play_test()
 
 	first_time = false;
 
-	set_test(test_scenario_);
-	state_.classification().campaign_define = "TEST";
+	if(test_scenarios_.size() == 0) {
+		// shouldn't happen, as test_scenarios_ is initialised to {"test"}
+		std::cerr << "Error in the test handling code" << std::endl;
+		return false;
+	}
+	if(test_scenarios_.size() > 1) {
+		std::cerr << "You can't run more than one unit test in interactive mode" << std::endl;
+	}
+	set_test(test_scenarios_.at(0));
 
 	game_config_manager::get()->
 		load_game_config_for_game(state_.classification());
@@ -503,26 +510,51 @@ bool game_launcher::play_test()
 	return false;
 }
 
+/**
+ * Runs unit tests specified on the command line.
+ *
+ * If multiple unit tests were specified, then this will stop at the first test
+ * which returns a non-zero status.
+ */
 // Same as play_test except that we return the results of play_game.
-int game_launcher::unit_test()
+// \todo "same ... except" ... and many other changes, such as testing the replay
+game_launcher::unit_test_result game_launcher::unit_test()
 {
-	static bool first_time_unit = true;
-
-	if(!cmdline_opts_.unit_test) {
-		return 0;
+	// There's no copy of play_test's first_time variable. That seems to be for handling
+	// the player loading a game via the GUI, which makes no sense in a non-interactive test.
+	if(cmdline_opts_.unit_test.empty()) {
+		return unit_test_result::TEST_FAIL;
 	}
-	if(!first_time_unit)
-		return 0;
 
-	first_time_unit = false;
+	auto ret = unit_test_result::TEST_FAIL; // will only be returned if no test is run
+	for(const auto& scenario : test_scenarios_) {
+		set_test(scenario);
+		ret = single_unit_test();
+		const char* describe_result;
+		switch(ret) {
+			case unit_test_result::TEST_PASS:
+				describe_result = "PASS TEST";
+				break;
+			case unit_test_result::TEST_FAIL_LOADING_REPLAY:
+				describe_result = "FAIL TEST (INVALID REPLAY)";
+				break;
+			case unit_test_result::TEST_FAIL_PLAYING_REPLAY:
+				describe_result = "FAIL TEST (ERRORED REPLAY)";
+				break;
+			default:
+				describe_result = "FAIL TEST";
+				break;
+		}
+		std::cerr << describe_result << ": " << scenario << std::endl;
+		if (ret != unit_test_result::TEST_PASS) {
+			break;
+		}
+	}
+	return ret;
+}
 
-	state_.classification().campaign_type = game_classification::CAMPAIGN_TYPE::TEST;
-	state_.classification().campaign_define = "TEST";
-	state_.set_carryover_sides_start(
-		config {"next_scenario", test_scenario_}
-	);
-
-
+game_launcher::unit_test_result game_launcher::single_unit_test()
+{
 	game_config_manager::get()->
 		load_game_config_for_game(state_.classification());
 
@@ -530,17 +562,17 @@ int game_launcher::unit_test()
 		campaign_controller ccontroller(state_, game_config_manager::get()->terrain_types(), true);
 		LEVEL_RESULT res = ccontroller.play_game();
 		if (!(res == LEVEL_RESULT::VICTORY) || lg::broke_strict()) {
-			return 1;
+			return unit_test_result::TEST_FAIL;
 		}
 	} catch(const wml_exception& e) {
 		std::cerr << "Caught WML Exception:" << e.dev_message << std::endl;
-		return 1;
+		return unit_test_result::TEST_FAIL;
 	}
 
 	savegame::clean_saves(state_.classification().label);
 
 	if (cmdline_opts_.noreplaycheck)
-		return 0; //we passed, huzzah!
+		return unit_test_result::TEST_PASS; //we passed, huzzah!
 
 	savegame::replay_savegame save(state_, compression::NONE);
 	save.save_game_automatic(false, "unit_test_replay"); //false means don't check for overwrite
@@ -549,7 +581,7 @@ int game_launcher::unit_test()
 
 	if (!load_game()) {
 		std::cerr << "Failed to load the replay!" << std::endl;
-		return 3; //failed to load replay
+		return unit_test_result::TEST_FAIL_LOADING_REPLAY; //failed to load replay
 	}
 
 	try {
@@ -557,14 +589,14 @@ int game_launcher::unit_test()
 		LEVEL_RESULT res = ccontroller.play_replay();
 		if (!(res == LEVEL_RESULT::VICTORY) || lg::broke_strict()) {
 			std::cerr << "Observed failure on replay" << std::endl;
-			return 4;
+			return unit_test_result::TEST_FAIL_PLAYING_REPLAY;
 		}
 	} catch(const wml_exception& e) {
 		std::cerr << "WML Exception while playing replay: " << e.dev_message << std::endl;
-		return 4; //failed with an error during the replay
+		return unit_test_result::TEST_FAIL_PLAYING_REPLAY;
 	}
 
-	return 0; //we passed, huzzah!
+	return unit_test_result::TEST_PASS; //we passed, huzzah!
 }
 
 bool game_launcher::play_screenshot_mode()

--- a/src/game_launcher.hpp
+++ b/src/game_launcher.hpp
@@ -64,8 +64,11 @@ public:
 	enum class unit_test_result : int {
 		TEST_PASS = 0,
 		TEST_FAIL = 1,
+		// 2 is reserved for timeouts
 		TEST_FAIL_LOADING_REPLAY = 3,
 		TEST_FAIL_PLAYING_REPLAY = 4,
+		TEST_FAIL_BROKE_STRICT = 5,
+		TEST_FAIL_WML_EXCEPTION = 6,
 	};
 
 	bool init_video();

--- a/src/game_launcher.hpp
+++ b/src/game_launcher.hpp
@@ -57,6 +57,17 @@ public:
 
 	enum mp_selection {MP_CONNECT, MP_HOST, MP_LOCAL};
 
+	/**
+	 * Status code after running a unit test, should match the run_wml_tests
+	 * script and the documentation for the --unit_test command-line option.
+	 */
+	enum class unit_test_result : int {
+		TEST_PASS = 0,
+		TEST_FAIL = 1,
+		TEST_FAIL_LOADING_REPLAY = 3,
+		TEST_FAIL_PLAYING_REPLAY = 4,
+	};
+
 	bool init_video();
 	bool init_language();
 	bool init_joystick();
@@ -65,7 +76,8 @@ public:
 	bool play_test();
 	bool play_screenshot_mode();
 	bool play_render_image_mode();
-	int unit_test();
+	/// Runs unit tests specified on the command line
+	unit_test_result unit_test();
 
 	bool is_loading() const;
 	void clear_loaded_game();
@@ -106,6 +118,10 @@ private:
 
 	editor::EXIT_STATUS start_editor(const std::string& filename);
 
+	/// Internal to the implementation of unit_test(). If a single instance of
+	/// Wesnoth is running multiple unit tests, this gets called once per test.
+	unit_test_result single_unit_test();
+
 	const commandline_options& cmdline_opts_;
 	//Never null.
 	const std::unique_ptr<CVideo> video_;
@@ -118,7 +134,7 @@ private:
 	sound::music_thinker music_thinker_;
 	sound::music_muter music_muter_;
 
-	std::string test_scenario_;
+	std::vector<std::string> test_scenarios_;
 
 	std::string screenshot_map_, screenshot_filename_;
 

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -766,17 +766,6 @@ static int do_gameloop(const std::vector<std::string>& args)
 		plugins.play_slice();
 
 		if(cmdline_opts.unit_test) {
-			if(cmdline_opts.timeout) {
-				std::cerr << "The wesnoth built-in timeout feature has been removed.\n" << std::endl;
-				std::cerr << "Please use a platform-specific script which will kill the overtime process instead.\n"
-						  << std::endl;
-				std::cerr << "For examples in bash, or in windows cmd, see the forums, or the wesnoth repository."
-						  << std::endl;
-				std::cerr
-						<< "The bash script is called `run_wml_tests`, the windows script is part of the VC project.\n"
-						<< std::endl;
-			}
-
 			int worker_result = game->unit_test();
 			std::cerr << ((worker_result == 0) ? "PASS TEST " : "FAIL TEST ")
 					  << ((worker_result == 3) ? "(INVALID REPLAY)" : "")

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -765,13 +765,8 @@ static int do_gameloop(const std::vector<std::string>& args)
 		plugins.play_slice();
 		plugins.play_slice();
 
-		if(cmdline_opts.unit_test) {
-			int worker_result = game->unit_test();
-			std::cerr << ((worker_result == 0) ? "PASS TEST " : "FAIL TEST ")
-					  << ((worker_result == 3) ? "(INVALID REPLAY)" : "")
-					  << ((worker_result == 4) ? "(ERRORED REPLAY)" : "") << ": " << *cmdline_opts.unit_test
-					  << std::endl;
-			return worker_result;
+		if(!cmdline_opts.unit_test.empty()) {
+			return static_cast<int>(game->unit_test());
 		}
 
 		if(game->play_test() == false) {

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -13,8 +13,8 @@
 #
 # Security test
 #
-0 cve_2018_1999023 0
-1 cve_2018_1999023_2
+5 cve_2018_1999023
+5 cve_2018_1999023_2
 #
 # Test Check Victory (If this isn't working other tests may have dubious value)
 #
@@ -54,12 +54,12 @@
 0 unit_spawns_at_nearest_vacant_hex
 0 units_offmap_goto_recall
 0 test_move
-1 test_move_fail_1
-1 test_move_fail_2
-1 test_move_fail_3
-1 test_move_fail_4
-1 test_move_fail_5
-1 test_move_fail_6
+5 test_move_fail_1
+5 test_move_fail_2
+5 test_move_fail_3
+5 test_move_fail_4
+5 test_move_fail_5
+5 test_move_fail_6
 0 test_move_unit
 0 sighted_events
 1 sighted_events_fail
@@ -175,9 +175,9 @@
 # Standard Unit Filter tests
 0 filter_this_unit_wml
 0 filter_this_unit_tl
-0 filter_this_unit_fai
-0 filter_fai_unit
-1 filter_fai_unit_error
+0 filter_this_unit_formula
+0 filter_formula_unit
+5 filter_formula_unit_error
 # Interrupt tag tests
 0 check_interrupts_break
 0 check_interrupts_return


### PR DESCRIPTION
Note: needs to wait for the AppVeyor build to confirm that it fixes #4471.

The main reason for backporting all of this is to have separate unit test
statuses for WML exceptions and strict warnings, so that this mechanism can be
used instead of a793bce96's method of running the cve_2018_1999023 test in
non-strict mode, which means that the test now passes without making
equivalent-to-a793bce96 changes to projectfiles/VC12/WML_tests.cmd and
projectfiles/VC16/WML_tests.cmd.

The final commit, converting run_wml_scripts to Python, could be omitted. To
allow this, commit 7359fddecb8dafdb8bec33660259ec5e2fec4141 was reordered
slightly, with the changes to the script (adding the new statuses) in a
separate commit to the C++ changes.

Cherry-picked from the commits:
* 657629322884286f938e9a25e5f7300d52536601
* 63bb076b971a4724c05659e3c59b23d4cdf7f38c
* 7359fddecb8dafdb8bec33660259ec5e2fec4141
* eb7f3674dc40ecc8102f5ae451f80cf9e86f103a
* 38a49ad068d3ed092ef2e8d759b08f6871640e21
* 7345ca7b0f3b61ae669233fd9fd89f6fb2a27fc1