### PR TITLE
Small typo fixes Diviner and Sicarius

### DIFF
--- a/data/core/units/merfolk/Diviner.cfg
+++ b/data/core/units/merfolk/Diviner.cfg
@@ -20,7 +20,7 @@
     {AMLA_DEFAULT}
     cost=57
     usage=healer
-    description= _ "Years of devotion may endow a priestess with great wisdom on the workings of the world, and grants some the favor of the light. The power thus given to these ladies of the water is a recurring motif in tale and song; such as the that of the knights of the silver spire, cornered and slain to a man at the banks of the Alavynne, but who rode again the next day, in full number, and wrought the downfall of the crimson duke."
+    description= _ "Years of devotion may endow a priestess with great wisdom on the workings of the world, and grants some the favor of the light. The power thus given to these ladies of the water is a recurring motif in tale and song; such as that of the knights of the silver spire, cornered and slain to a man at the banks of the Alavynne, but who rode again the next day, in full number, and wrought the downfall of the crimson duke."
     {NOTE_MAGICAL}
     {NOTE_ARCANE}
     {NOTE_CURES}

--- a/data/core/units/nagas/Sicarius.cfg
+++ b/data/core/units/nagas/Sicarius.cfg
@@ -16,7 +16,7 @@
     {AMLA_DEFAULT}
     cost=48
     usage=fighter
-    description= _ "While they sometimes still stand in as sellswords for potential Dunefolk allies, Naga Sicarii are more often the keepers of trade routes and resource beds close to waterways. For the right fee or exchange of goods, a Sicarius will guarantee safe travel or free access to valuable supplies in his territory. Rubbed the wrong way and a Sicarius becomes a fearsome foe, not because of their personal strength in combat, but instead due to the numerous allies that he can call upon to quash any potential nuisance. Though perfectly capable warriors when the time is necessary, these experienced mercenaries know perfectly well that the best methods for generating money are those that do not place themselves in danger."
+    description= _ "While they sometimes still stand in as sellswords for potential Dunefolk allies, Naga Sicarii are more often the keepers of trade routes and resource beds close to waterways. For the right fee or exchange of goods, a Sicarius will guarantee safe travel or free access to valuable supplies in their territory. Rubbed the wrong way, a Sicarius becomes a fearsome foe, not because of their personal strength in combat, but instead due to the numerous allies that they can call upon to quash any potential nuisance. Though perfectly capable warriors when forced by circumstances, these experienced mercenaries know perfectly well that the best methods for generating money are those that do not place themselves in danger."
     die_sound=naga-die.ogg
     {DEFENSE_ANIM "units/nagas/sicarius.png" "units/nagas/sicarius.png" {SOUND_LIST:NAGA_HIT} }
 


### PR DESCRIPTION
The Sicarius unit can be female as well, so I changed the description from male to neutral wording, but I'm not sure if that works stylistically. Otherwise change it to plural?

The whole description should probably get an overhaul at a later date anyway...