### PR TITLE
i18n: Use <game dir>/translations on Windows

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -58,6 +58,8 @@
      Esperanto, French, Italian, Korean, Portuguese (Brazil), Russian, Spanish,
      Turkish
    * Fix Rename Unit dialog having untranslated text (issue #4569).
+   * Use <game dir>/translations instead of <process working dir>/translations to find core
+     translation catalogues on Windows.
  ### Terrains
    * Add Stone Walls variation Catacombs (Xot) including some overlays
    * New dwarf castle variations: Non-cave (Cf), ruined (Cfr) and snow (Cfa)

--- a/src/filesystem_common.cpp
+++ b/src/filesystem_common.cpp
@@ -78,7 +78,7 @@ std::string get_addons_dir()
 std::string get_intl_dir()
 {
 #ifdef _WIN32
-	return get_cwd() + "/translations";
+	return game_config::path + "/" LOCALEDIR;
 #else
 
 #ifdef USE_INTERNAL_DATA


### PR DESCRIPTION
This replaces the previous behaviour of using `<pwd>/translations`, which could break on certain edge cases (e.g. if Wesnoth is launched from the command line from a different dir).