### PR TITLE
NR S5a: fix issue #4853 naga triggers door

### DIFF
--- a/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
@@ -2433,6 +2433,7 @@
         name=moveto
         first_time_only=no
         [filter]
+            side=1
             x,y=34,9
         [/filter]
         [filter_condition]


### PR DESCRIPTION
Small fix for issue #4853 .

Edit: Should probably be backported to 1.14 as well.