### PR TITLE
Fix MINGW (with MSYS2) build in Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,9 +83,18 @@ find_package(Gettext)
 find_package(X11)
 
 # needed to get some SDL2 defines in... (as of rev31694 -D_GNU_SOURCE=1 is required!)
-set(SDL2_CONFIG "sdl2-config" CACHE STRING "Path to sdl2-config script")
-exec_program(${SDL2_CONFIG} ARGS "--cflags" OUTPUT_VARIABLE SDL2_CFLAGS)
-add_definitions(${SDL2_CFLAGS})
+if(NOT MINGW)
+	set(SDL2_CONFIG "sdl2-config" CACHE STRING "Path to sdl2-config script")
+	exec_program(${SDL2_CONFIG} ARGS "--cflags" OUTPUT_VARIABLE SDL2_CFLAGS)
+	add_definitions(${SDL2_CFLAGS})
+else()
+	# equivalent to sdl2-config --cflags --libs
+	# since cmake cannot execute sdl2-config in msys2 shell
+	set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -I/mingw64/include/SDL2 -Dmain=SDL_main -L/mingw64/lib -lmingw32 -lSDL2main -lSDL2 -mwindows)
+
+	# MinGW system libraries that should be linked to wesnoth
+	set(MINGW_SYSTEM_LIBS wsock32 ws2_32 shlwapi winmm)
+endif()
 
 if(NOT WIN32)
 	# Use the safer `mkstemp' instead of `tmpnam' on POSIX systems.

--- a/cmake/FindSDL2.cmake
+++ b/cmake/FindSDL2.cmake
@@ -132,7 +132,7 @@ if(NOT SDL2_BUILDING_LIBRARY)
     # seem to provide SDLmain for compatibility even though they don't
     # necessarily need it.
     find_library(SDL2MAIN_LIBRARY
-      NAMES SDLmain SDLmain-1.1
+      NAMES SDL2main SDLmain SDLmain-1.1
       HINTS
         ENV SDL2DIR
       PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,6 +117,12 @@ endif(X11_FOUND)
 if(APPLE)
 	set(game-external-libs ${game-external-libs} "-framework IOKit")
 endif(APPLE)
+
+if(MINGW)
+	set(server-external-libs ${server-external-libs} ${MINGW_SYSTEM_LIBS})
+	set(game-external-libs ${game-external-libs} ${MINGW_SYSTEM_LIBS})
+endif(MINGW)
+
 ########### Set Library mode ###############
 
 if(ENABLE_SHARED_LIBRARIES)


### PR DESCRIPTION
Previously, only scons build in MSYS2 is possible. Now cmake also works with this fix.

`cmake .. -G "MSYS Makefiles" -DCMAKE_BUILD_TYPE=Release -DARCH=native`