### PR TITLE
Fix multi-line deprecation messages

### DIFF
--- a/src/serialization/preprocessor.cpp
+++ b/src/serialization/preprocessor.cpp
@@ -1238,7 +1238,7 @@ bool preprocessor_data::get_chunk()
 							if(!deprecation_detail.empty()){
 								deprecation_detail += '\n';
 							}
-							deprecation_detail = read_rest_of_line();
+							deprecation_detail += read_rest_of_line();
 							skip_eol();
 						}
 					}


### PR DESCRIPTION
Several of the deprecated macros have two or three lines of explanation, but
only the last one was printed. This change fixes a cppcheck warning that the
value of deprecation_detail was overwritten without being used.

For example:

    #define SOUND:POISON
        #deprecated 3 1.15 This was used to play a sound when poisoning a unit, it had to
        #deprecated 3 1.15 be placed inside an attack animation. Now this sound is played
        #deprecated 3 1.15 automatically, there is no other use for this macro.
    #enddef

Ended up printing:

    20191229 21:39:36 error deprecation: SOUND:POISON has been deprecated and will be removed in version 1.15.0.
      automatically, there is no other use for this macro.