### PR TITLE
[WIP] Run the pre-release translation targets on travis.

### DIFF
--- a/utils/dockerbuilds/travis/Dockerfile-base-1604-master
+++ b/utils/dockerbuilds/travis/Dockerfile-base-1604-master
@@ -13,6 +13,10 @@ RUN apt install -y -qq libsdl2-2.0-0 libsdl2-dev libsdl2-image-2.0-0 libsdl2-ima
 # make tzdata not prompt for a timezone
 ENV DEBIAN_FRONTEND=noninteractive
 
+# translations
+RUN apt install -y -qq asciidoc dos2unix xsltproc po4a docbook-xsl language-pack-en
+RUN locale-gen en_US.UTF-8
+
 # misc
 RUN apt install -y -qq libpng12-0 libpng12-dev libreadline6-dev libvorbis-dev libcairo2 libcairo2-dev libpango-1.0-0 libpango1.0-dev libfribidi0 libfribidi-dev libbz2-1.0 libbz2-dev zlib1g zlib1g-dev libpangocairo-1.0-0 libssl-dev libmysqlclient-dev expect-dev python3-pip moreutils
 RUN pip3 install --upgrade pip

--- a/utils/dockerbuilds/travis/Dockerfile-base-1804-master
+++ b/utils/dockerbuilds/travis/Dockerfile-base-1804-master
@@ -13,6 +13,10 @@ RUN apt install -y -qq libsdl2-2.0-0 libsdl2-dev libsdl2-image-2.0-0 libsdl2-ima
 # make tzdata not prompt for a timezone
 ENV DEBIAN_FRONTEND=noninteractive
 
+# translations
+RUN apt install -y -qq asciidoc dos2unix xsltproc po4a docbook-xsl language-pack-en
+RUN locale-gen en_US.UTF-8
+
 # misc
 RUN apt install -y -qq libpng16-16 libpng-dev libreadline6-dev libvorbis-dev libcairo2 libcairo2-dev libpango-1.0-0 libpango1.0-dev libfribidi0 libfribidi-dev libbz2-1.0 libbz2-dev zlib1g zlib1g-dev libpangocairo-1.0-0 libssl-dev libmysqlclient-dev expect-dev python3-pip moreutils
 RUN pip3 install --upgrade pip

--- a/utils/travis/docker_run.sh
+++ b/utils/travis/docker_run.sh
@@ -51,6 +51,10 @@ echo "build_timeout(mins): $build_timeout"
 $CXX --version
 
 if [ "$NLS" == "only" ]; then
+    export LANGUAGE=en_US.UTF-8
+    export LANG=en_US.UTF-8
+    export LC_ALL=en_US.UTF-8
+
     ./utils/travis/check_utf8.sh || exit 1
     ./utils/travis/utf8_bom_dog.sh || exit 1
 
@@ -58,7 +62,9 @@ if [ "$NLS" == "only" ]; then
     make VERBOSE=1 -j2 || exit 1
     make clean
 
-    scons translations build=release --debug=time nls=true jobs=2
+    scons translations build=release --debug=time nls=true jobs=2 || exit 1
+
+    scons pot-update update-po4a manual
 elif [ "$LTS" == "flatpak" ]; then
 # docker's --volume means the directory is on a separate filesystem
 # flatpak-builder doesn't support this

--- a/utils/travis/steps/script.sh
+++ b/utils/travis/steps/script.sh
@@ -41,7 +41,9 @@ elif [ "$TRAVIS_OS_NAME" = "windows" ]; then
     exit $BUILD_RET
 else
 # additional permissions required due to flatpak's use of bubblewrap
-    docker run --cap-add=ALL --privileged \
+# enabling tty/using unbuffer causes po4a-translate to hang during the translation job
+    if [ "$NLS" != "only" ]; then
+        docker run --cap-add=ALL --privileged \
                --env SFTP_PASSWORD --env LTS --env TRAVIS_COMMIT --env BRANCH --env UPLOAD_ID --env TRAVIS_PULL_REQUEST --env NLS --env CC --env CXX --env TOOL \
                --env CXXSTD --env OPT --env WML_TESTS --env WML_TEST_TIME --env PLAY_TEST --env MP_TEST --env BOOST_TEST --env LTO --env SAN --env VALIDATE \
                --env TRAVIS_TAG \
@@ -50,4 +52,15 @@ else
                --volume "$HOME"/.ccache:/root/.ccache \
                --tty wesnoth-repo:"$LTS"-"$BRANCH" \
                unbuffer ./utils/travis/docker_run.sh
+    else
+        docker run --cap-add=ALL --privileged \
+               --env SFTP_PASSWORD --env LTS --env TRAVIS_COMMIT --env BRANCH --env UPLOAD_ID --env TRAVIS_PULL_REQUEST --env NLS --env CC --env CXX --env TOOL \
+               --env CXXSTD --env OPT --env WML_TESTS --env WML_TEST_TIME --env PLAY_TEST --env MP_TEST --env BOOST_TEST --env LTO --env SAN --env VALIDATE \
+               --env TRAVIS_TAG \
+               --volume "$HOME"/build-cache:/home/wesnoth-travis/build \
+               --volume "$HOME"/flatpak-cache:/home/wesnoth-travis/flatpak-cache \
+               --volume "$HOME"/.ccache:/root/.ccache \
+               wesnoth-repo:"$LTS"-"$BRANCH" \
+               ./utils/travis/docker_run.sh
+    fi
 fi


### PR DESCRIPTION
This will then catch errors on the commit it happens instead of usually much later.

---

Also removes the `--tty` and `unbuffer` command usage, since for some reason their presence causes `po4a-translate` to hang ([example](https://travis-ci.org/Pentarctagon/wesnoth/jobs/653932887#L15095-L15098) - in this case cancelled by me early, but this job has the `--verbose --debug` options enabled for it).

If anyone knows of a solution then great, otherwise I'll fully remove the logic for coloring the output since I think running the additional translation targets is more important.