### PR TITLE
make mode=append value by default in set_specials

### DIFF
--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -328,7 +328,7 @@ bool attack_type::apply_modification(const config& cfg)
 
 	if (set_specials) {
 		const std::string &mode = set_specials["mode"];
-		if (mode != "append") {
+		if (mode == "replace") {
 			specials_.clear();
 		}
 		for (const config::any_child &value : set_specials.all_children_range()) {


### PR DESCRIPTION
in set_specials, mode=append is more used what mode=replaced an din utbs mode no specified because the author blelieved what mode=append was already value by default. if mode=replace is few used then it don't must be used by default,like @gfgtdf said.