### PR TITLE
Update base terrain for deprecated *^Uf*

### DIFF
--- a/data/core/about.cfg
+++ b/data/core/about.cfg
@@ -1414,6 +1414,9 @@
         name = "legoktm"
     [/entry]
     [entry]
+        name = "leonardoInf"
+    [/entry]
+    [entry]
         name = "lilinitsy"
     [/entry]
     [entry]

--- a/data/core/terrain-graphics.cfg
+++ b/data/core/terrain-graphics.cfg
@@ -888,7 +888,7 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 {NEW:TRANSITION            (Ms,Ha)          (W*,S*)                     -171               hills/snow-to-water}
 {NEW:TRANSITION            (Ms,Ha)          (!,Ha,Qx*,Mm,Ms,Md)         -172               hills/snow}
 
-{NEW:TRANSITION            (Tb,*^Uf*)       (!,M*,Tb)                   -184               forest/mushroom-base}
+{NEW:TRANSITION            (Tb,*^Uf*)       (!,M*,Tb,*^Uf*)             -184               forest/mushroom-base}
 {NEW:TRANSITION            (Mm,Hh)          (!,M*,Hh,Ai,W*,S*)          -180               hills/regular}
 {NEW:TRANSITION            (Md,Hhd)         (!,M*,Hhd,Ai,W*,S*)         -183               hills/dry}
 {NEW:TRANSITION            Hd               (!,Hd,Qx*,W*)               -184               hills/desert}

--- a/data/core/terrain-graphics.cfg
+++ b/data/core/terrain-graphics.cfg
@@ -448,7 +448,7 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 #
 
 # Flat base terrains
-{NEW:BASE                Tb                                forest/mushroom-base LAYER=-319}
+{NEW:BASE                Tb,*^Uf*                                       forest/mushroom-base LAYER=-319}
 
 # The first grass tile of each kind is the most standard and generic one, thus it appears more frequently to space out the rest
 {NEW:BASE_P              Gg                                     20                 grass/green}
@@ -888,7 +888,7 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 {NEW:TRANSITION            (Ms,Ha)          (W*,S*)                     -171               hills/snow-to-water}
 {NEW:TRANSITION            (Ms,Ha)          (!,Ha,Qx*,Mm,Ms,Md)         -172               hills/snow}
 
-{NEW:TRANSITION            (Tb)             (!,M*,Tb)                   -184               forest/mushroom-base}
+{NEW:TRANSITION            (Tb,*^Uf*)       (!,M*,Tb)                   -184               forest/mushroom-base}
 {NEW:TRANSITION            (Mm,Hh)          (!,M*,Hh,Ai,W*,S*)          -180               hills/regular}
 {NEW:TRANSITION            (Md,Hhd)         (!,M*,Hhd,Ai,W*,S*)         -183               hills/dry}
 {NEW:TRANSITION            Hd               (!,Hd,Qx*,W*)               -184               hills/desert}


### PR DESCRIPTION
I mistakingly deleted my fork so I had to open this PR instead of https://github.com/wesnoth/wesnoth/pull/4838.