### PR TITLE
Work around issue #4908.

### DIFF
--- a/data/gui/widget/label_default.cfg
+++ b/data/gui/widget/label_default.cfg
@@ -97,7 +97,7 @@
 # dpi. It came out looking pretty decent on my 90-micron monitor.
 
 #define _GUI_SCALE_RES SIZE
-	"(floor({SIZE} * 265 * 2 / (3 * screen_pitch_microns)))"
+	"(max({SIZE}, floor({SIZE} * 265 * 2 / (3 * screen_pitch_microns))))"
 #enddef
 
 #define _GUI_DEFINITION ID DESCRIPTION FONT_FAMILY FONT_SIZE FONT_STYLE FONT_COLOR


### PR DESCRIPTION
PR #4860 scales fonts by the observed screen pitch in microns when the main window is 1200x900 or larger. However, it seems based on the issue report #4908 that in some cases, the reported pixel pitch is not correct, and the scaling was shrinking fonts intolerably. This PR ensures that the scaling will never decrease font sizes, although it does not address why or under what circumstances the screen_pitch_microns may be incorrect.