### PR TITLE
Changes UtBS 9 and Liberty 6,7,8

### DIFF
--- a/data/campaigns/Liberty/scenarios/06_The_Hunters.cfg
+++ b/data/campaigns/Liberty/scenarios/06_The_Hunters.cfg
@@ -686,7 +686,7 @@
 #enddef
 
     #
-    # End condition
+    # End condition: turns run out
     #
     [event]
         name=time over
@@ -708,60 +708,95 @@
                 [/endlevel]
             [/then]
             [else]
-                [message]
-                    speaker=Baldras
-                    message= _ "What a bloody mess, but it is done. Their patrols are shattered and broken."
-                [/message]
-
-                [message]
-                    speaker=Helicrom
-                    message= _ "A job well done, but the fight is far from over. We have only sacked a few of their platoons, but more will come. These tactics will not work forever."
-                [/message]
-
-                [message]
-                    speaker=Baldras
-                    message= _ "It seems to me that our only choice is to attack Halstead itself. If we wait, their armies will become invincible. If we can burn it to the ground before the Queen’s forces rally, we may yet be able to break their foothold in this province."
-                [/message]
-
-                [message]
-                    speaker=Harper
-                    message= _ "Attack them directly? I thought you said there was no way we could fight them head on."
-                [/message]
-
-                [message]
-                    speaker=Helicrom
-                    message= _ "The only other option is to flee, but just as you have chosen to fight to protect your village, we are not so keen on abandoning our home in these woods."
-                [/message]
-
-                [message]
-                    speaker=Baldras
-                    message= _ "So you’ll join us?"
-                [/message]
-
-                [message]
-                    speaker=Helicrom
-                    message= _ "We will."
-                [/message]
-
-                [message]
-                    speaker=Baldras
-                    message= _ "Then it’s decided. We will attack the fort and raze it. Rest well tonight. Tomorrow’s battle will be a difficult one."
-                [/message]
-
-                [modify_unit]
-                    [filter]
-                        side=2
-                    [/filter]
-                    side=1
-                [/modify_unit]
-
-                [endlevel]
-                    result=victory
-                    bonus=yes
-                    {NEW_GOLD_CARRYOVER 40}
-                [/endlevel]
+                [fire_event]
+                    name=win event
+                [/fire_event]
             [/else]
         [/if]
+    [/event]
+
+    #
+    # End condition: last patrol defeated
+    #
+    [event]
+        name=die
+
+        [filter_condition]
+            [have_unit]
+                side=3
+                count=0
+            [/have_unit]
+            [and]
+                [variable]
+                    name=turn_number
+                    greater_than=20
+                [/variable]
+            [/and]
+        [/filter_condition]
+
+
+        [fire_event]
+            name=win event
+        [/fire_event]
+    [/event]
+
+    #
+    # Victory event
+    #
+    [event]
+        name=win event
+        [message]
+            speaker=Baldras
+            message= _ "What a bloody mess, but it is done. Their patrols are shattered and broken."
+        [/message]
+
+        [message]
+            speaker=Helicrom
+            message= _ "A job well done, but the fight is far from over. We have only sacked a few of their platoons, but more will come. These tactics will not work forever."
+        [/message]
+
+        [message]
+            speaker=Baldras
+            message= _ "It seems to me that our only choice is to attack Halstead itself. If we wait, their armies will become invincible. If we can burn it to the ground before the Queen’s forces rally, we may yet be able to break their foothold in this province."
+        [/message]
+
+        [message]
+            speaker=Harper
+                    message= _ "Attack them directly? I thought you said there was no way we could fight them head on."
+        [/message]
+
+        [message]
+            speaker=Helicrom
+            message= _ "The only other option is to flee, but just as you have chosen to fight to protect your village, we are not so keen on abandoning our home in these woods."
+        [/message]
+
+        [message]
+            speaker=Baldras
+            message= _ "So you’ll join us?"
+        [/message]
+
+        [message]
+            speaker=Helicrom
+            message= _ "We will."
+        [/message]
+
+        [message]
+            speaker=Baldras
+            message= _ "Then it’s decided. We will attack the fort and raze it. Rest well tonight. Tomorrow’s battle will be a difficult one."
+        [/message]
+
+        [modify_unit]
+            [filter]
+                side=2
+            [/filter]
+            side=1
+        [/modify_unit]
+
+        [endlevel]
+            result=victory
+            bonus=yes
+            {NEW_GOLD_CARRYOVER 40}
+        [/endlevel]
     [/event]
 
     #

--- a/data/campaigns/Liberty/scenarios/07_Glory.cfg
+++ b/data/campaigns/Liberty/scenarios/07_Glory.cfg
@@ -441,16 +441,31 @@
 
     #
     # Special Event - The cavalry comes (to help THEM) -
-    # every other afternoon a platoon arrives
+    # every afternoon a platoon arrives
     #
 #define BAD_CAVALRY TURN
     [event]
         name=turn {TURN}
-        [message]
-            speaker=narrator
-            message= _ "That afternoon, another advance element of the main Wesnoth army arrived..."
-            image="wesnoth-icon.png"
-        [/message]
+        [if]
+            [variable]
+                name=turn_number
+                numerical_equals=7
+            [/variable]
+            [then]
+                [message]
+                    speaker=narrator
+                    message= _ "The siege on Halstead did not go unnoticed. Not even a full day had passed before the first advance elements of Wesnoth's main army started to arrive..."
+                    image="wesnoth-icon.png"
+                [/message]
+            [/then]
+            [else]
+                [message]
+                    speaker=narrator
+                    message= _ "That afternoon, another advance element of the main Wesnoth army arrived..."
+                    image="wesnoth-icon.png"
+                [/message]
+            [/else]
+        [/if]
 
         # The side filter in MOVE_UNIT is used to ensure that only the spawned
         # unit can be moved, in case the player would have misplaced his units
@@ -492,10 +507,10 @@
     [event]
         name=attack
         [filter]
-            side=2
+            side=1,4
         [/filter]
         [filter_second]
-            side=1,4
+            side=2
         [/filter_second]
         [message]
             speaker=Dommel
@@ -642,7 +657,7 @@
                             {QUAKE "cave-in.ogg"}
                             [message]
                                 speaker=narrator
-                                message= _ "With a thunderous roar and a vast billowing of dust, thousands of tons of stone and wood crashed in on itself. Some of it tumbled down the steep sides, while the remainder came to rest several hundred feet below ground, in the bowels of the hollowed-out mountain."
+                                message= _ "With a thunderous roar and a vast billowing of dust, thousands of tons of stone and wood crashed in on itself. Some of the wreckage tumbled down the steep sides, while the remainder came to rest several hundred feet below ground, in the bowels of the hollowed-out mountain."
                                 image="wesnoth-icon.png"
                             [/message]
                             [message]

--- a/data/campaigns/Liberty/scenarios/08_Epilogue.cfg
+++ b/data/campaigns/Liberty/scenarios/08_Epilogue.cfg
@@ -14,16 +14,16 @@
             story= _ "The rest of the battle was a blur. The shock of what had happened stunned everybody."
         [/part]
         [part]
-            story= _ "Baldras and his men fled the plains of western Wesnoth under the cover of night. The spectacle of Halstead’s destruction stunned them into a daze that only slowly wore off as they made their way north to and past Elensefar."
+            story= _ "Baldras and his men fled the plains of western Wesnoth under the cover of night. The spectacle of Halstead’s destruction held them in a daze that only slowly wore off as they made their way north to and past Elensefar."
         [/part]
         [part]
-            story= _ "The Elense riders routed the orcish army, small as it was, and sent them back across the Great River. They then scattered to the countryside and were not heard from again. Baldras thought this behavior odd when he heard about it."
+            story= _ "The Elense riders routed the orcish army, small as it was, and sent them back across the Great River. They then scattered to the countryside and were not heard from again. Baldras thought this behavior odd when word of this first reached him."
         [/part]
         [part]
             story= _ "As the main body of Asheviere’s army neared the ruins of Halstead, strange things began to happen. Every night, men would disappear. Others were found hacked to bloody pieces. Unexplained misfortune plagued the marching columns. Soldiers dropped dead where they stood, slain by unseen assassins. Fear of an undead menace spread through the ranks."
         [/part]
         [part]
-            story= _ "When the army of Wesnoth found the ruins of the mighty fortress Halstead, it was too much. Their shock that such a thing could happen combined with the invisible terror stalking them convinced Asheviere’s second in command the entire countryside was cursed. He quickly retreated to the traditional border and set up strong defenses against the west."
+            story= _ "When the army of Wesnoth found the ruins of the mighty fortress Halstead, it was too much. Their shock that such a thing could happen, combined with the invisible terror stalking them, convinced Asheviere’s second in command the entire countryside was cursed. He quickly retreated to the traditional border and set up strong defenses against the west."
         [/part]
         [part]
             story= _ "Baldras had just crossed the Great River when rumors of night-stalkers filtered through his ranks. With bitter humor he realized that Lord Maddock’s men were successfully using tactics Baldras had mastered and used during his resistance."
@@ -49,6 +49,7 @@
     [event]
         name=prestart
         [endlevel]
+            result=victory
             carryover_report=no
             replay_save=no
             linger_mode=no

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg
@@ -2463,20 +2463,39 @@
         [/message]
         [message]
             race=merman
+            [not]
+                id=Esanoo
+            [/not]
             message= _ "Actually we prefer to dwell in the shallow waters, where we may frolic in the great coral reefs under the sun and moon. But I digress, we realize that you people cannot swim like us, and I believe I may have a solution."
         [/message]
         [message]
             race=merman
+            [not]
+                id=Esanoo
+            [/not]
             message= _ "The humans of the Iron Council dwell in a large island to the northwest; I was taken there several times for interrogation. It is a fearsome place, full of black rock and tall peaks, but in the center is a lagoon. In the lagoon, I saw several ships anchored, which we might be able to use to transport your people across the waves."
         [/message]
         [message]
             speaker=Zhul
             message= _ "Across the waves?! We are a people of the desert, we know nothing of piloting such vessels! And I do not like the idea of putting my life at the mercy of some human-built ship."
         [/message]
-        [message]
-            race=merman
-            message= _ "We have often spied on the humans and have picked up some knowledge of piloting. We also have some magical skills that allow us to control the winds and thus we can easily propel the ships in the right direction. Once out on the open sea we should be safe from danger. Besides, our master lives far out in the waters. Trying to find her and bearing her back here would take too long and there is no other way to get you to her."
-        [/message]
+        [if]
+            [have_unit]
+                type=Mermaid Priestess,Mermaid Diviner,Mermaid Enchantress,Mermaid Siren
+            [/have_unit]
+            [then]
+                [message]
+                    type=Mermaid Priestess,Mermaid Diviner,Mermaid Enchantress,Mermaid Siren
+                    message= _ "We have often spied on the humans and have picked up some knowledge of piloting. We also have some magical skills that allow us to control the winds and thus we can easily propel the ships in the right direction. Once out on the open sea we should be safe from danger. Besides, our master lives far out in the waters. Trying to find her and bearing her back here would take too long and there is no other way to get you to her."
+                [/message]
+            [/then]
+            [else]
+                [message]
+                    race=merman
+                    message= _ "We have often spied on the humans and have picked up some knowledge of piloting. We also have some magical skills that allow us to control the winds and thus we can easily propel the ships in the right direction. Once out on the open sea we should be safe from danger. Besides, our master lives far out in the waters. Trying to find her and bearing her back here would take too long and there is no other way to get you to her."
+                [/message]
+            [/else]
+        [/if]
         [message]
             speaker=Kaleh
             message= _ "We have already gone to many strange places and survived. I trust the merfolk. If they believe that they can transport us safely across the waters, then I will put my life in their hands."
@@ -2708,11 +2727,23 @@
             speaker=Kaleh
             message= _ "Good, then let’s get out of here. The merfolk will help you guide the ships. I’ll muster the rest of our people and retreat from this bloody battlefield. We’ll meet you along the coastline west of here. Don’t worry about losing us, we’ll stick to the coast and the merfolk will help us keep in contact. Once we’ve escaped and are out of range of any counterattacks by the humans, we can load the rest of our people onto the ships."
         [/message]
-        [message]
-            race=merman
-            message= _ "Then by the Sea God’s hand I call forth the winds. May they confound our enemies and blow these ships to safety!"
-        [/message]
-
+        [if]
+            [have_unit]
+                type=Mermaid Priestess,Mermaid Diviner,Mermaid Enchantress,Mermaid Siren
+            [/have_unit]
+            [then]
+                [message]
+                    type=Mermaid Priestess,Mermaid Diviner,Mermaid Enchantress,Mermaid Siren
+                    message= _ "Then by the Sea God’s hand I call forth the winds. May they confound our enemies and blow these ships to safety!"
+                [/message]
+            [/then]
+            [else]
+                [message]
+                    race=merman
+                    message= _ "Then by the Sea God’s hand I call forth the winds. May they confound our enemies and blow these ships to safety!"
+                [/message]
+            [/else]
+        [/if]
         # Elves and troll/dwarf get in the ships, enemies disappear (the enemy side won't persist to the next scenario)
         [put_to_recall_list]
             [not]


### PR DESCRIPTION
Liberty scenario 6:
- added victory event when the player defeated all patrols
- this is to prevent the player having to end turn (for two sides) for a couple turns to wait for victory on _time over_.

UtBS scenario 9:
- fix a dialogue attribution error (if alive, Esanoo speaks of his imprisonment despite never being captured)
- add further merfolk dialogue attribution as flavor

Edit:
- Liberty scenario 7: fixed a small number error, added flavor text to the army arrivals.
- Liberty scenario 8: added a victory event (display credits and add laurel in campaign menu), small text adjustments