### PR TITLE
Backport of cba53cd471e1b4bb44b2a57d477cf3401422219c

### DIFF
--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -571,6 +571,7 @@ static void check_fpu()
 			}
 		}
 
+#ifndef _M_AMD64
 		if(precision_mode != _PC_53) {
 			std::cerr << "Floating point precision mode is currently '"
 				<< ((precision_mode == _PC_53)
@@ -584,6 +585,8 @@ static void check_fpu()
 				std::cerr << "failed to set floating point precision type to 'double'\n";
 			}
 		}
+#endif
+
 	} else {
 		std::cerr << "_controlfp_s failed.\n";
 	}


### PR DESCRIPTION
Since it seems that the 64-bit enabled projectfiles for Visual Studio were added without also being tested that they generate a working executable.

---

Related: https://forums.wesnoth.org/viewtopic.php?p=653865#p653865