### PR TITLE
Fixed a bug with rezising in the recall unit window

### DIFF
--- a/src/gui/dialogs/unit_recall.cpp
+++ b/src/gui/dialogs/unit_recall.cpp
@@ -362,6 +362,8 @@ void unit_recall::dismiss_unit(window& window)
 		message << _("This unit is close to advancing a level.") << " " << (u.gender() == unit_race::MALE
 		         ? _("Do you really want to dismiss him?")
 		         : _("Do you really want to dismiss her?"));
+	}else {
+		message << _("Are you sure you want to dismiss this unit?");
 	}
 
 	if(!message.str().empty()) {


### PR DESCRIPTION
As described in issue #4877 sometimes the recall unit window would layer on top of another one after dismissing a unit. I noticed that only happens if you dismiss a unit that you aren't asked whether you are sure to dismiss said unit. by adding a else case and always asking if the user is sure to dismiss the unit I fixed that problem. I'm not sure if that is the best solution for this problem, but so far I haven't come up with a better fix.