### PR TITLE
Resolve #4736 (XP always displayed in light blue)

### DIFF
--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -340,8 +340,8 @@ void unit_preview_pane::set_displayed_type(const unit_type& type)
 
 		tree_details_->clear();
 		tree_details_->add_node("hp_xp_mp", {
-			{ "hp",{	// hard-coded span values based on unit::hp_color()
-				{ "label", (formatter() << "<small>" << "<span color='#21e100'>" << "<b>" << _("HP: ") << "</b>" << type.hitpoints() << "</span>" << " | </small>").str() },
+			{ "hp",{
+				{ "label", (formatter() << "<small>" << font::span_color(unit::hp_color_max()) << "<b>" << _("HP: ") << "</b>" << type.hitpoints() << "</span>" << " | </small>").str() },
 				{ "use_markup", "true" },
 				{ "tooltip", get_hp_tooltip(type.movement_type().get_resistances().damage_table(), [&type](const std::string& dt, bool is_attacker) { return type.resistance_against(dt, is_attacker); }) }
 			} },

--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -340,13 +340,13 @@ void unit_preview_pane::set_displayed_type(const unit_type& type)
 
 		tree_details_->clear();
 		tree_details_->add_node("hp_xp_mp", {
-			{ "hp",{
+			{ "hp",{	// hard-coded span values based on unit::hp_color()
 				{ "label", (formatter() << "<small>" << "<span color='#21e100'>" << "<b>" << _("HP: ") << "</b>" << type.hitpoints() << "</span>" << " | </small>").str() },
 				{ "use_markup", "true" },
 				{ "tooltip", get_hp_tooltip(type.movement_type().get_resistances().damage_table(), [&type](const std::string& dt, bool is_attacker) { return type.resistance_against(dt, is_attacker); }) }
 			} },
-			{ "xp",{
-				{ "label", (formatter() << "<small>" << "<span color='#00a0e1'>" << "<b>" << _("XP: ") << "</b>" << type.experience_needed() << "</span>" << " | </small>").str() },
+			{ "xp",{	// hard-coded span values based on unit::xp_color()
+				{ "label", (formatter() << "<small>" << (type.can_advance() ? "<span color='#00a0e1'>" : "<span color='#aa00ff'>") << "<b>" << _("XP: ") << "</b>" << type.experience_needed() << "</span>" << " | </small>").str() },
 				{ "use_markup", "true" },
 				{ "tooltip", (formatter() << _("Experience Modifier: ") << unit_experience_accelerator::get_acceleration() << '%').str() }
 			} },

--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -345,8 +345,8 @@ void unit_preview_pane::set_displayed_type(const unit_type& type)
 				{ "use_markup", "true" },
 				{ "tooltip", get_hp_tooltip(type.movement_type().get_resistances().damage_table(), [&type](const std::string& dt, bool is_attacker) { return type.resistance_against(dt, is_attacker); }) }
 			} },
-			{ "xp",{	// hard-coded span values based on unit::xp_color()
-				{ "label", (formatter() << "<small>" << (type.can_advance() ? "<span color='#00a0e1'>" : "<span color='#aa00ff'>") << "<b>" << _("XP: ") << "</b>" << type.experience_needed() << "</span>" << " | </small>").str() },
+			{ "xp",{
+				{ "label", (formatter() << "<small>" << font::span_color(unit::xp_color(100, type.can_advance(), true)) << "<b>" << _("XP: ") << "</b>" << type.experience_needed() << "</span>" << " | </small>").str() },
 				{ "use_markup", "true" },
 				{ "tooltip", (formatter() << _("Experience Modifier: ") << unit_experience_accelerator::get_acceleration() << '%').str() }
 			} },

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1131,7 +1131,7 @@ color_t unit::hp_color(int new_hitpoints) const
 	return hp_color_impl(new_hitpoints, hitpoints());
 }
 
-color_t unit::xp_color() const
+color_t unit::xp_color(int xp_to_advance, bool can_advance, bool has_amla)
 {
 	const color_t near_advance_color {255,255,255,255};
 	const color_t mid_advance_color  {150,255,255,255};
@@ -1142,18 +1142,12 @@ color_t unit::xp_color() const
 	const color_t far_amla_color     {139,0,237,255};
 	const color_t amla_color         {170,0,255,255};
 
-	const bool near_advance = static_cast<int>(experience_to_advance()) <= game_config::kill_experience;
-	const bool mid_advance  = static_cast<int>(experience_to_advance()) <= game_config::kill_experience*2;
-	const bool far_advance  = static_cast<int>(experience_to_advance()) <= game_config::kill_experience*3;
+	const bool near_advance = static_cast<int>(xp_to_advance) <= game_config::kill_experience;
+	const bool mid_advance  = static_cast<int>(xp_to_advance) <= game_config::kill_experience*2;
+	const bool far_advance  = static_cast<int>(xp_to_advance) <= game_config::kill_experience*3;
 
 	color_t color = normal_color;
-	bool major_amla = false;
-	bool has_amla = false;
-	for(const config& adv:get_modification_advances()){
-		major_amla |= adv["major_amla"].to_bool();
-		has_amla = true;
-	}
-	if(advances_to().size() ||major_amla){
+	if(can_advance){
 		if(near_advance){
 			color=near_advance_color;
 		} else if(mid_advance){
@@ -1174,6 +1168,17 @@ color_t unit::xp_color() const
 	}
 
 	return(color);
+}
+
+color_t unit::xp_color() const
+{
+	bool major_amla = false;
+	bool has_amla = false;
+	for(const config& adv:get_modification_advances()){
+		major_amla |= adv["major_amla"].to_bool();
+		has_amla = true;
+	}
+	return xp_color(experience_to_advance(), !advances_to().empty() || major_amla, has_amla);
 }
 
 void unit::set_recruits(const std::vector<std::string>& recruits)

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1131,6 +1131,11 @@ color_t unit::hp_color(int new_hitpoints) const
 	return hp_color_impl(new_hitpoints, hitpoints());
 }
 
+color_t unit::hp_color_max()
+{
+	return hp_color_impl(1, 1);
+}
+
 color_t unit::xp_color(int xp_to_advance, bool can_advance, bool has_amla)
 {
 	const color_t near_advance_color {255,255,255,255};

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1584,6 +1584,7 @@ public:
 	 * Color for this unit's XP. See also @ref hp_color
 	 */
 	color_t xp_color() const;
+	static color_t xp_color(int xp_to_advance, bool can_advance, bool has_amla);
 
 	/**
 	 * @}

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1571,6 +1571,7 @@ public:
 	 *                            The maximum_hitpoints are considered as base.
 	 */
 	color_t hp_color() const;
+	static color_t hp_color_max();
 
 	/**
 	 * Color for this unit's hitpoints.


### PR DESCRIPTION
Alternative to #4738, also resolves #4736 and also should be applicable to 1.14 branch. If one is accepted the other can be closed.

This one avoids the performance concerns of #4738 but retains the problem of hard-coded colour values.