### PR TITLE
Fixes for clang warnings for Ubuntu 20.04

### DIFF
--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -167,7 +167,7 @@ if(ENABLE_POT_UPDATE_TARGET)
 	add_custom_command(
 			# Same idea with a dummy file as in pot-update: we never make it, and run the command each time.
 			OUTPUT ${PROJECT_SOURCE_DIR}/po/po_stat.dummy
-			COMMAND python utils/po_stat.py
+			COMMAND python3 utils/po_stat.py
 			--update-cfg
 			--textdomains=wesnoth,wesnoth-editor,wesnoth-help,wesnoth-lib,wesnoth-multiplayer,wesnoth-tutorial,wesnoth-units
 			WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}

--- a/po/SConscript
+++ b/po/SConscript
@@ -91,7 +91,7 @@ if "pot-update" in COMMAND_LINE_TARGETS:
             env.Command(new_pot, source_pot, ["msgcat --sort-by-file $SOURCES -o $TARGET", Delete(source_pot)])
         env.Command(pot, new_pot, Action(update_pot))
 
-    env.Alias("pot-update", "../translations", "python utils/po_stat.py --update-cfg --textdomains=wesnoth,wesnoth-editor,wesnoth-help,wesnoth-lib,wesnoth-multiplayer,wesnoth-tutorial,wesnoth-units")
+    env.Alias("pot-update", "../translations", "python3 utils/po_stat.py --update-cfg --textdomains=wesnoth,wesnoth-editor,wesnoth-help,wesnoth-lib,wesnoth-multiplayer,wesnoth-tutorial,wesnoth-units")
 
 if "update-po" in COMMAND_LINE_TARGETS or "pot-update" in COMMAND_LINE_TARGETS or "update-po4a" in COMMAND_LINE_TARGETS:
     for domain in textdomains:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -196,6 +196,12 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 		APPEND_STRING PROPERTY COMPILE_FLAGS
 			" -Wno-parentheses-equality"
 	)
+# silence a Clang specific warning when compiling the lua code
+	set_property(SOURCE
+		SOURCE ${lua_STAT_SRC}
+		APPEND_STRING PROPERTY COMPILE_FLAGS
+			" -Wno-string-plus-int"
+	)
 endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 
 # a 'lib' is automatically set in front when creating the library (as in the filename)

--- a/src/SConscript
+++ b/src/SConscript
@@ -109,8 +109,9 @@ env_lua = env.Clone(
 
 env_lua.AppendUnique(CCFLAGS = Split("-Wno-old-style-cast -Wno-useless-cast"))
 # Silence some Clang-specific warnings due to extra parentheses in if statements when comparing.
+# also silence a warning for the lua code
 if "clang" in env["CXX"]:
-    env_lua.AppendUnique(CCFLAGS = Split("-Wno-parentheses-equality"))
+    env_lua.AppendUnique(CCFLAGS = Split("-Wno-parentheses-equality -Wno-string-plus-int"))
 
 if env_lua["enable_lto"] == True:
     env_lua["AR"] = 'gcc-ar'

--- a/src/actions/create.cpp
+++ b/src/actions/create.cpp
@@ -134,7 +134,7 @@ namespace { // Helpers for get_recalls()
 
 		const unit_filter ufilt(vconfig(leader->recall_filter()));
 
-		for (const unit_const_ptr & recall_unit_ptr : leader_team.recall_list())
+		for (const unit_const_ptr recall_unit_ptr : leader_team.recall_list())
 		{
 			const unit & recall_unit = *recall_unit_ptr;
 			// Do not add a unit twice.

--- a/src/addon/info.hpp
+++ b/src/addon/info.hpp
@@ -87,6 +87,8 @@ struct addon_info
 		this->read(cfg);
 	}
 
+	addon_info(const addon_info&) = default;
+
 	addon_info& operator=(const addon_info& o) {
 		if(this != &o) {
 			this->id = o.id;

--- a/src/ai/contexts.cpp
+++ b/src/ai/contexts.cpp
@@ -284,13 +284,13 @@ config readwrite_context_impl::to_readwrite_context_config() const
 config readonly_context_impl::to_readonly_context_config() const
 {
 	config cfg;
-	for(const engine_ptr e : engines_) {
+	for(const engine_ptr &e : engines_) {
 		cfg.add_child("engine",e->to_config());
 	}
-	for(const aspect_map::value_type a : aspects_) {
+	for(const aspect_map::value_type &a : aspects_) {
 		cfg.add_child("aspect",a.second->to_config());
 	}
-	for(const goal_ptr g : goals_) {
+	for(const goal_ptr &g : goals_) {
 		cfg.add_child("goal",g->to_config());
 	}
 	return cfg;

--- a/src/ai/default/recruitment.cpp
+++ b/src/ai/default/recruitment.cpp
@@ -266,7 +266,7 @@ void recruitment::execute() {
 		// Add recalls.
 		// Recalls are treated as recruits. While recruiting
 		// we'll check if we can do a recall instead of a recruitment.
-		for (const unit_const_ptr & recall : current_team().recall_list()) {
+		for (const unit_const_ptr recall : current_team().recall_list()) {
 			// Check if this leader is allowed to recall this unit.
 			const unit_filter ufilt( vconfig(leader->recall_filter()));
 			if (!ufilt(*recall, map_location::null_location())) {
@@ -523,7 +523,7 @@ const std::string* recruitment::get_appropriate_recall(const std::string& type,
 		const data& leader_data) const {
 	const std::string* best_recall_id = nullptr;
 	double best_recall_value = -1;
-	for (const unit_const_ptr & recall_unit : current_team().recall_list()) {
+	for (const unit_const_ptr recall_unit : current_team().recall_list()) {
 		if (type != recall_unit->type_id()) {
 			continue;
 		}

--- a/src/carryover.cpp
+++ b/src/carryover.cpp
@@ -50,7 +50,7 @@ carryover::carryover(const team& t, const int gold, const bool add)
 		, save_id_(t.save_id())
 		, variables_(t.variables())
 {
-	for(const unit_const_ptr & u : t.recall_list()) {
+	for(const unit_const_ptr u : t.recall_list()) {
 		recall_list_.emplace_back();
 		u->write(recall_list_.back());
 	}

--- a/src/game_board.cpp
+++ b/src/game_board.cpp
@@ -354,7 +354,7 @@ void game_board::write_config(config & cfg) const
 			}
 		}
 		//recall list
-		for(const unit_const_ptr & j : t->recall_list()) {
+		for(const unit_const_ptr j : t->recall_list()) {
 			config& u = side.add_child("unit");
 			j->write(u);
 		}

--- a/src/game_initialization/connect_engine.cpp
+++ b/src/game_initialization/connect_engine.cpp
@@ -505,7 +505,7 @@ void connect_engine::start_game_commandline(const commandline_options& cmdline_o
 
 		// Set the faction, if commandline option is given.
 		if(cmdline_opts.multiplayer_side) {
-			for(const mp_option& option : *cmdline_opts.multiplayer_side) {
+			for(const mp_option option : *cmdline_opts.multiplayer_side) {
 
 				if(std::get<0>(option) == num) {
 					if(std::find_if(era_factions_.begin(), era_factions_.end(), [&option](const config* faction) { return (*faction)["id"] == std::get<1>(option); }) != era_factions_.end()) {
@@ -522,7 +522,7 @@ void connect_engine::start_game_commandline(const commandline_options& cmdline_o
 
 		// Set the controller, if commandline option is given.
 		if(cmdline_opts.multiplayer_controller) {
-			for(const mp_option& option : *cmdline_opts.multiplayer_controller) {
+			for(const mp_option option : *cmdline_opts.multiplayer_controller) {
 
 				if(std::get<0>(option) == num) {
 					DBG_MP << "\tsetting side " << std::get<0>(option) <<
@@ -538,7 +538,7 @@ void connect_engine::start_game_commandline(const commandline_options& cmdline_o
 		std::string ai_algorithm = game_config.child("ais")["default_ai_algorithm"].str();
 		side->set_ai_algorithm(ai_algorithm);
 		if(cmdline_opts.multiplayer_algorithm) {
-			for(const mp_option& option : *cmdline_opts.multiplayer_algorithm) {
+			for(const mp_option option : *cmdline_opts.multiplayer_algorithm) {
 
 				if(std::get<0>(option) == num) {
 					DBG_MP << "\tsetting side " << std::get<0>(option) <<
@@ -565,7 +565,7 @@ void connect_engine::start_game_commandline(const commandline_options& cmdline_o
 
 	for(config &side : scenario().child_range("side")) {
 		if(cmdline_opts.multiplayer_ai_config) {
-			for(const mp_option& option : *cmdline_opts.multiplayer_ai_config) {
+			for(const mp_option option : *cmdline_opts.multiplayer_ai_config) {
 
 				if(std::get<0>(option) == side["side"].to_unsigned()) {
 					DBG_MP << "\tsetting side " << side["side"] <<

--- a/src/game_initialization/create_engine.cpp
+++ b/src/game_initialization/create_engine.cpp
@@ -575,7 +575,7 @@ std::pair<level::TYPE, int> create_engine::find_level_by_id(const std::string& i
 	for(const auto& type : type_map_) {
 		int i = 0;
 
-		for(const auto game : type.second.games) {
+		for(const auto& game : type.second.games) {
 			if(game->id() == id) {
 				return {type.first, i};
 			}
@@ -801,7 +801,7 @@ void create_engine::apply_level_filters()
 std::vector<create_engine::level_ptr> create_engine::get_levels_by_type_unfiltered(level::TYPE type) const
 {
 	std::vector<level_ptr> levels;
-	for(const level_ptr lvl : type_map_.at(type.v).games) {
+	for(const level_ptr& lvl : type_map_.at(type.v).games) {
 		levels.push_back(lvl);
 	}
 

--- a/src/gui/dialogs/gamestate_inspector.cpp
+++ b/src/gui/dialogs/gamestate_inspector.cpp
@@ -755,7 +755,7 @@ void team_mode_controller::show_recall(tree_view_node& node, int side)
 		return;
 	}
 
-	for(const unit_ptr u : dc().get_team(side).recall_list()) {
+	for(const unit_ptr& u : dc().get_team(side).recall_list()) {
 		auto progress = view().stuff_list_entry(&node, "unit");
 		add_unit_entry(progress, *u, dc());
 		c.set_node_callback(progress.add(), &team_mode_controller::show_recall_unit, side);

--- a/src/gui/dialogs/terrain_layers.cpp
+++ b/src/gui/dialogs/terrain_layers.cpp
@@ -63,7 +63,7 @@ void terrain_layers::pre_show(window& window)
 	listbox& list = find_widget<listbox>(&window, "layer_list", false);
 
 	int order = 1;
-	for(const terrain_builder::tile::log_details det : tile_logs_) {
+	for(const terrain_builder::tile::log_details& det : tile_logs_) {
 		const terrain_builder::tile::rule_image_rand& ri   = *det.first;
 		const terrain_builder::rule_image_variant& variant = *det.second;
 

--- a/src/hotkey/hotkey_item.cpp
+++ b/src/hotkey/hotkey_item.cpp
@@ -452,7 +452,7 @@ std::string get_names(const std::string& id)
 {
 	// Names are used in places like the hot-key preferences menu
 	std::vector<std::string> names;
-	for (const hotkey::hotkey_ptr item : hotkeys_) {
+	for (const hotkey::hotkey_ptr& item : hotkeys_) {
 		if (item->get_command() == id && !item->null() && !item->is_disabled()) {
 			names.push_back(item->get_name());
 		}

--- a/src/preferences/game.cpp
+++ b/src/preferences/game.cpp
@@ -138,7 +138,7 @@ manager::~manager()
 {
 	config campaigns;
 	typedef const std::pair<std::string, std::set<std::string>> cc_elem;
-	for (cc_elem &elem : completed_campaigns) {
+	for (cc_elem elem : completed_campaigns) {
 		config cmp;
 		cmp["name"] = elem.first;
 		cmp["difficulty_levels"] = utils::join(elem.second);
@@ -159,7 +159,7 @@ manager::~manager()
 */
 	config history;
 	typedef std::pair<std::string, std::vector<std::string>> hack;
-	for (const hack& history_id : history_map) {
+	for (const hack history_id : history_map) {
 
 		config history_id_cfg; // [history_id]
 		for (const std::string& line : history_id.second) {
@@ -1016,7 +1016,7 @@ void encounter_start_units(const unit_map& units){
 
 static void encounter_recallable_units(const std::vector<team>& teams){
 	for (const team& t : teams) {
-		for (const unit_const_ptr & u : t.recall_list()) {
+		for (const unit_const_ptr u : t.recall_list()) {
 			encountered_units_set.insert(u->type_id());
 		}
 	}

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -526,8 +526,7 @@ static config unit_advancement_options(const unit* u)
 {
 	if (!u) return config();
 	config res;
-	typedef std::pair<std::string, std::string> pair_string;
-	for (const pair_string &ps : u->advancement_icons()) {
+	for (const auto& ps : u->advancement_icons()) {
 		add_image(res, ps.first, ps.second);
 	}
 	return res;
@@ -873,8 +872,7 @@ static int attack_info(reports::context & rc, const attack_type &at, config &res
 			}
 		}
 
-		typedef std::pair<int, std::set<std::string>> resist_units;
-		for (const resist_units &resist : resistances) {
+		for (const auto& resist : resistances) {
 			int damage_with_resistance = round_damage(specials_damage, damage_multiplier * resist.first, damage_divisor);
 			tooltip << "<b>" << damage_with_resistance << "</b>  "
 				<< "<span color='" << attack_info_percent_color(resist.first-100).to_hex_string() << "'>"

--- a/src/side_filter.cpp
+++ b/src/side_filter.cpp
@@ -138,7 +138,7 @@ bool side_filter::match_internal(const team &t) const
 			}
 		}
 		if(!found && ufilt_cfg["search_recall_list"].to_bool(false)) {
-			for(const unit_const_ptr & u : t.recall_list()) {
+			for(const unit_const_ptr u : t.recall_list()) {
 				scoped_recall_unit this_unit("this_unit", t.save_id_or_number(), t.recall_list().find_index(u->id()));
 				if(ufilter_->matches(*u)) {
 					found = true;

--- a/src/units/animation.cpp
+++ b/src/units/animation.cpp
@@ -1197,7 +1197,7 @@ std::ostream& operator<<(std::ostream& outstream, const unit_animation& u_animat
 
 	if(u_animation.primary_attack_filter_.size() > 0) {
 		outstream << "[filter_attack]\n";
-		for(const config cfg : u_animation.primary_attack_filter_) {
+		for(const config& cfg : u_animation.primary_attack_filter_) {
 			outstream << cfg.debug();
 		}
 
@@ -1206,7 +1206,7 @@ std::ostream& operator<<(std::ostream& outstream, const unit_animation& u_animat
 
 	if(u_animation.secondary_attack_filter_.size() > 0) {
 		outstream << "[filter_second_attack]\n";
-		for(const config cfg : u_animation.secondary_attack_filter_) {
+		for(const config& cfg : u_animation.secondary_attack_filter_) {
 			outstream << cfg.debug();
 		}
 
@@ -1215,7 +1215,7 @@ std::ostream& operator<<(std::ostream& outstream, const unit_animation& u_animat
 
 	for(std::size_t i = 0; i < u_animation.unit_anim_.get_frames_count(); i++) {
 		outstream << "\t[frame]\n";
-		for(const std::string frame_string : u_animation.unit_anim_.get_frame(i).debug_strings()) {
+		for(const std::string& frame_string : u_animation.unit_anim_.get_frame(i).debug_strings()) {
 			outstream << "\t\t" << frame_string <<"\n";
 		}
 		outstream << "\t[/frame]\n";
@@ -1230,7 +1230,7 @@ std::ostream& operator<<(std::ostream& outstream, const unit_animation& u_animat
 			outstream << "\t" << sub_frame_name << "_start_time=" << p.second.get_begin_time() << '\n';
 			outstream << "\t[" << p.first << "]\n";
 
-			for(const std::string frame_string : p.second.get_frame(i).debug_strings()) {
+			for(const std::string& frame_string : p.second.get_frame(i).debug_strings()) {
 				outstream << "\t\t" << frame_string << '\n';
 			}
 

--- a/src/whiteboard/move.cpp
+++ b/src/whiteboard/move.cpp
@@ -523,7 +523,7 @@ config move::to_config() const
 		route_cfg.add_child("step", std::move(loc_cfg));
 	}
 	typedef std::pair<map_location,pathfind::marked_route::mark> pair_loc_mark;
-	for(const pair_loc_mark& item : route_->marks)
+	for(const pair_loc_mark item : route_->marks)
 	{
 		config mark_cfg;
 		mark_cfg["x"]=item.first.wml_x();


### PR DESCRIPTION
The first commit changes two uses of `python` -> `python3`, since 20.04 doesn't come with the `python` link by default.

Clang fix for `-Wdeprecated-copy` adds a copy constructor due to it warning about having an assignment operator defined but no copy constructor defined is deprecated.

Clang fix `-Wstring-plus-int` silences a warning from the lua source code stating that `<string> + <int>` does nothing.  This sounds... incorrect, but the lua code isn't ours and it doesn't seem to be breaking anything.

Everything else is for `-Wrange-loop-construct` warnings.