### PR TITLE
Workaround for the warning about conflicting files called "l10n-track"

### DIFF
--- a/src/picture.cpp
+++ b/src/picture.cpp
@@ -461,7 +461,10 @@ static bool localized_file_uptodate(const std::string& loc_file)
 	if(fuzzy_localized_files.empty()) {
 		// First call, parse track index to collect fuzzy files by path.
 		std::string fsep = "\xC2\xA6"; // UTF-8 for "broken bar"
-		std::string trackpath = filesystem::get_binary_file_location("", "l10n-track");
+		// Issue #4716 is that passing an empty string as the first argument of get_binary_file_location
+		// causes that function to find the file in both "wesnoth_dir//l10n-track" and "wesnoth_dir/l10n-track",
+		// triggering the warning about conflicting files with the same name.
+		std::string trackpath = filesystem::get_binary_file_location("workaround_for_issue_4716", "l10n-track");
 
 		// l10n-track file not present. Assume image is up-to-date.
 		if(trackpath.empty()) {


### PR DESCRIPTION
I think the correct fix is to simply delete the localized_file_uptodate
function, however this commit is the minimal change to avoid #4716
for 1.14.11.

The functionality still works, which can be tested by:

1. set Wesnoth to French
2. note the logo on the title screen says "Bataille pour Wesnoth"
3. change l10n-track
    -ok        ¦images/misc/l10n/fr/logo.png¦  f13ab03e31b1aaeec3036ebfe049e78f  6e0af4f77ed425d62ae06ce7157a5b37f67c8f7
    +fuzzy        ¦images/misc/l10n/fr/logo.png¦  f13ab03e31b1aaeec3036ebfe049e78f  6e0af4f77ed425d62ae06ce7157a5b37f67c8f7
4. exit and re-launch Wesnoth (just pressing F5 does not work)
5. note the logo on the title screen is in English