### PR TITLE
Add installed addons and addon versions to the build report.

### DIFF
--- a/src/addon/manager.cpp
+++ b/src/addon/manager.cpp
@@ -31,6 +31,7 @@
 #include "game_version.hpp"
 #include "serialization/string_utils.hpp"
 #include "addon/client.hpp"
+#include "game_config_manager.hpp"
 
 #include <boost/algorithm/string.hpp>
 
@@ -158,6 +159,17 @@ std::vector<std::string> installed_addons()
 	}
 
 	return res;
+}
+
+std::vector<std::pair<std::string, std::string>> installed_addons_and_versions()
+{
+	std::vector<std::pair<std::string, std::string>> addons;
+
+	for(const std::string& addon_id : installed_addons()) {
+		addons.push_back(std::pair<std::string, std::string>(addon_id, game_config_manager::get()->get_addon_version(addon_id)));
+	}
+
+	return addons;
 }
 
 bool is_addon_installed(const std::string& addon_name)

--- a/src/addon/manager.hpp
+++ b/src/addon/manager.hpp
@@ -113,6 +113,9 @@ std::vector<std::string> available_addons();
 /** Retrieves the names of all installed add-ons. */
 std::vector<std::string> installed_addons();
 
+/** Retrieves the ids and versions of all installed add-ons. */
+std::vector<std::pair<std::string, std::string>> installed_addons_and_versions();
+
 /** Check whether the specified add-on is currently installed. */
 bool is_addon_installed(const std::string& addon_name);
 

--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -24,6 +24,7 @@
 #include "serialization/unicode.hpp"
 #include "game_version.hpp"
 #include "video.hpp"
+#include "addon/manager.hpp"
 
 #include <algorithm>
 #include <fstream>
@@ -487,7 +488,14 @@ std::string full_build_report()
 	  << '\n'
 	  << report_heading("Current video settings")
 	  << '\n'
-	  << CVideo::video_settings_report();
+	  << CVideo::video_settings_report()
+	  << '\n'
+	  << report_heading("Installed Add-ons")
+	  << '\n';
+	for(const auto& addon_info : installed_addons_and_versions())
+	{
+		o << addon_info.first << " : " << addon_info.second << '\n';
+	}
 	return o.str();
 }
 

--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -550,6 +550,25 @@ void game_config_manager::load_addons_cfg()
 	}
 }
 
+std::string game_config_manager::get_addon_version(const std::string& addon_id)
+{
+	const std::string info_cfg = filesystem::get_addons_dir() + "/" + addon_id + "/_info.cfg";
+	if(have_addon_pbl_info(addon_id)) {
+		// Publishing info needs to be read from disk.
+		try {
+			return get_addon_pbl_info(addon_id)["version"].str();
+		} catch(const invalid_pbl_exception& e) {
+			return "Invalid pbl file, version unknown";
+		}
+	} else if(filesystem::file_exists(info_cfg)) {
+		// Addon server-generated info can be fetched from cache.
+		config temp;
+		cache_.get_config(info_cfg, temp);
+		return temp.child("info")["version"].str();
+	}
+	return "Unknown";
+}
+
 void game_config_manager::set_multiplayer_hashes()
 {
 	config& hashes = game_config_.add_child("multiplayer_hashes");

--- a/src/game_config_manager.hpp
+++ b/src/game_config_manager.hpp
@@ -48,6 +48,8 @@ public:
 	void load_game_config_for_game(const game_classification& classification);
 	void load_game_config_for_create(bool is_mp, bool is_test = false);
 
+	std::string get_addon_version(const std::string& addon_id);
+
 	static game_config_manager * get();
 
 private:


### PR DESCRIPTION
This would be useful since often one of the things asked when a user reports issues is if they have any addons installed.

---

Tested locally with two addons (first with an _info.cfg, second with a _server.pbl):
```
Installed Add-ons
=================

Ally_Village_Modification : 1.0.3
Ally_Village_Modification_pbl : 0.1.80
```

If there are no issues, I'd like to get this merged and backported prior to 1.14.13's release.

Edit-
Fixes #4873 as well.