### PR TITLE
wip add student variable to ability formulas

### DIFF
--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -163,7 +163,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 		opp.undead_variation() != "null" && !resources::gameboard->map().is_village(opp_loc);
 
 	if(plagues) {
-		plague_type = (*plague_specials.front().first)["type"].str();
+		plague_type = (*plague_specials.front().ability_cfg)["type"].str();
 
 		if(plague_type.empty()) {
 			plague_type = u.type().base_id();
@@ -313,7 +313,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 		opp_type->undead_variation() != "null";
 
 	if(plagues) {
-		plague_type = (*plague_specials.front().first)["type"].str();
+		plague_type = (*plague_specials.front().ability_cfg)["type"].str();
 		if(plague_type.empty()) {
 			plague_type = u_type->base_id();
 		}

--- a/src/actions/heal.cpp
+++ b/src/actions/heal.cpp
@@ -97,7 +97,7 @@ namespace {
 			// Regeneration?
 			for (const unit_ability & regen : patient.get_abilities("regenerate"))
 			{
-				curing = std::max(curing, poison_status((*regen.first)["poison"]));
+				curing = std::max(curing, poison_status((*regen.ability_cfg)["poison"]));
 				if ( curing == POISON_CURE )
 					// This is as good as it gets.
 					return POISON_CURE;
@@ -109,14 +109,14 @@ namespace {
 		// Assumed: curing is not POISON_CURE at the start of any iteration.
 		for (const unit_ability & heal : patient.get_abilities("heals"))
 		{
-			POISON_STATUS this_cure = poison_status((*heal.first)["poison"]);
+			POISON_STATUS this_cure = poison_status((*heal.ability_cfg)["poison"]);
 			if ( this_cure <= curing )
 				// We already recorded this level of curing.
 				continue;
 
 			// NOTE: At this point, this_cure will be *_SLOW or *_CURE.
 
-			unit_map::iterator cure_it = units.find(heal.second);
+			unit_map::iterator cure_it = units.find(heal.teacher_loc);
 			assert(cure_it != units.end());
 			const int cure_side = cure_it->side();
 
@@ -201,7 +201,7 @@ namespace {
 		// Remove all healers not on this side (since they do not heal now).
 		unit_ability_list::iterator heal_it = heal_list.begin();
 		while ( heal_it != heal_list.end() ) {
-			unit_map::iterator healer = units.find(heal_it->second);
+			unit_map::iterator healer = units.find(heal_it->teacher_loc);
 			assert(healer != units.end());
 
 			if ( healer->side() != side )

--- a/src/actions/move.cpp
+++ b/src/actions/move.cpp
@@ -850,7 +850,7 @@ namespace { // Private helpers for move_unit()
 	{
 		for(const unit_ability &hide : ambusher.get_abilities("hides"))
 		{
-			const std::string & ambush_string = (*hide.first)["alert"].str();
+			const std::string & ambush_string = (*hide.ability_cfg)["alert"].str();
 			if (!ambush_string.empty()) {
 				return ambush_string;
 			}

--- a/src/pathfind/teleport.cpp
+++ b/src/pathfind/teleport.cpp
@@ -264,9 +264,9 @@ const teleport_map get_teleport_locations(const unit &u,
 	std::vector<teleport_group> groups;
 
 	for (const unit_ability & teleport : u.get_abilities("teleport")) {
-		const int tunnel_count = (teleport.first)->child_count("tunnel");
+		const int tunnel_count = (teleport.ability_cfg)->child_count("tunnel");
 		for(int i = 0; i < tunnel_count; ++i) {
-			config teleport_group_cfg = (teleport.first)->child("tunnel", i);
+			config teleport_group_cfg = (teleport.ability_cfg)->child("tunnel", i);
 			groups.emplace_back(vconfig(teleport_group_cfg, true), false);
 		}
 	}

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -189,7 +189,7 @@ unit_ability_list unit::get_abilities(const std::string& tag_name, const map_loc
 		if(ability_active(tag_name, i, loc)
 			&& ability_affects_self(tag_name, i, loc))
 			{
-			res.emplace_back(&i, loc);
+			res.emplace_back(&i, loc, loc);
 		}
 	}
 
@@ -214,7 +214,7 @@ unit_ability_list unit::get_abilities(const std::string& tag_name, const map_loc
 				&& it->ability_active(tag_name, j, adjacent[i])
 				&& ability_affects_adjacent(tag_name, j, i, loc, *it))
 				{
-				res.emplace_back(&j, adjacent[i]);
+				res.emplace_back(&i, loc, adjacent[i]);
 			}
 		}
 	}
@@ -518,10 +518,10 @@ T get_single_ability_value(const config::attribute_value& v, T def, const unit_a
 					return def;
 				}
 				wfl::map_formula_callable callable(std::make_shared<wfl::unit_callable>(*u_itor));
-				if (auto uptr = unit.find_unit_ptr(ability_info.student_loc)) {
+				if (auto uptr = units.find_unit_ptr(ability_info.student_loc)) {
 					callable.add("student", wfl::variant(std::make_shared<wfl::unit_callable>(*uptr)));
 				}
-				if (auto uptr = unit.find_unit_ptr(receiver_loc)) {
+				if (auto uptr = units.find_unit_ptr(receiver_loc)) {
 					callable.add("other", wfl::variant(std::make_shared<wfl::unit_callable>(*uptr)));
 				}
 				return formula_handler(wfl::formula(s, new wfl::gamestate_function_symbol_table), callable);
@@ -773,7 +773,7 @@ unit_ability_list attack_type::get_specials(const std::string& special) const
 
 	for(const config& i : other_attack_->specials_.child_range(special)) {
 		if(other_attack_->special_active(i, AFFECT_OTHER, special)) {
-			res.emplace_back(&i, other_loc_);
+			res.emplace_back(&i, other_loc_, other_loc_);
 		}
 	}
 	return res;

--- a/src/units/map.hpp
+++ b/src/units/map.hpp
@@ -384,6 +384,20 @@ public:
 		return const_cast<unit_map*>(this)->find(id);
 	}
 
+	template<typename T>
+	unit_ptr find_unit_ptr(const T& val)
+	{
+		auto res = find(val);
+		return res != end() ? res.get_shared_ptr() : unit_ptr();
+	}
+
+	template<typename T>
+	unit_const_ptr find_unit_ptr(const T& val) const
+	{
+		auto res = find(val);
+		return res != end() ? res.get_shared_ptr() : unit_ptr();
+	}
+
 	unit_iterator find_leader(int side);
 
 	const_unit_iterator find_leader(int side) const

--- a/src/units/types.cpp
+++ b/src/units/types.cpp
@@ -796,7 +796,7 @@ int unit_type::resistance_against(const std::string& damage_name, bool attacker)
 				continue;
 			}
 
-			resistance_abilities.emplace_back(&cfg, map_location::null_location());
+			resistance_abilities.emplace_back(&cfg, map_location::null_location(), map_location::null_location());
 		}
 	}
 

--- a/src/units/udisplay.cpp
+++ b/src/units/udisplay.cpp
@@ -647,35 +647,35 @@ void unit_attack(display * disp, game_board & board,
 	animator.add_animation(&defender, defender_anim, def->get_location(), true, text, {255, 0, 0});
 
 	for(const unit_ability& ability : attacker.get_abilities_weapons("leadership", attack.shared_from_this(), secondary_attack)) {
-		if(ability.second == a) {
+		if(ability.teacher_loc == a) {
 			continue;
 		}
 
-		if(ability.second == b) {
+		if(ability.teacher_loc == b) {
 			continue;
 		}
 
-		unit_map::const_iterator leader = board.units().find(ability.second);
+		unit_map::const_iterator leader = board.units().find(ability.teacher_loc);
 		assert(leader.valid());
-		leader->set_facing(ability.second.get_relative_dir(a));
-		animator.add_animation(&*leader, "leading", ability.second,
+		leader->set_facing(ability.teacher_loc.get_relative_dir(a));
+		animator.add_animation(&*leader, "leading", ability.teacher_loc,
 			att->get_location(), damage, true,  "", {0,0,0},
 			hit_type, attack.shared_from_this(), secondary_attack, swing);
 	}
 
 	for(const unit_ability& ability : defender.get_abilities_weapons("resistance", attack.shared_from_this(), secondary_attack)) {
-		if(ability.second == a) {
+		if(ability.teacher_loc == a) {
 			continue;
 		}
 
-		if(ability.second == b) {
+		if(ability.teacher_loc == b) {
 			continue;
 		}
 
-		unit_map::const_iterator helper = board.units().find(ability.second);
+		unit_map::const_iterator helper = board.units().find(ability.teacher_loc);
 		assert(helper.valid());
-		helper->set_facing(ability.second.get_relative_dir(b));
-		animator.add_animation(&*helper, "resistance", ability.second,
+		helper->set_facing(ability.teacher_loc.get_relative_dir(b));
+		animator.add_animation(&*helper, "resistance", ability.teacher_loc,
 			def->get_location(), damage, true,  "", {0,0,0},
 			hit_type, attack.shared_from_this(), secondary_attack, swing);
 	}
@@ -715,7 +715,7 @@ void reset_helpers(const unit *attacker,const unit *defender)
 	const unit_map& units = disp->get_units();
 	if(attacker) {
 		for(const unit_ability& ability : attacker->get_abilities("leadership")) {
-			unit_map::const_iterator leader = units.find(ability.second);
+			unit_map::const_iterator leader = units.find(ability.teacher_loc);
 			assert(leader != units.end());
 			leader->anim_comp().set_standing();
 		}
@@ -723,7 +723,7 @@ void reset_helpers(const unit *attacker,const unit *defender)
 
 	if(defender) {
 		for(const unit_ability& ability : defender->get_abilities("resistance")) {
-			unit_map::const_iterator helper = units.find(ability.second);
+			unit_map::const_iterator helper = units.find(ability.teacher_loc);
 			assert(helper != units.end());
 			helper->anim_comp().set_standing();
 		}

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1695,7 +1695,7 @@ int unit::resistance_against(const std::string& damage_name,bool attacker,const 
 
 	unit_ability_list resistance_abilities = get_abilities_weapons("resistance",loc, weapon, opp_weapon);
 	for(unit_ability_list::iterator i = resistance_abilities.begin(); i != resistance_abilities.end();) {
-		if(!resistance_filter_matches(*i->first, attacker, damage_name, 100-res)) {
+		if(!resistance_filter_matches(*i->ability_cfg, attacker, damage_name, 100-res)) {
 			i = resistance_abilities.erase(i);
 		} else {
 			++i;

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -44,8 +44,20 @@ namespace unit_detail
 	}
 }
 
-// Data typedef for unit_ability_list.
-using unit_ability = std::pair<const config*, map_location>;
+/// Data typedef for unit_ability_list.
+struct unit_ability
+{
+	/// Used by the formula in the ability.
+	/// The REAL location of the student (not the 'we are assiming the student is at this position' location)
+	/// once unit_ability_list can contain abilities from different 'students', as it contains abilities from
+	/// a unit aswell from its opponents (abilities with apply_to= opponent)
+	map_location student_loc;
+	/// The location of the teacher, that is the unit who owns the ability tags
+	/// (differnt from student because of [afect_adjacent])
+	map_location teacher_loc;
+	/// The contents of the ability tag, never nullptr.
+	const config* ability_cfg;
+};
 
 class unit_ability_list
 {

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -47,6 +47,13 @@ namespace unit_detail
 /// Data typedef for unit_ability_list.
 struct unit_ability
 {
+	unit_ability(const config* ability_cfg, map_location student_loc, map_location teacher_loc)
+		: student_loc(student_loc)
+		, teacher_loc(teacher_loc)
+		, ability_cfg(ability_cfg)
+	{
+
+	}
 	/// Used by the formula in the ability.
 	/// The REAL location of the student (not the 'we are assiming the student is at this position' location)
 	/// once unit_ability_list can contain abilities from different 'students', as it contains abilities from


### PR DESCRIPTION
This can be different from 'other' in case of a
an ability that effects the enemy, where 'other'
should be the unit that receives the effect
(here: the enemy), studend is the unit that
matches the [affect_adjacent], and the unnamed
unit is the unit that has the ability.

I think it'd be nice to have even more variables
available so that for example the effect could
depend on the opponent even when it doesn't
effect the opponent.