### PR TITLE
Upload executables from travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,33 +15,37 @@ cache:
 git:
   depth: 5
 
+env:
+  global:
+    secure: Fw9j5BpL8e5f2boEC2D8l0Cm+pCJx7lyvpZvockSM9cF2Cnt/QPbknJLXPryExLhweQO/lvi0MPuoMhRJv0QbChBjdXzJmR+uU1ejCHfpkTc6Cm/yo3tZMG3Zm7vHs00gla2ytK+XyFIVZLtFxyzy2fxjD64sFO3YrUp0KzSXp8=
+
 matrix:
   include:
     - os: windows
-      env: OPT=Debug
+      env: OPT=Debug BRANCH=master
 
     - os: windows
-      env: OPT=Release
+      env: OPT=Release BRANCH=master
 
     - os: osx
       compiler: clang
-      env: TOOL=scons CXXSTD=14 NLS=false OPT=-O0
+      env: TOOL=scons CXXSTD=14 NLS=false BRANCH=master OPT=-O0
 
     - os: osx
       compiler: clang
-      env: TOOL=xcodebuild
+      env: TOOL=xcodebuild BRANCH=master
 
     - compiler: gcc
       env: CXXSTD=14 NLS=true LTS=1604 BRANCH=master
 
     - compiler: gcc
-      env: TOOL=scons CXXSTD=17 NLS=false LTS=1804 BRANCH=master VALIDATE=true
+      env: TOOL=scons CXXSTD=17 NLS=false LTS=1804 BRANCH=master VALIDATE=true UPLOAD_ID=ubuntu-1804
 
     - compiler: gcc
       env: TOOL=scons CXXSTD=14 NLS=false LTS=1604 BRANCH=master OPT=-O0
 
     - compiler: gcc
-      env: TOOL=cmake CXXSTD=14 NLS=false LTS=1604 BRANCH=master
+      env: TOOL=cmake CXXSTD=14 NLS=false LTS=1604 BRANCH=master UPLOAD_ID=ubuntu-1604
 
     - compiler: clang
       env: TOOL=scons CXXSTD=14 NLS=false LTS=1604 BRANCH=master OPT=-O0
@@ -49,7 +53,7 @@ matrix:
     - compiler: clang
       env: TOOL=cmake CXXSTD=14 NLS=false LTS=1604 BRANCH=master
 
-    - env: CXXSTD=14 NLS=false LTS=mingw BRANCH=master STRICT=false
+    - env: CXXSTD=14 NLS=false LTS=mingw BRANCH=master STRICT=false UPLOAD_ID=mingw
     
     - env: CXXSTD=14 NLS=false LTS=steamrt BRANCH=master CC=gcc-5 CXX=g++-5
 

--- a/utils/dockerbuilds/travis/Dockerfile-base-1604-master
+++ b/utils/dockerbuilds/travis/Dockerfile-base-1604-master
@@ -14,7 +14,9 @@ RUN apt install -y -qq libsdl2-2.0-0 libsdl2-dev libsdl2-image-2.0-0 libsdl2-ima
 ENV DEBIAN_FRONTEND=noninteractive
 
 # misc
-RUN apt install -y -qq libpng12-0 libpng12-dev libreadline6-dev libvorbis-dev libcairo2 libcairo2-dev libpango-1.0-0 libpango1.0-dev libfribidi0 libfribidi-dev libbz2-1.0 libbz2-dev zlib1g zlib1g-dev libpangocairo-1.0-0 libssl-dev libmysqlclient-dev expect-dev
+RUN apt install -y -qq libpng12-0 libpng12-dev libreadline6-dev libvorbis-dev libcairo2 libcairo2-dev libpango-1.0-0 libpango1.0-dev libfribidi0 libfribidi-dev libbz2-1.0 libbz2-dev zlib1g zlib1g-dev libpangocairo-1.0-0 libssl-dev libmysqlclient-dev expect-dev python3-pip
+RUN pip3 install --upgrade pip
+RUN yes | pip3 install paramiko
 
 # programs
 RUN apt install -y -qq openssl gdb xvfb bzip2 git scons cmake make ccache gcc g++ clang python3

--- a/utils/dockerbuilds/travis/Dockerfile-base-1804-master
+++ b/utils/dockerbuilds/travis/Dockerfile-base-1804-master
@@ -14,7 +14,9 @@ RUN apt install -y -qq libsdl2-2.0-0 libsdl2-dev libsdl2-image-2.0-0 libsdl2-ima
 ENV DEBIAN_FRONTEND=noninteractive
 
 # misc
-RUN apt install -y -qq libpng16-16 libpng-dev libreadline6-dev libvorbis-dev libcairo2 libcairo2-dev libpango-1.0-0 libpango1.0-dev libfribidi0 libfribidi-dev libbz2-1.0 libbz2-dev zlib1g zlib1g-dev libpangocairo-1.0-0 libssl-dev libmysqlclient-dev expect-dev
+RUN apt install -y -qq libpng16-16 libpng-dev libreadline6-dev libvorbis-dev libcairo2 libcairo2-dev libpango-1.0-0 libpango1.0-dev libfribidi0 libfribidi-dev libbz2-1.0 libbz2-dev zlib1g zlib1g-dev libpangocairo-1.0-0 libssl-dev libmysqlclient-dev expect-dev python3-pip
+RUN pip3 install --upgrade pip
+RUN yes | pip3 install paramiko
 
 # programs
 RUN apt install -y -qq openssl gdb xvfb bzip2 git scons cmake make ccache gcc g++ clang lld

--- a/utils/dockerbuilds/travis/Dockerfile-base-mingw
+++ b/utils/dockerbuilds/travis/Dockerfile-base-mingw
@@ -2,7 +2,9 @@ FROM rwgrim/msys2-cross
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get install -y scons g++-mingw-w64-x86-64 pkg-config python3-pefile expect && \
+    apt-get install -y scons g++-mingw-w64-x86-64 pkg-config python3-pefile expect python3-pip && \
+    pip3 install --upgrade pip && \
+    yes | pip3 install paramiko && \
     update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists

--- a/utils/travis/docker_run.sh
+++ b/utils/travis/docker_run.sh
@@ -26,7 +26,6 @@ BOOST_TEST="${11}"
 LTO="${12}"
 SAN="${13}"
 VALIDATE="${14}"
-LTS="${15}"
 
 if [ "$OPT" == "-O0" ]; then
     STRICT="true"
@@ -56,6 +55,10 @@ echo "LTO: $LTO"
 echo "SAN: $SAN"
 echo "VALIDATE: $VALIDATE"
 echo "LTS: $LTS"
+echo "TRAVIS_COMMIT: $TRAVIS_COMMIT"
+echo "BRANCH: $BRANCH"
+echo "UPLOAD_ID: $UPLOAD_ID"
+echo "TRAVIS_PULL_REQUEST: $TRAVIS_PULL_REQUEST"
 
 echo "STRICT: $STRICT"
 echo "build_timeout(mins): $build_timeout"
@@ -87,6 +90,10 @@ elif [ "$LTS" == "mingw" ]; then
         cxx_std=$CXXSTD opt="$OPT" strict="$STRICT" \
         nls=false enable_lto="$LTO" sanitize="$SAN" jobs=2 --debug=time \
         arch=x86-64 prefix=/windows/mingw64 gtkdir=/windows/mingw64 host=x86_64-w64-mingw32
+
+    if [ "$UPLOAD_ID" != "" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+        ./utils/travis/sftp
+    fi
 elif [ "$LTS" == "steamrt" ]; then
     scons ctool=$CC cxxtool=$CXX boostdir=/usr/local/include boostlibdir=/usr/local/lib extra_flags_config=-lrt \
         cxx_std=$CXXSTD opt="$OPT" strict="$STRICT" nls=false enable_lto="$LTO" sanitize="$SAN" jobs=2 --debug=time \
@@ -116,6 +123,10 @@ else
 
     if [ $BUILD_RET != 0 ]; then
         exit $BUILD_RET
+    fi
+
+    if [ "$UPLOAD_ID" != "" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+        ./utils/travis/sftp
     fi
 
     if (( SECONDS > 60*build_timeout )); then

--- a/utils/travis/sftp
+++ b/utils/travis/sftp
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+import paramiko
+import platform
+import os
+import datetime
+import time
+
+start = int(time.time())
+now = datetime.datetime.now()
+dest = "/home/frs/project/bfw-travis-upload/"
+
+with paramiko.Transport(("frs.sourceforge.net", 22)) as transport:
+    transport.connect(None, "bfw-uploader", os.environ["SFTP_PASSWORD"])
+    with paramiko.SFTPClient.from_transport(transport) as sftp:
+# make remote directories if they don't already exist
+        dest = dest+os.environ["BRANCH"]+"/"
+        try:
+            sftp.mkdir(dest)
+        except:
+            pass
+
+        dest = dest+str(now.year)+"-"+str(now.month).zfill(2)+"-"+str(now.day).zfill(2)+"/"
+        try:
+            sftp.mkdir(dest)
+        except:
+            pass
+
+        dest = dest+os.environ["TRAVIS_COMMIT"]+"/"
+        try:
+            sftp.mkdir(dest)
+        except:
+            pass
+
+        dest = dest+os.environ["UPLOAD_ID"]+"/"
+        try:
+            sftp.mkdir(dest)
+        except:
+            pass
+
+        if platform.system() == "Windows" or os.environ["LTS"] == "mingw":
+            sftp.put("wesnoth.exe", dest+"wesnoth.exe")
+            sftp.put("wesnothd.exe", dest+"wesnothd.exe")
+        else:
+            sftp.put("wesnoth", dest+"wesnoth")
+            sftp.put("wesnothd", dest+"wesnothd")
+
+print("SFTP duration: "+str(int(time.time())-start)+" seconds")

--- a/utils/travis/steps/script.sh
+++ b/utils/travis/steps/script.sh
@@ -58,9 +58,10 @@ elif [ "$TRAVIS_OS_NAME" = "windows" ]; then
 else
 # additional permissions required due to flatpak's use of bubblewrap
     docker run --cap-add=ALL --privileged \
+               --env SFTP_PASSWORD --env LTS --env TRAVIS_COMMIT --env BRANCH --env UPLOAD_ID --env TRAVIS_PULL_REQUEST \
                --volume "$HOME"/build-cache:/home/wesnoth-travis/build \
                --volume "$HOME"/flatpak-cache:/home/wesnoth-travis/flatpak-cache \
                --volume "$HOME"/.ccache:/root/.ccache \
                --tty wesnoth-repo:"$LTS"-"$BRANCH" \
-               unbuffer ./utils/travis/docker_run.sh "$NLS" "$TOOL" "$CC" "$CXX" "$CXXSTD" "$OPT" "$WML_TESTS" "$WML_TEST_TIME" "$PLAY_TEST" "$MP_TEST" "$BOOST_TEST" "$LTO" "$SAN" "$VALIDATE" "$LTS"
+               unbuffer ./utils/travis/docker_run.sh "$NLS" "$TOOL" "$CC" "$CXX" "$CXXSTD" "$OPT" "$WML_TESTS" "$WML_TEST_TIME" "$PLAY_TEST" "$MP_TEST" "$BOOST_TEST" "$LTO" "$SAN" "$VALIDATE"
 fi


### PR DESCRIPTION
This will SFTP the wesnoth and wesnothd executables from Travis (`UPLOAD_ID=<something>`) to SourceForge.

---

The files are SFTPed to the [bfw-travis-upload](https://sourceforge.net/projects/bfw-travis-upload/files/) project on SourceForge using the independent `bfw-uploader` ID, so it doesn't compromise the main Wesnoth project's files on SourceForge if the password used here were leaked.  The password is encrypted in the `travis.yml` via travis' support for [encrypted environment variables](https://docs.travis-ci.com/user/environment-variables/#defining-encrypted-variables-in-travisyml).  This means is should work for all branches, but not for PRs from forks.