### PR TITLE
fix leadership animation played when weapon don't matche [filter_weapon]

### DIFF
--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1563,14 +1563,7 @@ void attack_unit_and_advance(const map_location& attacker,
 
 int under_leadership(const unit &u, const map_location& loc, const_attack_ptr weapon, const_attack_ptr opp_weapon)
 {
-	unit_ability_list abil = u.get_abilities("leadership", loc);
-	for(unit_ability_list::iterator i = abil.begin(); i != abil.end();) {
-		if((!u.ability_affects_weapon(*i->first, weapon, false) || !u.ability_affects_weapon(*i->first, opp_weapon, true))) {
-			i = abil.erase(i);
-		} else {
-			++i;
-		}
-	}
+	unit_ability_list abil = u.get_abilities_weapons("leadership", loc, weapon, opp_weapon);
 	unit_abilities::effect leader_effect(abil, 0, false);
 	return leader_effect.get_composite_value();
 }

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -225,46 +225,14 @@ unit_ability_list unit::get_abilities(const std::string& tag_name, const map_loc
 
 unit_ability_list unit::get_abilities_weapons(const std::string& tag_name, const map_location& loc, const_attack_ptr weapon, const_attack_ptr opp_weapon) const
 {
-	unit_ability_list res(loc_);
-
-	for(const config& i : this->abilities_.child_range(tag_name)) {
-		if(ability_active(tag_name, i, loc)
-			&& ability_affects_self(tag_name, i, loc)
-			&& ability_affects_weapon(i, weapon, false)
-			&& ability_affects_weapon(i, opp_weapon, true)
-		) {
-			res.emplace_back(&i, loc);
+	unit_ability_list res = get_abilities(tag_name, loc);
+	for(unit_ability_list::iterator i = res.begin(); i != res.end();) {
+		if((!ability_affects_weapon(*i->first, weapon, false) || !ability_affects_weapon(*i->first, opp_weapon, true))) {
+			i = res.erase(i);
+		} else {
+			++i;
 		}
 	}
-
-	assert(display::get_singleton());
-	const unit_map& units = display::get_singleton()->get_units();
-
-	adjacent_loc_array_t adjacent;
-	get_adjacent_tiles(loc,adjacent.data());
-	for(unsigned i = 0; i < adjacent.size(); ++i) {
-		const unit_map::const_iterator it = units.find(adjacent[i]);
-		if (it == units.end() || it->incapacitated())
-			continue;
-		// Abilities may be tested at locations other than the unit's current
-		// location. This is intentional to allow for less messing with the unit
-		// map during calculations, particularly with regards to movement.
-		// Thus, we need to make sure the adjacent unit (*it) is not actually
-		// ourself.
-		if ( &*it == this )
-			continue;
-		for(const config& j : it->abilities_.child_range(tag_name)) {
-			if(affects_side(j, side(), it->side())
-				&& it->ability_active(tag_name, j, adjacent[i])
-				&& ability_affects_adjacent(tag_name, j, i, loc, *it) && ability_affects_weapon(j, weapon, false)
-				&& ability_affects_weapon(j, opp_weapon, true)
-			) {
-				res.emplace_back(&j, adjacent[i]);
-			}
-		}
-	}
-
-
 	return res;
 }
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -223,6 +223,51 @@ unit_ability_list unit::get_abilities(const std::string& tag_name, const map_loc
 	return res;
 }
 
+unit_ability_list unit::get_abilities_weapons(const std::string& tag_name, const map_location& loc, const_attack_ptr weapon, const_attack_ptr opp_weapon) const
+{
+	unit_ability_list res(loc_);
+
+	for(const config& i : this->abilities_.child_range(tag_name)) {
+		if(ability_active(tag_name, i, loc)
+			&& ability_affects_self(tag_name, i, loc)
+			&& ability_affects_weapon(i, weapon, false)
+			&& ability_affects_weapon(i, opp_weapon, true)
+		) {
+			res.emplace_back(&i, loc);
+		}
+	}
+
+	assert(display::get_singleton());
+	const unit_map& units = display::get_singleton()->get_units();
+
+	adjacent_loc_array_t adjacent;
+	get_adjacent_tiles(loc,adjacent.data());
+	for(unsigned i = 0; i < adjacent.size(); ++i) {
+		const unit_map::const_iterator it = units.find(adjacent[i]);
+		if (it == units.end() || it->incapacitated())
+			continue;
+		// Abilities may be tested at locations other than the unit's current
+		// location. This is intentional to allow for less messing with the unit
+		// map during calculations, particularly with regards to movement.
+		// Thus, we need to make sure the adjacent unit (*it) is not actually
+		// ourself.
+		if ( &*it == this )
+			continue;
+		for(const config& j : it->abilities_.child_range(tag_name)) {
+			if(affects_side(j, side(), it->side())
+				&& it->ability_active(tag_name, j, adjacent[i])
+				&& ability_affects_adjacent(tag_name, j, i, loc, *it) && ability_affects_weapon(j, weapon, false)
+				&& ability_affects_weapon(j, opp_weapon, true)
+			) {
+				res.emplace_back(&j, adjacent[i]);
+			}
+		}
+	}
+
+
+	return res;
+}
+
 std::vector<std::string> unit::get_ability_list() const
 {
 	std::vector<std::string> res;

--- a/src/units/udisplay.cpp
+++ b/src/units/udisplay.cpp
@@ -646,7 +646,7 @@ void unit_attack(display * disp, game_board & board,
 
 	animator.add_animation(&defender, defender_anim, def->get_location(), true, text, {255, 0, 0});
 
-	for(const unit_ability& ability : attacker.get_abilities("leadership")) {
+	for(const unit_ability& ability : attacker.get_abilities_weapons("leadership", attack.shared_from_this(), secondary_attack)) {
 		if(ability.second == a) {
 			continue;
 		}
@@ -663,7 +663,7 @@ void unit_attack(display * disp, game_board & board,
 			hit_type, attack.shared_from_this(), secondary_attack, swing);
 	}
 
-	for(const unit_ability& ability : defender.get_abilities("resistance")) {
+	for(const unit_ability& ability : defender.get_abilities_weapons("resistance", attack.shared_from_this(), secondary_attack)) {
 		if(ability.second == a) {
 			continue;
 		}

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1693,9 +1693,9 @@ int unit::resistance_against(const std::string& damage_name,bool attacker,const 
 {
 	int res = movement_type_.resistance_against(damage_name);
 
-	unit_ability_list resistance_abilities = get_abilities("resistance",loc);
+	unit_ability_list resistance_abilities = get_abilities_weapons("resistance",loc, weapon, opp_weapon);
 	for(unit_ability_list::iterator i = resistance_abilities.begin(); i != resistance_abilities.end();) {
-		if(!resistance_filter_matches(*i->first, attacker, damage_name, 100-res) || (!ability_affects_weapon(*i->first, weapon, false) || !ability_affects_weapon(*i->first, opp_weapon, true))) {
+		if(!resistance_filter_matches(*i->first, attacker, damage_name, 100-res)) {
 			i = resistance_abilities.erase(i);
 		} else {
 			++i;

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1638,6 +1638,13 @@ public:
 	{
 		return get_abilities(tag_name, loc_);
 	}
+	
+	unit_ability_list get_abilities_weapons(const std::string& tag_name, const map_location& loc, const_attack_ptr weapon = nullptr, const_attack_ptr opp_weapon = nullptr) const;
+
+	unit_ability_list get_abilities_weapons(const std::string& tag_name, const_attack_ptr weapon = nullptr, const_attack_ptr opp_weapon = nullptr) const
+	{
+		return get_abilities_weapons(tag_name, loc_, weapon, opp_weapon);
+	}
 
 	/**
 	 * Gets the names and descriptions of this unit's abilities. Location-independent variant
@@ -1686,8 +1693,6 @@ public:
 	 */
 	void remove_ability_by_id(const std::string& ability);
 
-	///filters the weapons that condition the use of abilities for combat ([resistance],[leadership] or abilities used like specials(deprecated in two last cases)
-	bool ability_affects_weapon(const config& cfg, const_attack_ptr weapon, bool is_opp) const;
 
 private:
 	/**
@@ -1715,6 +1720,9 @@ private:
 	 * @param loc The location on which to resolve the ability
 	 */
 	bool ability_affects_self(const std::string& ability, const config& cfg, const map_location& loc) const;
+	
+	///filters the weapons that condition the use of abilities for combat ([resistance],[leadership] or abilities used like specials(deprecated in two last cases)
+	bool ability_affects_weapon(const config& cfg, const_attack_ptr weapon, bool is_opp) const;
 
 public:
 	/** Get the unit formula manager. */


### PR DESCRIPTION
if a unit under leadership use a weapon don't matched with [leadership] [filter_(second_)weapon], then leader_anim of leader is played, or the attack not helped in that case, it musn't be like that.