### PR TITLE
Error handling for campaigns without id (fixes #4664)

### DIFF
--- a/src/game_initialization/create_engine.cpp
+++ b/src/game_initialization/create_engine.cpp
@@ -727,6 +727,15 @@ void create_engine::init_all_levels()
 	// Campaigns.
 	for(const config& data : game_config_.child_range("campaign"))
 	{
+		if(data["id"].empty()) {
+			if(data["name"].empty()) {
+				ERR_CF << "Found a [campaign] with neither a name nor an id attribute, ignoring it" << std::endl;
+			} else {
+				ERR_CF << "Ignoring a [campaign] with no id attribute, but name '" << data["name"] << "'" << std::endl;
+			}
+			continue;
+		}
+
 		const std::string& type = data["type"];
 		bool mp = state_.classification().campaign_type == game_classification::CAMPAIGN_TYPE::MULTIPLAYER;
 


### PR DESCRIPTION
Can be cleanly cherry-picked between 1.14 and master, and tested on both. Sample output:
```
20191229 18:22:08 error config: Found a [campaign] with neither a name nor an id attribute, ignoring it
20191229 18:25:18 error config: Ignoring a [campaign] with no id attribute, but name 'Tactics Puzzles'
```