### PR TITLE
Do not use SDL render API for certain drawing operations

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1841,7 +1841,25 @@ void display::draw_minimap()
 		view_h + 2
 	};
 
-	sdl::draw_rectangle(outline_rect, {255, 255, 255, 255});
+	// SDL 2.0.10's render batching changes result in the
+	// surface's clipping rectangle being overridden even if
+	// no render clipping rectangle set operaton was queued,
+	// so let's not use the render API to draw the rectangle.
+
+	const SDL_Rect outline_parts[] = {
+		// top
+		{ outline_rect.x,                      outline_rect.y,                  outline_rect.w, 1              },
+		// bottom
+		{ outline_rect.x,                      outline_rect.y + outline_rect.h, outline_rect.w, 1              },
+		// left
+		{ outline_rect.x,                      outline_rect.y,                  1,              outline_rect.h },
+		// right
+		{ outline_rect.x + outline_rect.w - 1, outline_rect.y,                  1,              outline_rect.h },
+	};
+
+	for(const auto& r : outline_parts) {
+		SDL_FillRect(screen_.getSurface(), &r, 0x00FFFFFF);
+	}
 }
 
 void display::draw_minimap_units()
@@ -1895,7 +1913,12 @@ void display::draw_minimap_units()
 				, int(std::round(u_h))
 		};
 
-		sdl::fill_rectangle(r, col);
+		// SDL 2.0.10's render batching changes result in the
+		// surface's clipping rectangle being overridden even if
+		// no render clipping rectangle set operaton was queued,
+		// so let's not use the render API to draw the rectangle.
+
+		SDL_FillRect(screen_.getSurface(), &r, col.to_argb_bytes());
 	}
 }
 

--- a/src/help/help_text_area.cpp
+++ b/src/help/help_text_area.cpp
@@ -552,7 +552,11 @@ void help_text_area::draw_contents()
 						it->rect.h - i * 2
 					};
 
-					sdl::draw_rectangle(draw_rect, {0, 0, 0, 0});
+					// SDL 2.0.10's render batching changes result in the
+					// surface's clipping rectangle being overridden even if
+					// no render clipping rectangle set operaton was queued,
+					// so let's not use the render API to draw the rectangle.
+					SDL_FillRect(screen, &draw_rect, 0);
 					++dst.x;
 					++dst.y;
 				}


### PR DESCRIPTION
With the introduction of batched rendering in SDL 2.0.10, the behaviour of the render API appears to have changed so that certain operations forcibly queue a renderer clip rectangle set operation, using a default rectangle if necessary. The command queue does not clean after itself since it appears that the operating assumption is that you either use the renderer API or you don't, and Wesnoth performs drawing operations both with and without it in a few places.

With commit 4cbd6529e3d5f378d4dd0080dda8a47025b0d50d, our drawing primitives were changed ("refactored") so that the render API is forcibly used by them. When combined with contexts that use the `clip_rect_setter` object, things get weird since the clipping rectangle is reset behind the code's back.

As I see it, there's two solutions to this:

1. Make `clip_rect_setter` use `SDL_RenderSetClipRect()`. The problem with this is that there are at least 3-4 places using `clip_rect_setter` on a target that isn't the screen framebuffer. Finding out whether the target surface *is* the screen seems like an inconvenient chore.
2. Don't use the render API ever.
3. Keep using the render API (a lot of other things do use it, such as the GUI2 canvas implementation) and change the few contexts where we use `clip_rect_setter` together with drawing primitives to call the SDL_Surface drawing primitives directly instead of using the render API.

This patch goes with option 3 since it seems the least intrusive. While this fixes the two known cases of bug #4510 as of this writing (help browser and minimap outline), I am not entirely sure if there are any other users of `clip_rect_setter` hiding drawing primitive calls somewhere underneath.

Also added relevant source comments in case someone decides to refactor the involved code and break it again. It's especially necessary in the minimap's case since we need to draw a grand total of 4 different rectangles at once.

Fixes #4510.