### PR TITLE
don't hardcode plague contraint

### DIFF
--- a/data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg
@@ -6,6 +6,11 @@
         name= _ "plague"
         description= _ "When a unit is killed by a Plague attack, that unit is replaced with a Walking Corpse on the same side as the unit with the Plague attack. This doesn’t work on Undead or units in villages."
         type=null # prevents normal corpse, and allows SotA code to handle it
+        [filter_opponent]
+            [filter_location]
+                terrain="*^V*"
+            [/filter_location]
+        [/filter_opponent]
     [/plague]
 #enddef
 

--- a/data/core/macros/abilities.cfg
+++ b/data/core/macros/abilities.cfg
@@ -371,6 +371,11 @@ Enemy units cannot see this unit while it is in deep water, except if they have 
         name= _ "plague"
         description= _ "When a unit is killed by a Plague attack, that unit is replaced with a unit on the same side as the unit with the Plague attack. This doesn’t work on Undead or units in villages."
         type={TYPE}
+        [filter_opponent]
+            [filter_location]
+                terrain="*^V*"
+            [/filter_location]
+        [/filter_opponent]
     [/plague]
 #enddef
 
@@ -382,6 +387,11 @@ Enemy units cannot see this unit while it is in deep water, except if they have 
         name= _ "plague"
         description= _ "When a unit is killed by a Plague attack, that unit is replaced with a Walking Corpse on the same side as the unit with the Plague attack. This doesn’t work on Undead or units in villages."
         type=Walking Corpse
+        [filter_opponent]
+            [filter_location]
+                terrain="*^V*"
+            [/filter_location]
+        [/filter_opponent]
     [/plague]
 #enddef
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1235,9 +1235,7 @@ bool attack_type::special_active_impl(const_attack_ptr self_attack, const_attack
 	if (tag_name == "drains" && other && other->get_state("undrainable")) {
 		return false;
 	}
-	if (tag_name == "plague" && other &&
-		(other->get_state("unplagueable") ||
-		 resources::gameboard->map().is_village(other_loc))) {
+	if (tag_name == "plague" && other && other->get_state("unplagueable")) {
 		return false;
 	}
 	if (tag_name == "poison" && other &&


### PR DESCRIPTION
as the title says.

There is no reason why we should have the 'plague doesn't work on villages' restruction encoded into the cpp engine

This is not really a priority of mine i justfound this weird when looking at the c++ code