### PR TITLE
HttT S23: change misleading dialogue

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/23_Test_of_the_Clans.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/23_Test_of_the_Clans.cfg
@@ -294,7 +294,7 @@
         [/message]
         [message]
             speaker=Bayar
-            message= _ "No, whelp. You may be weakened, but the horse clans are eternal. I will promise you this, however. If you can defeat me personally, I myself will join your siege of Weldyn."
+            message= _ "No, whelp. You may be weakened, but the horse clans are eternal. I will promise you this, however. If you can defeat me in battle, I myself will join your siege of Weldyn."
         [/message]
         [message]
             speaker=Sir Ruga


### PR DESCRIPTION
Change a misleading word because of some confusion that came up on Discord.

(Someone actually tried to kill all horse lords with Konrad personally).