### PR TITLE
Avoid hard-coding of HP/XP colours for unit types (resolves #4736)

### DIFF
--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -341,12 +341,12 @@ void unit_preview_pane::set_displayed_type(const unit_type& type)
 		tree_details_->clear();
 		tree_details_->add_node("hp_xp_mp", {
 			{ "hp",{
-				{ "label", (formatter() << "<small>" << "<span color='#21e100'>" << "<b>" << _("HP: ") << "</b>" << type.hitpoints() << "</span>" << " | </small>").str() },
+				{ "label", (formatter() << "<small>" << font::span_color(unit::create(type, 1, false)->hp_color()) << "<b>" << _("HP: ") << "</b>" << type.hitpoints() << "</span>" << " | </small>").str() },
 				{ "use_markup", "true" },
 				{ "tooltip", get_hp_tooltip(type.movement_type().get_resistances().damage_table(), [&type](const std::string& dt, bool is_attacker) { return type.resistance_against(dt, is_attacker); }) }
 			} },
 			{ "xp",{
-				{ "label", (formatter() << "<small>" << "<span color='#00a0e1'>" << "<b>" << _("XP: ") << "</b>" << type.experience_needed() << "</span>" << " | </small>").str() },
+				{ "label", (formatter() << "<small>" << font::span_color(unit::create(type, 1, false)->xp_color()) << "<b>" << _("XP: ") << "</b>" << type.experience_needed() << "</span>" << " | </small>").str() },
 				{ "use_markup", "true" },
 				{ "tooltip", (formatter() << _("Experience Modifier: ") << unit_experience_accelerator::get_acceleration() << '%').str() }
 			} },


### PR DESCRIPTION
Attempt to resolve #4736 by removing hard-coding. I'm not sure this is the right way to go about it though - a couple of questions to start with:
* Is the side number 0-based or 1-based?
* Does the unit get destroyed automatically afterwards or do I need to clean up manually?

Either way, this seems to work for me, and should equally apply to 1.14 branch.