### PR TITLE
Tutorial S2 - Capturing village bug-fix, add more instructions about capturing and recruiting

### DIFF
--- a/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
+++ b/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
@@ -382,16 +382,31 @@ A full list of abilities and weapons specials, along with traits, may be found i
             [/show_if]
         [/message]
 
-        [message]
-            speaker=Galdrad
-            message= _ "While none of your recruited units can move yet, you still can. You need more income; there are some villages near the keep you can capture."
-        [/message]
+        [if]
+            [not]
+                [have_location]
+                    terrain=^V
+                [/have_location]
+            [/not]
+            [then]
+                [message]
+                    speaker=Galdrad
+                    message= _ "While none of your recruited units can move yet, you still can. You need more income; there are some villages near the keep you can capture."
+                [/message]
 
-        {PRINT ( _ "Capture a village")}
+                {PRINT ( _ "Capture a village")}
+
+                [disallow_end_turn]
+                    reason=_"You still have to capture a village!"
+                [/disallow_end_turn]
+            [/then]
+        [/if]
     [/event]
 
     [event]
         name=capture
+        first_time_only=no
+
         [filter]
             side=1
         [/filter]
@@ -400,32 +415,58 @@ A full list of abilities and weapons specials, along with traits, may be found i
 
         # NOTE: maybe give live income stats?
 
-        [message]
-            speaker=Galdrad
-            message= _ "Excellent! As Delfador mentioned earlier, each captured village will support one unit and provide you with 1 extra gold per turn."
-        [/message]
+        [if]
+            [not]
+                [have_unit]
+                    side=1
+                    race=elf
+                    count=5
+                [/have_unit]
+            [/not]
+            [then]
+                {PRINT ( _ "You forgot to recruit troops! You can press <b>u</b> to undo your last move.")}
 
-        [message]
-            speaker=narrator
-            caption= _ "Income and Upkeep"
-            image=wesnoth-icon.png
-            message= _ "Each turn, you will gain 2 gold plus one for each village you own. However, <i>upkeep</i> is subtracted from that. You can support as many levels worth of units as the number of villages you own; beyond that, you must pay 1 gold per turn. Be careful, as owning too many units can cause you to have negative income and lose gold each turn!"
-        [/message]
+                [disallow_end_turn]
+                    reason=_"You still have to recruit troops!"
+                [/disallow_end_turn]
 
-        [message]
-            speaker=narrator
-            caption= _ "Status Table"
-            image=wesnoth-icon.png
-            message= _ "The Status Table details the sides’ current status and starting conditions. Fog and shroud will affect what you can see in this table, and occasionally a side may be hidden; however, it is still useful to check this table when a scenario begins. You can access it in the <b>Menu</b> menu."
-        [/message]
+                [allow_undo] [/allow_undo]
+            [/then]
+            [else]
+                [message]
+                    speaker=Galdrad
+                    message= _ "Excellent! As Delfador mentioned earlier, each captured village will support one unit and provide you with 1 extra gold per turn."
+                [/message]
 
-        [allow_end_turn][/allow_end_turn]
+                [message]
+                    speaker=narrator
+                    caption= _ "Income and Upkeep"
+                    image=wesnoth-icon.png
+                    message= _ "Each turn, you will gain 2 gold plus one for each village you own. However, <i>upkeep</i> is subtracted from that. You can support as many levels worth of units as the number of villages you own; beyond that, you must pay 1 gold per turn. Be careful, as owning too many units can cause you to have negative income and lose gold each turn!"
+                [/message]
 
-        {PRINT (_"End your turn")}
-        [event]
-            name=side 1 turn end
+                [message]
+                    speaker=narrator
+                    caption= _ "Status Table"
+                    image=wesnoth-icon.png
+                    message= _ "The Status Table details the sides’ current status and starting conditions. Fog and shroud will affect what you can see in this table, and occasionally a side may be hidden; however, it is still useful to check this table when a scenario begins. You can access it in the <b>Menu</b> menu."
+                [/message]
+
+                [allow_end_turn][/allow_end_turn]
+
+                {PRINT (_"End your turn")}
+                [event]
+                    name=side 1 turn end
+                    {CLEAR_PRINT}
+                [/event]
+            [/else]
+        [/if]
+
+        [on_undo]
             {CLEAR_PRINT}
-        [/event]
+
+            {PRINT ( _ "Recruit or recall your troops")}
+        [/on_undo]
     [/event]
 
     [event]

--- a/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
+++ b/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
@@ -382,25 +382,16 @@ A full list of abilities and weapons specials, along with traits, may be found i
             [/show_if]
         [/message]
 
-        [if]
-            [not]
-                [have_location]
-                    terrain=^V
-                [/have_location]
-            [/not]
-            [then]
-                [message]
-                    speaker=Galdrad
-                    message= _ "While none of your recruited units can move yet, you still can. You need more income; there are some villages near the keep you can capture."
-                [/message]
+        [message]
+            speaker=Galdrad
+            message= _ "While none of your recruited units can move yet, you still can. You need more income; there are some villages near the keep you can capture."
+        [/message]
 
-                {PRINT ( _ "Capture a village")}
+        {PRINT ( _ "Capture a village")}
 
-                [disallow_end_turn]
-                    reason=_"You still have to capture a village!"
-                [/disallow_end_turn]
-            [/then]
-        [/if]
+        [disallow_end_turn]
+            reason=_"You still have to capture a village!"
+        [/disallow_end_turn]
     [/event]
 
     [event]
@@ -410,6 +401,12 @@ A full list of abilities and weapons specials, along with traits, may be found i
         [filter]
             side=1
         [/filter]
+        [filter_condition]
+            [variable]
+                name=turn_number
+                numerical_equals=1
+            [/variable]
+        [/filter_condition]
 
         {CLEAR_PRINT}
 


### PR DESCRIPTION
Add more reminding PRINT messages, disallow_end_turn messages, and fix a bug where player can just capture village and end turn without recruiting/recalling units.