### PR TITLE
Add a flatpak travis job.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
   ccache: true
   directories:
     - $HOME/build-cache
+    - $HOME/flatpak-cache
 
 git:
   depth: 5
@@ -35,6 +36,8 @@ matrix:
     - env: CXXSTD=14 NLS=false LTS=mingw BRANCH=master STRICT=false
     
     - env: CXXSTD=14 NLS=false LTS=steamrt BRANCH=master CC=gcc-5 CXX=g++-5
+
+    - env: NLS=true LTS=flatpak BRANCH=master
 
     - os: osx
       compiler: clang

--- a/packaging/flatpak/org.wesnoth.Wesnoth.json
+++ b/packaging/flatpak/org.wesnoth.Wesnoth.json
@@ -19,6 +19,17 @@
         "/share/man",
         "*.la", "*.a"
     ],
+    "build-options": {
+        "cflags-override": true,
+        "cppflags-override": true,
+        "cxxflags-override": true,
+        "cflags": "",
+        "cppflags": "",
+        "cxxflags": "",
+        "env": {
+            "FLATPAK_BUILDER_N_JOBS": "4"
+        }
+    },
     "modules": [
         {
             "name": "boost",
@@ -32,7 +43,7 @@
             ],
             "build-commands": [
                 "./bootstrap.sh --prefix=/app --with-libraries=filesystem,locale,iostreams,program_options,regex,random,thread",
-                "./b2 -j4 install cxxflags='-fPIE -fstack-protector-strong' define=_FORTIFY_SOURCE=2 link=static variant=release address-model=64 --layout=system"
+                "./b2 -j$FLATPAK_BUILDER_N_JOBS install cxxflags='-fPIE -fstack-protector-strong' define=_FORTIFY_SOURCE=2 link=static variant=release address-model=64 --layout=system"
 ]
         },
 	{
@@ -57,7 +68,7 @@
                 "/share/applications/wesnoth_editor.desktop"
             ],
             "build-commands": [
-                "python3 /app/bin/scons -j $FLATPAK_BUILDER_N_JOBS prefix=/app ccache=true install wesnoth wesnothd"
+                "python3 /app/bin/scons -j $FLATPAK_BUILDER_N_JOBS prefix=/app ccache=true --debug=time install wesnoth wesnothd"
 	    ],
             "sources": [
                 {

--- a/utils/dockerbuilds/travis/Dockerfile-base-flatpak
+++ b/utils/dockerbuilds/travis/Dockerfile-base-flatpak
@@ -1,0 +1,11 @@
+FROM wesnoth/wesnoth:1804-master
+
+# install ppa for more recent flatpak version, otherwise "dir" source type is unrecognized
+RUN apt install -y software-properties-common
+RUN add-apt-repository -y ppa:alexlarsson/flatpak
+RUN apt update
+# install flatpak
+RUN apt install -y flatpak flatpak-builder jq
+RUN flatpak remote-add flathub https://flathub.org/repo/flathub.flatpakrepo
+# install runtime
+RUN flatpak install -y flathub org.freedesktop.Platform/x86_64/19.08 org.freedesktop.Sdk/x86_64/19.08

--- a/utils/travis/steps/script.sh
+++ b/utils/travis/steps/script.sh
@@ -40,8 +40,10 @@ if [ "$TRAVIS_OS_NAME" = "osx" ]; then
         fi
     fi
 else
-    docker run --cap-add=SYS_PTRACE \
+# additional permissions required due to flatpak's use of bubblewrap
+    docker run --cap-add=ALL --privileged \
     					 --volume "$HOME"/build-cache:/home/wesnoth-travis/build \
+    					 --volume "$HOME"/flatpak-cache:/home/wesnoth-travis/flatpak-cache \
                --volume "$HOME"/.ccache:/root/.ccache \
                --tty wesnoth-repo:"$LTS"-"$BRANCH" \
                unbuffer ./utils/travis/docker_run.sh "$NLS" "$TOOL" "$CC" "$CXX" "$CXXSTD" "$OPT" "$WML_TESTS" "$WML_TEST_TIME" "$PLAY_TEST" "$MP_TEST" "$BOOST_TEST" "$LTO" "$SAN" "$VALIDATE" "$LTS"


### PR DESCRIPTION
NOTE: This doesn't sign/upload/etc the output anywhere.

---

The lines:
```
"cflags-override": true,
"cppflags-override": true,
"cxxflags-override": true,
"cflags": "",
"cppflags": "",
"cxxflags": "",
```
are there in order to clear out the default compiler flags that flatpak seems to put there.  Those being:
CFLAGS/CXXFLAGS - `-O2 -g -pipe -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection`
With those gone (I'd guess mostly the `-g`), a full build of scons, boost, wesnoth, and wesnothd can be done within travis' time limit.

There's also:
LDFLAGS - `-L/app/lib -Wl,-z,relro,-z,now -Wl,--as-needed`
however I left those alone.