### PR TITLE
Add comments about minimap.cpp's use of "team colors"

### DIFF
--- a/src/game_config.hpp
+++ b/src/game_config.hpp
@@ -150,6 +150,10 @@ namespace game_config
 	extern std::vector<std::string> foot_speed_prefix;
 	extern std::string foot_teleport_enter, foot_teleport_exit;
 
+	/**
+	 * Colors defined by WML [color_range] tags. In addition to team colors such as "red" and
+	 * "blue", this also contains the colors used on the minimap for "cave", "fungus" etc.
+	 */
 	extern std::map<std::string, color_range> team_rgb_range;
 	extern std::map<std::string, t_string> team_rgb_name;
 	extern std::map<std::string, std::vector<color_t>> team_rgb_colors;

--- a/src/minimap.cpp
+++ b/src/minimap.cpp
@@ -179,6 +179,8 @@ surface getMinimap(int w, int h, const gamemap &map, const team *vw, const std::
 
 				} else {
 
+					// Despite its name, game_config::team_rgb_range isn't just team colors,
+					// it has "red", "lightblue", "cave", "reef", "fungus", etc.
 					color_t col;
 					std::map<std::string, color_range>::const_iterator it = game_config::team_rgb_range.find(terrain_info.id());
 					if (it == game_config::team_rgb_range.end()) {


### PR DESCRIPTION
A comment-only change, opening as a PR because I'm still wondering whether to
make it a code-change as well. Maybe the "team_rgb_range" should be renamed as "named_color_range", because
it's used for everything defined by the WML `[color_range]` tag. In addition to
the ones normally used for teams (`red`, `lightblue`, etc) it has the minimap
colors for `reef`, `cave`, etc.

Separating the team colors from the terrain colors probably shouldn't be done.
Looking from the opposite perspective, using the terrain colors as team colors
has been discussed on the forums and found to be a useful feature:

* https://r.wesnoth.org/p627592
* https://r.wesnoth.org/p627588