### PR TITLE
GDB (Gnu C++ debugger) pretty printers

### DIFF
--- a/utils/gdb/register_wesnoth_pretty_printers.py
+++ b/utils/gdb/register_wesnoth_pretty_printers.py
@@ -12,7 +12,8 @@ import re
 import itertools
 
 import wesnoth_type_tools
-reload(wesnoth_type_tools)
+import importlib
+importlib.reload(wesnoth_type_tools)
 from wesnoth_type_tools import strip_all_type
 
 
@@ -34,7 +35,7 @@ def create_wesnoth_lookup_function(pretty_printers_dict):
         "Look-up and return a pretty-printer that can print val."
 
         #If it is a null pointer or object return the null pointer printer
-        if (val.type.code == gdb.TYPE_CODE_PTR and long(val) == 0) or (val.address == 0):
+        if (val.type.code == gdb.TYPE_CODE_PTR and int(val) == 0) or (val.address == 0):
             return NullPointerPrinter(val)
 
         # Get the type name.
@@ -65,7 +66,7 @@ def register(new_pretty_printers):
     #delete all previous wesnoth printers
     remove_printers=[]
     for a in gdb.pretty_printers:
-        if a.__name__ == 'wesnoth_lookup_function':
+        if a.name == 'wesnoth_lookup_function':
             remove_printers.append(a)
             for a in remove_printers:
                 gdb.pretty_printers.remove(a)

--- a/utils/gdb/wesnoth_gdb.py
+++ b/utils/gdb/wesnoth_gdb.py
@@ -1,50 +1,48 @@
-
 # This file loads Wesnoth specific code into gdb
 
 """
-Usage:
-1. Add these lines line into your .gdbinit that you use for wesnoth file:
+# Usage:
+# Add these lines line into your .gdbinit file that you use for wesnoth, or add then
+# to a different file and run it with gdb's -x option.
 
-#Load the wesnoth pretty-printers
+# Load the wesnoth pretty-printers. If you use a separate build tree, edit this and
+# replace the os.path.abspath('utils/gdb/') with hardcoding the correct directory.
 python import os
 python sys.path.append(os.path.abspath('utils/gdb/'))
 python import wesnoth_gdb
 
-#Get help with
-python print wesnoth_gdb.__doc__
+# Show a help banner when GDB starts
+python wesnoth_gdb.help()
 
-#Set expanded printing on
+# Set expanded printing on, but hide static members
 set print pretty on
-
-#Hide static members
 set print static-members off
-
 """
 
-__doc__ = """
+documentation_banner = """Commands for controlling the Wesnoth pretty-printers:
+
 python reload(wesnoth_gdb)              #Interactively reload wesnoth_gdb
-python wesnoth.gdb.help()               #Help message
-python print wesnoth_gdb.__doc__        #Help message
+python wesnoth_gdb.help()               #Help message
 
-python print wesnoth_gdb.set_levels_of_recursion( number )  #Sets the levels of recursion (default 1)
-python print wesnoth_gdb.get_levels_of_recursion( )         #Gets the levels of recursion (default 1)
-
+python wesnoth_gdb.set_levels_of_recursion( number )  #Sets the levels of recursion (default 1)
+python print(wesnoth_gdb.get_levels_of_recursion())   #Gets the levels of recursion (default 1)
 """
 
 import sys, gdb
+import importlib
 
 
 def help():
-    print __doc__
+    print(documentation_banner)
 
 #Force a reload, which is handy if you are interactively editing
 if 'register_wesnoth_pretty_printers' in sys.modules:
-    reload(register_wesnoth_pretty_printers)
+    importlib.reload(register_wesnoth_pretty_printers)
 else:
     import register_wesnoth_pretty_printers
 
 if 'wesnoth_pretty_printers' in sys.modules:
-    reload(wesnoth_pretty_printers)
+    importlib.reload(wesnoth_pretty_printers)
 else:
     import wesnoth_pretty_printers
 

--- a/utils/gdb/wesnoth_pretty_printers.py
+++ b/utils/gdb/wesnoth_pretty_printers.py
@@ -269,8 +269,8 @@ class ConfigPrinter(object):
     def children(self):
         if RecursionManager.should_display():
             #yield "invalid",  self.val['invalid']
-            yield "values", self.lval['values']
-            yield "children", self.lval['children']
+            yield "values", self.lval['values_']
+            yield "children", self.lval['children_']
             RecursionManager.inc()
             try:
                 yield "ordered_children", self.lval['ordered_children']

--- a/utils/gdb/wesnoth_pretty_printers.py
+++ b/utils/gdb/wesnoth_pretty_printers.py
@@ -7,7 +7,8 @@ import itertools
 
 
 import wesnoth_type_tools
-reload(wesnoth_type_tools)
+import importlib
+importlib.reload(wesnoth_type_tools)
 from wesnoth_type_tools import strip_all_type, dereference_if_possible
 
 
@@ -112,7 +113,7 @@ class TstringPrinter(object):
         #Print the untranslated string or an error
         try:
             ret = shared.dereference()['val']['value_']['iter_']['first']
-        except RuntimeError, e:
+        except RuntimeError as e:
             return "wesnoth_gdb error invalid tstring"
         return ret
 
@@ -162,7 +163,7 @@ class AttributeValuePrinter(object):
             else:
                 yield 'unknown', "unknown type code = " + ('%d' % attr_type)
 
-        except RuntimeError, e:
+        except RuntimeError as e:
             yield 'error', "wesnoth_gdb error invalid %s" % self.val.type
 
     def display_hint(self):
@@ -192,7 +193,7 @@ class BoostUnorderedMapPrinter(object):
         def __iter__(self):
             return self
 
-        def next(self):
+        def __next__(self):
             if self.buckets == 0 or not RecursionManager.should_display():
                 raise StopIteration
             while not self.node:
@@ -274,7 +275,7 @@ class ConfigPrinter(object):
             RecursionManager.inc()
             try:
                 yield "ordered_children", self.lval['ordered_children']
-            except RuntimeError, e:
+            except RuntimeError as e:
                 RecursionManager.dec()
             else:
                 RecursionManager.dec()


### PR DESCRIPTION
Updates to the utility that adds support for showing Wesnoth's `config` class in the Gnu C++ debugger.

Two commits doing two separate tasks:
* Support GDB linked with Python3; has the side-effect of dropping support for GDB linked with Python2.
* Support `config.hpp` from b6e398fdb1a7fde15e6c6941c0d21a9eb5bd2ed9 (Wesnoth 1.13.9) or later; has the side-effect of no longer supporting earlier versions.

Given the time since b6e398fd, I assume that anyone using this is using a locally fixed version; therefore I'm not concerned about breaking support for GDB linked with Python2 pretty-printer support. Just going to leave the PR open for a couple of days, and merge unless someone objects.