### PR TITLE
Fix issue #4909.

### DIFF
--- a/data/themes/_initial.cfg
+++ b/data/themes/_initial.cfg
@@ -234,7 +234,7 @@
     [change]
         id=minimap-panel
         image=themes/classic/minimap-800.png
-        rect="842,=+6,+181,+177"
+        rect="=,=+6,+181,+177"
     [/change]
 
     # reduce size of minimap
@@ -255,7 +255,7 @@
     [/change]
     [change]
         id=minimap-button-2
-        rect="=,+3,25,+25"
+        rect="=,+3,+25,+25"
     [/change]
     [change]
         id=minimap-button-3

--- a/data/themes/default.cfg
+++ b/data/themes/default.cfg
@@ -588,6 +588,11 @@
         width=800
         height=600
 
+        [change]
+            id=main-map
+            rect="=,+0,+618,600"
+        [/change]
+
         # fix top pane at 800x600
         {CHANGE_STATUS_BOX +3 =+0 +85 +15 turn     actions-menu}
         {CHANGE_STATUS_BOX +1 =+0 +56 +15 gold     turn-box-topright}

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -330,10 +330,10 @@ SDL_Rect& theme::object::location(const SDL_Rect& screen) const
 			break;
 		case TOP_ANCHORED:
 			relative_loc_.x = loc_.x;
-			relative_loc_.w = screen.w - std::min<std::size_t>(spec_width_ - loc_.w, screen.w);
+			relative_loc_.w = loc_.w + screen.w - std::min<std::size_t>(spec_width_, loc_.w + screen.w);
 			break;
 		case BOTTOM_ANCHORED:
-			relative_loc_.x = screen.w - std::min<std::size_t>(spec_width_ - loc_.x, screen.w);
+			relative_loc_.x = loc_.x + screen.w - std::min<std::size_t>(spec_width_, loc_.x + screen.w);
 			relative_loc_.w = loc_.w;
 			break;
 		case PROPORTIONAL:
@@ -351,10 +351,10 @@ SDL_Rect& theme::object::location(const SDL_Rect& screen) const
 			break;
 		case TOP_ANCHORED:
 			relative_loc_.y = loc_.y;
-			relative_loc_.h = screen.h - std::min<std::size_t>(spec_height_ - loc_.h, screen.h);
+			relative_loc_.h = loc_.h + screen.h - std::min<std::size_t>(spec_height_, loc_.h + screen.h);
 			break;
 		case BOTTOM_ANCHORED:
-			relative_loc_.y = screen.h - std::min<std::size_t>(spec_width_ - loc_.y, screen.h);
+			relative_loc_.y = loc_.y + screen.h - std::min<std::size_t>(spec_height_, loc_.y + screen.h);
 			relative_loc_.h = loc_.h;
 			break;
 		case PROPORTIONAL:
@@ -365,9 +365,16 @@ SDL_Rect& theme::object::location(const SDL_Rect& screen) const
 			assert(false);
 	}
 
-	relative_loc_.x = std::min<int>(relative_loc_.x, screen.w);
+	relative_loc_.w = std::min<int>(relative_loc_.w, screen.w);
+	if(relative_loc_.x > screen.w) {
+		relative_loc_.x = std::min<int>(relative_loc_.x, screen.w - relative_loc_.w);
+	}
 	relative_loc_.w = std::min<int>(relative_loc_.w, screen.w - relative_loc_.x);
-	relative_loc_.y = std::min<int>(relative_loc_.y, screen.h);
+
+	relative_loc_.h = std::min<int>(relative_loc_.h, screen.h);
+	if(relative_loc_.y > screen.h) {
+		relative_loc_.y = std::min<int>(relative_loc_.y, screen.h - relative_loc_.h);
+	}
 	relative_loc_.h = std::min<int>(relative_loc_.h, screen.h - relative_loc_.y);
 
 	return relative_loc_;


### PR DESCRIPTION
As Pentarctagon suggested, before PR #4851 the lower resolutions of the default theme were still calculating off of a base resolution of 1024x768. After PR #4851, they were calculating off of their specified resolutions. This is more sensible, but given the scaling code and the old theme specification, could cause the main map to disappear via a bug complementary to the one that PR #4851 fixed (that the main map was disappearing when the resolutions were *too high*). This PR tweaks the rescaling to handle these cases when the screen resolution is small, and tweaks the definition of the 800x600 resolution of the default theme to specify the main map at a reasonable size for that resolution (formerly it was specified as larger than the screen (!) which was only working due to the quirks of location and size scaling). 