### PR TITLE
Fix divide by zero when SDL can't get DPI for scale factor.

### DIFF
--- a/src/gui/widgets/settings.cpp
+++ b/src/gui/widgets/settings.cpp
@@ -59,6 +59,11 @@ void update_screen_size_variables()
 	float scalew, scaleh;
 	std::tie(scalew, scaleh) = vid.get_dpi_scale_factor();
 	float avgscale = (scalew + scaleh)/2;
+	// Note that if DPI can't be determined, SDL returns zero. Fallback to default scale.
+	if (avgscale == 0.0) {
+		avgscale = 1.0;
+	}
+
 	screen_pitch_microns = MICRONS_PER_INCH / (avgscale * MAGIC_DPI_MATCH_VIDEO);
 
 	gamemap_width = screen_width;

--- a/src/gui/widgets/settings.cpp
+++ b/src/gui/widgets/settings.cpp
@@ -59,11 +59,6 @@ void update_screen_size_variables()
 	float scalew, scaleh;
 	std::tie(scalew, scaleh) = vid.get_dpi_scale_factor();
 	float avgscale = (scalew + scaleh)/2;
-	// Note that if DPI can't be determined, SDL returns zero. Fallback to default scale.
-	if (avgscale == 0.0) {
-		avgscale = 1.0;
-	}
-
 	screen_pitch_microns = MICRONS_PER_INCH / (avgscale * MAGIC_DPI_MATCH_VIDEO);
 
 	gamemap_width = screen_width;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -390,10 +390,13 @@ std::pair<float, float> CVideo::get_dpi_scale_factor() const
 	}
 
 	float hdpi, vdpi;
-	SDL_GetDisplayDPI(window->get_display_index(), nullptr, &hdpi, &vdpi);
+	int returncode;
+	returncode = SDL_GetDisplayDPI(window->get_display_index(), nullptr, &hdpi, &vdpi);
 
-	result.first = hdpi / MAGIC_DPI_SCALE_NUMBER;
-	result.second = vdpi / MAGIC_DPI_SCALE_NUMBER;
+	if (returncode == 0) {
+		result.first = hdpi / MAGIC_DPI_SCALE_NUMBER;
+		result.second = vdpi / MAGIC_DPI_SCALE_NUMBER;
+	}
 
 	return result;
 }

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -390,8 +390,7 @@ std::pair<float, float> CVideo::get_dpi_scale_factor() const
 	}
 
 	float hdpi, vdpi;
-	int returncode;
-	returncode = SDL_GetDisplayDPI(window->get_display_index(), nullptr, &hdpi, &vdpi);
+	int returncode = SDL_GetDisplayDPI(window->get_display_index(), nullptr, &hdpi, &vdpi);
 
 	if (returncode == 0) {
 		result.first = hdpi / MAGIC_DPI_SCALE_NUMBER;


### PR DESCRIPTION
SDL_GetDisplayDPI  returns zero if it can't determine the DPI scale factor.

This fix will fall back to a 1.0 scale factor instead of dividing by zero when this happens.