### PR TITLE
sdl: Prevent undefined behaviour in clip_rect_setter

### DIFF
--- a/src/sdl/surface.hpp
+++ b/src/sdl/surface.hpp
@@ -183,17 +183,24 @@ struct clip_rect_setter
 	// if r is nullptr, clip to the full size of the surface.
 	clip_rect_setter(const surface &surf, const SDL_Rect* r, bool operate = true) : surface_(surf), rect_(), operate_(operate)
 	{
-		if(operate_){
+		if(operate_ && surface_.get()){
 			SDL_GetClipRect(surface_, &rect_);
-			SDL_Rect final_rect;
-			SDL_IntersectRect(&rect_, r, &final_rect);
+			SDL_Rect final_rect = { 0, 0, 0, 0 };
+
+			if(r) {
+				SDL_IntersectRect(&rect_, r, &final_rect);
+			} else {
+				final_rect.w = surface_->w;
+				final_rect.h = surface_->h;
+			}
+
 			SDL_SetClipRect(surface_, &final_rect);
 		}
 	}
 
 	~clip_rect_setter()
 	{
-		if(operate_) {
+		if(operate_ && surface_.get()) {
 			SDL_SetClipRect(surface_, &rect_);
 		}
 	}


### PR DESCRIPTION
(Found while investigating issue #4510.)

Unlike what the constructor's documentation says, passing a null `SDL_Rect*` does have unexpected consequences. First, one of the first two arguments to `SDL_IntersectRect` will be a null pointer, which results in `SDL_IntersectRect` returning SDL_FALSE without ever touching the output `SDL_Rect`:

```c
SDL_bool
SDL_IntersectRect(const SDL_Rect * A, const SDL_Rect * B, SDL_Rect * result)
{
    int Amin, Amax, Bmin, Bmax;

    if (!A) {
        SDL_InvalidParamError("A");
        return SDL_FALSE;
    }

    if (!B) {
        SDL_InvalidParamError("B");
        return SDL_FALSE;
    }
```

In this context that means that next `SDL_SetClipRect` will receive a pointer to a fresh `SDL_Rect` full of uninitialized values and all kinds of weirdness could ensue next depending on the phase of the moon.

Additionally, while the SDL functions called here will do nothing on a null pointer to a surface, the check introduced here requires dereferencing the surface's members, so we need to explicitly do nothing if the surface is null.

Both cases don't seem to ever happen in practice, judging from a cursory glance at how `clip_rect_setter` is currently used in the codebase, but that doesn't mean they will never turn up in the future.

This issue applies to both master and 1.14.