### PR TITLE
Separate unit test results from scenario victory/defeat.

### DIFF
--- a/data/lua/wml/endlevel.lua
+++ b/data/lua/wml/endlevel.lua
@@ -100,5 +100,6 @@ function wesnoth.wml_actions.endlevel(cfg)
 		reveal_map = cfg.reveal_map,
 		proceed_to_next_level = proceed_to_next_level,
 		result = victory and "victory" or "defeat",
+		test_result = cfg.test_result,
 	}
 end

--- a/data/schema/core/actionwml.cfg
+++ b/data/schema/core/actionwml.cfg
@@ -157,6 +157,7 @@
 		{DEFAULT_KEY end_credits s_bool yes}
 		{SIMPLE_KEY end_text t_string}
 		{SIMPLE_KEY end_text_duration s_unsigned}
+		{SIMPLE_KEY test_result string}
 		[tag]
 			name="result"
 			max=infinite

--- a/data/test/macros/wml_unit_test_macros.cfg
+++ b/data/test/macros/wml_unit_test_macros.cfg
@@ -11,7 +11,7 @@
                 [then]
                     {VARIABLE ended yes}
                     [endlevel]
-                        result=victory
+                        test_result=pass
                         linger_mode = yes
                     [/endlevel]
                 [/then]
@@ -22,7 +22,7 @@
                     [/test_condition]
                     {VARIABLE ended yes}
                     [endlevel]
-                        result=defeat
+                        test_result=fail
                         linger_mode = yes
                     [/endlevel]
                 [/else]
@@ -47,7 +47,7 @@
                     [/test_condition]
                     {VARIABLE ended yes}
                     [endlevel]
-                        result=defeat
+                        test_result=fail
                         linger_mode = yes
                     [/endlevel]
                 [/else]
@@ -57,10 +57,23 @@
 #enddef
 
 #define GENERIC_UNIT_TEST NAME CONTENT
+#arg SIDE1_CONTROLLER
+human#endarg
+#arg SIDE2_CONTROLLER
+human#endarg
+#arg TURNS
+-1#endarg
+#arg SIDE1_RECRUIT
+#endarg
+#arg SIDE1_GOLD
+100#endarg
+#arg SIDE1_LEADER
+Elvish Archer#endarg
+
     [test]
         name = "Unit Test " + {NAME}
         map_file=test/maps/generic_unit_test.map
-        turns = -1
+        turns = {TURNS}
         id = {NAME}
         is_unit_test = yes
 
@@ -68,17 +81,23 @@
 
         [side]
             side=1
-            controller=human
-            name = "Alice"
-            type = Elvish Archer
-            id=alice
+            controller={SIDE1_CONTROLLER}
+            recruit={SIDE1_RECRUIT}
+            gold={SIDE1_GOLD}
+            [leader]
+                name = "Alice"
+                type = {SIDE1_LEADER}
+                id=alice
+            [/leader]
         [/side]
         [side]
             side=2
-            controller=human
-            name = "Bob"
-            type = Orcish Grunt
-            id=bob
+            controller={SIDE2_CONTROLLER}
+            [leader]
+                name = "Bob"
+                type = Orcish Grunt
+                id=bob
+            [/leader]
         [/side]
 
         {CONTENT}
@@ -91,4 +110,16 @@
 
 #define SUCCEED
     {RETURN ([true][/true])}
+#enddef
+
+#define FAIL_IF_NOT FLAG NOT_EQUALS
+[if]
+    [variable]
+        name={FLAG}
+        not_equals={NOT_EQUALS}
+    [/variable]
+    [then]
+        {FAIL}
+    [/then]
+[/if]
 #enddef

--- a/data/test/scenarios/events-test_defeat.cfg
+++ b/data/test/scenarios/events-test_defeat.cfg
@@ -1,0 +1,39 @@
+# time over
+# local_defeat
+# defeat
+# scenario_end
+{GENERIC_UNIT_TEST "events-test_defeat" (
+    [event]
+        name=time over
+        {VARIABLE time_over_flag 1}
+        {FAIL_IF_NOT time_over_flag 1}
+        {FAIL_IF_NOT local_defeat_flag $null}
+        {FAIL_IF_NOT defeat_flag $null}
+        {FAIL_IF_NOT scenario_end_flag $null}
+    [/event]
+    [event]
+        name=local_defeat
+        {VARIABLE local_defeat_flag 1}
+        {FAIL_IF_NOT time_over_flag 1}
+        {FAIL_IF_NOT local_defeat_flag 1}
+        {FAIL_IF_NOT defeat_flag $null}
+        {FAIL_IF_NOT scenario_end_flag $null}
+    [/event]
+    [event]
+        name=defeat
+        {VARIABLE defeat_flag 1}
+        {FAIL_IF_NOT time_over_flag 1}
+        {FAIL_IF_NOT local_defeat_flag 1}
+        {FAIL_IF_NOT defeat_flag 1}
+        {FAIL_IF_NOT scenario_end_flag $null}
+    [/event]
+    [event]
+        name=scenario_end
+        {VARIABLE scenario_end_flag 1}
+        {FAIL_IF_NOT time_over_flag 1}
+        {FAIL_IF_NOT local_defeat_flag 1}
+        {FAIL_IF_NOT defeat_flag 1}
+        {FAIL_IF_NOT scenario_end_flag 1}
+        {SUCCEED}
+    [/event]
+) TURNS=1 SIDE1_CONTROLLER=ai SIDE2_CONTROLLER=ai}

--- a/data/test/scenarios/events-test_die.cfg
+++ b/data/test/scenarios/events-test_die.cfg
@@ -1,0 +1,24 @@
+# last breath
+# die
+{GENERIC_UNIT_TEST "events-test_die" (
+    [event]
+        name=start
+        [kill]
+            side=2
+            fire_event=yes
+        [/kill]
+    [/event]
+    [event]
+        name=last breath
+        {VARIABLE last_breath_flag 1}
+        {FAIL_IF_NOT last_breath_flag 1}
+        {FAIL_IF_NOT die_flag $null}
+    [/event]
+    [event]
+        name=die
+        {VARIABLE die_flag 1}
+        {FAIL_IF_NOT last_breath_flag 1}
+        {FAIL_IF_NOT die_flag 1}
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/events-test_filterable1.cfg
+++ b/data/test/scenarios/events-test_filterable1.cfg
@@ -1,0 +1,198 @@
+# unit placed
+# prerecruit
+# recruit
+# exit_hex
+# enter_hex
+# moveto
+# attack
+# attacker hits
+# defender misses
+# attack end
+# attacker misses
+# defender hits
+# pre advance
+# advance
+# post advance
+{GENERIC_UNIT_TEST "events-test_filterable1" (
+    [event]
+        name=start
+# ensure attacker/defender hits/misses events are triggered
+        [modify_unit]
+            [filter]
+                name="Alice"
+            [/filter]
+            [effect]
+                apply_to=defense
+                replace=yes
+                [defense]
+                    flat=0
+                [/defense]
+            [/effect]
+        [/modify_unit]
+        [modify_unit]
+            [filter]
+                name="Bob"
+            [/filter]
+            [effect]
+                apply_to=max_experience
+                set=2
+            [/effect]
+            [effect]
+                apply_to=defense
+                replace=yes
+                [defense]
+                    castle=100
+                    frozen=100
+                    flat=100
+                [/defense]
+            [/effect]
+        [/modify_unit]
+    [/event]
+    [event]
+        name=unit placed
+        {VARIABLE unit_placed_flag 1}
+        {FAIL_IF_NOT unit_placed_flag 1}
+        {FAIL_IF_NOT prerecruit_flag $null}
+        {FAIL_IF_NOT recruit_flag $null}
+    [/event]
+    [event]
+        name=prerecruit
+        {VARIABLE prerecruit_flag 1}
+        {FAIL_IF_NOT unit_placed_flag 1}
+        {FAIL_IF_NOT prerecruit_flag 1}
+        {FAIL_IF_NOT recruit_flag $null}
+    [/event]
+    [event]
+        name=recruit
+        {VARIABLE recruit_flag 1}
+        {FAIL_IF_NOT unit_placed_flag 1}
+        {FAIL_IF_NOT prerecruit_flag 1}
+        {FAIL_IF_NOT recruit_flag 1}
+# ensure it's side 2's unit that dies
+        [modify_unit]
+            [filter]
+                x,y=$x1,$y1
+            [/filter]
+            [effect]
+                apply_to=defense
+                replace=yes
+                [defense]
+                    flat=0
+                [/defense]
+            [/effect]
+        [/modify_unit]
+        [do_command]
+            [move]
+                x=7,8,9,10,11,12
+                y=3,3,3,3,3,3
+            [/move]
+        [/do_command]
+        [do_command]
+            [attack]
+                weapon=0
+                defender_weapon=0
+                [source]
+                    x,y=12,3
+                [/source]
+                [destination]
+                    x,y=13,3
+                [/destination]
+            [/attack]
+        [/do_command]
+        [do_command]
+            [attack]
+                weapon=0
+                defender_weapon=0
+                [source]
+                    x,y=13,3
+                [/source]
+                [destination]
+                    x,y=12,3
+                [/destination]
+            [/attack]
+        [/do_command]
+    [/event]
+    [event]
+        name=exit_hex
+        {VARIABLE exit_hex_flag 1}
+        {FAIL_IF_NOT exit_hex_flag 1}
+        {FAIL_IF_NOT enter_hex_flag $null}
+        {FAIL_IF_NOT moveto_flag $null}
+    [/event]
+    [event]
+        name=enter_hex
+        {VARIABLE enter_hex_flag 1}
+        {FAIL_IF_NOT exit_hex_flag 1}
+        {FAIL_IF_NOT enter_hex_flag 1}
+        {FAIL_IF_NOT moveto_flag $null}
+    [/event]
+    [event]
+        name=moveto
+        {VARIABLE moveto_flag 1}
+        {FAIL_IF_NOT exit_hex_flag 1}
+        {FAIL_IF_NOT enter_hex_flag 1}
+        {FAIL_IF_NOT moveto_flag 1}
+    [/event]
+    [event]
+        name=attack
+        {VARIABLE attack_flag 1}
+        {FAIL_IF_NOT attack_flag 1}
+        {FAIL_IF_NOT attack_end_flag $null}
+    [/event]
+    [event]
+        name=attacker hits
+        {VARIABLE attacker_hits_flag 1}
+    [/event]
+    [event]
+        name=defender misses
+        {VARIABLE defender_misses_flag 1}
+    [/event]
+    [event]
+        name=attack end
+        {VARIABLE attack_end_flag 1}
+        {FAIL_IF_NOT attack_flag 1}
+        {FAIL_IF_NOT attack_end_flag 1}
+    [/event]
+    [event]
+        name=attacker misses
+        {VARIABLE attacker_misses_flag 1}
+    [/event]
+    [event]
+        name=defender hits
+        {VARIABLE defender_hits_flag 1}
+    [/event]
+    [event]
+        name=pre advance
+        {VARIABLE pre_advance_flag 1}
+        {FAIL_IF_NOT pre_advance_flag 1}
+        {FAIL_IF_NOT advance_flag $null}
+        {FAIL_IF_NOT post_advance_flag $null}
+    [/event]
+    [event]
+        name=advance
+        {VARIABLE advance_flag 1}
+        {FAIL_IF_NOT pre_advance_flag 1}
+        {FAIL_IF_NOT advance_flag 1}
+        {FAIL_IF_NOT post_advance_flag $null}
+    [/event]
+    [event]
+        name=post advance
+        {VARIABLE post_advance_flag 1}
+        {FAIL_IF_NOT unit_placed_flag 1}
+        {FAIL_IF_NOT prerecruit_flag 1}
+        {FAIL_IF_NOT recruit_flag 1}
+        {FAIL_IF_NOT exit_hex_flag 1}
+        {FAIL_IF_NOT enter_hex_flag 1}
+        {FAIL_IF_NOT moveto_flag 1}
+        {FAIL_IF_NOT attack_flag 1}
+        {FAIL_IF_NOT attacker_hits_flag 1}
+        {FAIL_IF_NOT defender_misses_flag 1}
+        {FAIL_IF_NOT attack_end_flag 1}
+        {FAIL_IF_NOT attacker_misses_flag 1}
+        {FAIL_IF_NOT defender_hits_flag 1}
+        {FAIL_IF_NOT pre_advance_flag 1}
+        {FAIL_IF_NOT advance_flag 1}
+        {FAIL_IF_NOT post_advance_flag 1}
+        {SUCCEED}
+    [/event]
+) SIDE1_CONTROLLER=ai SIDE1_LEADER="Orcish Grunt" SIDE1_GOLD=20 SIDE1_RECRUIT=Wose}

--- a/data/test/scenarios/events-test_filterable2.cfg
+++ b/data/test/scenarios/events-test_filterable2.cfg
@@ -1,0 +1,47 @@
+# petrified
+{GENERIC_UNIT_TEST "events-test_filterable2" (
+    [event]
+        name=start
+# ensure the petrifying attack hits
+        [modify_unit]
+            [filter]
+                name="Alice"
+            [/filter]
+            [effect]
+                apply_to=defense
+                replace=yes
+                [defense]
+                    flat=0
+                [/defense]
+            [/effect]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    {WEAPON_SPECIAL_PETRIFY}
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+        [modify_unit]
+            [filter]
+                name="Bob"
+            [/filter]
+            [effect]
+                apply_to=max_experience
+                set=2
+            [/effect]
+            [effect]
+                apply_to=defense
+                replace=yes
+                [defense]
+                    castle=100
+                    frozen=100
+                    flat=100
+                [/defense]
+            [/effect]
+        [/modify_unit]
+    [/event]
+    [event]
+        name=petrified
+        {SUCCEED}
+    [/event]
+) SIDE1_CONTROLLER=ai SIDE1_LEADER="Orcish Grunt"}

--- a/data/test/scenarios/events-test_filterable3.cfg
+++ b/data/test/scenarios/events-test_filterable3.cfg
@@ -1,0 +1,32 @@
+# petrified
+{GENERIC_UNIT_TEST "events-test_filterable3" (
+    [event]
+        name=start
+        [terrain]
+            x,y=5,5
+            terrain=Gd^Vo
+        [/terrain]
+    [/event]
+    [event]
+        name=prestart
+        [modify_side]
+            side=1
+            [ai]
+                aggression=0
+                caution=1
+                [goal]
+                    name=target_location
+                    [criteria]
+                        x,y=5,5
+                    [/criteria]
+                    value=5000
+                [/goal]
+            [/ai]
+        [/modify_side]
+    [/event]
+    [event]
+        name=capture
+        {FAIL_IF_NOT owner_side 0}
+        {SUCCEED}
+    [/event]
+) SIDE1_CONTROLLER=ai SIDE1_LEADER="Orcish Grunt"}

--- a/data/test/scenarios/events-test_nonfilterable.cfg
+++ b/data/test/scenarios/events-test_nonfilterable.cfg
@@ -1,0 +1,505 @@
+# preload
+# prestart
+# start
+# turn 1
+# new turn
+# side turn
+# ai turn
+# side 1 turn
+# side turn 1
+# side 1 turn 1
+# turn refresh
+# side 1 turn refresh
+# turn 1 refresh
+# side 1 turn 1 refresh
+# side turn end
+# side 1 turn end
+# side turn 1 end
+# side 1 turn 1 end
+# turn end
+# turn 1 end
+# time over
+{GENERIC_UNIT_TEST "events-test_nonfilterable" (
+    [event]
+        name=preload
+        first_time_only=no
+        {VARIABLE preload_flag 1}
+        {FAIL_IF_NOT preload_flag 1}
+        {FAIL_IF_NOT prestart_flag $null}
+        {FAIL_IF_NOT start_flag $null}
+        {FAIL_IF_NOT turn1_flag $null}
+        {FAIL_IF_NOT new_turn_flag $null}
+        {FAIL_IF_NOT side_turn_flag $null}
+        {FAIL_IF_NOT side1_turn_flag $null}
+        {FAIL_IF_NOT side_turn1_flag $null}
+        {FAIL_IF_NOT side1_turn1_flag $null}
+        {FAIL_IF_NOT turn_refresh_flag $null}
+        {FAIL_IF_NOT side1_turn_refresh_flag $null}
+        {FAIL_IF_NOT turn1_refresh_flag $null}
+        {FAIL_IF_NOT side1_turn1_refresh_flag $null}
+        {FAIL_IF_NOT side_turn_end_flag $null}
+        {FAIL_IF_NOT side1_turn_end_flag $null}
+        {FAIL_IF_NOT side_turn1_end_flag $null}
+        {FAIL_IF_NOT side1_turn1_end_flag $null}
+        {FAIL_IF_NOT turn_end_flag $null}
+        {FAIL_IF_NOT turn1_end_flag $null}
+        {FAIL_IF_NOT time_over_flag $null}
+    [/event]
+    [event]
+        name=prestart
+        {VARIABLE prestart_flag 1}
+        {FAIL_IF_NOT preload_flag 1}
+        {FAIL_IF_NOT prestart_flag 1}
+        {FAIL_IF_NOT start_flag $null}
+        {FAIL_IF_NOT turn1_flag $null}
+        {FAIL_IF_NOT new_turn_flag $null}
+        {FAIL_IF_NOT side_turn_flag $null}
+        {FAIL_IF_NOT side1_turn_flag $null}
+        {FAIL_IF_NOT side_turn1_flag $null}
+        {FAIL_IF_NOT side1_turn1_flag $null}
+        {FAIL_IF_NOT turn_refresh_flag $null}
+        {FAIL_IF_NOT side1_turn_refresh_flag $null}
+        {FAIL_IF_NOT turn1_refresh_flag $null}
+        {FAIL_IF_NOT side1_turn1_refresh_flag $null}
+        {FAIL_IF_NOT side_turn_end_flag $null}
+        {FAIL_IF_NOT side1_turn_end_flag $null}
+        {FAIL_IF_NOT side_turn1_end_flag $null}
+        {FAIL_IF_NOT side1_turn1_end_flag $null}
+        {FAIL_IF_NOT turn_end_flag $null}
+        {FAIL_IF_NOT turn1_end_flag $null}
+        {FAIL_IF_NOT time_over_flag $null}
+    [/event]
+    [event]
+        name=start
+        {VARIABLE start_flag 1}
+        {FAIL_IF_NOT preload_flag 1}
+        {FAIL_IF_NOT prestart_flag 1}
+        {FAIL_IF_NOT start_flag 1}
+        {FAIL_IF_NOT turn1_flag $null}
+        {FAIL_IF_NOT new_turn_flag $null}
+        {FAIL_IF_NOT side_turn_flag $null}
+        {FAIL_IF_NOT side1_turn_flag $null}
+        {FAIL_IF_NOT side_turn1_flag $null}
+        {FAIL_IF_NOT side1_turn1_flag $null}
+        {FAIL_IF_NOT turn_refresh_flag $null}
+        {FAIL_IF_NOT side1_turn_refresh_flag $null}
+        {FAIL_IF_NOT turn1_refresh_flag $null}
+        {FAIL_IF_NOT side1_turn1_refresh_flag $null}
+        {FAIL_IF_NOT side_turn_end_flag $null}
+        {FAIL_IF_NOT side1_turn_end_flag $null}
+        {FAIL_IF_NOT side_turn1_end_flag $null}
+        {FAIL_IF_NOT side1_turn1_end_flag $null}
+        {FAIL_IF_NOT turn_end_flag $null}
+        {FAIL_IF_NOT turn1_end_flag $null}
+        {FAIL_IF_NOT time_over_flag $null}
+    [/event]
+    [event]
+        name=turn 1
+        {VARIABLE turn1_flag 1}
+        {FAIL_IF_NOT preload_flag 1}
+        {FAIL_IF_NOT prestart_flag 1}
+        {FAIL_IF_NOT start_flag 1}
+        {FAIL_IF_NOT turn1_flag 1}
+        {FAIL_IF_NOT new_turn_flag $null}
+        {FAIL_IF_NOT side_turn_flag $null}
+        {FAIL_IF_NOT side1_turn_flag $null}
+        {FAIL_IF_NOT side_turn1_flag $null}
+        {FAIL_IF_NOT side1_turn1_flag $null}
+        {FAIL_IF_NOT turn_refresh_flag $null}
+        {FAIL_IF_NOT side1_turn_refresh_flag $null}
+        {FAIL_IF_NOT turn1_refresh_flag $null}
+        {FAIL_IF_NOT side1_turn1_refresh_flag $null}
+        {FAIL_IF_NOT side_turn_end_flag $null}
+        {FAIL_IF_NOT side1_turn_end_flag $null}
+        {FAIL_IF_NOT side_turn1_end_flag $null}
+        {FAIL_IF_NOT side1_turn1_end_flag $null}
+        {FAIL_IF_NOT turn_end_flag $null}
+        {FAIL_IF_NOT turn1_end_flag $null}
+        {FAIL_IF_NOT time_over_flag $null}
+    [/event]
+    [event]
+        name=new turn
+        {VARIABLE new_turn_flag 1}
+        {FAIL_IF_NOT preload_flag 1}
+        {FAIL_IF_NOT prestart_flag 1}
+        {FAIL_IF_NOT start_flag 1}
+        {FAIL_IF_NOT turn1_flag 1}
+        {FAIL_IF_NOT new_turn_flag 1}
+        {FAIL_IF_NOT side_turn_flag $null}
+        {FAIL_IF_NOT side1_turn_flag $null}
+        {FAIL_IF_NOT side_turn1_flag $null}
+        {FAIL_IF_NOT side1_turn1_flag $null}
+        {FAIL_IF_NOT turn_refresh_flag $null}
+        {FAIL_IF_NOT side1_turn_refresh_flag $null}
+        {FAIL_IF_NOT turn1_refresh_flag $null}
+        {FAIL_IF_NOT side1_turn1_refresh_flag $null}
+        {FAIL_IF_NOT side_turn_end_flag $null}
+        {FAIL_IF_NOT side1_turn_end_flag $null}
+        {FAIL_IF_NOT side_turn1_end_flag $null}
+        {FAIL_IF_NOT side1_turn1_end_flag $null}
+        {FAIL_IF_NOT turn_end_flag $null}
+        {FAIL_IF_NOT turn1_end_flag $null}
+        {FAIL_IF_NOT time_over_flag $null}
+    [/event]
+    [event]
+        name=side turn
+        {VARIABLE side_turn_flag 1}
+        {FAIL_IF_NOT preload_flag 1}
+        {FAIL_IF_NOT prestart_flag 1}
+        {FAIL_IF_NOT start_flag 1}
+        {FAIL_IF_NOT turn1_flag 1}
+        {FAIL_IF_NOT new_turn_flag 1}
+        {FAIL_IF_NOT side_turn_flag 1}
+        {FAIL_IF_NOT side1_turn_flag $null}
+        {FAIL_IF_NOT side_turn1_flag $null}
+        {FAIL_IF_NOT side1_turn1_flag $null}
+        {FAIL_IF_NOT turn_refresh_flag $null}
+        {FAIL_IF_NOT side1_turn_refresh_flag $null}
+        {FAIL_IF_NOT turn1_refresh_flag $null}
+        {FAIL_IF_NOT side1_turn1_refresh_flag $null}
+        {FAIL_IF_NOT side_turn_end_flag $null}
+        {FAIL_IF_NOT side1_turn_end_flag $null}
+        {FAIL_IF_NOT side_turn1_end_flag $null}
+        {FAIL_IF_NOT side1_turn1_end_flag $null}
+        {FAIL_IF_NOT turn_end_flag $null}
+        {FAIL_IF_NOT turn1_end_flag $null}
+        {FAIL_IF_NOT time_over_flag $null}
+    [/event]
+    [event]
+        name=side 1 turn
+        {VARIABLE side1_turn_flag 1}
+        {FAIL_IF_NOT preload_flag 1}
+        {FAIL_IF_NOT prestart_flag 1}
+        {FAIL_IF_NOT start_flag 1}
+        {FAIL_IF_NOT turn1_flag 1}
+        {FAIL_IF_NOT new_turn_flag 1}
+        {FAIL_IF_NOT side_turn_flag 1}
+        {FAIL_IF_NOT side1_turn_flag 1}
+        {FAIL_IF_NOT side_turn1_flag $null}
+        {FAIL_IF_NOT side1_turn1_flag $null}
+        {FAIL_IF_NOT turn_refresh_flag $null}
+        {FAIL_IF_NOT side1_turn_refresh_flag $null}
+        {FAIL_IF_NOT turn1_refresh_flag $null}
+        {FAIL_IF_NOT side1_turn1_refresh_flag $null}
+        {FAIL_IF_NOT side_turn_end_flag $null}
+        {FAIL_IF_NOT side1_turn_end_flag $null}
+        {FAIL_IF_NOT side_turn1_end_flag $null}
+        {FAIL_IF_NOT side1_turn1_end_flag $null}
+        {FAIL_IF_NOT turn_end_flag $null}
+        {FAIL_IF_NOT turn1_end_flag $null}
+        {FAIL_IF_NOT time_over_flag $null}
+    [/event]
+    [event]
+        name=side turn 1
+        {VARIABLE side_turn1_flag 1}
+        {FAIL_IF_NOT preload_flag 1}
+        {FAIL_IF_NOT prestart_flag 1}
+        {FAIL_IF_NOT start_flag 1}
+        {FAIL_IF_NOT turn1_flag 1}
+        {FAIL_IF_NOT new_turn_flag 1}
+        {FAIL_IF_NOT side_turn_flag 1}
+        {FAIL_IF_NOT side1_turn_flag 1}
+        {FAIL_IF_NOT side_turn1_flag 1}
+        {FAIL_IF_NOT side1_turn1_flag $null}
+        {FAIL_IF_NOT turn_refresh_flag $null}
+        {FAIL_IF_NOT side1_turn_refresh_flag $null}
+        {FAIL_IF_NOT turn1_refresh_flag $null}
+        {FAIL_IF_NOT side1_turn1_refresh_flag $null}
+        {FAIL_IF_NOT side_turn_end_flag $null}
+        {FAIL_IF_NOT side1_turn_end_flag $null}
+        {FAIL_IF_NOT side_turn1_end_flag $null}
+        {FAIL_IF_NOT side1_turn1_end_flag $null}
+        {FAIL_IF_NOT turn_end_flag $null}
+        {FAIL_IF_NOT turn1_end_flag $null}
+        {FAIL_IF_NOT time_over_flag $null}
+    [/event]
+    [event]
+        name=side 1 turn 1
+        {VARIABLE side1_turn1_flag 1}
+        {FAIL_IF_NOT preload_flag 1}
+        {FAIL_IF_NOT prestart_flag 1}
+        {FAIL_IF_NOT start_flag 1}
+        {FAIL_IF_NOT turn1_flag 1}
+        {FAIL_IF_NOT new_turn_flag 1}
+        {FAIL_IF_NOT side_turn_flag 1}
+        {FAIL_IF_NOT side1_turn_flag 1}
+        {FAIL_IF_NOT side_turn1_flag 1}
+        {FAIL_IF_NOT side1_turn1_flag 1}
+        {FAIL_IF_NOT turn_refresh_flag $null}
+        {FAIL_IF_NOT side1_turn_refresh_flag $null}
+        {FAIL_IF_NOT turn1_refresh_flag $null}
+        {FAIL_IF_NOT side1_turn1_refresh_flag $null}
+        {FAIL_IF_NOT side_turn_end_flag $null}
+        {FAIL_IF_NOT side1_turn_end_flag $null}
+        {FAIL_IF_NOT side_turn1_end_flag $null}
+        {FAIL_IF_NOT side1_turn1_end_flag $null}
+        {FAIL_IF_NOT turn_end_flag $null}
+        {FAIL_IF_NOT turn1_end_flag $null}
+        {FAIL_IF_NOT time_over_flag $null}
+    [/event]
+    [event]
+        name=turn refresh
+        {VARIABLE turn_refresh_flag 1}
+        {FAIL_IF_NOT preload_flag 1}
+        {FAIL_IF_NOT prestart_flag 1}
+        {FAIL_IF_NOT start_flag 1}
+        {FAIL_IF_NOT turn1_flag 1}
+        {FAIL_IF_NOT new_turn_flag 1}
+        {FAIL_IF_NOT side_turn_flag 1}
+        {FAIL_IF_NOT side1_turn_flag 1}
+        {FAIL_IF_NOT side_turn1_flag 1}
+        {FAIL_IF_NOT side1_turn1_flag 1}
+        {FAIL_IF_NOT turn_refresh_flag 1}
+        {FAIL_IF_NOT side1_turn_refresh_flag $null}
+        {FAIL_IF_NOT turn1_refresh_flag $null}
+        {FAIL_IF_NOT side1_turn1_refresh_flag $null}
+        {FAIL_IF_NOT side_turn_end_flag $null}
+        {FAIL_IF_NOT side1_turn_end_flag $null}
+        {FAIL_IF_NOT side_turn1_end_flag $null}
+        {FAIL_IF_NOT side1_turn1_end_flag $null}
+        {FAIL_IF_NOT turn_end_flag $null}
+        {FAIL_IF_NOT turn1_end_flag $null}
+        {FAIL_IF_NOT time_over_flag $null}
+    [/event]
+    [event]
+        name=side 1 turn refresh
+        {VARIABLE side1_turn_refresh_flag 1}
+        {FAIL_IF_NOT preload_flag 1}
+        {FAIL_IF_NOT prestart_flag 1}
+        {FAIL_IF_NOT start_flag 1}
+        {FAIL_IF_NOT turn1_flag 1}
+        {FAIL_IF_NOT new_turn_flag 1}
+        {FAIL_IF_NOT side_turn_flag 1}
+        {FAIL_IF_NOT side1_turn_flag 1}
+        {FAIL_IF_NOT side_turn1_flag 1}
+        {FAIL_IF_NOT side1_turn1_flag 1}
+        {FAIL_IF_NOT turn_refresh_flag 1}
+        {FAIL_IF_NOT side1_turn_refresh_flag 1}
+        {FAIL_IF_NOT turn1_refresh_flag $null}
+        {FAIL_IF_NOT side1_turn1_refresh_flag $null}
+        {FAIL_IF_NOT side_turn_end_flag $null}
+        {FAIL_IF_NOT side1_turn_end_flag $null}
+        {FAIL_IF_NOT side_turn1_end_flag $null}
+        {FAIL_IF_NOT side1_turn1_end_flag $null}
+        {FAIL_IF_NOT turn_end_flag $null}
+        {FAIL_IF_NOT turn1_end_flag $null}
+        {FAIL_IF_NOT time_over_flag $null}
+    [/event]
+    [event]
+        name=turn 1 refresh
+        {VARIABLE turn1_refresh_flag 1}
+        {FAIL_IF_NOT preload_flag 1}
+        {FAIL_IF_NOT prestart_flag 1}
+        {FAIL_IF_NOT start_flag 1}
+        {FAIL_IF_NOT turn1_flag 1}
+        {FAIL_IF_NOT new_turn_flag 1}
+        {FAIL_IF_NOT side_turn_flag 1}
+        {FAIL_IF_NOT side1_turn_flag 1}
+        {FAIL_IF_NOT side_turn1_flag 1}
+        {FAIL_IF_NOT side1_turn1_flag 1}
+        {FAIL_IF_NOT turn_refresh_flag 1}
+        {FAIL_IF_NOT side1_turn_refresh_flag 1}
+        {FAIL_IF_NOT turn1_refresh_flag 1}
+        {FAIL_IF_NOT side1_turn1_refresh_flag $null}
+        {FAIL_IF_NOT side_turn_end_flag $null}
+        {FAIL_IF_NOT side1_turn_end_flag $null}
+        {FAIL_IF_NOT side_turn1_end_flag $null}
+        {FAIL_IF_NOT side1_turn1_end_flag $null}
+        {FAIL_IF_NOT turn_end_flag $null}
+        {FAIL_IF_NOT turn1_end_flag $null}
+        {FAIL_IF_NOT time_over_flag $null}
+    [/event]
+    [event]
+        name=side 1 turn 1 refresh
+        {VARIABLE side1_turn1_refresh_flag 1}
+        {FAIL_IF_NOT preload_flag 1}
+        {FAIL_IF_NOT prestart_flag 1}
+        {FAIL_IF_NOT start_flag 1}
+        {FAIL_IF_NOT turn1_flag 1}
+        {FAIL_IF_NOT new_turn_flag 1}
+        {FAIL_IF_NOT side_turn_flag 1}
+        {FAIL_IF_NOT side1_turn_flag 1}
+        {FAIL_IF_NOT side_turn1_flag 1}
+        {FAIL_IF_NOT side1_turn1_flag 1}
+        {FAIL_IF_NOT turn_refresh_flag 1}
+        {FAIL_IF_NOT side1_turn_refresh_flag 1}
+        {FAIL_IF_NOT turn1_refresh_flag 1}
+        {FAIL_IF_NOT side1_turn1_refresh_flag 1}
+        {FAIL_IF_NOT side_turn_end_flag $null}
+        {FAIL_IF_NOT side1_turn_end_flag $null}
+        {FAIL_IF_NOT side_turn1_end_flag $null}
+        {FAIL_IF_NOT side1_turn1_end_flag $null}
+        {FAIL_IF_NOT turn_end_flag $null}
+        {FAIL_IF_NOT turn1_end_flag $null}
+        {FAIL_IF_NOT time_over_flag $null}
+    [/event]
+    [event]
+        name=side turn end
+        {VARIABLE side_turn_end_flag 1}
+        {FAIL_IF_NOT preload_flag 1}
+        {FAIL_IF_NOT prestart_flag 1}
+        {FAIL_IF_NOT start_flag 1}
+        {FAIL_IF_NOT turn1_flag 1}
+        {FAIL_IF_NOT new_turn_flag 1}
+        {FAIL_IF_NOT side_turn_flag 1}
+        {FAIL_IF_NOT side1_turn_flag 1}
+        {FAIL_IF_NOT side_turn1_flag 1}
+        {FAIL_IF_NOT side1_turn1_flag 1}
+        {FAIL_IF_NOT turn_refresh_flag 1}
+        {FAIL_IF_NOT side1_turn_refresh_flag 1}
+        {FAIL_IF_NOT turn1_refresh_flag 1}
+        {FAIL_IF_NOT side1_turn1_refresh_flag 1}
+        {FAIL_IF_NOT side_turn_end_flag 1}
+        {FAIL_IF_NOT side1_turn_end_flag $null}
+        {FAIL_IF_NOT side_turn1_end_flag $null}
+        {FAIL_IF_NOT side1_turn1_end_flag $null}
+        {FAIL_IF_NOT turn_end_flag $null}
+        {FAIL_IF_NOT turn1_end_flag $null}
+        {FAIL_IF_NOT time_over_flag $null}
+    [/event]
+    [event]
+        name=side 1 turn end
+        {VARIABLE side1_turn_end_flag 1}
+        {FAIL_IF_NOT preload_flag 1}
+        {FAIL_IF_NOT prestart_flag 1}
+        {FAIL_IF_NOT start_flag 1}
+        {FAIL_IF_NOT turn1_flag 1}
+        {FAIL_IF_NOT new_turn_flag 1}
+        {FAIL_IF_NOT side_turn_flag 1}
+        {FAIL_IF_NOT side1_turn_flag 1}
+        {FAIL_IF_NOT side_turn1_flag 1}
+        {FAIL_IF_NOT side1_turn1_flag 1}
+        {FAIL_IF_NOT turn_refresh_flag 1}
+        {FAIL_IF_NOT side1_turn_refresh_flag 1}
+        {FAIL_IF_NOT turn1_refresh_flag 1}
+        {FAIL_IF_NOT side1_turn1_refresh_flag 1}
+        {FAIL_IF_NOT side_turn_end_flag 1}
+        {FAIL_IF_NOT side1_turn_end_flag 1}
+        {FAIL_IF_NOT side_turn1_end_flag $null}
+        {FAIL_IF_NOT side1_turn1_end_flag $null}
+        {FAIL_IF_NOT turn_end_flag $null}
+        {FAIL_IF_NOT turn1_end_flag $null}
+        {FAIL_IF_NOT time_over_flag $null}
+    [/event]
+    [event]
+        name=side turn 1 end
+        {VARIABLE side_turn1_end_flag 1}
+        {FAIL_IF_NOT preload_flag 1}
+        {FAIL_IF_NOT prestart_flag 1}
+        {FAIL_IF_NOT start_flag 1}
+        {FAIL_IF_NOT turn1_flag 1}
+        {FAIL_IF_NOT new_turn_flag 1}
+        {FAIL_IF_NOT side_turn_flag 1}
+        {FAIL_IF_NOT side1_turn_flag 1}
+        {FAIL_IF_NOT side_turn1_flag 1}
+        {FAIL_IF_NOT side1_turn1_flag 1}
+        {FAIL_IF_NOT turn_refresh_flag 1}
+        {FAIL_IF_NOT side1_turn_refresh_flag 1}
+        {FAIL_IF_NOT turn1_refresh_flag 1}
+        {FAIL_IF_NOT side1_turn1_refresh_flag 1}
+        {FAIL_IF_NOT side_turn_end_flag 1}
+        {FAIL_IF_NOT side1_turn_end_flag 1}
+        {FAIL_IF_NOT side_turn1_end_flag 1}
+        {FAIL_IF_NOT side1_turn1_end_flag $null}
+        {FAIL_IF_NOT turn_end_flag $null}
+        {FAIL_IF_NOT turn1_end_flag $null}
+        {FAIL_IF_NOT time_over_flag $null}
+    [/event]
+    [event]
+        name=side 1 turn 1 end
+        {VARIABLE side1_turn1_end_flag 1}
+        {FAIL_IF_NOT preload_flag 1}
+        {FAIL_IF_NOT prestart_flag 1}
+        {FAIL_IF_NOT start_flag 1}
+        {FAIL_IF_NOT turn1_flag 1}
+        {FAIL_IF_NOT new_turn_flag 1}
+        {FAIL_IF_NOT side_turn_flag 1}
+        {FAIL_IF_NOT side1_turn_flag 1}
+        {FAIL_IF_NOT side_turn1_flag 1}
+        {FAIL_IF_NOT side1_turn1_flag 1}
+        {FAIL_IF_NOT turn_refresh_flag 1}
+        {FAIL_IF_NOT side1_turn_refresh_flag 1}
+        {FAIL_IF_NOT turn1_refresh_flag 1}
+        {FAIL_IF_NOT side1_turn1_refresh_flag 1}
+        {FAIL_IF_NOT side_turn_end_flag 1}
+        {FAIL_IF_NOT side1_turn_end_flag 1}
+        {FAIL_IF_NOT side_turn1_end_flag 1}
+        {FAIL_IF_NOT side1_turn1_end_flag 1}
+        {FAIL_IF_NOT turn_end_flag $null}
+        {FAIL_IF_NOT turn1_end_flag $null}
+        {FAIL_IF_NOT time_over_flag $null}
+    [/event]
+    [event]
+        name=turn end
+        {VARIABLE turn_end_flag 1}
+        {FAIL_IF_NOT preload_flag 1}
+        {FAIL_IF_NOT prestart_flag 1}
+        {FAIL_IF_NOT start_flag 1}
+        {FAIL_IF_NOT turn1_flag 1}
+        {FAIL_IF_NOT new_turn_flag 1}
+        {FAIL_IF_NOT side_turn_flag 1}
+        {FAIL_IF_NOT side1_turn_flag 1}
+        {FAIL_IF_NOT side_turn1_flag 1}
+        {FAIL_IF_NOT side1_turn1_flag 1}
+        {FAIL_IF_NOT turn_refresh_flag 1}
+        {FAIL_IF_NOT side1_turn_refresh_flag 1}
+        {FAIL_IF_NOT turn1_refresh_flag 1}
+        {FAIL_IF_NOT side1_turn1_refresh_flag 1}
+        {FAIL_IF_NOT side_turn_end_flag 1}
+        {FAIL_IF_NOT side1_turn_end_flag 1}
+        {FAIL_IF_NOT side_turn1_end_flag 1}
+        {FAIL_IF_NOT side1_turn1_end_flag 1}
+        {FAIL_IF_NOT turn_end_flag 1}
+        {FAIL_IF_NOT turn1_end_flag $null}
+        {FAIL_IF_NOT time_over_flag $null}
+    [/event]
+    [event]
+        name=turn 1 end
+        {VARIABLE turn1_end_flag 1}
+        {FAIL_IF_NOT preload_flag 1}
+        {FAIL_IF_NOT prestart_flag 1}
+        {FAIL_IF_NOT start_flag 1}
+        {FAIL_IF_NOT turn1_flag 1}
+        {FAIL_IF_NOT new_turn_flag 1}
+        {FAIL_IF_NOT side_turn_flag 1}
+        {FAIL_IF_NOT side1_turn_flag 1}
+        {FAIL_IF_NOT side_turn1_flag 1}
+        {FAIL_IF_NOT side1_turn1_flag 1}
+        {FAIL_IF_NOT turn_refresh_flag 1}
+        {FAIL_IF_NOT side1_turn_refresh_flag 1}
+        {FAIL_IF_NOT turn1_refresh_flag 1}
+        {FAIL_IF_NOT side1_turn1_refresh_flag 1}
+        {FAIL_IF_NOT side_turn_end_flag 1}
+        {FAIL_IF_NOT side1_turn_end_flag 1}
+        {FAIL_IF_NOT side_turn1_end_flag 1}
+        {FAIL_IF_NOT side1_turn1_end_flag 1}
+        {FAIL_IF_NOT turn_end_flag 1}
+        {FAIL_IF_NOT turn1_end_flag 1}
+        {FAIL_IF_NOT time_over_flag $null}
+    [/event]
+    [event]
+        name=time over
+        {VARIABLE time_over_flag 1}
+        {FAIL_IF_NOT preload_flag 1}
+        {FAIL_IF_NOT prestart_flag 1}
+        {FAIL_IF_NOT start_flag 1}
+        {FAIL_IF_NOT turn1_flag 1}
+        {FAIL_IF_NOT new_turn_flag 1}
+        {FAIL_IF_NOT side_turn_flag 1}
+        {FAIL_IF_NOT side1_turn_flag 1}
+        {FAIL_IF_NOT side_turn1_flag 1}
+        {FAIL_IF_NOT side1_turn1_flag 1}
+        {FAIL_IF_NOT turn_refresh_flag 1}
+        {FAIL_IF_NOT side1_turn_refresh_flag 1}
+        {FAIL_IF_NOT turn1_refresh_flag 1}
+        {FAIL_IF_NOT side1_turn1_refresh_flag 1}
+        {FAIL_IF_NOT side_turn_end_flag 1}
+        {FAIL_IF_NOT side1_turn_end_flag 1}
+        {FAIL_IF_NOT side_turn1_end_flag 1}
+        {FAIL_IF_NOT side1_turn1_end_flag 1}
+        {FAIL_IF_NOT turn_end_flag 1}
+        {FAIL_IF_NOT turn1_end_flag 1}
+        {FAIL_IF_NOT time_over_flag 1}
+        {SUCCEED}
+    [/event]
+) TURNS=1 SIDE1_CONTROLLER=ai SIDE2_CONTROLLER=ai}

--- a/data/test/scenarios/events-test_victory.cfg
+++ b/data/test/scenarios/events-test_victory.cfg
@@ -1,0 +1,45 @@
+# enemies defeated
+# local_victory
+# victory
+# scenario_end
+{GENERIC_UNIT_TEST "events-test_victory" (
+    [event]
+        name=turn 1
+        [kill]
+            side=2
+        [/kill]
+    [/event]
+    [event]
+        name=enemies defeated
+        {VARIABLE enemies_defeated_flag 1}
+        {FAIL_IF_NOT enemies_defeated_flag 1}
+        {FAIL_IF_NOT local_victory_flag $null}
+        {FAIL_IF_NOT victory_flag $null}
+        {FAIL_IF_NOT scenario_end_flag $null}
+    [/event]
+    [event]
+        name=local_victory
+        {VARIABLE local_victory_flag 1}
+        {FAIL_IF_NOT enemies_defeated_flag 1}
+        {FAIL_IF_NOT local_victory_flag 1}
+        {FAIL_IF_NOT victory_flag $null}
+        {FAIL_IF_NOT scenario_end_flag $null}
+    [/event]
+    [event]
+        name=victory
+        {VARIABLE victory_flag 1}
+        {FAIL_IF_NOT enemies_defeated_flag 1}
+        {FAIL_IF_NOT local_victory_flag 1}
+        {FAIL_IF_NOT victory_flag 1}
+        {FAIL_IF_NOT scenario_end_flag $null}
+    [/event]
+    [event]
+        name=scenario_end
+        {VARIABLE scenario_end_flag 1}
+        {FAIL_IF_NOT enemies_defeated_flag 1}
+        {FAIL_IF_NOT local_victory_flag 1}
+        {FAIL_IF_NOT victory_flag 1}
+        {FAIL_IF_NOT scenario_end_flag 1}
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/interrupts.cfg
+++ b/data/test/scenarios/interrupts.cfg
@@ -89,14 +89,14 @@
     [event]
         name=success
         [endlevel]
-            result=victory
+            test_result=pass
             linger_mode = yes
         [/endlevel]
     [/event]
     [event]
         name=fail
         [endlevel]
-            result=defeat
+            test_result=fail
             linger_mode = yes
         [/endlevel]
     [/event]

--- a/data/test/scenarios/test_lua_wml_tagnames.cfg
+++ b/data/test/scenarios/test_lua_wml_tagnames.cfg
@@ -10,7 +10,7 @@
                 local function assert_equal(expect, status)
                     if status ~= expect then
                         -- Fail the test
-                        wesnoth.wml_actions.endlevel({result = "defeat", linger_mode = true})
+                        wesnoth.wml_actions.endlevel({test_result = "fail", linger_mode = true})
                     end
                 end
 
@@ -77,7 +77,7 @@
                 end))
 
                 -- Pass the test. Doesn't do anything if any of the above assertions has failed.
-                wesnoth.wml_actions.endlevel({result = "victory", linger_mode = true})
+                wesnoth.wml_actions.endlevel({test_result = "pass", linger_mode = true})
             >>
         [/lua]
     [/event]

--- a/run_wml_tests
+++ b/run_wml_tests
@@ -19,6 +19,8 @@ class UnitTestResult(enum.Enum):
     FAIL_PLAYING_REPLAY = 4
     FAIL_BROKE_STRICT = 5
     FAIL_WML_EXCEPTION = 6
+    FAIL_BY_DEFEAT = 7
+    PASS_BY_VICTORY = 8
 
 class TestCase:
     """Represents a single line of the wml_test_schedule."""

--- a/src/game_end_exceptions.cpp
+++ b/src/game_end_exceptions.cpp
@@ -28,6 +28,7 @@ end_level_data::end_level_data()
 	, replay_save(true)
 	, proceed_to_next_level(false)
 	, is_victory(true)
+	, test_result(LEVEL_RESULT::enum_to_string(LEVEL_RESULT::TEST_NOT_SET))
 	, transient()
 {
 }
@@ -38,6 +39,7 @@ void end_level_data::write(config& cfg) const
 	cfg["replay_save"] = replay_save;
 	cfg["proceed_to_next_level"] = proceed_to_next_level;
 	cfg["is_victory"] = is_victory;
+	cfg["test_result"] = test_result;
 }
 
 void end_level_data::read(const config& cfg)
@@ -46,6 +48,7 @@ void end_level_data::read(const config& cfg)
 	replay_save = cfg["replay_save"].to_bool(true);
 	proceed_to_next_level = cfg["proceed_to_next_level"].to_bool(true);
 	is_victory = cfg["is_victory"].to_bool(true);
+	test_result = cfg["test_result"].str();
 }
 
 config end_level_data::to_config() const

--- a/src/game_end_exceptions.hpp
+++ b/src/game_end_exceptions.hpp
@@ -35,6 +35,10 @@ MAKE_ENUM(LEVEL_RESULT,
 	(DEFEAT,       "defeat")
 	(QUIT,         "quit")
 	(OBSERVER_END, "observer_end")
+	(TEST_NOT_SET, "result_not_set")
+	(TEST_PASS,    "pass")
+	(TEST_FAIL,    "fail")
+	(TEST_INVALID, "test_result_value_invalid")
 )
 
 /**
@@ -98,6 +102,7 @@ struct end_level_data
 	bool replay_save;                  /**< Should a replay save be made? */
 	bool proceed_to_next_level;        /**< whether to proceed to the next scenario, equals is_victory in sp. We need to save this in saves during linger mode. > */
 	bool is_victory;
+	std::string test_result;           /**< result to use if this is a unit test */
 	transient_end_level transient;
 	void write(config& cfg) const;
 

--- a/src/game_launcher.hpp
+++ b/src/game_launcher.hpp
@@ -22,6 +22,7 @@
 #include "picture.hpp"                    // for manager
 #include "saved_game.hpp"               // for saved_game
 #include "sound.hpp"                    // for music_thinker
+#include "game_end_exceptions.hpp"      // for LEVEL_RESULT, etc
 
 #include <string>                       // for string
 #include <vector>                       // for vector
@@ -69,6 +70,8 @@ public:
 		TEST_FAIL_PLAYING_REPLAY = 4,
 		TEST_FAIL_BROKE_STRICT = 5,
 		TEST_FAIL_WML_EXCEPTION = 6,
+		TEST_FAIL_BY_DEFEAT = 7,
+		TEST_PASS_BY_VICTORY = 8,
 	};
 
 	bool init_video();
@@ -119,6 +122,7 @@ private:
 	void mark_completed_campaigns(std::vector<config>& campaigns);
 
 	editor::EXIT_STATUS start_editor(const std::string& filename);
+	unit_test_result pass_victory_or_defeat(LEVEL_RESULT res);
 
 	/// Internal to the implementation of unit_test(). If a single instance of
 	/// Wesnoth is running multiple unit tests, this gets called once per test.

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -335,7 +335,12 @@ LEVEL_RESULT playsingle_controller::play_scenario(const config& level)
 			sound::play_music_once(end_music);
 		}
 		persist_.end_transaction();
-		return is_victory ? LEVEL_RESULT::VICTORY : LEVEL_RESULT::DEFEAT;
+		LEVEL_RESULT res = LEVEL_RESULT::string_to_enum(end_level.test_result);
+		if(res == LEVEL_RESULT::TEST_NOT_SET) {
+			return is_victory ? LEVEL_RESULT::VICTORY : LEVEL_RESULT::DEFEAT;
+		} else {
+			return res;
+		}
 	} catch(const savegame::load_game_exception &) {
 		// Loading a new game is effectively a quit.
 		saved_game_.clear();

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -1546,6 +1546,7 @@ static int impl_end_level_data_get(lua_State* L)
 	return_bool_attrib("is_victory", data.is_victory);
 	return_bool_attrib("is_loss", !data.is_victory);
 	return_cstring_attrib("result", data.is_victory ? "victory" : "loss"); // to match wesnoth.end_level()
+	return_string_attrib("test_result", data.test_result);
 	return_cfg_attrib("__cfg", data.to_config_full());
 
 	return 0;
@@ -1574,6 +1575,7 @@ int game_lua_kernel::impl_end_level_data_set(lua_State* L)
 	modify_bool_attrib("carryover_report", data.transient.carryover_report = value);
 	modify_bool_attrib("prescenario_save", data.prescenario_save = value);
 	modify_bool_attrib("replay_save", data.replay_save = value);
+	modify_string_attrib("test_result", data.test_result = value);
 
 	return 0;
 }
@@ -1618,6 +1620,7 @@ int game_lua_kernel::intf_end_level(lua_State *L)
 	data.transient.linger_mode = cfg["linger_mode"].to_bool(true) && !teams().empty();
 	data.transient.reveal_map = cfg["reveal_map"].to_bool(true);
 	data.is_victory = cfg["result"] == "victory";
+	data.test_result = cfg["test_result"].str(LEVEL_RESULT::enum_to_string(LEVEL_RESULT::TEST_NOT_SET));
 	play_controller_.set_end_level_data(data);
 	return 0;
 }

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -20,28 +20,28 @@
 #
 2 check_victory_basic_timeout
 1 check_victory_basic_macro_check
-0 check_victory_basic
+8 check_victory_basic
 1 check_victory_basic_fail
-0 check_victory_basic_two
-0 check_victory_basic_ai
+8 check_victory_basic_two
+8 check_victory_basic_ai
 1 check_victory_basic_ai_fail
-0 check_victory_basic_ai_two
+8 check_victory_basic_ai_two
 1 check_victory_one_no_units_fail_one
 1 check_victory_one_no_units_fail_two
-0 check_victory_one_no_units
+8 check_victory_one_no_units
 1 check_victory_two_no_units_fail_one
 1 check_victory_two_no_units_fail_two
-0 check_victory_two_no_units
-0 check_victory_always_one
-0 check_victory_always_two
+8 check_victory_two_no_units
+8 check_victory_always_one
+8 check_victory_always_two
 1 check_victory_always_no_units_fail
-0 check_victory_always_no_units
+8 check_victory_always_no_units
 1 check_victory_always_fail
 1 check_victory_never_fail_one
 1 check_victory_never_fail_two
 1 check_victory_never_fail_three
-0 check_victory_never_pass
-1 check_victory_never_ai_fail
+8 check_victory_never_pass
+7 check_victory_never_ai_fail
 #
 # WML API tests
 #
@@ -96,6 +96,13 @@
 0 test_role_2
 0 test_role_3
 0 test_role_lua
+0 events-test_nonfilterable
+0 events-test_filterable1
+0 events-test_filterable2
+0 events-test_filterable3
+0 events-test_victory
+0 events-test_defeat
+0 events-test_die
 #
 # LUA
 #
@@ -143,12 +150,12 @@
 #
 # Attack calculations & codepath tests
 #
-0 alice_kills_bob
-0 bob_kills_alice_on_retal
-0 alice_kills_bob_levelup
-0 bob_kills_alice
-0 alice_kills_bob_on_retal
-0 alice_kills_bob_on_retal_levelup
+8 alice_kills_bob
+8 bob_kills_alice_on_retal
+8 alice_kills_bob_levelup
+8 bob_kills_alice
+8 alice_kills_bob_on_retal
+8 alice_kills_bob_on_retal_levelup
 0 test_grunt_tod_damage
 0 test_time_area_damage
 0 test_time_area_prestart


### PR DESCRIPTION
This adds an additional `test_result` attribute to [endlevel], intended for use with the automated unit tests. This allows for the unit tests to differentiate a pass/fail result separately from scenario victory or defeat, which allows for more accurately determining the outcome of a test as well as addresses the potential, for example, for a scenario to be expect to pass because of the {SUCCEED} macro but instead passes because the scenario ended as a victory through some other method.

Additional unit tests which were the original motivation for this change are also added as part of this.  They test, as much as possible, that events are executed at all, and are then also executed in the expected order.