### PR TITLE
Scale buttons and toggle buttons with screen pitch also.

### DIFF
--- a/data/gui/macros/_initial.cfg
+++ b/data/gui/macros/_initial.cfg
@@ -349,6 +349,28 @@
 	hint_image = "icons/action/zoomdefault_25.png~FL(horiz)"
 #enddef
 
+# The following is a more-or-less arbitrary resolution, larger than 1024x768
+# in both dimensions, at which to switch over from the traditional
+# everything-is-fixed-size layout to one that scales proportionally to
+# the screen_pitch_microns.
+
+#define GUI_BIG_RESOLUTION
+	window_width = 1200
+	window_height = 900
+#enddef
+
+# The magic number 265 in the below formula is the pixel pitch in microns
+# corresponding to 96 dpi, which the old layout seems to have been based on.
+# The extra factor of 2/3 in the formula is a fudge factor based on the guess
+# that the old fonts took up approximately 1.5 pixels per point size at 96
+# dpi. It came out looking pretty decent on my 90-micron monitor.
+
+#define GUI_SCALE_RESOLUTION SIZE
+	"(max({SIZE}, floor({SIZE} * 265 * 2 / (3 * screen_pitch_microns))))"
+#enddef
+
+
+
 ###############################################################################
 ###                                                                         ###
 ### Macros for the normal gui.                                              ###

--- a/data/gui/widget/button_default.cfg
+++ b/data/gui/widget/button_default.cfg
@@ -156,6 +156,10 @@
 	description = "Default button"
 
 	{_GUI_RESOLUTION () 40 112 26 13 4 ({_GUI_BUTTON_FONT_SIZE}) () 255}
+	{_GUI_RESOLUTION ({GUI_BIG_RESOLUTION})
+			 50 128 30 16 6
+			 ({GUI_SCALE_RESOLUTION {_GUI_BUTTON_FONT_SIZE}})
+			 () 255}
 
 [/button_definition]
 
@@ -165,6 +169,10 @@
 	description = "Large button"
 
 	{_GUI_RESOLUTION () 40 116 30 13 4 ({_GUI_BUTTON_FONT_SIZE}) () 255}
+	{_GUI_RESOLUTION ({GUI_BIG_RESOLUTION})
+			 50 136 32 16 6
+			 ({GUI_SCALE_RESOLUTION {_GUI_BUTTON_FONT_SIZE}})
+			 () 255}
 
 [/button_definition]
 
@@ -174,6 +182,10 @@
 	description = "Large button"
 
 	{_GUI_RESOLUTION () 40 172 40 13 4 ({GUI_FONT_SIZE_LARGE}) () 255}
+	{_GUI_RESOLUTION ({GUI_BIG_RESOLUTION})
+			 50 192 44 16 6
+			 ({GUI_SCALE_RESOLUTION {GUI_FONT_SIZE_LARGE}})
+			 () 255}
 
 [/button_definition]
 
@@ -183,6 +195,10 @@
 	description = "Default transparent button"
 
 	{_GUI_RESOLUTION () 40 112 26 13 4 ({_GUI_BUTTON_FONT_SIZE}) "~O(65%)" 165}
+	{_GUI_RESOLUTION ({GUI_BIG_RESOLUTION})
+			 50 128 30 16 6
+			 ({GUI_SCALE_RESOLUTION {_GUI_BUTTON_FONT_SIZE}})
+			 "~O(65%)" 165}
 
 [/button_definition]
 

--- a/data/gui/widget/label_default.cfg
+++ b/data/gui/widget/label_default.cfg
@@ -80,26 +80,6 @@
 	[/resolution]
 #enddef
 
-# The following is a more-or-less arbitrary resolution, larger than 1024x768
-# in both dimensions, at which to switch over from the traditional
-# everything-is-fixed-size layout to one that scales proportionally to
-# the screen_pitch_microns.
-
-#define _GUI_BIG_RES
-	window_width = 1200
-	window_height = 900
-#enddef
-
-# The magic number 265 in the below formula is the pixel pitch in microns
-# corresponding to 96 dpi, which the old layout seems to have been based on.
-# The extra factor of 2/3 in the formula is a fudge factor based on the guess
-# that the old fonts took up approximately 1.5 pixels per point size at 96
-# dpi. It came out looking pretty decent on my 90-micron monitor.
-
-#define _GUI_SCALE_RES SIZE
-	"(max({SIZE}, floor({SIZE} * 265 * 2 / (3 * screen_pitch_microns))))"
-#enddef
-
 #define _GUI_DEFINITION ID DESCRIPTION FONT_FAMILY FONT_SIZE FONT_STYLE FONT_COLOR
 [label_definition]
 	id = {ID}
@@ -115,9 +95,9 @@
 	}
 
 	{_GUI_RESOLUTION
-		({_GUI_BIG_RES})
+		({GUI_BIG_RESOLUTION})
 		({FONT_FAMILY})
-		({_GUI_SCALE_RES {GUI_FONT_SIZE_{FONT_SIZE}}})
+		({GUI_SCALE_RESOLUTION {GUI_FONT_SIZE_{FONT_SIZE}}})
 		({FONT_STYLE})
 		({GUI__FONT_COLOR_ENABLED__{FONT_COLOR}  ALPHA=""})
 		({GUI__FONT_COLOR_DISABLED__{FONT_COLOR} ALPHA=""})

--- a/data/gui/widget/toggle_button_default.cfg
+++ b/data/gui/widget/toggle_button_default.cfg
@@ -134,6 +134,9 @@
 	description = "Checkbox."
 
 	{_GUI_RESOLUTION () 30 18 25 ({GUI_FONT_SIZE_SMALL}) }
+	{_GUI_RESOLUTION ({GUI_BIG_RESOLUTION})
+			 36 20 28
+			 ({GUI_SCALE_RESOLUTION {GUI_FONT_SIZE_SMALL}}) }
 
 [/toggle_button_definition]
 


### PR DESCRIPTION
This is a follow-on to PR #4860 -- it extends the scaling initiated in that PR to most of the buttons and toggle buttons in the game. Somewhat mysteriously, the "Menu," "Actions,", and "End Turn" buttons in the main gameplay window are still not scaling. Hopefully that can be tracked down in the future.