### PR TITLE
proposed new resistances for Giant Scorpion, fix to SotBE 7

### DIFF
--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/07_The_Desert_of_Death.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/07_The_Desert_of_Death.cfg
@@ -191,20 +191,20 @@
             message= _ "We don’t have any other choice. If we remain here we’ll die."
         [/message]
 
-        {NOTRAIT_UNIT 3 "Giant Scorpion" 8 13}
-        {NOTRAIT_UNIT 3 "Giant Scorpion" 15  6}
-        {NOTRAIT_UNIT 3 "Giant Scorpion" 19 12}
-        {NOTRAIT_UNIT 3 "Giant Scorpion" 13 10}
-        {NOTRAIT_UNIT 3 "Giant Scorpion" 11 16}
+        {UNIT 3 "Giant Scorpion"  8 13 variation=scuttler}
+        {UNIT 3 "Giant Scorpion" 15  6 variation=scuttler}
+        {UNIT 3 "Giant Scorpion" 19 12 variation=scuttler}
+        {UNIT 3 "Giant Scorpion" 13 10 variation=scuttler}
+        {UNIT 3 "Giant Scorpion" 11 16 variation=scuttler}
 #ifdef NORMAL
-        {NOTRAIT_UNIT 3 "Giant Scorpion" 15  3}
+        {UNIT 3 "Giant Scorpion" 15  3 variation=scuttler}
 #endif
 #ifdef HARD
-        {NOTRAIT_UNIT 3 "Giant Scorpion"  6 14}
-        {NOTRAIT_UNIT 3 "Giant Scorpion" 15  3}
+        {UNIT 3 "Giant Scorpion"  6 14 variation=scuttler}
+        {UNIT 3 "Giant Scorpion" 15  3 variation=scuttler}
 #endif
-        {NOTRAIT_UNIT 3 "Giant Scorpion" 26  4}
-        {NOTRAIT_UNIT 3 "Giant Scorpion" 11 22}
+        {UNIT 3 "Giant Scorpion" 26  4 variation=scuttler}
+        {UNIT 3 "Giant Scorpion" 11 22 variation=scuttler}
     [/event]
 
     [event]
@@ -259,7 +259,7 @@
                 {RANDOM "1..$scorpion_locs.length"}
                 {VARIABLE_OP random sub 1}
                 #{MESSAGE narrator "" "" "New scorpion at: $scorpion_locs[$random].x $scorpion_locs[$random].y"}
-                {NOTRAIT_UNIT 3 "Giant Scorpion" $scorpion_locs[$random].x $scorpion_locs[$random].y}
+                {UNIT 3 "Giant Scorpion" $scorpion_locs[$random].x $scorpion_locs[$random].y variation=scuttler}
             [/then]
         [/if]
         {CLEAR_VARIABLE random,scorp_prob,scorpion_locs}

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg
@@ -198,7 +198,7 @@
         [/message]
         [message]
             speaker="Pirk"
-            message= _ "Leave your people here Kapou’e — they are safe for the moment — and go defend Prestim. In the meantime, now that the council is complete again, we will decide. We may have to form the Great Horde again, and give you the leadership of it."
+            message= _ "Go defend Prestim, Kapou'e. In the meantime, now that the council is complete again, we will decide. We may have to form the Great Horde again, and give you the leadership of it."
         [/message]
         [kill]
             id="Pirk"

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg
@@ -21,7 +21,7 @@
     {EXTRA_SCENARIO_MUSIC northern_mountains.ogg}
     {EXTRA_SCENARIO_MUSIC casualties_of_war.ogg}
 
-    {THOT_TRACK {JOURNEY_STAGE6}}
+    {THOT_TRACK {JOURNEY_STAGE4}}
 
     # wmllint: validate-off
     [side]

--- a/data/core/units/monsters/Giant_Scorpion.cfg
+++ b/data/core/units/monsters/Giant_Scorpion.cfg
@@ -20,14 +20,14 @@
             image="units/monsters/scorpion/scorpion-ne.png:150"
         [/frame]
     [/standing_anim]
-    hitpoints=40
+    hitpoints=35
     movement_type=scuttlefoot
     [resistance]
-        blade=100
-        pierce=100
-        impact=100
-        fire=100
-        cold=100
+        blade=90
+        pierce=80
+        impact=110
+        fire=90
+        cold=110
         arcane=80
     [/resistance]
     movement=8
@@ -127,6 +127,7 @@
                 image="units/monsters/scorpion/sand-scuttler-ne.png:150"
             [/frame]
         [/standing_anim]
+        hitpoints=40
         [resistance]
             blade=90
             pierce=90

--- a/data/core/units/monsters/Giant_Scorpling.cfg
+++ b/data/core/units/monsters/Giant_Scorpling.cfg
@@ -10,10 +10,10 @@
     movement_type=scuttlefoot
     [resistance]
         blade=100
-        pierce=100
-        impact=100
-        fire=100
-        cold=100
+        pierce=90
+        impact=110
+        fire=90
+        cold=110
         arcane=80
     [/resistance]
     movement=6
@@ -21,10 +21,10 @@
     level=0
     alignment=neutral
     advances_to=Giant Scorpion
-    cost=10
+    cost=13
     usage=fighter
     undead_variation=spider
-    description= _ "One of the most potent known venoms is that of the monstrous scorpions of the frontier. Fetching a high price by assassins and apothecaries alike, this venom is often seen as a quick way to make coin, alluring bold hunters to venture into the wilderness to harvest it. However, even in a juvenile state, these scorpions can deliver deadly stings and are faster than most men. What's worse is that they can live in rather large nests, and angering a seemingly lone scorpion can lead to swarms of them crawling up from the ground — quickly turning the hunter into the hunted."
+    description= _ "One of the most potent known venoms is that of the monstrous scorpions of the frontier. Fetching a high price by assassins and apothecaries alike, this venom is often seen as a quick way to make coin, alluring bold hunters to venture into the wilderness to harvest it. However, even in a juvenile state, these scorpions can deliver deadly stings and are faster than most men. What's worse is that they can live in rather large nests, and angering a seemingly lone scorpion can lead to swarms of them crawling up from the ground — quickly turning the hunter into the hunted. They are protected by a sturdy shell which hardens as they age, becoming more resilient. This carapace is very resistant to normal blade strikes or piercing attacks, but can be broken with heavy blows."
     {NOTE_POISON}
     die_sound=hiss-big.wav
     {DEFENSE_ANIM "units/monsters/scorpion/scorpling-defend2.png" "units/monsters/scorpion/scorpling-defend1.png" hiss.wav }


### PR DESCRIPTION
The addition of a variation for the Giant Scorpion and respective resistance change in #4015 left the unit with the uninspired values of standard humans.

I propose to change the resistances back to something more interesting that builds on their carapace (hard to hurt with normal blades, but you can crush or cook them). Note, that especially the impact resistances go in the _opposite_ direction of the Scuttle variation. Didn't want to overdo it, but I'd also be open to add +10% pierce resistance.

Also added a fix to SotBE scenario 7 to use the variation because scenario dialogue clearly talks about the old resistance values.


Edit: updated the commit with resistances as discussed below and according modifications to the unit description.
I pulled the changes to the Scuttler, because simply reducing the extremes of good ol' Mudcrawler resistances doesn't make it much better and doesn't help for scenarios currently balanced around it - might as well keep it as is, we have the standard Scorpion for a more realistic (and mundane) representation.

Edit: also fixed a continuity error between SotBE scenarios 5 and 9 (scenario 5 says: `Leaving most of his people at Barag Gór, Kapou’e, accompanied by the shamans and his warriors, set off to Tirigaz`) which I caught multiple times over the years but now have the means to remedy...