### PR TITLE
Add the ability to output preprocessed WML as XML.

### DIFF
--- a/src/actions/undo.cpp
+++ b/src/actions/undo.cpp
@@ -300,11 +300,11 @@ void undo_list::read(const config & cfg)
 			}
 		} catch (const bad_lexical_cast &) {
 			ERR_NG << "Error when parsing undo list from config: bad lexical cast." << std::endl;
-			ERR_NG << "config was: " << child.debug() << std::endl;
+			ERR_NG << "config was: " << child.as_text() << std::endl;
 			ERR_NG << "Skipping this undo action..." << std::endl;
 		} catch (const config::error& e) {
 			ERR_NG << "Error when parsing undo list from config: " << e.what() << std::endl;
-			ERR_NG << "config was: " << child.debug() << std::endl;
+			ERR_NG << "config was: " << child.as_text() << std::endl;
 			ERR_NG << "Skipping this undo action..." << std::endl;
 		}
 	}
@@ -315,11 +315,11 @@ void undo_list::read(const config & cfg)
 			redos_.emplace_back(new config(child));
 		} catch (const bad_lexical_cast &) {
 			ERR_NG << "Error when parsing redo list from config: bad lexical cast." << std::endl;
-			ERR_NG << "config was: " << child.debug() << std::endl;
+			ERR_NG << "config was: " << child.as_text() << std::endl;
 			ERR_NG << "Skipping this redo action..." << std::endl;
 		} catch (const config::error& e) {
 			ERR_NG << "Error when parsing redo list from config: " << e.what() << std::endl;
-			ERR_NG << "config was: " << child.debug() << std::endl;
+			ERR_NG << "config was: " << child.as_text() << std::endl;
 			ERR_NG << "Skipping this redo action..." << std::endl;
 		}
 	}

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -499,7 +499,10 @@ public:
 	void clear_attributes();
 	bool empty() const;
 
-	std::string debug() const;
+	// minorly modified XML re-implementation of the as_text() and operator<< methods
+	std::string as_xml() const;
+	std::ostream& as_xml(std::ostream& outstream, const config& cfg) const;
+	std::string as_text() const;
 	std::string hash() const;
 
 	struct error : public game::error, public boost::exception {

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -462,7 +462,7 @@ void add_color_info(const config& v, bool build_defaults)
 				temp.push_back(color_t::from_hex_string(s));
 			} catch(const std::invalid_argument&) {
 				std::stringstream ss;
-				ss << "can't parse color string:\n" << teamC.debug() << "\n";
+				ss << "can't parse color string:\n" << teamC.as_text() << "\n";
 				throw config::error(ss.str());
 			}
 		}

--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -485,7 +485,7 @@ void game_config_manager::load_addons_cfg()
 							"[advancefrom]",
 							DEP_LEVEL::FOR_REMOVAL,
 							{1, 17, 0},
-							_("Use [modify_unit_type]\n") + modify_unit_type.debug()  + "\n [/modify_unit_type] instead in [campaign]"
+							_("Use [modify_unit_type]\n") + modify_unit_type.as_text()  + "\n [/modify_unit_type] instead in [campaign]"
 						);
 	
 						advancefroms.add_child("modify_unit_type", modify_unit_type);

--- a/src/game_events/action_wml.cpp
+++ b/src/game_events/action_wml.cpp
@@ -545,7 +545,7 @@ WML_HANDLER_FUNCTION(recall,, cfg)
 			}
 		}
 	}
-	LOG_WML << "A [recall] tag with the following content failed:\n" << cfg.get_config().debug();
+	LOG_WML << "A [recall] tag with the following content failed:\n" << cfg.get_config().as_text();
 }
 
 namespace {
@@ -650,7 +650,7 @@ WML_HANDLER_FUNCTION(set_variables,, cfg)
 	const t_string& name = cfg["name"];
 	variable_access_create dest = resources::gamedata->get_variable_access_write(name);
 	if(name.empty()) {
-		ERR_NG << "trying to set a variable with an empty name:\n" << cfg.get_config().debug();
+		ERR_NG << "trying to set a variable with an empty name:\n" << cfg.get_config().as_text();
 		return;
 	}
 
@@ -667,7 +667,7 @@ WML_HANDLER_FUNCTION(set_variables,, cfg)
 		}
 		catch(const invalid_variablename_exception&)
 		{
-			ERR_NG << "Cannot do [set_variables] with invalid to_variable variable: " << cfg["to_variable"] << " with " << cfg.get_config().debug() << std::endl;
+			ERR_NG << "Cannot do [set_variables] with invalid to_variable variable: " << cfg["to_variable"] << " with " << cfg.get_config().as_text() << std::endl;
 		}
 	} else {
 		typedef std::pair<std::string, vconfig> vchild;
@@ -691,7 +691,7 @@ WML_HANDLER_FUNCTION(set_variables,, cfg)
 
 				char* separator = separator_string.empty() ? nullptr : &separator_string[0];
 				if(separator_string.size() > 1){
-					ERR_NG << "[set_variables] [split] separator only supports 1 character, multiple passed: " << split_element["separator"] << " with " << cfg.get_config().debug() << std::endl;
+					ERR_NG << "[set_variables] [split] separator only supports 1 character, multiple passed: " << split_element["separator"] << " with " << cfg.get_config().as_text() << std::endl;
 				}
 
 				std::vector<std::string> split_vector;
@@ -746,7 +746,7 @@ WML_HANDLER_FUNCTION(set_variables,, cfg)
 	}
 	catch(const invalid_variablename_exception&)
 	{
-		ERR_NG << "Cannot do [set_variables] with invalid destination variable: " << name << " with " << cfg.get_config().debug() << std::endl;
+		ERR_NG << "Cannot do [set_variables] with invalid destination variable: " << name << " with " << cfg.get_config().as_text() << std::endl;
 	}
 }
 
@@ -781,7 +781,7 @@ WML_HANDLER_FUNCTION(store_relative_direction,, cfg)
 	}
 	catch(const invalid_variablename_exception&)
 	{
-		ERR_NG << "Cannot do [store_relative_direction] with invalid destination variable: " << variable << " with " << cfg.get_config().debug() << std::endl;
+		ERR_NG << "Cannot do [store_relative_direction] with invalid destination variable: " << variable << " with " << cfg.get_config().as_text() << std::endl;
 	}
 }
 
@@ -818,7 +818,7 @@ WML_HANDLER_FUNCTION(store_rotate_map_location,, cfg)
 	}
 	catch(const invalid_variablename_exception&)
 	{
-		ERR_NG << "Cannot do [store_rotate_map_location] with invalid destination variable: " << variable << " with " << cfg.get_config().debug() << std::endl;
+		ERR_NG << "Cannot do [store_rotate_map_location] with invalid destination variable: " << variable << " with " << cfg.get_config().as_text() << std::endl;
 	}
 }
 
@@ -844,7 +844,7 @@ WML_HANDLER_FUNCTION(store_time_of_day,, cfg)
 	}
 	catch(const invalid_variablename_exception&)
 	{
-		ERR_NG << "Found invalid variablename " << variable << " in [store_time_of_day] with " << cfg.get_config().debug() << "\n";
+		ERR_NG << "Found invalid variablename " << variable << " in [store_time_of_day] with " << cfg.get_config().as_text() << "\n";
 	}
 }
 
@@ -861,7 +861,7 @@ WML_HANDLER_FUNCTION(tunnel,, cfg)
 		cfg.get_children("target").empty() ||
 		cfg.get_children("filter").empty()) {
 		ERR_WML << "[tunnel] is missing a mandatory tag:\n"
-			 << cfg.get_config().debug();
+			 << cfg.get_config().as_text();
 	} else {
 		pathfind::teleport_group tunnel(delay ? cfg : vconfig(cfg.get_parsed_config()), false);
 		resources::tunnels->add(tunnel);
@@ -894,7 +894,7 @@ WML_HANDLER_FUNCTION(unit,, cfg)
 		}
 		catch(const invalid_variablename_exception&)
 		{
-			ERR_NG << "Cannot do [unit] with invalid to_variable:  " << to_variable << " with " << cfg.get_config().debug() << std::endl;
+			ERR_NG << "Cannot do [unit] with invalid to_variable:  " << to_variable << " with " << cfg.get_config().as_text() << std::endl;
 		}
 		return;
 
@@ -905,7 +905,7 @@ WML_HANDLER_FUNCTION(unit,, cfg)
 
 	if ((side<1)||(side > static_cast<int>(resources::gameboard->teams().size()))) {
 		ERR_NG << "wrong side in [unit] tag - no such side: "<<side<<" ( number of teams :"<<resources::gameboard->teams().size()<<")"<<std::endl;
-		DBG_NG << parsed_cfg.debug();
+		DBG_NG << parsed_cfg.as_text();
 		return;
 	}
 	team &tm = resources::gameboard->get_team(side);

--- a/src/generators/lua_map_generator.cpp
+++ b/src/generators/lua_map_generator.cpp
@@ -40,7 +40,7 @@ lua_map_generator::lua_map_generator(const config & cfg, const config* vars)
 			}
 			std::string msg = "Error when constructing a lua map generator -- missing a required attribute '";
 			msg += req + "'\n";
-			msg += "Config was '" + cfg.debug() + "'";
+			msg += "Config was '" + cfg.as_text() + "'";
 			throw mapgen_exception(msg);
 		}
 	}

--- a/src/help/help_impl.cpp
+++ b/src/help/help_impl.cpp
@@ -827,7 +827,7 @@ void generate_era_sections(const config* help_cfg, section & sec, int level)
 
 		section_cfg["generator"] = "era:" + era["id"].str();
 
-		DBG_HP << section_cfg.debug() << "\n";
+		DBG_HP << section_cfg.as_text() << "\n";
 
 		parse_config_internal(help_cfg, &section_cfg, era_section, level+1);
 		sec.add_section(era_section);

--- a/src/mp_game_settings.cpp
+++ b/src/mp_game_settings.cpp
@@ -171,7 +171,7 @@ void mp_game_settings::addon_version_info::write(config & cfg) const {
 
 void mp_game_settings::update_addon_requirements(const config & cfg) {
 	if (cfg["id"].empty()) {
-		WRN_NG << "Tried to add add-on metadata to a game, missing mandatory id field... skipping.\n" << cfg.debug() << "\n";
+		WRN_NG << "Tried to add add-on metadata to a game, missing mandatory id field... skipping.\n" << cfg.as_text() << "\n";
 		return;
 	}
 

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -257,7 +257,7 @@ LEVEL_RESULT playsingle_controller::play_scenario(const config& level)
 			soundsources_manager_->add(spec);
 		} catch (const bad_lexical_cast &) {
 			ERR_NG << "Error when parsing sound_source config: bad lexical cast." << std::endl;
-			ERR_NG << "sound_source config was: " << s.debug() << std::endl;
+			ERR_NG << "sound_source config was: " << s.as_text() << std::endl;
 			ERR_NG << "Skipping this sound source..." << std::endl;
 		}
 	}

--- a/src/playturn.cpp
+++ b/src/playturn.cpp
@@ -180,7 +180,7 @@ turn_info::PROCESS_DATA_RESULT turn_info::process_network_data(const config& cfg
 		const std::string player = change["player"];
 		const std::size_t index = side - 1;
 		if(index >= resources::gameboard->teams().size()) {
-			ERR_NW << "Bad [change_controller] signal from server, side out of bounds: " << change.debug() << std::endl;
+			ERR_NW << "Bad [change_controller] signal from server, side out of bounds: " << change.as_text() << std::endl;
 			return PROCESS_CONTINUE;
 		}
 
@@ -378,7 +378,7 @@ turn_info::PROCESS_DATA_RESULT turn_info::process_network_data(const config& cfg
 	}
 	else
 	{
-		ERR_NW << "found unknown command:\n" << cfg.debug() << std::endl;
+		ERR_NW << "found unknown command:\n" << cfg.as_text() << std::endl;
 	}
 
 	return PROCESS_CONTINUE;

--- a/src/playturn_network_adapter.cpp
+++ b/src/playturn_network_adapter.cpp
@@ -51,7 +51,7 @@ void playturn_network_adapter::read_from_network()
 
 	if(!back.attribute_range().empty() )
 	{
-		ERR_NW << "found unexpected attribute:" <<back.debug() << std::endl;
+		ERR_NW << "found unexpected attribute:" << back.as_text() << std::endl;
 		this->data_.pop_back();
 		//ignore those here
 	}

--- a/src/replay.cpp
+++ b/src/replay.cpp
@@ -246,7 +246,7 @@ void replay::add_synced_command(const std::string& name, const config& command)
 	config& cmd = add_command();
 	cmd.add_child(name,command);
 	cmd["from_side"] = resources::controller->current_side();
-	LOG_REPLAY << "add_synced_command: \n" << cmd.debug() << "\n";
+	LOG_REPLAY << "add_synced_command: \n" << cmd.as_text() << "\n";
 }
 
 
@@ -461,7 +461,7 @@ static bool fix_rename_command(const config& c, config& async_child)
 		try {
 			read_locations(child,steps);
 		} catch(const bad_lexical_cast &) {
-			WRN_REPLAY << "Warning: Path data contained something which could not be parsed to a sequence of locations:" << "\n config = " << child.debug() << std::endl;
+			WRN_REPLAY << "Warning: Path data contained something which could not be parsed to a sequence of locations:" << "\n config = " << child.as_text() << std::endl;
 		}
 
 		if (steps.empty()) {
@@ -724,7 +724,7 @@ REPLAY_RETURN do_replay_handle(bool one_move)
 		{
 			//this shouldn't happen anymore because replaycontroller now moves over the [start] with get_next_action
 			//also we removed the the "add empty replay entry at scenario reload" behavior.
-			ERR_REPLAY << "found "<<  cfg->debug() <<" in replay" << std::endl;
+			ERR_REPLAY << "found "<<  cfg->as_text() <<" in replay" << std::endl;
 			//do nothing
 		}
 		else if (const config &speak = cfg->child("speak"))

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -3976,7 +3976,7 @@ int game_lua_kernel::intf_add_sound_source(lua_State *L)
 		man->update();
 	} catch (const bad_lexical_cast &) {
 		ERR_LUA << "Error when parsing sound_source config: invalid parameter." << std::endl;
-		ERR_LUA << "sound_source config was: " << cfg.debug() << std::endl;
+		ERR_LUA << "sound_source config was: " << cfg.as_text() << std::endl;
 		ERR_LUA << "Skipping this sound source..." << std::endl;
 	}
 	return 0;

--- a/src/serialization/preprocessor.cpp
+++ b/src/serialization/preprocessor.cpp
@@ -1779,6 +1779,7 @@ void preprocess_resource(const std::string& res_name,
 		read(cfg, streamContent);
 
 		const std::string preproc_res_name = parent_directory + "/" + filesystem::base_name(res_name);
+		const std::string preproc_res_name_xml = parent_directory + "/" + filesystem::base_name(res_name, true)+".xml";
 
 		// Write the processed cfg file
 		if(write_cfg) {
@@ -1788,6 +1789,8 @@ void preprocess_resource(const std::string& res_name,
 			filesystem::scoped_ostream outStream(filesystem::ostream_file(preproc_res_name));
 
 			write(*outStream, cfg);
+
+			filesystem::write_file(preproc_res_name_xml, cfg.as_xml());
 		}
 
 		// Write the plain cfg file

--- a/src/synced_commands.cpp
+++ b/src/synced_commands.cpp
@@ -262,7 +262,7 @@ SYNCED_COMMAND_HANDLER_FUNCTION(move, child,  use_undo, show, error_handler)
 	try {
 		read_locations(child,steps);
 	} catch (const std::invalid_argument&) {
-		WRN_REPLAY << "Warning: Path data contained something which could not be parsed to a sequence of locations:" << "\n config = " << child.debug() << std::endl;
+		WRN_REPLAY << "Warning: Path data contained something which could not be parsed to a sequence of locations:" << "\n config = " << child.as_text() << std::endl;
 		return false;
 	}
 

--- a/src/synced_context.cpp
+++ b/src/synced_context.cpp
@@ -353,7 +353,7 @@ config synced_context::ask_server_choice(const server_choice& sch)
 			}
 			if (!action->has_child(sch.name()))
 			{
-				replay::process_error("[" + std::string(sch.name()) + "] expected but none found, found instead:\n " + action->debug() + "\n");
+				replay::process_error("[" + std::string(sch.name()) + "] expected but none found, found instead:\n " + action->as_text() + "\n");
 
 				resources::recorder->revert_action();
 				return sch.local_choice();
@@ -465,7 +465,7 @@ void set_scontext_synced::do_final_checkup(bool dont_throw)
 	}
 	if(!msg.str().empty())
 	{
-		msg << co.debug() << std::endl;
+		msg << co.as_text() << std::endl;
 		if(dont_throw)
 		{
 			ERR_REPLAY << msg.str() << std::flush;

--- a/src/synced_user_choice.cpp
+++ b/src/synced_user_choice.cpp
@@ -264,7 +264,7 @@ void user_choice_manager::search_in_replay()
 		assert(action); //action cannot be null because resources::recorder->at_end() returned false.
 		if( !action->has_child(tagname_) || !(*action)["dependent"].to_bool())
 		{
-			replay::process_error("[" + tagname_ + "] expected but none found\n. found instead:\n" + action->debug());
+			replay::process_error("[" + tagname_ + "] expected but none found\n. found instead:\n" + action->as_text());
 			//We save this action for later
 			resources::recorder->revert_action();
 			// execute this local choice locally

--- a/src/teambuilder.cpp
+++ b/src/teambuilder.cpp
@@ -193,7 +193,7 @@ protected:
 		if (u["type"].empty()) {
 			WRN_NG_TC << "warning: when building level, skipping a unit (id=[" << u["id"] << "]) from " << origin
 			<< " with no type information,\n"
-			<< "for side:\n" << side_cfg_.debug() << std::endl;
+			<< "for side:\n" << side_cfg_.as_text() << std::endl;
 
 			return ;
 		}

--- a/src/units/animation.cpp
+++ b/src/units/animation.cpp
@@ -1180,7 +1180,7 @@ std::ostream& operator<<(std::ostream& outstream, const unit_animation& u_animat
 	if(u_animation.unit_filter_.size() > 0) {
 		outstream << "[filter]\n";
 		for(const config& cfg : u_animation.unit_filter_) {
-			outstream << cfg.debug();
+			outstream << cfg.as_text();
 		}
 
 		outstream << "[/filter]\n";
@@ -1189,7 +1189,7 @@ std::ostream& operator<<(std::ostream& outstream, const unit_animation& u_animat
 	if(u_animation.secondary_unit_filter_.size() > 0) {
 		outstream << "[filter_second]\n";
 		for(const config& cfg : u_animation.secondary_unit_filter_) {
-			outstream << cfg.debug();
+			outstream << cfg.as_text();
 		}
 
 		outstream << "[/filter_second]\n";
@@ -1198,7 +1198,7 @@ std::ostream& operator<<(std::ostream& outstream, const unit_animation& u_animat
 	if(u_animation.primary_attack_filter_.size() > 0) {
 		outstream << "[filter_attack]\n";
 		for(const config& cfg : u_animation.primary_attack_filter_) {
-			outstream << cfg.debug();
+			outstream << cfg.as_text();
 		}
 
 		outstream << "[/filter_attack]\n";
@@ -1207,7 +1207,7 @@ std::ostream& operator<<(std::ostream& outstream, const unit_animation& u_animat
 	if(u_animation.secondary_attack_filter_.size() > 0) {
 		outstream << "[filter_second_attack]\n";
 		for(const config& cfg : u_animation.secondary_attack_filter_) {
-			outstream << cfg.debug();
+			outstream << cfg.as_text();
 		}
 
 		outstream << "[/filter_second_attack]\n";

--- a/src/units/types.cpp
+++ b/src/units/types.cpp
@@ -1164,7 +1164,7 @@ void unit_type_data::set_config(config& cfg)
 
 		// Every type is required to have an id.
 		if(id.empty()) {
-			ERR_CF << "[unit_type] with empty id=, ignoring:\n" << ut.debug();
+			ERR_CF << "[unit_type] with empty id=, ignoring:\n" << ut.as_text();
 			continue;
 		}
 


### PR DESCRIPTION
This commit:
* Renames config's debug() method to as_text() to be more descriptive.
* Adds two as_xml methods to config.
* Also writes the XML out when using the --preprocess command line option.