### PR TITLE
add "damage" ability in damage calculation window(UI)

### DIFF
--- a/src/gui/dialogs/attack_predictions.cpp
+++ b/src/gui/dialogs/attack_predictions.cpp
@@ -135,7 +135,7 @@ void attack_predictions::set_data(window& window, const combatant_data& attacker
 	}
 
 	// Get damage modifiers.
-	unit_ability_list dmg_specials = weapon->get_specials("damage");
+	unit_ability_list dmg_specials = weapon->get_special_ability("damage");
 	unit_abilities::effect dmg_effect(dmg_specials, weapon->damage(), attacker.stats_.backstab_pos);
 
 	// Get the SET damage modifier, if any.


### PR DESCRIPTION
In damage calculation window, the "damage" weapons specials were used in calculation but not the abilities equivalent.