### PR TITLE
remove [advancefrom] from mainline

### DIFF
--- a/data/campaigns/Dead_Water/_main.cfg
+++ b/data/campaigns/Dead_Water/_main.cfg
@@ -71,6 +71,10 @@
     {campaigns/Dead_Water/units}
 [/units]
 
+[+campaign]
+    {ENABLE_KRAKEN}
+[/campaign]
+
 {campaigns/Dead_Water/scenarios}
 
 [lua]

--- a/data/campaigns/Dead_Water/units/Kraken.cfg
+++ b/data/campaigns/Dead_Water/units/Kraken.cfg
@@ -1,5 +1,13 @@
 #textdomain wesnoth-dw
 
+#define ENABLE_KRAKEN
+    [modify_unit_type]
+        id="Cuttle Fish"
+        add_advancement="Kraken"
+        set_experience=80
+    [/modify_unit_type]
+#enddef 
+
 [unit_type]
     id=Kraken
     name= _ "Kraken"
@@ -12,10 +20,6 @@
     level=3
     alignment=neutral
     advances_to=null
-    [advancefrom]
-        unit=Cuttle Fish
-        experience=80
-    [/advancefrom]
     attacks=1
     {AMLA_DEFAULT}
     cost=62

--- a/data/campaigns/Legend_of_Wesmere/_main.cfg
+++ b/data/campaigns/Legend_of_Wesmere/_main.cfg
@@ -24,7 +24,6 @@
 #endif
 
 [campaign]
-    extra_defines=ENABLE_DWARVISH_RUNESMITH
     id=LOW
     define=CAMPAIGN_LOW
     rank=160
@@ -48,6 +47,7 @@
 
 " + _"(Hard level, 18 scenarios.)"
 
+    {ENABLE_DWARVISH_RUNESMITH}
     {CAMPAIGN_DIFFICULTY EASY   "units/elves-wood/fighter.png~RC(magenta>brown)" ( _ "Soldier") ( _ "Easy")}
     {CAMPAIGN_DIFFICULTY NORMAL "units/elves-wood/lord.png~RC(magenta>brown)" ( _ "Lord") ( _ "Normal")} {DEFAULT_DIFFICULTY}
     {CAMPAIGN_DIFFICULTY HARD   "units/elves-wood/high-lord.png~RC(magenta>brown)" ( _ "High Lord") ( _ "Challenging")}

--- a/data/campaigns/Sceptre_of_Fire/_main.cfg
+++ b/data/campaigns/Sceptre_of_Fire/_main.cfg
@@ -14,9 +14,9 @@
     start_year="25 YW"
     end_year="40 YW"
     define="CAMPAIGN_SCEPTRE_FIRE"
-    extra_defines=ENABLE_DWARVISH_RUNESMITH
     first_scenario="1_A_Bargain_is_Struck"
 
+    {ENABLE_DWARVISH_RUNESMITH}
     {CAMPAIGN_DIFFICULTY EASY   "units/dwarves/fighter.png~RC(magenta>red)" ( _ "Fighter") ( _ "Normal")}
     {CAMPAIGN_DIFFICULTY NORMAL "units/dwarves/steelclad.png~RC(magenta>red)" ( _ "Steelclad") ( _ "Challenging")} {DEFAULT_DIFFICULTY}
     {CAMPAIGN_DIFFICULTY HARD   "units/dwarves/lord.png~RC(magenta>red)" ( _ "Lord") ( _ "Difficult")}

--- a/data/campaigns/Secrets_of_the_Ancients/_main.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/_main.cfg
@@ -13,7 +13,8 @@
     start_year="22 YW"
     end_year="23 YW"
     first_scenario=01_Slipping_Away
-    extra_defines=ENABLE_ANCIENT_LICH,ENABLE_DEATH_KNIGHT
+    {ENABLE_DEATH_KNIGHT}
+    {ENABLE_ANCIENT_LICH}
     {CAMPAIGN_DIFFICULTY EASY "units/undead-skeletal/skeleton/skeleton-idle-2.png~RC(magenta>red)"( _ "Unpleasant") ( _ "Normal")}
     {CAMPAIGN_DIFFICULTY NORMAL "units/undead-skeletal/revenant/revenant-defend-2.png~RC(magenta>red)" ( _ "Corrupt") ( _ "Challenging")} {DEFAULT_DIFFICULTY}
     {CAMPAIGN_DIFFICULTY HARD "units/undead-skeletal/deathknight.png~RC(magenta>red)" ( _ "Diabolic") ( _ "Difficult")}

--- a/data/campaigns/The_Rise_Of_Wesnoth/_main.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/_main.cfg
@@ -14,9 +14,9 @@
     image="data/campaigns/The_Rise_Of_Wesnoth/images/campaign_image.png"
     abbrev= _ "TRoW"
     define=CAMPAIGN_THE_RISE_OF_WESNOTH
-    extra_defines=DISABLE_GRAND_MARSHAL
     first_scenario=01_A_Summer_of_Storms
 
+    {DISABLE_GRAND_MARSHAL}
     {CAMPAIGN_DIFFICULTY EASY   "data/campaigns/The_Rise_Of_Wesnoth/images/units/noble-fighter.png" ( _ "Fighter") ( _ "Easy")}
     {CAMPAIGN_DIFFICULTY NORMAL "data/campaigns/The_Rise_Of_Wesnoth/images/units/noble-commander.png" ( _ "Commander") ( _ "Normal")} {DEFAULT_DIFFICULTY}
     {CAMPAIGN_DIFFICULTY HARD   "data/campaigns/The_Rise_Of_Wesnoth/images/units/noble-lord.png" ( _ "Lord") ( _ "Challenging")}

--- a/data/core/macros/optional_unit_advancements.cfg
+++ b/data/core/macros/optional_unit_advancements.cfg
@@ -1,3 +1,18 @@
+#define ENABLE_PARAGON
+    [modify_unit_type]
+        id="Dune Blademaster"
+        add_advancement="Dune Paragon"
+        set_experience=220
+    [/modify_unit_type]
+#enddef
+
+#define DISABLE_GRAND_MARSHAL
+    [modify_unit_type]
+        id="General"
+        remove_advancement="Grand Marshal"
+        set_experience=150
+    [/modify_unit_type]
+#enddef
 
 #define ENABLE_ARMAGEDDON_DRAKE
     [modify_unit_type]

--- a/data/core/macros/optional_unit_advancements.cfg
+++ b/data/core/macros/optional_unit_advancements.cfg
@@ -1,0 +1,75 @@
+
+#define ENABLE_ARMAGEDDON_DRAKE
+    [modify_unit_type]
+        id="Inferno Drake"
+        add_advancement="Armageddon Drake"
+        set_experience=220
+    [/modify_unit_type]
+#enddef
+
+#define ENABLE_DWARVISH_ARCANISTER
+    [modify_unit_type]
+        id="Dwarvish Runemaster"
+        add_advancement="Dwarvish Arcanister"
+        set_experience=210
+    [/modify_unit_type]
+#enddef
+
+#define ENABLE_DWARVISH_RUNESMITH
+    [modify_unit_type]
+        id="Dwarvish Fighter"
+        add_advancement="Dwarvish Runesmith"
+    [/modify_unit_type]
+#enddef
+
+#define ENABLE_WOLF_ADVANCEMENT
+    [modify_unit_type]
+        id="Wolf"
+        add_advancement="Great Wolf"
+        set_experience=30
+    [/modify_unit_type]
+    [modify_unit_type]
+        id="Great Wolf"
+        add_advancement="Direwolf"
+        set_experience=65
+    [/modify_unit_type]
+#enddef
+
+#define ENABLE_NIGHTBLADE
+    [modify_unit_type]
+        id="Orcish Slayer"
+        add_advancement="Orcish Nightblade"
+        set_experience=100
+    [/modify_unit_type]
+#enddef
+
+#define ENABLE_TROLL_SHAMAN
+    [modify_unit_type]
+        id="Troll Whelp"
+        add_advancement="Troll Shaman"
+    [/modify_unit_type]
+#enddef
+
+#define ENABLE_ANCIENT_LICH
+    [modify_unit_type]
+        id="Lich"
+        add_advancement="Ancient Lich"
+        set_experience=250
+    [/modify_unit_type]
+#enddef
+
+#define ENABLE_DEATH_KNIGHT
+    [modify_unit_type]
+        id="Revenant"
+        add_advancement="Death Knight"
+        set_experience=85
+    [/modify_unit_type]
+#enddef
+
+#define ENABLE_WOSE_SHAMAN
+    [modify_unit_type]
+        id="Wose"
+        add_advancement="Wose Shaman"
+        set_experience=80
+    [/modify_unit_type]
+#enddef

--- a/data/core/units/drakes/Armageddon.cfg
+++ b/data/core/units/drakes/Armageddon.cfg
@@ -12,12 +12,6 @@
     level=4
     alignment=lawful
     advances_to=null
-#ifdef ENABLE_ARMAGEDDON_DRAKE
-    [advancefrom]
-        unit=Inferno Drake
-        experience=220
-    [/advancefrom]
-#endif
     {AMLA_DEFAULT}
     cost=85
     usage=archer

--- a/data/core/units/dunefolk/Blademaster.cfg
+++ b/data/core/units/dunefolk/Blademaster.cfg
@@ -13,14 +13,9 @@ units/dunefolk/soldier/#enddef
     movement=5
     level=3
     alignment=lawful
-#ifdef ENABLE_PARAGON
-    experience=220
-    advances_to=Dune Paragon
-#else
     experience=150
     advances_to=null
     {AMLA_DEFAULT}
-#endif
     cost=52
     usage=fighter
     description= _ "Dunefolk swordsmen are known for playing a game called the ‘Laeqad Challenge’, in which Laeqads—thick, sturdy reeds that are several sword-lengths in height—are hurled at them like javelins and they attempt to split the reed length-wise in midair. The trick to the game is that the reed is not circularly symmetric: most of the stalk is quite hard, but there is a thin line across the cross section that is softer and easier to cut. For even an experienced swordsman, splitting an entire Laeqad down its length would be an extraordinary achievement; most would be hard-pressed to cut even a single sword length, given the precise aim required to line up the blade with the reed’s soft spot. For a Blademaster, however, splitting several Laeqads in quick succession is quite ordinary, and some are even able to cut through two or three reeds simultaneously with a single sword swish.

--- a/data/core/units/dwarves/Arcanister.cfg
+++ b/data/core/units/dwarves/Arcanister.cfg
@@ -20,12 +20,6 @@
     usage=fighter
     advances_to=null
     experience=200
-#ifdef ENABLE_DWARVISH_ARCANISTER
-    [advancefrom]
-        unit=Dwarvish Runemaster
-        experience=210
-    [/advancefrom]
-#endif
     {AMLA_DEFAULT}
     description= _ "The most powerful of all the runecrafters, the Dwarvish Arcanister destroys wounded enemies almost instantly, and rarely fails to cause a wound when that is his intent. His skill in runecrafting is unrivaled, and the glyphs he carves into his weapons and armor deflect the blows of his enemies."
     {NOTE_MAGICAL}

--- a/data/core/units/dwarves/Runesmith.cfg
+++ b/data/core/units/dwarves/Runesmith.cfg
@@ -20,11 +20,6 @@
     usage=fighter
     experience=86
     advances_to=Dwarvish Runemaster
-#ifdef ENABLE_DWARVISH_RUNESMITH
-    [advancefrom]
-        unit=Dwarvish Fighter
-    [/advancefrom]
-#endif
     description= _ "Dwarvish runesmiths, now practiced at their craft, carve arcane runes into their weapons and armor. These runes infuse the runesmith’s blows with power and accuracy, and disrupt the blows of their enemies, causing them to strike softly, weakly and on the armor of the defender."
     {NOTE_MAGICAL}
     {DEFENSE_ANIM "units/dwarves/runesmith-defend-2.png" "units/dwarves/runesmith-defend-1.png" {SOUND_LIST:DWARF_HIT} }

--- a/data/core/units/humans/Loyalist_General.cfg
+++ b/data/core/units/humans/Loyalist_General.cfg
@@ -16,14 +16,9 @@
     movement=6
     level=3
     alignment=lawful
-#ifdef DISABLE_GRAND_MARSHAL
-    experience=150
-    advances_to=null
-    {AMLA_DEFAULT}
-#else
     experience=180
     advances_to=Grand Marshal
-#endif
+    {AMLA_DEFAULT}
     cost=54
     usage=fighter
     description= _ "As the leaders of their armies, Generals are responsible for the protection of large or important areas in the kingdoms to which they have sworn fealty. Well seasoned in the art of war, Generals can direct even the freshest recruits to strike strategically against imposing odds and emerge victorious. Recognized by nobility and citizenry alike, they are outfitted in ornate plate armor and granted some of the finest weaponry that human craftsmen can offer."

--- a/data/core/units/monsters/Wolf_Dire.cfg
+++ b/data/core/units/monsters/Wolf_Dire.cfg
@@ -14,12 +14,6 @@
     level=3
     alignment=neutral
     advances_to=null
-#ifdef ENABLE_WOLF_ADVANCEMENT
-    [advancefrom]
-        unit=Great Wolf
-        experience=65
-    [/advancefrom]
-#endif
     cost=36
     usage=scout
     description=_ "Wolves are aggressive animals that hunt in packs. Although weak individually, a wolf pack can kill even the strongest man in minutes."

--- a/data/core/units/monsters/Wolf_Great.cfg
+++ b/data/core/units/monsters/Wolf_Great.cfg
@@ -14,12 +14,6 @@
     level=2
     alignment=neutral
     advances_to=null
-#ifdef ENABLE_WOLF_ADVANCEMENT
-    [advancefrom]
-        unit=Wolf
-        experience=30
-    [/advancefrom]
-#endif
     cost=30
     usage=scout
     description=_ "Wolves are aggressive animals that hunt in packs. Although weak individually, a wolf pack can kill even the strongest man in minutes."

--- a/data/core/units/orcs/Nightblade.cfg
+++ b/data/core/units/orcs/Nightblade.cfg
@@ -15,12 +15,6 @@
     level=3
     alignment=chaotic
     advances_to=null
-#ifdef ENABLE_NIGHTBLADE
-    [advancefrom]
-        unit=Orcish Slayer
-        experience=100
-    [/advancefrom]
-#endif
     {AMLA_DEFAULT}
     cost=43
     usage=mixed fighter

--- a/data/core/units/trolls/Troll_Shaman.cfg
+++ b/data/core/units/trolls/Troll_Shaman.cfg
@@ -18,11 +18,6 @@
     level=2
     alignment=chaotic
     advances_to=null
-#ifdef ENABLE_TROLL_SHAMAN
-    [advancefrom]
-        unit=Troll Whelp
-    [/advancefrom]
-#endif
     {AMLA_DEFAULT}
     cost=32
     usage=mixed fighter

--- a/data/core/units/undead/Necro_Ancient_Lich.cfg
+++ b/data/core/units/undead/Necro_Ancient_Lich.cfg
@@ -12,12 +12,6 @@
     level=4
     alignment=chaotic
     advances_to=null
-#ifdef ENABLE_ANCIENT_LICH
-    [advancefrom]
-        unit=Lich
-        experience=250
-    [/advancefrom]
-#endif
     {AMLA_DEFAULT}
     cost=100
     usage=mixed fighter

--- a/data/core/units/undead/Skele_Death_Knight.cfg
+++ b/data/core/units/undead/Skele_Death_Knight.cfg
@@ -19,12 +19,6 @@
     level=3
     alignment=chaotic
     advances_to=null
-#ifdef ENABLE_DEATH_KNIGHT
-    [advancefrom]
-        unit=Revenant
-        experience=85
-    [/advancefrom]
-#endif
     {AMLA_DEFAULT}
     cost=45
     usage=fighter

--- a/data/core/units/wose/Wose_Shaman.cfg
+++ b/data/core/units/wose/Wose_Shaman.cfg
@@ -8,12 +8,6 @@
         {ABILITY_AMBUSH}
         {ABILITY_REGENERATES}
     [/abilities]
-#ifdef ENABLE_WOSE_SHAMAN
-    [advancefrom]
-        unit=Wose
-        experience=80
-    [/advancefrom]
-#endif
     hitpoints=50
     movement_type=treefolk
     movement=3

--- a/data/schema/core/addons.cfg
+++ b/data/schema/core/addons.cfg
@@ -151,6 +151,14 @@
 	{LINK_TAG "event"}
 	{LINK_TAG "lua"}
 	{LINK_TAG "ais/ai"}
+	[tag]
+		name="modify_unit_type"
+		max=infinite
+		{REQUIRED_KEY id string}
+		{SIMPLE_KEY add_advancement string}
+		{SIMPLE_KEY remove_advancement string}
+		{SIMPLE_KEY set_experience int}
+	[/tag]
 [/tag]
 [tag]
 	name="campaign"

--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -476,24 +476,43 @@ void game_config_manager::load_addons_cfg()
 				for(auto& unit_type : units.child_range("unit_type")) {
 					for(const auto& advancefrom : units.child_range("advancefrom")) {
 
-						deprecated_message(
-							_("[advancefrom]"),
-							DEP_LEVEL::FOR_REMOVAL,
-							{1, 17, 0},
-							_("Use [modify_unit_type] instead")
-						);
-	
-						advancefroms.add_child("modify_unit_type", config {
+						config modify_unit_type {
 							"id", unit_type["id"],
 							"add_advancement", advancefrom["unit"],
 							"experience", advancefrom["experience"]
-						});
+						};
+						deprecated_message(
+							"[advancefrom]",
+							DEP_LEVEL::FOR_REMOVAL,
+							{1, 17, 0},
+							_("Use [modify_unit_type]\n") + modify_unit_type.debug()  + "\n [/modify_unit_type] instead in [campaign]"
+						);
+	
+						advancefroms.add_child("modify_unit_type", modify_unit_type);
 					}
 					unit_type.remove_children("advancefrom", [](const config&){return true;});
 				}
 			}
+			//hardcoded list of 1.14 advancement macros, just used for the werro mesage below.
+			std::set<std::string> deprecated_defeines = {"ENABLE_PARAGON", "DISABLE_GRAND_MARSHAL", "ENABLE_ARMAGEDDON_DRAKE", "ENABLE_DWARVISH_ARCANISTER", "ENABLE_DWARVISH_RUNESMITH ", "ENABLE_WOLF_ADVANCEMENT", "ENABLE_NIGHTBLADE", "ENABLE_TROLL_SHAMAN", "ENABLE_ANCIENT_LICH", "ENABLE_DEATH_KNIGHT", "ENABLE_WOSE_SHAMAN"};
 			for(auto& campaign : umc_cfg.child_range("campaign")) {
 				campaign.append_children(std::move(advancefroms));
+				for(auto str : utils::split(campaign["extra_defines"])) {
+					if(deprecated_defeines.count(str) > 0) {
+						//TODO: we could try to implement a compatabiltiy path by
+						//      somehow getting the content of that macro from the
+						//      cache_ object, but considering that 1) the breakage
+						//      isn't that bad (just one disabled unit) and 2)
+						//      it before also didn't work in all cases (see #4402)
+						//      i don't think it is worth it.
+						deprecated_message(
+							"extra_defines=" + str,
+							DEP_LEVEL::REMOVED,
+							{1, 15, 4},
+							_("instead, use the macro with the same name in the [campaign] tag")
+						);
+					}
+				}
 			}
 
 			game_config_.append(std::move(umc_cfg));

--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -471,6 +471,30 @@ void game_config_manager::load_addons_cfg()
 					cfg["addon_version"] = addon_version.str();
 				}
 			}
+			config advancefroms;
+			for(auto& units : umc_cfg.child_range("units")) {
+				for(auto& unit_type : units.child_range("unit_type")) {
+					for(const auto& advancefrom : units.child_range("advancefrom")) {
+
+						deprecated_message(
+							_("[advancefrom]"),
+							DEP_LEVEL::FOR_REMOVAL,
+							{1, 17, 0},
+							_("Use [modify_unit_type] instead")
+						);
+	
+						advancefroms.add_child("modify_unit_type", config {
+							"id", unit_type["id"],
+							"add_advancement", advancefrom["unit"],
+							"experience", advancefrom["experience"]
+						});
+					}
+					unit_type.remove_children("advancefrom", [](const config&){return true;});
+				}
+			}
+			for(auto& campaign : umc_cfg.child_range("campaign")) {
+				campaign.append_children(std::move(advancefroms));
+			}
 
 			game_config_.append(std::move(umc_cfg));
 		} catch(const config::error& err) {

--- a/src/units/types.cpp
+++ b/src/units/types.cpp
@@ -88,7 +88,6 @@ unit_type::unit_type(const unit_type& o)
 	, do_not_list_(o.do_not_list_)
 	, advances_to_(o.advances_to_)
 	, experience_needed_(o.experience_needed_)
-	, in_advancefrom_(o.in_advancefrom_)
 	, alignment_(o.alignment_)
 	, movement_type_(o.movement_type_)
 	, possible_traits_(o.possible_traits_)
@@ -139,7 +138,6 @@ unit_type::unit_type(const config& cfg, const std::string& parent_id)
 	, do_not_list_(cfg_["do_not_list"].to_bool(false))
 	, advances_to_()
 	, experience_needed_(0)
-	, in_advancefrom_(false)
 	, alignment_(unit_type::ALIGNMENT::NEUTRAL)
 	, movement_type_()
 	, possible_traits_()
@@ -592,67 +590,6 @@ bool unit_type::hide_help() const
 	return hide_help_ || unit_types.hide_help(id_, race_->id());
 }
 
-void unit_type::add_advancement(const unit_type& to_unit, int xp)
-{
-	const std::string& to_id = to_unit.id_;
-
-	// Add extra advancement path to this unit type
-	LOG_CONFIG << "adding advancement from " << log_id() << " to " << to_unit.log_id() << "\n";
-	if(std::find(advances_to_.begin(), advances_to_.end(), to_id) == advances_to_.end()) {
-		advances_to_.push_back(to_id);
-	} else {
-		LOG_CONFIG << "advancement from " << log_id() << " to " << to_unit.log_id() << " already known, ignoring.\n";
-		return;
-	}
-
-	if(xp > 0) {
-		// xp is 0 in case experience= wasn't given.
-		if(!in_advancefrom_) {
-			// This function is called for and only for an [advancefrom] tag in a unit_type referencing this unit_type.
-			in_advancefrom_ = true;
-			experience_needed_ = xp;
-
-			DBG_UT << "Changing experience_needed from " << experience_needed_ << " to " << xp
-				   << " due to (first) [advancefrom] of " << to_unit.log_id() << "\n";
-		} else if(experience_needed_ > xp) {
-			experience_needed_ = xp;
-			DBG_UT << "Lowering experience_needed from " << experience_needed_ << " to " << xp
-				   << " due to (multiple, lower) [advancefrom] of " << to_unit.log_id() << "\n";
-		} else {
-			DBG_UT << "Ignoring experience_needed change from " << experience_needed_ << " to " << xp
-				   << " due to (multiple, higher) [advancefrom] of " << to_unit.log_id() << "\n";
-		}
-	}
-
-	// Add advancements to gendered subtypes, if supported by to_unit
-	for(int gender = 0; gender <= 1; ++gender) {
-		if(!gender_types_[gender]) {
-			continue;
-		}
-
-		if(!to_unit.gender_types_[gender]) {
-			WRN_CF << to_unit.log_id() << " does not support gender " << gender << std::endl;
-			continue;
-		}
-
-		LOG_CONFIG << "gendered advancement " << gender << ": ";
-		gender_types_[gender]->add_advancement(*(to_unit.gender_types_[gender]), xp);
-	}
-
-	if(cfg_.has_child("variation")) {
-		// Make sure the variations are created.
-		unit_types.build_unit_type(*this, VARIATIONS);
-
-		// Add advancements to variation subtypes.
-		// Since these are still a rare and special-purpose feature,
-		// we assume that the unit designer knows what they're doing,
-		// and don't block advancements that would remove a variation.
-		for(auto& v : variations_) {
-			LOG_CONFIG << "variation advancement: ";
-			v.second.add_advancement(to_unit, xp);
-		}
-	}
-}
 
 static void advancement_tree_internal(const std::string& id, std::set<std::string>& tree)
 {
@@ -1329,15 +1266,6 @@ void unit_type_data::build_all(unit_type::BUILD_STATUS status)
 		gui2::dialogs::loading_screen::progress();
 	}
 
-	// Handle [advancefrom] (once) after building to (at least) the CREATED level.
-	// (Currently, this could be simply a test for build_status_ == NOT_BUILT,
-	// but to guard against future changes, use a more thorough test.)
-	if(build_status_ < unit_type::CREATED && unit_type::CREATED <= status) {
-		for(auto& type : types_) {
-			add_advancement(type.second);
-		}
-	}
-
 	build_status_ = status;
 }
 
@@ -1387,30 +1315,6 @@ bool unit_type_data::hide_help(const std::string& type, const std::string& race)
 	}
 
 	return res;
-}
-
-void unit_type_data::add_advancement(unit_type& to_unit) const
-{
-	const config& cfg = to_unit.get_cfg();
-
-	for(const config& af : cfg.child_range("advancefrom")) {
-		const std::string& from = af["unit"];
-		int xp = af["experience"];
-
-		unit_type_data::unit_type_map::iterator from_unit = types_.find(from);
-
-		if(from_unit == types_.end()) {
-			std::ostringstream msg;
-			msg << "unit type '" << from << "' not found when resolving [advancefrom] tag for '" << to_unit.log_id()
-				<< "'";
-			throw config::error(msg.str());
-		}
-
-		// Fix up advance_from references
-		from_unit->second.add_advancement(to_unit, xp);
-
-		DBG_UT << "Added advancement ([advancefrom]) from " << from << " to " << to_unit.log_id() << "\n";
-	}
 }
 
 const unit_race* unit_type_data::find_race(const std::string& key) const

--- a/src/units/types.hpp
+++ b/src/units/types.hpp
@@ -96,12 +96,6 @@ public:
 	{ const_cast<unit_type *>(this)->build(status, movement_types, races, traits); }
 
 
-	/**
-	 * Adds an additional advancement path to a unit type.
-	 * This is used to implement the [advancefrom] tag.
-	 */
-	void add_advancement(const unit_type &advance_to,int experience);
-
 	/** Get the advancement tree
 	 *  @return A set of ids of all unit_type objects that this unit_type can
 	 *  directly or indirectly advance to.
@@ -336,7 +330,6 @@ private:
 
 	std::vector<std::string> advances_to_;
 	int experience_needed_;
-	bool in_advancefrom_;
 
 
 	ALIGNMENT alignment_;
@@ -389,9 +382,6 @@ private:
 	void read_hide_help(const config &cfg);
 
 	void clear();
-
-	void add_advancefrom(const config& unit_cfg) const;
-	void add_advancement(unit_type& to_unit) const;
 
 	mutable unit_type_map types_;
 	movement_type_map movement_types_;


### PR DESCRIPTION
See issue #3955
the intention is to deprecate [advancefrom] in
favour of [modify_unit_type], because it was a
common source of OOS errors, and it is less flexible.

As a secondary effect this also fixes issue #4402 :
"changing units via extra_defines sometimes not working
because extra_defines had bugs".
Now we no longer use extra_defines for that.

Addon authors should now no longer use these extra_defines,
instead put the new core marcos with the same name directly
into [campaign].