### PR TITLE
EI S11: Trigger the guards if an undisguised unit moves into the throne room

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
@@ -735,17 +735,43 @@
     [/event]
 
     [event]
+        name=enter_hex
+
+        [filter]
+            side=1
+            x=20,20
+            y=17,18
+
+            [filter_wml]
+                [not]
+                    [variables]
+                        undercover=yes
+                    [/variables]
+                [/not]
+            [/filter_wml]
+        [/filter]
+
+        [fire_event]
+            name=exposed
+
+            [primary_unit]
+                x,y=$x1,$y1
+            [/primary_unit]
+        [/fire_event]
+    [/event]
+
+    # Triggers if any unit on side 1 attacks, whether they're in disguise or not.
+    [event]
         name=attack
 
         [filter]
             side=1
-
-            [filter_wml]
-                [variables]
-                    undercover=yes
-                [/variables]
-            [/filter_wml]
         [/filter]
+
+        # Ignore bats and the Orcish Grunt on 11,4 (in the bat cave)
+        [filter_second]
+            type=Troll,Troll Warrior,Orcish Warrior,Orcish Warlord
+        [/filter_second]
 
         [fire_event]
             name=exposed
@@ -763,14 +789,8 @@
             [have_unit]
                 side=1
 
-                [filter_wml]
-                    [variables]
-                        undercover=yes
-                    [/variables]
-                [/filter_wml]
-
                 [filter_adjacent]
-                    type=Troll Warrior,Orcish Warrior,Orcish Warlord
+                    type=Troll,Troll Warrior,Orcish Warrior,Orcish Warlord
                 [/filter_adjacent]
             [/have_unit]
         [/filter_condition]
@@ -781,15 +801,15 @@
             [primary_unit]
                 side=1
 
-                [filter_wml]
-                    [variables]
-                        undercover=yes
-                    [/variables]
-                [/filter_wml]
+                [filter_adjacent]
+                    type=Troll,Troll Warrior,Orcish Warrior,Orcish Warlord
+                [/filter_adjacent]
             [/primary_unit]
         [/fire_event]
     [/event]
 
+    # This event's primary_unit should be the one who has been spotted, no matter
+    # whether that's the one in disguise or one of the other two escapees.
     [event]
         name=exposed
 
@@ -831,7 +851,13 @@
             name=remove disguise
 
             [primary_unit]
-                x,y=$x1,$y1
+                side=1
+
+                [filter_wml]
+                    [variables]
+                        undercover=yes
+                    [/variables]
+                [/filter_wml]
             [/primary_unit]
         [/fire_event]
 
@@ -1196,6 +1222,8 @@
         [/event]
     [/event]
 
+    # This event should be fired with the disguised unit as the primary unit, even
+    # if indirectly triggered by a name=exposed event on another unit.
     [event]
         name=remove disguise
 


### PR DESCRIPTION
Add an enter_hex event for moving into the throne room, and modify the "attack"
event so that the undisguised units can trigger it too. For reviewing, note that
the diff shows these as if the existing "attack" was changed to a "enter_hex",
but in fact it's the existing `[filter_wml]` moving from "attack" to "enter_hex".

Add L2 Trolls to various lists, as they're used on easy/normal difficulties.

The main bug fixed here is #4674 "When a guard sees one of the two units not
disguised as an orc, it chases after the unit, but no other enemies are
alerted. This allows a player to pick off each enemy unit individually, then
release the prisoners."