### PR TITLE
Remove redundant macro

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
@@ -1326,8 +1326,6 @@
             message= _ "Where are you going?! Come back!"
         [/message]
 
-        {FOREIGN_DEFEAT}
-
         [endlevel]
             result=defeat
         [/endlevel]


### PR DESCRIPTION
Remove redundant macro that adds a defeat event before triggering [endlevel]. The defeat event is already added at the end of the file.