### PR TITLE
Sceptre of Fire: bug fixes and small tweaks to dialogue

### DIFF
--- a/data/campaigns/Sceptre_of_Fire/_main.cfg
+++ b/data/campaigns/Sceptre_of_Fire/_main.cfg
@@ -22,7 +22,7 @@
     {CAMPAIGN_DIFFICULTY HARD   "units/dwarves/lord.png~RC(magenta>red)" ( _ "Lord") ( _ "Difficult")}
 
     # wmllint: directory spelling Dwarfdom
-    description= _ "<i>The land of Wesnoth’s banner bold
+    description= _ "<i>The mark of Wesnoth’s banner bold
 Comes not from its own land;
 It comes from Dwarfdom, grim and old
 Made by a runesmith’s hand.

--- a/data/campaigns/Sceptre_of_Fire/maps/8_The_Dragon.map
+++ b/data/campaigns/Sceptre_of_Fire/maps/8_The_Dragon.map
@@ -15,8 +15,8 @@ Gd, Aa, Cea, Uu, Re, Rb, Uh, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Uh, Uh, Ur, Uu, Uu^Tf, 
 Gd, Cea, Cea, Re, Uu^Vud, Uu, Xu, Xu, Xu, Xu, Ql, Ql, Ql, Ql, Uu, Ur, Uu, Uu, Uu, Uu^Vu, Xu, Xu, Xu, Xu, Uu, Uh, Uu, Uu^Em, Uu, Uu^Em, Uu^Em, Uh, Xu, Xu
 Aa, Aa, Ha, Ha, Xu, Xu, Xu, Xu, Cud, Xu, Ql, Xu, Ql, Ql, Uu, Ur^Es, Uh, Uh, Xu, Xu, Xu, Xu, Uh, Uh, Rb^Es, Rb, Uu, Ur, Ur^Es, Xu, Uu, Uu^Em, Xu, Xu
 Aa^Fpa, Aa^Fpa, Xu, Xu, Xu, Xu, Cud, Cud, Ql, Ql, Ql, Ql, Ql, Uu, Uu, Uu, Uh, Xu, Xu, Xu, Xu, Xu, Uh, Uh, Uu, Uh, Xu, Xu, Rd, Uu^Es, Uh, Uh, Xu, Xu
-Ha, Ha^Fma, Xu, Xu, 3 Kud, Cud, Uu^Vu, Ql, Ql, Ql, Xu, Xu, Xu, Xu, Uh, Uu, Uu, Uu^Vu, Xu, Xu, Xu, Tb^Tf, Uu^Tf, Uu, Ql, Xu, Xu, Ql, Uu^Vu, Uu, Uh, Uh, Xu, Xu
-Ha, Ha^Fma, Xu, Xu, Cud, Cud, Ql, Ql, Ql, Ql, Uu^Vu, Xu, Xu, Xu, Uh, Uu, Uu, Ur, Ur, Ur, Ur, Uu^Tf, Uu, Uu, Xu, Xu, Ql, Ql, Uu, Uu, Uh, Xu, Xu, Xu
+Ha, Ha^Fma, Xu, Xu, Cud, Cud, Uu^Vu, Ql, Ql, Ql, Xu, Xu, Xu, Xu, Uh, Uu, Uu, Uu^Vu, Xu, Xu, Xu, Tb^Tf, Uu^Tf, Uu, Ql, Xu, Xu, Ql, Uu^Vu, Uu, Uh, Uh, Xu, Xu
+Ha, Xu, Xu, 3 Kud, Cud, Cud, Ql, Ql, Ql, Ql, Uu^Vu, Xu, Xu, Xu, Uh, Uu, Uu, Ur, Ur, Ur, Ur, Uu^Tf, Uu, Uu, Xu, Xu, Ql, Ql, Uu, Uu, Uh, Xu, Xu, Xu
 Ha, Ha, Xu, Xu, Cud, Ql, Ql, Ql, Ql, Ql, Xu, Xu, Xu, Xu, Xu, Uu^Vu, Uu, Uu^Es, Uh, Uu, Uu^Tf, Uu, Uu^Vu, Ql, Xu, Xu, Uh, Uh, Uu, Uu, Ql, Ql, Xu, Xu
 Ha, Ms, Xu, Xu, Cud, Uu^Vu, Ql, Ql, Ql, Ql, Ql, Xu, Xu, Xu, Ql, Ql, Ql, Uu, Uh, Tb^Tf, Uh, Uu^Tf, Xu, Xu, Ql, Ql, Rd^Es, Uu^Tf, Uh, Xu, Xu, Xu, Xu, Xu
 Ms, Ms, Xu, Xu, Xu, Cud, Ql, Ql, Ql, Ql, Ql, Uu^Vu, Xu, Xu, Ql, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Ql, Xu, Rd, Uh, Ql, Xu, Xu, Xu, Xu, Xu

--- a/data/campaigns/Sceptre_of_Fire/scenarios/1_A_Bargain_is_Struck.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/1_A_Bargain_is_Struck.cfg
@@ -982,6 +982,8 @@
     [event]
         name=scenario_end
 
+        {SOF_CLEAR_RUNE_VARS 1}
+
         {CLEAR_VARIABLE incominggold,havestone}
     [/event]
 

--- a/data/campaigns/Sceptre_of_Fire/scenarios/1_A_Bargain_is_Struck.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/1_A_Bargain_is_Struck.cfg
@@ -358,7 +358,7 @@
         [/message]
         [message]
             speaker=Rugnur
-            message= _ "Well... I think we can make a deal, but I’m not sure. I’ll have to ask the tribal leaders."
+            message= _ "Well... I think we can make a deal, but I’m not sure. I’ll have to ask the clan leaders."
         [/message]
         [message]
             speaker=Haldric II
@@ -371,7 +371,7 @@
         [/message]
         [message]
             speaker=Haldric II
-            message= _ "I can always take my offer to another tribe more friendly to its potential patrons. You are not the only smiths in the Northlands!"
+            message= _ "I can always take my offer to another clan more friendly to its potential patrons. You are not the only smiths in the Northlands!"
             scroll=no
         [/message]
         [message]

--- a/data/campaigns/Sceptre_of_Fire/scenarios/2_Closing_the_Gates.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/2_Closing_the_Gates.cfg
@@ -769,6 +769,8 @@
     [event]
         name=scenario_end
 
+        {SOF_CLEAR_RUNE_VARS 1}
+
         {CLEAR_VARIABLE glyphs,glyph_i,locations_outside,gate_closed}
     [/event]
 

--- a/data/campaigns/Sceptre_of_Fire/scenarios/2p5_Reaching_the_Runecrafter.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/2p5_Reaching_the_Runecrafter.cfg
@@ -325,12 +325,12 @@
         [filter_condition]
             [have_unit]
                 id=Baglur
-                y=1-5
+                y=1-3
             [/have_unit]
             [and]
                 [have_unit]
                     id=Alanin
-                    y=1-5
+                    y=1-3
                 [/have_unit]
             [/and]
         [/filter_condition]

--- a/data/campaigns/Sceptre_of_Fire/scenarios/2t_In_the_Dwarven_City.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/2t_In_the_Dwarven_City.cfg
@@ -207,11 +207,11 @@
         [/message]
         [message]
             speaker=Rugnur
-            message= _ "Sorry, lord, but he said he would move on to another tribe if I left."
+            message= _ "Sorry, lord, but he said he would move on to another clan if I left."
         [/message]
         [message]
             speaker=Durstorn
-            message= _ "Can’t you tell a bluff when you hear one?! He knows we’re the best craftsmen, and he wouldn’t have gone to another tribe if we stalled for a year. Oh well, what’s done is done. We’ll have to work for less than I would prefer..."
+            message= _ "Can’t you tell a bluff when you hear one?! He knows we’re the best craftsmen, and he wouldn’t have gone to another clan if we stalled for a year. Oh well, what’s done is done. We’ll have to work for less than I would prefer..."
         [/message]
         [message]
             speaker=Baglur

--- a/data/campaigns/Sceptre_of_Fire/scenarios/3_Searching_for_the_Runecrafter.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/3_Searching_for_the_Runecrafter.cfg
@@ -612,6 +612,7 @@
         [/message]
         {MAKE_LOYAL_NORMAL Baglur}
         {CLEAR_VARIABLE thur_x,thur_y}
+        {SOF_CLEAR_RUNE_VARS 1}
         [endlevel]
             result=victory
             bonus=yes

--- a/data/campaigns/Sceptre_of_Fire/scenarios/3_Searching_for_the_Runecrafter.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/3_Searching_for_the_Runecrafter.cfg
@@ -37,10 +37,10 @@
 
     [story]
         [part]
-            story= _ "It was a couple more weeks of marching along the tracks before a chill breeze touched Rugnur's group, washing over them from a tunnel leading up to the surface. Had they reached the Northlands?"
+            story= _ "It was a couple more weeks of marching along the tracks before a chill breeze touched Rugnur's group, washing over them from a side tunnel leading up to the surface. Had they reached the Northlands?"
         [/part]
         [part]
-            story= _ "Much to his chagrin, Alanin was dispatched to scout further up the rails, but he soon came back and claimed the rails ended, the tunnel was unfinished to the north. For this reason, Rugnur lead the dwarves up the cold tunnel, and began to search for the runesmith named Thursagan. Thursagan, the Sage of Fire."
+            story= _ "Much to his chagrin, Alanin was dispatched to scout further up the rails, but he soon came back and claimed the rails ended, the main tunnel was unfinished to the north. For this reason, Rugnur lead the dwarves up the cold passage, and began to search for the runesmith named Thursagan. Thursagan, the Sage of Fire."
         [/part]
     [/story]
 
@@ -212,7 +212,7 @@
         [/message]
         [message]
             speaker=Baglur
-            message= _ "We need to find the mage Thursagan and convince him to return to the citadel with us. He’s somewhere up here."
+            message= _ "We need to find the sage Thursagan and convince him to return to the citadel with us. He’s somewhere up here."
         [/message]
         [message]
             speaker=Rugnur
@@ -598,6 +598,21 @@
         [/show_objectives]
     [/event]
 
+    # Event to tell players about Thursagan's rune shop so they do not need to discover it by chance
+
+    [event]
+        name=moveto
+        [filter]
+            x=5-8
+            y=25-29
+            id=Thursagan
+        [/filter]
+        [message]
+            speaker=Thursagan
+            message= _ "If we want to make this work, we will need every rune-blasted edge we can get. If I have some time to set up shop at a keep, I can prepare a little rune-craft for your troops. My goods do not come cheap though, I will not stoop to trifling apprentice-work..."
+        [/message]
+    [/event]
+
     # Thursagan reaches the signpost
 
     [event]
@@ -607,8 +622,8 @@
             id=Thursagan
         [/filter]
         [message]
-            speaker=Thursagan
-            message= _ "Well, now we are in the caves again! Come on, back south, to the city."
+            speaker=Rugnur
+            message= _ "Well, now we reached the caves again! Come on, back south, to the city."
         [/message]
         {MAKE_LOYAL_NORMAL Baglur}
         {CLEAR_VARIABLE thur_x,thur_y}

--- a/data/campaigns/Sceptre_of_Fire/scenarios/4_Gathering_Materials.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/4_Gathering_Materials.cfg
@@ -1182,6 +1182,8 @@
             variable=krawg
         [/unstore_unit]
 
+        {SOF_CLEAR_RUNE_VARS 1}
+
         {CLEAR_VARIABLE alanin}
         {CLEAR_VARIABLE krawg}
 

--- a/data/campaigns/Sceptre_of_Fire/scenarios/4_Gathering_Materials.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/4_Gathering_Materials.cfg
@@ -406,7 +406,7 @@
             radius=5
 
             [filter_radius]
-                terrain=!,Xu,Qxu,*^V*
+                terrain=!,Xu,Qxu,Cud,Kud,*^V*
             [/filter_radius]
 
             variable=possible_coal_1_locations
@@ -429,7 +429,7 @@
             radius=5
 
             [filter_radius]
-                terrain=!,Xu,Qxu,*^V*
+                terrain=!,Xu,Qxu,Cud,Kud,*^V*
             [/filter_radius]
 
             variable=possible_coal_2_locations
@@ -453,7 +453,7 @@
                 radius=12
 
                 [filter_radius]
-                    terrain=!,Xu,Qxu,*^V*
+                    terrain=!,Xu,Qxu,Cud,Kud,*^V*
                 [/filter_radius]
             [/and]
 
@@ -467,7 +467,7 @@
 
                 # Not sure if this is really needed
                 [filter_radius]
-                    terrain=!,Xu,Qxu,*^V*
+                    terrain=!,Xu,Qxu,Cud,Kud,*^V*
                 [/filter_radius]
             [/not]
 

--- a/data/campaigns/Sceptre_of_Fire/scenarios/5_Hills_of_the_Shorbear_Clan.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/5_Hills_of_the_Shorbear_Clan.cfg
@@ -898,6 +898,8 @@
     [event]
         name=victory
 
+        {SOF_CLEAR_RUNE_VARS 1}
+
         {CLEAR_VARIABLE elves_come}
     [/event]
 

--- a/data/campaigns/Sceptre_of_Fire/scenarios/5_Hills_of_the_Shorbear_Clan.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/5_Hills_of_the_Shorbear_Clan.cfg
@@ -287,7 +287,7 @@
         [/message]
         [message]
             speaker=Durstorn
-            message= _ "<i>I’ll </i> be doing the talking! I remember what happened last time you negotiated a deal, Rugnur! We lost five thousand pieces of silver!"
+            message= _ "<i>I’ll</i> be doing the talking! I remember what happened last time you negotiated a deal, Rugnur! We lost five thousand pieces of silver!"
         [/message]
         [message]
             speaker=Glonoin
@@ -295,7 +295,7 @@
         [/message]
         [message]
             speaker=Durstorn
-            message= _ "I’m Lord Durstorn, ruler of the Chaincolt Range. I have been told you are great jeweler-workers, and so we come to rent some of your tools for a short time, a few years at most."
+            message= _ "I’m Lord Durstorn, ruler of the Chaincolt Range. I have been told you are great jewel-workers, and so we come to rent some of your tools for a short time, a few years at most."
         [/message]
         [message]
             speaker=Glonoin
@@ -441,7 +441,7 @@
         [/unit]
         [message]
             speaker=narrator
-            message= _ "A brave dwarf ran out, grabbed the friendly gryphon by the sturdy neck-feathers, and hauled himself up over its back. The big animal took it all in stride, and seemed to understand what the pats and strokes of the dwarf's hands meant."
+            message= _ "A brave dwarf ran out, grabbed a friendly gryphon by the sturdy neck-feathers, and hauled himself up over its back. The big animal took it all in stride, and seemed to understand what the pats and strokes of the dwarf's hands meant."
             image=wesnoth-icon.png
         [/message]
         [message]
@@ -483,7 +483,7 @@
         [/message]
         [message]
             speaker=Glonoin
-            message= _ "Who the devil are you?"
+            message= _ "Who in the earth’s guts are you?"
         [/message]
         [message]
             speaker=Rugnur

--- a/data/campaigns/Sceptre_of_Fire/scenarios/6_Towards_the_Caves.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/6_Towards_the_Caves.cfg
@@ -632,6 +632,8 @@
     [event]
         name=victory
 
+        {SOF_CLEAR_RUNE_VARS 1}
+
         # This [if] is used only in the case the player happened to defeat all
         # the enemy leaders and didn't move Alanin to the signpost
         [if]

--- a/data/campaigns/Sceptre_of_Fire/scenarios/8_The_Dragon.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/8_The_Dragon.cfg
@@ -264,7 +264,7 @@
         {RANDOM_MERCENARY "Dwarvish Lord" 2 13 ()}
         {RANDOM_MERCENARY "Dwarvish Lord" 2 14 ()}
         {RANDOM_MERCENARY "Dwarvish Dragonguard" 2 15 ()}
-        {RANDOM_MERCENARY "Dwarvish Dragonguard" 2 16 ()}
+        {RANDOM_MERCENARY "Dwarvish Dragonguard" 1 12 ()}
 
         [message]
             speaker=Rugnur

--- a/data/campaigns/Sceptre_of_Fire/scenarios/8_The_Dragon.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/8_The_Dragon.cfg
@@ -472,6 +472,8 @@
             [/unstore_unit]
             {CLEAR_VARIABLE thur}
 
+            {SOF_CLEAR_RUNE_VARS 1}
+
             [object]
                 id=sceptre of fire
                 silent=yes

--- a/data/campaigns/Sceptre_of_Fire/scenarios/Epilogue.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/Epilogue.cfg
@@ -32,7 +32,7 @@
 
     [story]
         [part]
-            story= _ "And thus Rugnur died — a glorious death, in the eyes of the dwarven sages. But our tale is not yet complete. For Alanin lived still, as did Krawg the Gryphon."
+            story= _ "And thus Rugnur died a glorious death, in the eyes of the dwarven sages — and with him, Thursagan, greatest of the Runesmiths, whose legacy was soon lost. But our tale is not yet complete. For Alanin lived still, as did Krawg the Gryphon."
             music=the_king_is_dead.ogg
         [/part]
         [part]

--- a/data/campaigns/Sceptre_of_Fire/utils/rune-equip.cfg
+++ b/data/campaigns/Sceptre_of_Fire/utils/rune-equip.cfg
@@ -99,6 +99,21 @@
         [/fire_event]
     [/event]
     [event]
+        name=moveto
+        id=sof_rune_shop_flavor_text
+        first_time_only=yes
+        [filter]
+            id=Thursagan
+            [filter_location]
+                terrain=K*
+            [/filter_location]
+        [/filter]
+        [message]
+            speaker=Thursagan
+            message= _ "My tools are ready. Step closer, if you want to witness my rune-work."
+        [/message]
+    [/event]
+    [event]
         name=side 1 turn
         id=sof_sfe_side1turn
         first_time_only=no
@@ -382,7 +397,7 @@
 #define SOF_RUNIC_CHEST_SWIFTNESS X Y
     {SOF_RUNIC_CHEST_GENERIC (
         [option]
-            {SOF_RUNIC_OPTION swiftness (_ "Swiftness") (_ "Adds 1 MP") ("misc/rune_icon.png~BLIT(scenery/summoning-circle4.png~CROP(6,6,60,60),0,0)") 8 (
+            {SOF_RUNIC_OPTION "swiftness" (_ "Swiftness") (_ "Adds 1 MP") ("misc/rune_icon.png~BLIT(scenery/summoning-circle4.png~CROP(6,6,60,60),0,0)") 8 (
                 [effect]
                     apply_to=movement
                     increase=1
@@ -420,7 +435,7 @@
 #define SOF_RUNIC_CHEST_ACCURACY X Y
     {SOF_RUNIC_CHEST_GENERIC (
         [option]
-            {SOF_RUNIC_OPTION accuracy (_ "Accuracy") (_ "Increases ranged weapon accuracy 10%") ("misc/rune_icon.png~BLIT(scenery/summoning-circle5.png~CROP(6,6,60,60),0,0)") 10 (
+            {SOF_RUNIC_OPTION "accuracy" (_ "Accuracy") (_ "Increases ranged weapon accuracy 10%") ("misc/rune_icon.png~BLIT(scenery/summoning-circle5.png~CROP(6,6,60,60),0,0)") 10 (
                 [effect]
                     apply_to=attack
                     range=ranged
@@ -493,4 +508,13 @@
             [/command]
         [/option]
     ) {X} {Y}}
+#enddef
+
+#define SOF_CLEAR_RUNE_VARS SIDE
+    [modify_unit]
+        [filter]
+            side={SIDE}
+        [/filter]
+        {CLEAR_VARIABLE swiftness_rune,accuracy_rune,force_rune}
+    [/modify_unit]
 #enddef

--- a/data/schema/core/actionwml.cfg
+++ b/data/schema/core/actionwml.cfg
@@ -369,6 +369,8 @@
 		{LINK_TAG "units/$modifications/advancement"}
 		{LINK_TAG "units/$modifications/object"}
 		{LINK_TAG "units/$modifications/base/effect"}
+        {LINK_TAG "$action_wml/clear_variable"}
+        {LINK_TAG "$action_wml/set_variable"}
 	[/tag]
 	[tag]
 		name="transform_unit"


### PR DESCRIPTION
I was previously asked to do one commit per file, they can be squashed for a merge.

I have added a macro to clear to rune variables added by @doofus-01 to `utils/rune-equip` and applied it to all scenarios where the player can buy runes.

Small dialogue tweaks were done for scenarios 1, 2t, 3, 5, and epilogue. This includes changing all mentions of "tribe" to "clan".

S8 map was slightly changed to keep the dragon from suiciding into the AI ulfserkers, which was actually not that improbable before and resulted in none of his dialogue lines triggering (and a scenario named "The Dragon" with no sign of a dragon whatsoever from the players perspective).