### PR TITLE
Fix [filter_weapon] that doesn't work in filter_opponent

### DIFF
--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1160,7 +1160,7 @@ bool attack_type::bool_ability(const std::string& ability) const
 bool attack_type::special_active(const config& special, AFFECTS whom, const std::string& tag_name,
                                  bool include_backstab, const std::string& filter_self) const
 {
-	return special_active_impl(shared_from_this(), const_attack_ptr(), special, whom, tag_name, include_backstab, filter_self);
+	return special_active_impl(shared_from_this(), other_attack_, special, whom, tag_name, include_backstab, filter_self);
 }
 
 /**


### PR DESCRIPTION
@gfgtdf without other_attack_ in special_active_impl, the opponent's attacks cannot be filtered and the use of filter_weapon filter_opponent always returns a null result.