### PR TITLE
Changes description of "righteous rage"

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg
@@ -700,7 +700,7 @@
                         id=berserk
                         name= _ "righteous rage"
                         name_inactive=""
-                        description= _ "If used offensively or defensively against Grak or Zur, this attack presses the engagement until one of the combatants is slain, or 30 rounds of attacks have occurred."
+                        description= _ "If used offensively or defensively against champions Grak or Zur, this attack presses the engagement until one of the combatants is slain, or 30 rounds of attacks have occurred."
                         value=30
                         [filter_opponent]
                             id=Grak,Zur

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg
@@ -700,7 +700,7 @@
                         id=berserk
                         name= _ "righteous rage"
                         name_inactive=""
-                        description= _ "Whether used offensively or defensively, this attack presses the engagement until one of the champions is slain, or 30 rounds of attacks have occurred."
+                        description= _ "If used offensively or defensively against Grak or Zur, this attack presses the engagement until one of the combatants is slain, or 30 rounds of attacks have occurred."
                         value=30
                         [filter_opponent]
                             id=Grak,Zur


### PR DESCRIPTION
In Under the Burning Sun scenario 3, Garak is given the ability "righteous rage" on both of his attacks. This effectively makes those attacks behave the same as berserk when Garak is fighting an enemy "champion", i.e. two undead units named Grak and Zur. I believe this was unclear and raised #4945 because I didn't understand that this ability only applies to fights against Grak and Zur, so I've made this PR to hopefully make the description a little clearer. 