### PR TITLE
bi: Refactor clipboard report formatting logic

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -32,14 +32,14 @@ static lg::log_domain log_display("display");
 #define LOG_DP LOG_STREAM(info, log_display)
 #define ERR_DP LOG_STREAM(err, log_display)
 
-#define MAGIC_DPI_SCALE_NUMBER 96
-
 CVideo* CVideo::singleton_ = nullptr;
 
 namespace
 {
 surface frameBuffer = nullptr;
 bool fake_interactive = false;
+
+const unsigned MAGIC_DPI_SCALE_NUMBER = 96;
 }
 
 namespace video2

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -406,23 +406,25 @@ bool CVideo::window_has_flags(uint32_t flags) const
 	return (window->get_flags() & flags) != 0;
 }
 
+std::pair<float, float> CVideo::get_dpi() const
+{
+	float hdpi, vdpi;
+	if(window && SDL_GetDisplayDPI(window->get_display_index(), nullptr, &hdpi, &vdpi) == 0) {
+		return { hdpi, vdpi };
+	}
+	// SDL doesn't know the screen dpi, there's a configuration issue, or we
+	// don't have a window yet.
+	return { 0.0f, 0.0f };
+}
+
 std::pair<float, float> CVideo::get_dpi_scale_factor() const
 {
-	std::pair<float, float> result{1.0f, 1.0f};
-
-	if(!window) {
-		return result;
+	auto dpi = get_dpi();
+	if(dpi.first != 0.0f && dpi.second != 0.0f) {
+		return { dpi.first / MAGIC_DPI_SCALE_NUMBER, dpi.second / MAGIC_DPI_SCALE_NUMBER };
 	}
-
-	float hdpi, vdpi;
-	int returncode = SDL_GetDisplayDPI(window->get_display_index(), nullptr, &hdpi, &vdpi);
-
-	if (returncode == 0) {
-		result.first = hdpi / MAGIC_DPI_SCALE_NUMBER;
-		result.second = vdpi / MAGIC_DPI_SCALE_NUMBER;
-	}
-
-	return result;
+	// Assume a scale factor of 1.0 if the screen dpi is currently unknown.
+	return { 1.0f, 1.0f };
 }
 
 std::vector<point> CVideo::get_available_resolutions(const bool include_current)

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -132,31 +132,6 @@ CVideo::~CVideo()
 	LOG_DP << "called SDL_Quit()\n";
 }
 
-std::string CVideo::video_settings_report()
-{
-	if (singleton_ == nullptr) return "No video initialized.\n";
-	if (singleton_->non_interactive())
-		return "Initialized but non-interactive.\n";
-	sdl::window* win = singleton_->get_window();
-	if (!win) return "Interactive but no SDL window.\n";
-	std::ostringstream o;
-	o << "Current pixel resolution: "
-	  << singleton_->get_width() << "x" << singleton_->get_height()
-	  << '\n'
-	  << "Refresh rate: " << singleton_->current_refresh_rate()
-	  << '\n';
-	float hdpi, vdpi;
-	int returncode = SDL_GetDisplayDPI(win->get_display_index(),
-					   nullptr, &hdpi, &vdpi);
-	if (returncode != 0) {
-		o << "SDL not supplying dots per inch.\n";
-	} else {
-		o << "SDL reports: " << hdpi << "x" << vdpi
-		  << " dots per inch.\n";
-	}
-	return o.str();
-}
-
 bool CVideo::non_interactive() const
 {
 	return fake_interactive ? false : (window == nullptr);

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -40,6 +40,11 @@ public:
 
 	~CVideo();
 
+	static bool setup_completed()
+	{
+		return singleton_ != nullptr;
+	}
+
 	static CVideo& get_singleton()
 	{
 		return *singleton_;

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -50,8 +50,6 @@ public:
 		return *singleton_;
 	}
 
-	static std::string video_settings_report();
-
 	/***** ***** ***** ***** Unit test-related functions ***** ***** ****** *****/
 
 	void make_fake();

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -79,6 +79,11 @@ public:
 	/** Returns a pointer to the underlying SDL window. */
 	sdl::window* get_window();
 
+	bool has_window()
+	{
+		return get_window() != nullptr;
+	}
+
 private:
 	enum MODE_EVENT { TO_RES, TO_FULLSCREEN, TO_WINDOWED, TO_MAXIMIZED_WINDOW };
 
@@ -126,6 +131,9 @@ public:
 
 	/** Returns the window renderer height in pixels or in screen coordinates. */
 	int get_height(bool as_pixels = true) const;
+
+	/** The current game screen dpi. */
+	std::pair<float, float> get_dpi() const;
 
 	/** The current scale factor on High-DPI screens. */
 	std::pair<float, float> get_dpi_scale_factor() const;


### PR DESCRIPTION
This makes all sections use a formatter class to deal with the issue of keeping the first column's width consistent within each section (but not across all sections), so that we don't run into inconveniences later in the future if any section's entry labels change. It also allows us to change the list formatting entirely in a single place rather than multiple places if we ever decide to do so.

The video and add-ons report sections are also made to use the new formatter, making them look more consistent than before compared to the rest of the report:

```
Current video settings
======================

Current pixel resolution: 1920x1015
Refresh rate: 60
SDL reports: 92.5389x92.6757 dots per inch.

Installed add-ons
=================

After_the_Storm : 0.10.0-dev
AtS_Music : 0.3.1
IftU_Music : 0.3.1
Invasion_from_the_Unknown : 2.1.1+dev
Millennium_Era : 1.2.1.0
Wings_of_Valor : 2.0.0
World_Conquest_II : 0.7.10.3
```

→

```
Current video settings
======================

Window size:             1610x794
Screen refresh rate:     60
Screen dots per inch:    92.538902x92.675674
Screen dpi scale factor: 0.963947x0.965372

Installed add-ons
=================

Creep_War_Dev: 1.5.8
pick_advance:  1.11.0
```