### PR TITLE
Fix #4135 - add the "Advances to" tooltip to the recruit and recall dialogs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -58,6 +58,10 @@
    * Reworked styling of progress bars and the network transfer progress dialog.
    * Moved the MP server list from a separate dialog to the Connect to Server dialog proper
      and added functionality for managing player-defined servers (issue #4564).
+   * The load-game dialog can now see the directories used by Wesnoth 1.14, 1.12, etc.
+   * The search box in the Campaigns menu now takes campaign abbreviations and descriptions
+     into account.
+   * The recruit and recall dialogs have a tooltip over the level number to show what the unit can advance to (issue #4135)
  ### Units
    * Add mushroom defense cap to mounted and some flying units
    * Decreased hitpoints of Dwarvish Lord from 79 to 74
@@ -68,10 +72,6 @@
    * Increased melee damage of Dwarvish Sentinel from 9-3 to 10-3
    * Dunefolk: rebalancing and renaming of various units
    * Orcs: revise some unit descriptions
- ### User interface
-   * The load-game dialog can now see the directories used by Wesnoth 1.14, 1.12, etc.
-   * The search box in the Campaigns menu now takes campaign abbreviations and descriptions
-     into account.
  ### Lua API
    * unit:transform() now takes an optional variation parameter
    * Support side.variables for access to side variables, similar to unit.variables

--- a/data/core/about.cfg
+++ b/data/core/about.cfg
@@ -1616,6 +1616,9 @@
         name = "rrigby"
     [/entry]
     [entry]
+        name = "Ryan Frame"
+    [/entry]
+    [entry]
         name = "Ryan Henszey"
     [/entry]
     [entry]

--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -3155,6 +3155,12 @@ For game purposes, the races group into factions; for example, orcs often cooper
             type=Fire Dragon
         [/unit]
 
+        [unit]
+            side=1
+            x,y="recall","recall"
+            type=Elvish Archer
+        [/unit]
+
         [lua]
             code=<<
                 wesnoth.units.to_recall { type = "Elvish Lady" }
@@ -3687,7 +3693,7 @@ Result:
         text="livingness"
         tooltip="<b>Tooltip for the livingness label</b>
 
-Moving to this hex will show you: 
+Moving to this hex will show you:
 
 <span color='red'><b>not_living</b> Subsums every of the following:</span>
 <span color='yellow'><b>unpoisonable</b> - Some more text here.</span>
@@ -4196,7 +4202,7 @@ unplagueable: $wml_unit.status.unplagueable"
         [filter_second]
            type=Lich
         [/filter_second]
-		
+
 	[store_unit]
             [filter]
                id=$unit.id

--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -77,7 +77,7 @@ void unit_preview_pane::finalize_setup()
 
 	// Labels
 	label_name_             = find_widget<label>(this, "type_name", false, false);
-	label_level_            = find_widget<label>(this, "type_level", false, false);
+	label_level_            = find_widget<styled_widget>(this, "type_level", false, false);
 	label_race_             = find_widget<label>(this, "type_race_label", false, false);
 	label_details_          = find_widget<styled_widget>(this, "type_details_minimal", false, false);
 
@@ -292,7 +292,11 @@ void unit_preview_pane::set_displayed_type(const unit_type& type)
 	if(label_level_) {
 		std::string l_str = VGETTEXT("Lvl $lvl", {{"lvl", std::to_string(type.level())}});
 
-		label_level_->set_label("<b>" + l_str + "</b>");
+		label_level_->set_members({
+			{ "label", "<b>" + l_str + "</b>" },
+			{ "tooltip", unit_helper::unit_level_tooltip(type) }
+		});
+
 		label_level_->set_use_markup(true);
 	}
 
@@ -443,7 +447,11 @@ void unit_preview_pane::set_displayed_unit(const unit& u)
 	if(label_level_) {
 		std::string l_str = VGETTEXT("Lvl $lvl", {{"lvl", std::to_string(u.level())}});
 
-		label_level_->set_label("<b>" + l_str + "</b>");
+		label_level_->set_members({
+			{ "label", "<b>" + l_str + "</b>" },
+			{ "tooltip", unit_helper::unit_level_tooltip(u) }
+		});
+
 		label_level_->set_use_markup(true);
 	}
 

--- a/src/gui/widgets/unit_preview_pane.hpp
+++ b/src/gui/widgets/unit_preview_pane.hpp
@@ -81,7 +81,7 @@ private:
 	image* icon_alignment_;
 
 	label* label_name_;
-	label* label_level_;
+	styled_widget* label_level_;
 	label* label_race_;
 
 	styled_widget* label_details_;

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -261,9 +261,7 @@ REPORT_GENERATOR(selected_unit_side, rc)
 static config unit_level(const unit* u)
 {
 	if (!u) return config();
-	std::ostringstream str, tooltip;
-	str << u->level();
-	return text_report(str.str(), unit_helper::unit_level_tooltip(*u));
+	return text_report(std::to_string(u->level()), unit_helper::unit_level_tooltip(*u));
 }
 REPORT_GENERATOR(unit_level, rc)
 {

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -263,27 +263,7 @@ static config unit_level(const unit* u)
 	if (!u) return config();
 	std::ostringstream str, tooltip;
 	str << u->level();
-	tooltip << _("Level: ") << "<b>" << u->level() << "</b>\n";
-	const std::vector<std::string> &adv_to_types = u->advances_to_translated();
-	const std::vector<config> &adv_to_mods = u->get_modification_advances();
-	const bool has_advancements = !adv_to_types.empty() || !adv_to_mods.empty();
-	if(has_advancements) {
-		tooltip << _("Advancements:") << "\n<b>\t";
-		if(!adv_to_types.empty())
-			tooltip << utils::join(adv_to_types, "\n\t");
-		if(!adv_to_mods.empty()) {
-			if(!adv_to_types.empty())
-				tooltip << "\n\t";
-			std::vector<std::string> descriptions;
-			for(const config& adv : adv_to_mods)
-				descriptions.push_back(adv["description"].str());
-			tooltip << utils::join(descriptions, "\n\t");
-		}
-		tooltip << "</b>";
-	} else {
-		tooltip << _("No advancement");
-	}
-	return text_report(str.str(), tooltip.str());
+	return text_report(str.str(), unit_helper::unit_level_tooltip(*u));
 }
 REPORT_GENERATOR(unit_level, rc)
 {

--- a/src/units/helper.cpp
+++ b/src/units/helper.cpp
@@ -46,4 +46,41 @@ std::string resistance_color(const int resistance)
 	return std::string("#00FF00");
 }
 
+std::string unit_level_tooltip(const int level, const std::vector<std::string> &adv_to_types, const std::vector<config> &adv_to_mods)
+{
+	std::ostringstream tooltip;
+	tooltip << _("Level: ") << "<b>" << level << "</b>\n";
+	const bool has_advancements = !adv_to_types.empty() || !adv_to_mods.empty();
+	if(has_advancements) {
+		tooltip << _("Advancements:") << "\n<b>\t";
+		if(!adv_to_types.empty())
+			tooltip << utils::join(adv_to_types, "\n\t");
+		if(!adv_to_mods.empty()) {
+			if(!adv_to_types.empty())
+				tooltip << "\n\t";
+			std::vector<std::string> descriptions;
+			for(const config& adv : adv_to_mods)
+				descriptions.push_back(adv["description"].str());
+			tooltip << utils::join(descriptions, "\n\t");
+		}
+		tooltip << "</b>";
+	} else {
+		tooltip << _("No advancement");
+	}
+	return tooltip.str();
+}
+
+std::string unit_level_tooltip(const unit &u)
+{
+	return unit_level_tooltip(u.level(), u.advances_to_translated(), u.get_modification_advances());
+}
+
+std::string unit_level_tooltip(const unit_type &type)
+{
+	const auto mod_adv_iters = type.modification_advancements();
+	const std::vector<config> mod_advancements(mod_adv_iters.begin(), mod_adv_iters.end());
+
+	return unit_level_tooltip(type.level(), type.advances_to(), mod_advancements);
+}
+
 }

--- a/src/units/helper.hpp
+++ b/src/units/helper.hpp
@@ -40,4 +40,14 @@ int number_of_possible_advances(const unit &unit);
  */
 std::string resistance_color(const int resistance);
 
+/**
+ * @return the tooltip text showing a unit's level and what it can advance to.
+ */
+std::string unit_level_tooltip(const unit &u);
+
+/**
+ * @return the tooltip text showing a unit type's level and what it can
+ * advance to.
+ */
+std::string unit_level_tooltip(const unit_type &u);
 }


### PR DESCRIPTION
Moves creation of the advancement tooltip text when you mouseover the "Lvl [number]" in the sidebar to a helper function and convert's the recruit/recall dialog's `level_label_` to a `gui2::implementation::styled_widget` so we can add the tooltip.

I merged the two "User Interface" sections for master in the changelog.

There's a lot of duplication in `unit_preview_pane::set_displayed_type` (recruit list) and `unit_preview_pane::set_displayed_unit` (recall list); they've diverged a bit over time, but I haven't looked closely enough to see how much of that is intentional versus forgetting to update both.