### PR TITLE
[WIP] allow ./../ in wml file inclusion

### DIFF
--- a/data/_main.cfg
+++ b/data/_main.cfg
@@ -94,7 +94,7 @@
 #endif
 
 [binary_path]
-    path=data/core
+    path=core
 [/binary_path]
 
 {advanced_preferences.cfg}

--- a/data/campaigns/Heir_To_The_Throne/_main.cfg
+++ b/data/campaigns/Heir_To_The_Throne/_main.cfg
@@ -82,7 +82,7 @@
 
 #ifdef CAMPAIGN_HEIR_TO_THE_THRONE
 [binary_path]
-    path=data/campaigns/Heir_To_The_Throne
+    path=campaigns/Heir_To_The_Throne
 [/binary_path]
 
 {campaigns/Heir_To_The_Throne/utils}

--- a/data/campaigns/Legend_of_Wesmere/_main.cfg
+++ b/data/campaigns/Legend_of_Wesmere/_main.cfg
@@ -7,7 +7,7 @@
 
 #ifdef CAMPAIGN_LOW
 [binary_path]
-    path=data/campaigns/Legend_of_Wesmere/
+    path=campaigns/Legend_of_Wesmere/
 [/binary_path]
 
 {campaigns/Legend_of_Wesmere/utils}

--- a/data/campaigns/Liberty/_main.cfg
+++ b/data/campaigns/Liberty/_main.cfg
@@ -74,7 +74,7 @@
 #ifdef CAMPAIGN_LIBERTY
 
 [binary_path]
-    path=data/campaigns/Liberty
+    path=campaigns/Liberty
 [/binary_path]
 
 {campaigns/Liberty/utils}

--- a/data/campaigns/Northern_Rebirth/_main.cfg
+++ b/data/campaigns/Northern_Rebirth/_main.cfg
@@ -70,7 +70,7 @@
 
 #ifdef CAMPAIGN_NORTHERN_REBIRTH
 [binary_path]
-    path=data/campaigns/Northern_Rebirth
+    path=campaigns/Northern_Rebirth
 [/binary_path]
 
 [units]

--- a/data/campaigns/Sceptre_of_Fire/_main.cfg
+++ b/data/campaigns/Sceptre_of_Fire/_main.cfg
@@ -113,7 +113,7 @@ Their tale I now relate...</i>
 
 #ifdef CAMPAIGN_SCEPTRE_FIRE
 [binary_path]
-    path=data/campaigns/Sceptre_of_Fire/
+    path=campaigns/Sceptre_of_Fire/
 [/binary_path]
 
 [units]

--- a/data/campaigns/Secrets_of_the_Ancients/_main.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/_main.cfg
@@ -49,7 +49,7 @@
 
 #ifdef CAMPAIGN_SECRETS_OF_THE_ANCIENTS
 [binary_path]
-    path=data/campaigns/Secrets_of_the_Ancients
+    path=campaigns/Secrets_of_the_Ancients
 [/binary_path]
 
 {campaigns/Secrets_of_the_Ancients/utils}
@@ -61,7 +61,7 @@
 
 #ifdef EDITOR
 [binary_path]
-    path=data/campaigns/Secrets_of_the_Ancients
+    path=campaigns/Secrets_of_the_Ancients
 [/binary_path]
 
 [editor_group]

--- a/data/campaigns/The_Hammer_of_Thursagan/_main.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/_main.cfg
@@ -66,7 +66,7 @@
 
 #ifdef CAMPAIGN_THE_HAMMER_OF_THURSAGAN
 [binary_path]
-    path=data/campaigns/The_Hammer_of_Thursagan/
+    path=campaigns/The_Hammer_of_Thursagan/
 [/binary_path]
 
 [lua]

--- a/data/campaigns/The_Rise_Of_Wesnoth/_main.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/_main.cfg
@@ -82,7 +82,7 @@
 
 #ifdef CAMPAIGN_THE_RISE_OF_WESNOTH
 [binary_path]
-    path=data/campaigns/The_Rise_Of_Wesnoth
+    path=campaigns/The_Rise_Of_Wesnoth
 [/binary_path]
 
 {campaigns/The_Rise_Of_Wesnoth/utils}

--- a/data/campaigns/The_South_Guard/_main.cfg
+++ b/data/campaigns/The_South_Guard/_main.cfg
@@ -87,7 +87,7 @@
 #ifdef CAMPAIGN_THE_SOUTH_GUARD
 
 [binary_path]
-    path=data/campaigns/The_South_Guard
+    path=campaigns/The_South_Guard
 [/binary_path]
 
 {campaigns/The_South_Guard/utils/sg_utils.cfg}

--- a/data/campaigns/Two_Brothers/_main.cfg
+++ b/data/campaigns/Two_Brothers/_main.cfg
@@ -91,7 +91,7 @@
 
 #ifdef CAMPAIGN_TWO_BROTHERS
 [binary_path]
-    path=data/campaigns/Two_Brothers
+    path=campaigns/Two_Brothers
 [/binary_path]
 {campaigns/Two_Brothers/utils}
 {campaigns/Two_Brothers/scenarios}

--- a/data/campaigns/Under_the_Burning_Suns/_main.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/_main.cfg
@@ -151,7 +151,7 @@
 #ifdef CAMPAIGN_UNDER_THE_BURNING_SUNS
 
 [binary_path]
-    path=data/campaigns/Under_the_Burning_Suns
+    path=campaigns/Under_the_Burning_Suns
 [/binary_path]
 
 # Define macro that expands into include paths for this campaign
@@ -241,7 +241,7 @@
 
 #ifdef EDITOR
 [binary_path]
-    path=data/campaigns/Under_the_Burning_Suns
+    path=campaigns/Under_the_Burning_Suns
 [/binary_path]
 
 [editor_group]

--- a/data/campaigns/tutorial/_main.cfg
+++ b/data/campaigns/tutorial/_main.cfg
@@ -33,7 +33,7 @@
 
 #ifdef TUTORIAL
 [binary_path]
-    path=data/campaigns/tutorial
+    path=campaigns/tutorial
 [/binary_path]
 
 [units]

--- a/data/multiplayer/scenarios/Wesbench_AI.cfg
+++ b/data/multiplayer/scenarios/Wesbench_AI.cfg
@@ -2,7 +2,7 @@
 
 #ifdef DEBUG_MODE
 [binary_path]
-    path=data/campaigns/Heir_To_The_Throne
+    path=campaigns/Heir_To_The_Throne
 [/binary_path]
 [multiplayer]
     id=wesbench_ai

--- a/data/multiplayer/scenarios/Wesbench_Scroll.cfg
+++ b/data/multiplayer/scenarios/Wesbench_Scroll.cfg
@@ -2,7 +2,7 @@
 
 #ifdef DEBUG_MODE
 [binary_path]
-    path=data/campaigns/Heir_To_The_Throne
+    path=campaigns/Heir_To_The_Throne
 [/binary_path]
 [multiplayer]
     id=wesbench_scroll

--- a/data/multiplayer/scenarios/Wesbench_Shroud_Walk.cfg
+++ b/data/multiplayer/scenarios/Wesbench_Shroud_Walk.cfg
@@ -2,7 +2,7 @@
 
 #ifdef DEBUG_MODE
 [binary_path]
-    path=data/campaigns/Heir_To_The_Throne
+    path=campaigns/Heir_To_The_Throne
 [/binary_path]
 [multiplayer]
     id=wesbench_shroud_walk

--- a/data/test/_main.cfg
+++ b/data/test/_main.cfg
@@ -32,7 +32,7 @@
 
 #ifndef DONT_RELOAD_CORE
 [binary_path]
-    path=data/core
+    path=core
 [/binary_path]
 
 {game_config.cfg}

--- a/source_lists/libwesnoth_core
+++ b/source_lists/libwesnoth_core
@@ -30,4 +30,5 @@ serialization/unicode.cpp
 serialization/validator.cpp
 terrain/type_data.cpp
 tstring.cpp
+wml_path.cpp
 game_version.cpp

--- a/source_lists/libwesnoth_core
+++ b/source_lists/libwesnoth_core
@@ -1,3 +1,4 @@
+binary_path.cpp
 color.cpp
 color_range.cpp
 config.cpp

--- a/src/ai/configuration.cpp
+++ b/src/ai/configuration.cpp
@@ -183,7 +183,7 @@ std::string configuration::default_ai_algorithm_;
 
 bool configuration::get_side_config_from_file(const std::string& file, config& cfg ){
 	try {
-		filesystem::scoped_istream stream = preprocess_file(filesystem::get_wml_location(file));
+		filesystem::scoped_istream stream = preprocess_file_safe(wml_path(file));
 		read(cfg, *stream);
 		LOG_AI_CONFIGURATION << "Reading AI configuration from file '" << file  << "'" << std::endl;
 	} catch(const config::error &) {

--- a/src/binary_path.cpp
+++ b/src/binary_path.cpp
@@ -1,0 +1,206 @@
+/*
+   Copyright (C) 2020 by the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+/**
+ * @file
+ * File-IO
+ */
+#define GETTEXT_DOMAIN "wesnoth-lib"
+
+#include "filesystem.hpp"
+#include "binary_path.hpp"
+
+#include "config.hpp"
+#include "deprecation.hpp"
+#include "game_config.hpp"
+#include "game_version.hpp"
+#include "gettext.hpp"
+#include "log.hpp"
+
+#include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
+#include "game_config_view.hpp"
+
+
+static lg::log_domain log_filesystem("filesystem");
+#define DBG_FS LOG_STREAM(debug, log_filesystem)
+#define LOG_FS LOG_STREAM(info, log_filesystem)
+#define WRN_FS LOG_STREAM(warn, log_filesystem)
+#define ERR_FS LOG_STREAM(err, log_filesystem)
+
+namespace bfs = boost::filesystem;
+using boost::system::error_code;
+
+
+/**
+ *  The paths manager is responsible for recording the various paths
+ *  that binary files may be located at.
+ *  It should be passed a config object which holds binary path information.
+ *  This is in the format
+ *@verbatim
+ *    [binary_path]
+ *      path=<path>
+ *    [/binary_path]
+ *  Binaries will be searched for in [wesnoth-path]/data/<path>/images/
+ *@endverbatim
+ */
+namespace
+{
+std::set<wml_path> binary_paths;
+
+typedef std::map<std::string, std::vector<wml_path>> paths_map;
+paths_map binary_paths_cache;
+
+} // namespace
+
+static void init_binary_paths()
+{
+	if(binary_paths.empty()) {
+		binary_paths.insert(wml_path::from_absolute(game_config::path + "/"));
+	}
+}
+
+namespace filesystem {
+
+binary_paths_manager::binary_paths_manager()
+{
+}
+
+binary_paths_manager::binary_paths_manager(const game_config_view& cfg)
+{
+	set_paths(cfg);
+}
+
+binary_paths_manager::~binary_paths_manager()
+{
+	cleanup();
+}
+
+void binary_paths_manager::set_paths(const game_config_view& cfg)
+{
+	cleanup();
+	init_binary_paths();
+
+	for(const config& bp : cfg.child_range("binary_path")) {
+		std::string path = bp["path"].str();
+		if(path.find("..") != std::string::npos) {
+			ERR_FS << "Invalid binary path '" << path << "'\n";
+			continue;
+		}
+
+		if(!path.empty() && path.back() != '/') {
+			path += "/";
+		}
+		if(binary_paths.count(wml_path(path)) == 0) {
+			binary_paths.insert(wml_path(path));
+		}
+	}
+}
+
+void binary_paths_manager::cleanup()
+{
+	binary_paths_cache.clear();
+	binary_paths.clear();
+}
+
+void clear_binary_paths_cache()
+{
+	binary_paths_cache.clear();
+}
+
+/**
+ * Returns a vector with all possible paths to a given type of binary,
+ * e.g. 'images', 'sounds', etc,
+ */
+const std::vector<wml_path>& get_binary_paths(const std::string& type)
+{
+	const paths_map::const_iterator itor = binary_paths_cache.find(type);
+	if(itor != binary_paths_cache.end()) {
+		return itor->second;
+	}
+
+	if(type.find("..") != std::string::npos) {
+		// Not an assertion, as language.cpp is passing user data as type.
+		ERR_FS << "Invalid WML type '" << type << "' for binary paths\n";
+		static std::vector<wml_path> dummy;
+		return dummy;
+	}
+
+	std::vector<wml_path>& res = binary_paths_cache[type];
+
+	init_binary_paths();
+
+	for(const wml_path& path : binary_paths) {
+		res.push_back(path.append(type + "/"));
+	}
+	// not found in "/type" directory, try main directory, todo: why?
+	//res.push_back(wml_path::from_absolutegame_config::path + "/./"));
+
+	return res;
+}
+
+wml_path get_binary_file_location(const std::string& type, const std::string& filename)
+{
+	wml_path result;
+	for(const wml_path& bp : get_binary_paths(type)) {
+		wml_path new_path = bp.append(filename);
+
+		DBG_FS << "  checking '" << new_path.safe_path() << "'\n";
+		if(!is_legal_file(new_path.safe_path())){
+			ERR_FS << "skipping invalid path " << new_path.safe_path() << "\n";
+			continue;
+		}
+
+		if(new_path.exists()) {
+			DBG_FS << "  found at '" << new_path.safe_path() << "'\n";
+			if(result.safe_path().empty()) {
+				result = new_path;
+			} else {
+				WRN_FS << "Conflicting files in binary_path: '" << new_path.safe_path()
+					   << "' and '" << new_path.safe_path() << "'\n";
+			}
+		}
+	}
+
+	return result;
+}
+
+std::string get_binary_dir_location(const std::string& type, const std::string& filename)
+{
+	for(const wml_path& bp : get_binary_paths(type)) {
+
+		wml_path new_path = bp.append(filename);
+		if(!is_legal_file(new_path.safe_path())){
+			ERR_FS << "skipping invalid path " << new_path.safe_path() << "\n";
+			continue;
+		}
+
+		DBG_FS << "  checking '" << bp.safe_path() << "'\n";
+		if(is_directory(new_path.get_abolute_path())) {
+			DBG_FS << "  found at '" << new_path.safe_path() << "'\n";
+			return new_path.get_abolute_path();
+		}
+	}
+
+	DBG_FS << "  not found\n";
+	return std::string();
+}
+
+std::string get_independent_image_path(const std::string& filename)
+{
+	wml_path path = get_binary_file_location("images", filename);
+	return path.has_abolute_part() ? path.get_abolute_path() : path.safe_path();
+}
+
+} // namespace filesystem

--- a/src/binary_path.cpp
+++ b/src/binary_path.cpp
@@ -144,8 +144,8 @@ const std::vector<wml_path>& get_binary_paths(const std::string& type)
 	for(const wml_path& path : binary_paths) {
 		res.push_back(path.append(type + "/"));
 	}
-	// not found in "/type" directory, try main directory, todo: why?
-	//res.push_back(wml_path::from_absolutegame_config::path + "/./"));
+	// some codes explicity specify the part in the form data/core/images ... etc.
+	res.push_back(wml_path::from_absolutegame_config::path + "/./"));
 
 	return res;
 }

--- a/src/binary_path.hpp
+++ b/src/binary_path.hpp
@@ -1,0 +1,100 @@
+/*
+   Copyright (C) 2020 by the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+/**
+ * @file
+ * Declarations for File-IO.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <ctime>
+#include <iosfwd>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "wml_path.hpp"
+
+#include "exceptions.hpp"
+#include "serialization/string_utils.hpp"
+
+class config;
+class game_config_view;
+
+namespace filesystem {
+
+using scoped_istream = std::unique_ptr<std::istream>;
+using scoped_ostream = std::unique_ptr<std::ostream>;
+
+
+/**
+ *  The paths manager is responsible for recording the various paths
+ *  that binary files may be located at.
+ *  It should be passed a config object which holds binary path information.
+ *  This is in the format
+ *@verbatim
+ *    [binary_path]
+ *      path=<path>
+ *    [/binary_path]
+ *  Binaries will be searched for in [wesnoth-path]/data/<path>/images/
+ *@endverbatim
+ */
+struct binary_paths_manager
+{
+	binary_paths_manager();
+	binary_paths_manager(const game_config_view& cfg);
+	~binary_paths_manager();
+
+	void set_paths(const game_config_view& cfg);
+
+private:
+	binary_paths_manager(const binary_paths_manager& o);
+	binary_paths_manager& operator=(const binary_paths_manager& o);
+
+	void cleanup();
+};
+
+void clear_binary_paths_cache();
+
+/**
+ * Returns a vector with all possible paths to a given type of binary,
+ * e.g. 'images', 'sounds', etc,
+ */
+const std::vector<wml_path>& get_binary_paths(const std::string& type);
+
+/**
+ * Returns a complete path to the actual file of a given @a type
+ * or an empty string if the file isn't present.
+ */
+wml_path get_binary_file_location(const std::string& type, const std::string& filename);
+
+/**
+ * Returns a complete path to the actual directory of a given @a type
+ * or an empty string if the directory isn't present.
+ */
+std::string get_binary_dir_location(const std::string &type, const std::string &filename);
+
+/**
+ * Returns an image path to @a filename for binary path-independent use in saved games.
+ *
+ * Example:
+ *   units/konrad-fighter.png ->
+ *   data/campaigns/Heir_To_The_Throne/images/units/konrad-fighter.png
+ */
+std::string get_independent_image_path(const std::string &filename);
+
+
+}

--- a/src/config_cache.cpp
+++ b/src/config_cache.cpp
@@ -143,7 +143,8 @@ void config_cache::add_defines_map_diff(preproc_map& defines_map)
 void config_cache::read_configs(const std::string& file_path, config& cfg, preproc_map& defines_map, abstract_validator* validator)
 {
 	//read the file and then write to the cache
-	filesystem::scoped_istream stream = preprocess_file(file_path, &defines_map);
+	//TODO: should this be a "safe_path" ?
+	filesystem::scoped_istream stream = preprocess_file_absolute(file_path, &defines_map);
 	read(cfg, *stream, validator);
 }
 

--- a/src/editor/map/map_context.cpp
+++ b/src/editor/map/map_context.cpp
@@ -318,7 +318,8 @@ void map_context::load_scenario(const game_config_view& game_config)
 	config scenario;
 
 	try {
-		read(scenario, *(preprocess_file(filename_)));
+		//todo: maybe make filename_ a wml_path ?
+		read(scenario, *(preprocess_file_absolute(filename_)));
 	} catch(const config::error& e) {
 		LOG_ED << "Caught a config error while parsing file: '" << filename_ << "'\n" << e.message << std::endl;
 		throw;

--- a/src/editor/palette/editor_palettes.cpp
+++ b/src/editor/palette/editor_palettes.cpp
@@ -16,6 +16,7 @@
 
 #include "editor/palette/editor_palettes.hpp"
 
+#include "binary_path.hpp"
 #include "gettext.hpp"
 #include "font/text_formatting.hpp"
 #include "tooltips.hpp"

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -463,7 +463,7 @@ void get_files_in_dir(const std::string& dir,
 	if(files != nullptr && reorder == DO_REORDER) {
 		// move finalcfg_filename, if present, to the end of the vector
 		for(unsigned int i = 0; i < files->size(); i++) {
-			if(ends_with((*files)[i], "/" + finalcfg_filename)) {
+			if(ends_with((*files)[i], "/" + finalcfg_filename) || (*files)[i] == finalcfg_filename) {
 				files->push_back((*files)[i]);
 				files->erase(files->begin() + i);
 				break;
@@ -473,7 +473,7 @@ void get_files_in_dir(const std::string& dir,
 		// move initialcfg_filename, if present, to the beginning of the vector
 		int foundit = -1;
 		for(unsigned int i = 0; i < files->size(); i++)
-			if(ends_with((*files)[i], "/" + initialcfg_filename)) {
+			if(ends_with((*files)[i], "/" + initialcfg_filename) || (*files)[i] == initialcfg_filename) {
 				foundit = i;
 				break;
 			}
@@ -1474,6 +1474,7 @@ std::string get_binary_dir_location(const std::string& type, const std::string& 
 std::string get_wml_location(const std::string& filename, const std::string& current_dir)
 {
 	if(!is_legal_file(filename)) {
+		std::cout << "filename:" << filename << "current_dir:" << current_dir << "\n";
 		return std::string();
 	}
 
@@ -1498,6 +1499,7 @@ std::string get_wml_location(const std::string& filename, const std::string& cur
 	}
 
 	if(result.empty() || !file_exists(result)) {
+		std::cout << "not found filename:" << filename << "current_dir:" << current_dir << "\n";
 		DBG_FS << "  not found\n";
 		result.clear();
 	} else {

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -445,7 +445,14 @@ void get_files_in_dir(const std::string& dir,
 			} else if(reorder == DO_REORDER && main_st.type() == bfs::regular_file) {
 				LOG_FS << "_main.cfg found : "
 					   << (mode == ENTIRE_FILE_PATH ? inner_main.string() : inner_main.filename().string()) << '\n';
-				push_if_exists(files, inner_main, mode == ENTIRE_FILE_PATH);
+
+	if(files != nullptr) {
+		if(mode == ENTIRE_FILE_PATH) {
+			files->push_back(inner_main.generic_string());
+		} else {
+			files->push_back((di->path().filename()  / maincfg_filename).generic_string());
+		}
+	}
 			} else {
 				push_if_exists(dirs, di->path(), mode == ENTIRE_FILE_PATH);
 			}
@@ -1474,7 +1481,6 @@ std::string get_binary_dir_location(const std::string& type, const std::string& 
 std::string get_wml_location(const std::string& filename, const std::string& current_dir)
 {
 	if(!is_legal_file(filename)) {
-		std::cout << "filename:" << filename << "current_dir:" << current_dir << "\n";
 		return std::string();
 	}
 
@@ -1499,7 +1505,7 @@ std::string get_wml_location(const std::string& filename, const std::string& cur
 	}
 
 	if(result.empty() || !file_exists(result)) {
-		std::cout << "not found filename:" << filename << "current_dir:" << current_dir << "\n";
+		//std::cout << "not found filename:" << filename << "current_dir:" << current_dir << "\n";
 		DBG_FS << "  not found\n";
 		result.clear();
 	} else {

--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -370,53 +370,9 @@ bool is_path_sep(char c);
 char path_separator();
 
 /**
- *  The paths manager is responsible for recording the various paths
- *  that binary files may be located at.
- *  It should be passed a config object which holds binary path information.
- *  This is in the format
- *@verbatim
- *    [binary_path]
- *      path=<path>
- *    [/binary_path]
- *  Binaries will be searched for in [wesnoth-path]/data/<path>/images/
- *@endverbatim
+ * Checks whether the path does not contain invalid chacters.
  */
-struct binary_paths_manager
-{
-	binary_paths_manager();
-	binary_paths_manager(const game_config_view& cfg);
-	~binary_paths_manager();
-
-	void set_paths(const game_config_view& cfg);
-
-private:
-	binary_paths_manager(const binary_paths_manager& o);
-	binary_paths_manager& operator=(const binary_paths_manager& o);
-
-	void cleanup();
-
-	std::vector<std::string> paths_;
-};
-
-void clear_binary_paths_cache();
-
-/**
- * Returns a vector with all possible paths to a given type of binary,
- * e.g. 'images', 'sounds', etc,
- */
-const std::vector<std::string>& get_binary_paths(const std::string& type);
-
-/**
- * Returns a complete path to the actual file of a given @a type
- * or an empty string if the file isn't present.
- */
-std::string get_binary_file_location(const std::string& type, const std::string& filename);
-
-/**
- * Returns a complete path to the actual directory of a given @a type
- * or an empty string if the directory isn't present.
- */
-std::string get_binary_dir_location(const std::string &type, const std::string &filename);
+bool is_legal_file(const std::string& filename_str);
 
 /**
  * Returns a complete path to the actual WML file or directory
@@ -429,15 +385,6 @@ std::string get_wml_location(const std::string &filename,
  * Returns a short path to @a filename, skipping the (user) data directory.
  */
 std::string get_short_wml_path(const std::string &filename);
-
-/**
- * Returns an image path to @a filename for binary path-independent use in saved games.
- *
- * Example:
- *   units/konrad-fighter.png ->
- *   data/campaigns/Heir_To_The_Throne/images/units/konrad-fighter.png
- */
-std::string get_independent_image_path(const std::string &filename);
 
 /**
  * Returns the appropriate invocation for a Wesnoth-related binary, assuming

--- a/src/filesystem_common.cpp
+++ b/src/filesystem_common.cpp
@@ -16,6 +16,7 @@
 #include "filesystem.hpp"
 #include "wesconfig.h"
 
+#include "binary_path.hpp"
 #include "config.hpp"
 #include "game_config.hpp"
 #include "log.hpp"
@@ -142,7 +143,7 @@ std::string read_map(const std::string& name)
 	if(map_location.empty()) {
 		// If this is an add-on or campaign that's set the [binary_path] for its image directory,
 		// automatically check for a sibling maps directory.
-		map_location = get_binary_file_location("maps", name);
+		map_location = get_binary_file_location("maps", name).get_abolute_path();
 	}
 	if(!map_location.empty()) {
 		res = read_file(map_location);

--- a/src/font/font_config.cpp
+++ b/src/font/font_config.cpp
@@ -21,6 +21,7 @@
 #include "log.hpp"
 #include "tstring.hpp"
 
+#include "binary_path.hpp"
 #include "filesystem.hpp"
 #include "game_config.hpp"
 
@@ -242,10 +243,10 @@ manager::manager()
 #endif
 
 #ifdef CAIRO_HAS_WIN32_FONT
-	for(const std::string& path : filesystem::get_binary_paths("fonts")) {
+	for(const wml_path& path : filesystem::get_binary_paths("fonts")) {
 		std::vector<std::string> files;
-		if(filesystem::is_directory(path)) {
-			filesystem::get_files_in_dir(path, &files, nullptr, filesystem::ENTIRE_FILE_PATH);
+		if(filesystem::is_directory(path.get_abolute_path())) {
+			filesystem::get_files_in_dir(path.get_abolute_path(), &files, nullptr, filesystem::ENTIRE_FILE_PATH);
 		}
 		for(const std::string& file : files) {
 			if(is_valid_font_file(file))
@@ -265,10 +266,11 @@ manager::~manager()
 #endif
 
 #ifdef CAIRO_HAS_WIN32_FONT
-	for(const std::string& path : filesystem::get_binary_paths("fonts")) {
+	for(const wml_path& path : filesystem::get_binary_paths("fonts")) {
 		std::vector<std::string> files;
-		if(filesystem::is_directory(path))
-			filesystem::get_files_in_dir(path, &files, nullptr, filesystem::ENTIRE_FILE_PATH);
+		if(filesystem::is_directory(path.get_abolute_path())) {
+			filesystem::get_files_in_dir(path.get_abolute_path(), &files, nullptr, filesystem::ENTIRE_FILE_PATH);
+		}
 		for(const std::string& file : files) {
 			if(is_valid_font_file(file))
 			{

--- a/src/font/font_config.cpp
+++ b/src/font/font_config.cpp
@@ -131,13 +131,13 @@ bool load_font_config()
 	//config when changing languages
 	config cfg;
 	try {
-		const std::string& cfg_path = filesystem::get_wml_location("hardwired/fonts.cfg");
-		if(cfg_path.empty()) {
+		wml_path cfg_path = wml_path("hardwired/fonts.cfg");
+		if(!cfg_path.exists()) {
 			ERR_FT << "could not resolve path to fonts.cfg, file not found\n";
 			return false;
 		}
 
-		filesystem::scoped_istream stream = preprocess_file(cfg_path);
+		filesystem::scoped_istream stream = preprocess_file_safe(cfg_path);
 		read(cfg, *stream);
 	} catch(const config::error &e) {
 		ERR_FT << "could not read fonts.cfg:\n"

--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -16,6 +16,7 @@
 #include "about.hpp"
 #include "addon/manager.hpp"
 #include "ai/configuration.hpp"
+#include "binary_path.hpp"
 #include "cursor.hpp"
 #include "events.hpp"
 #include "formatter.hpp"
@@ -56,7 +57,7 @@ game_config_manager::game_config_manager(
 	addon_cfgs_(),
 	active_addons_(),
 	old_defines_map_(),
-	paths_manager_(),
+	paths_manager_(new filesystem::binary_paths_manager()),
 	cache_(game_config::config_cache::instance())
 {
 	assert(!singleton);
@@ -366,7 +367,7 @@ void game_config_manager::load_game_config(bool reload_everything)
 	old_defines_map_ = cache_.get_preproc_map();
 
 	// Set new binary paths.
-	paths_manager_.set_paths(game_config());
+	paths_manager_->set_paths(game_config());
 }
 
 void game_config_manager::load_addons_cfg()

--- a/src/game_config_manager.hpp
+++ b/src/game_config_manager.hpp
@@ -18,11 +18,14 @@
 
 #include "commandline_options.hpp"
 #include "config_cache.hpp"
-#include "filesystem.hpp"
 #include "terrain/type_data.hpp"
 #include "config.hpp"
 #include "game_config_view.hpp"
 
+#include <memory>
+namespace filesystem {
+	class binary_paths_manager;
+}
 class game_classification;
 class game_config_manager
 {
@@ -81,7 +84,7 @@ private:
 	
 	preproc_map old_defines_map_;
 
-	filesystem::binary_paths_manager paths_manager_;
+	std::unique_ptr<filesystem::binary_paths_manager> paths_manager_;
 
 	game_config::config_cache& cache_;
 

--- a/src/game_initialization/create_engine.cpp
+++ b/src/game_initialization/create_engine.cpp
@@ -685,7 +685,7 @@ void create_engine::init_all_levels()
 		{
 			config data;
 			try {
-				read(data, *preprocess_file(filesystem::get_user_data_dir() + "/editor/scenarios/" + user_scenario_names_[i]));
+				read(data, *preprocess_file_absolute(filesystem::get_user_data_dir() + "/editor/scenarios/" + user_scenario_names_[i]));
 			} catch(const config::error & e) {
 				ERR_CF << "Caught a config error while parsing user made (editor) scenarios:\n" << e.message << std::endl;
 				ERR_CF << "Skipping file: " << (filesystem::get_user_data_dir() + "/editor/scenarios/" + user_scenario_names_[i]) << std::endl;

--- a/src/gui/dialogs/game_load.cpp
+++ b/src/gui/dialogs/game_load.cpp
@@ -16,6 +16,7 @@
 
 #include "gui/dialogs/game_load.hpp"
 
+#include "binary_path.hpp"
 #include "desktop/open.hpp"
 #include "filesystem.hpp"
 #include "font/pango/escape.hpp"

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -51,7 +51,7 @@ void init()
 		schema_validation::schema_validator validator(filesystem::get_wml_location("schema/gui.cfg"));
 
 		preproc_map preproc(game_config::config_cache::instance().get_preproc_map());
-		filesystem::scoped_istream stream = preprocess_file(filesystem::get_wml_location("gui/_main.cfg"), &preproc);
+		filesystem::scoped_istream stream = preprocess_file_safe(wml_path("gui/_main.cfg"), &preproc);
 
 		read(cfg, *stream, &validator);
 	} catch(const config::error& e) {

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -94,7 +94,7 @@ bool load_language_list()
 {
 	config cfg;
 	try {
-		filesystem::scoped_istream stream = preprocess_file(filesystem::get_wml_location("hardwired/language.cfg"));
+		filesystem::scoped_istream stream = preprocess_file_safe(wml_path("hardwired/language.cfg"));
 		read(cfg, *stream);
 	} catch(const config::error &) {
 		return false;

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -12,6 +12,7 @@
    See the COPYING file for more details.
 */
 
+#include "binary_path.hpp"
 #include "filesystem.hpp"
 #include "gettext.hpp"
 #include "language.hpp"

--- a/src/picture.cpp
+++ b/src/picture.cpp
@@ -19,6 +19,7 @@
 
 #include "picture.hpp"
 
+#include "binary_path.hpp"
 #include "config.hpp"
 #include "display.hpp"
 #include "filesystem.hpp"
@@ -461,7 +462,7 @@ static surface load_image_file(const image::locator& loc)
 {
 	surface res;
 
-	std::string location = filesystem::get_binary_file_location("images", loc.get_filename());
+	std::string location = filesystem::get_binary_file_location("images", loc.get_filename()).get_abolute_path();
 
 	{
 		if(!location.empty()) {
@@ -1081,10 +1082,10 @@ static void precache_file_existence_internal(const std::string& dir, const std::
 
 void precache_file_existence(const std::string& subdir)
 {
-	const std::vector<std::string>& paths = filesystem::get_binary_paths("images");
+	const std::vector<wml_path>& paths = filesystem::get_binary_paths("images");
 
 	for(const auto& p : paths) {
-		precache_file_existence_internal(p, subdir);
+		precache_file_existence_internal(p.get_abolute_path(), subdir);
 	}
 }
 

--- a/src/save_index.cpp
+++ b/src/save_index.cpp
@@ -15,6 +15,7 @@
 
 #include "save_index.hpp"
 
+#include "binary_path.hpp"
 #include "config.hpp"
 #include "filesystem.hpp"
 #include "format_time_summary.hpp"

--- a/src/scripting/lua_wml.cpp
+++ b/src/scripting/lua_wml.cpp
@@ -80,13 +80,12 @@ static int intf_load_wml(lua_State* L)
 		validator.reset(new schema_validation::schema_validator(filesystem::get_wml_location(schema_path)));
 		validator->set_create_exceptions(false); // Don't crash if there's an error, just go ahead anyway
 	}
-	std::string wml_file = filesystem::get_wml_location(file);
 	filesystem::scoped_istream stream;
 	config result;
 	if(preprocess) {
-		stream = preprocess_file(wml_file, &defines_map);
+		stream = preprocess_file_safe(wml_path(file), &defines_map);
 	} else {
-		stream.reset(new std::ifstream(wml_file));
+		stream.reset(new std::ifstream(wml_path(file).get_abolute_path()));
 	}
 	read(result, *stream, validator.get());
 	luaW_pushconfig(L, result);

--- a/src/serialization/preprocessor.cpp
+++ b/src/serialization/preprocessor.cpp
@@ -1503,7 +1503,7 @@ bool preprocessor_data::get_chunk()
 				std::size_t optional_arg_num = 0;
 
 				std::unique_ptr<std::map<std::string, std::string>> defines{new std::map<std::string, std::string>};
-				const std::string& dir = filesystem::directory_name(val.location.substr(0, val.location.find(' ')));
+
 
 				if(val.is_deprecated()) {
 					deprecated_message(symbol, *val.deprecation_level, val.deprecation_version, val.deprecation_message);
@@ -1559,7 +1559,7 @@ bool preprocessor_data::get_chunk()
 							temp_defines->insert(defines->begin(), defines->end());
 
 							buf->add_preprocessor<preprocessor_data>(
-								std::move(buffer), val.location, "", val.linenum, dir, val.textdomain, std::move(temp_defines), false);
+								std::move(buffer), val.location, "", val.linenum, "", val.textdomain, std::move(temp_defines), false);
 
 							std::ostringstream res;
 							res << in.rdbuf();
@@ -1590,7 +1590,7 @@ bool preprocessor_data::get_chunk()
 					DBG_PREPROC << "substituting macro " << symbol << '\n';
 
 					parent_.add_preprocessor<preprocessor_data>(
-						std::move(buffer), val.location, "", val.linenum, dir, val.textdomain, std::move(defines), true);
+						std::move(buffer), val.location, "", val.linenum, "", val.textdomain, std::move(defines), true);
 				} else {
 					DBG_PREPROC << "substituting (slow) macro " << symbol << '\n';
 
@@ -1604,7 +1604,7 @@ bool preprocessor_data::get_chunk()
 					{
 						std::istream in(buf.get());
 						buf->add_preprocessor<preprocessor_data>(
-							std::move(buffer), val.location, "", val.linenum, dir, val.textdomain, std::move(defines), true);
+							std::move(buffer), val.location, "", val.linenum, "", val.textdomain, std::move(defines), true);
 
 						res << in.rdbuf();
 					}

--- a/src/serialization/preprocessor.hpp
+++ b/src/serialization/preprocessor.hpp
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "filesystem.hpp"
+#include "wml_path.hpp"
 #include <iosfwd>
 #include <map>
 #include <vector>
@@ -139,6 +140,8 @@ std::ostream& operator<<(std::ostream& stream, const preproc_map::value_type& de
  * @returns                       The resulting preprocessed file data.
  */
 filesystem::scoped_istream preprocess_file(const std::string& fname, preproc_map* defines = nullptr);
+filesystem::scoped_istream preprocess_file_absolute(const std::string& fname, preproc_map* defines = nullptr);
+filesystem::scoped_istream preprocess_file_safe(const wml_path& fname, preproc_map* defines = nullptr);
 
 void preprocess_resource(const std::string& res_name,
 		preproc_map* defines_map,

--- a/src/serialization/preprocessor_include_history.cpp
+++ b/src/serialization/preprocessor_include_history.cpp
@@ -1,0 +1,128 @@
+/*
+   Copyright (C) 2003 by David White <dave@whitevine.net>
+   Copyright (C) 2005 - 2018 by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+/**
+ * @file
+ * WML preprocessor.
+ */
+
+#include "serialization/preprocessor.hpp"
+
+#include "buffered_istream.hpp"
+#include "config.hpp"
+#include "filesystem.hpp"
+#include "log.hpp"
+#include "serialization/binary_or_text.hpp"
+#include "serialization/parser.hpp"
+#include "serialization/string_utils.hpp"
+#include "game_version.hpp"
+#include "wesconfig.h"
+#include "deprecation.hpp"
+
+#include <stdexcept>
+#include <deque>
+
+static lg::log_domain log_preprocessor("preprocessor");
+#define ERR_PREPROC LOG_STREAM(err, log_preprocessor)
+#define WRN_PREPROC LOG_STREAM(warn, log_preprocessor)
+#define LOG_PREPROC LOG_STREAM(info, log_preprocessor)
+#define DBG_PREPROC LOG_STREAM(debug, log_preprocessor)
+
+static const std::string current_file_str = "CURRENT_FILE";
+static const std::string current_dir_str = "CURRENT_DIRECTORY";
+static const std::string left_curly_str = "LEFT_BRACE";
+static const std::string right_curly_str = "RIGHT_BRACE";
+
+// map associating each filename encountered to a number
+static std::map<std::string, int> file_number_map;
+
+static bool encode_filename = true;
+
+static std::string preprocessor_error_detail_prefix = "\n    ";
+
+static const char OUTPUT_SEPARATOR = '\xFE';
+
+// get filename associated to this code
+static std::string get_filename(const std::string& file_code)
+{
+	if(!encode_filename) {
+		return file_code;
+	}
+
+	std::stringstream s;
+	s << file_code;
+	int n = 0;
+	s >> std::hex >> n;
+
+	for(const auto& p : file_number_map) {
+		if(p.second == n) {
+			return p.first;
+		}
+	}
+
+	return "<unknown>";
+}
+
+// Get code associated to this filename
+static std::string get_file_code(const std::string& filename)
+{
+	if(!encode_filename) {
+		return filename;
+	}
+
+	// Current number of encountered filenames
+	static int current_file_number = 0;
+
+	int& fnum = file_number_map[utils::escape(filename, " \\")];
+	if(fnum == 0) {
+		fnum = ++current_file_number;
+	}
+
+	std::ostringstream shex;
+	shex << std::hex << fnum;
+
+	return shex.str();
+}
+
+// decode the filenames placed in a location
+static std::string get_location(const std::string& loc)
+{
+	std::string res;
+	std::vector<std::string> pos = utils::quoted_split(loc, ' ');
+
+	if(pos.empty()) {
+		return res;
+	}
+
+	std::vector<std::string>::const_iterator i = pos.begin(), end = pos.end();
+	while(true) {
+		res += get_filename(*(i++));
+
+		if(i == end) {
+			break;
+		}
+
+		res += ' ';
+		res += *(i++);
+
+		if(i == end) {
+			break;
+		}
+
+		res += ' ';
+	}
+
+	return res;
+}

--- a/src/serialization/preprocessor_include_history.hpp
+++ b/src/serialization/preprocessor_include_history.hpp
@@ -1,0 +1,35 @@
+/*
+   Copyright (C) 2003 by David White <dave@whitevine.net>
+   Copyright (C) 2005 - 2018 by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+/** @file */
+
+#pragma once
+
+#include <string>
+
+std::string lineno_string(const std::string& lineno);
+
+class include_history {
+public:
+	std::string& data() { return data_; }
+
+	std::string get_location():
+
+	static std::string get_filename(const std::string& file_code);
+	static std::string get_file_code(const std::string& filename);
+private:
+	std::string data_;
+};
+

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -423,7 +423,7 @@ config server::read_config() const
 	}
 
 	try {
-		filesystem::scoped_istream stream = preprocess_file(config_file_);
+		filesystem::scoped_istream stream = preprocess_file_absolute(config_file_);
 		read(configuration, *stream);
 		LOG_SERVER << "Server configuration from file: '" << config_file_ << "' read.\n";
 	} catch(const config::error& e) {

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -13,6 +13,7 @@
 */
 
 #include "sound.hpp"
+#include "binary_path.hpp"
 #include "config.hpp"
 #include "filesystem.hpp"
 #include "log.hpp"
@@ -925,7 +926,7 @@ static Mix_Chunk* load_chunk(const std::string& file, channel_group group)
 		}
 
 		temp_chunk.group = group;
-		const std::string& filename = filesystem::get_binary_file_location("sounds", file);
+		const std::string filename = filesystem::get_binary_file_location("sounds", file).get_abolute_path();
 		const std::string localized = filesystem::get_localized_path(filename);
 
 		if(!filename.empty()) {

--- a/src/sound_music_track.cpp
+++ b/src/sound_music_track.cpp
@@ -15,6 +15,7 @@
 
 #include "sound_music_track.hpp"
 
+#include "binary_path.hpp"
 #include "config.hpp"
 #include "filesystem.hpp"
 #include "log.hpp"
@@ -74,7 +75,7 @@ void music_track::resolve()
 		return;
 	}
 
-	file_path_ = filesystem::get_binary_file_location("music", id_);
+	file_path_ = filesystem::get_binary_file_location("music", id_).get_abolute_path();
 
 	if (file_path_.empty()) {
 		LOG_AUDIO << "could not find track '" << id_ << "' for track identification\n";

--- a/src/units/race.cpp
+++ b/src/units/race.cpp
@@ -19,6 +19,7 @@
 
 #include "units/race.hpp"
 
+#include "binary_path.hpp"
 #include "filesystem.hpp"
 #include "log.hpp"
 #include "serialization/string_utils.hpp"
@@ -156,7 +157,7 @@ std::string unit_race::get_icon_path_stem() const
 	std::string path = "icons/unit-groups/race_" + id_;
 
 	// FIXME: hardcoded '30' is bad...
-	if(!filesystem::file_exists(filesystem::get_binary_file_location("images", path + "_30.png"))) {
+	if(!filesystem::get_binary_file_location("images", path + "_30.png").exists()) {
 		path = "icons/unit-groups/race_custom";
 	}
 

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -346,7 +346,8 @@ static int handle_validate_command(const std::string& file, abstract_validator& 
 	}
 	std::cout << "Validating " << file << " against schema " << validator.name_ << std::endl;
 	lg::set_strict_severity(0);
-	filesystem::scoped_istream stream = preprocess_file(file, &defines_map);
+	//TODO: maybe also allow 'safe' paths here ?
+	filesystem::scoped_istream stream = preprocess_file_absolute(file, &defines_map);
 	config result;
 	read(result, *stream, &validator);
 	if(lg::broke_strict()) {

--- a/src/wml_path.cpp
+++ b/src/wml_path.cpp
@@ -1,0 +1,165 @@
+/*
+   Copyright (C) 2003 - 2012 by David White <dave@whitevine.net>
+   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+/**
+ * @file
+ * File-IO
+ */
+#define GETTEXT_DOMAIN "wesnoth-lib"
+
+#include "wml_path.hpp"
+#include "filesystem.hpp"
+
+#include "config.hpp"
+#include "deprecation.hpp"
+#include "game_config.hpp"
+#include "game_version.hpp"
+#include "gettext.hpp"
+#include "log.hpp"
+#include "serialization/unicode.hpp"
+#include "serialization/unicode_cast.hpp"
+
+#include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
+#include <boost/iostreams/device/file_descriptor.hpp>
+#include <boost/iostreams/stream.hpp>
+#include <boost/system/windows_error.hpp>
+
+
+namespace {
+	utils::string_view name_of_directory(const std::string& path)
+	{
+		size_t pos = path.rfind('/');
+		if(pos != std::string::npos) {
+			return utils::string_view(path).substr(0, pos);
+		}
+		else {
+			return utils::string_view();
+		}
+
+	}
+}
+namespace filesystem {
+
+
+wml_path::wml_path(utils::string_view base, utils::string_view path)
+	: base_(base.to_string())
+	, path_(path.to_string())
+{
+
+}
+
+wml_path wml_path::from_absolute(const std::string& path)
+{
+
+	std::string dir = filesystem::directory_name(path);
+	std::string base = "./" +  filesystem::base_name(path);
+
+	return wml_path(utils::string_view(dir), utils::string_view(base));
+}
+
+std::string wml_path::get_abolute_path() const
+{
+	return get_wml_location(path_, base_);
+}
+
+wml_path wml_path::get_relative_path(const std::string& path) const
+{
+	std::string path2 = path;
+	canonical_path(path2, name_of_directory(path_));
+
+	wml_path res = wml_path(utils::string_view(base_), utils::string_view());
+
+	res.path_ = std::move(path2);
+	return res;
+}
+
+wml_path wml_path::append(const std::string& path) const
+{
+	std::string path2 = "./" + path;
+	canonical_path(path2, path_);
+
+	wml_path res = wml_path(utils::string_view(base_), utils::string_view());
+
+	res.path_ = std::move(path2);
+	return res;
+}
+
+void wml_path::get_files_in_dir(std::vector<wml_path>* files, std::vector<wml_path>* dirs, bool) const
+{
+	std::vector<std::string> file_names;
+	std::vector<std::string> dir_names;
+	filesystem::get_files_in_dir(get_abolute_path(), files ? &file_names : nullptr , dirs ? &dir_names : nullptr, FILE_NAME_ONLY, NO_FILTER, DO_REORDER);
+	std::cerr << "get_files_in_dir:\n";
+	for(const auto& str: file_names) {
+		std::cerr << "    " << str << "\n";
+		files->push_back(append(str));
+	}
+	for(const auto& str: dir_names) {
+		dirs->push_back(append(str));
+	}
+}
+
+bool wml_path::exists() const
+{
+	return !get_abolute_path().empty();
+}
+
+bool wml_path::canonical_path(std::string& filename, utils::string_view currentdir)
+{
+	if(filename.size() < 2) {
+		return false;
+	}
+	if(filename[0] == '.' && filename[1] == '/') {
+		filename = currentdir.to_string() + filename.substr(1);
+	}
+	if(std::find(filename.begin(), filename.end(), '\\') != filename.end()) {
+		return false;
+	}
+	//resolve /./
+	while(true) {
+		std::size_t pos = filename.find("/./");
+		if(pos == std::string::npos) {
+			break;
+		}
+		filename = filename.replace(pos, 2, "");
+	}
+	//resolve //
+	while(true) {
+		std::size_t pos = filename.find("//");
+		if(pos == std::string::npos) {
+			break;
+		}
+		filename = filename.replace(pos, 1, "");
+	}
+	//resolve /../
+	while(true) {
+		std::size_t pos = filename.find("/..");
+		if(pos == std::string::npos) {
+			break;
+		}
+		std::size_t pos2 = filename.find_last_of('/', pos - 1);
+		if(pos2 == std::string::npos || pos2 >= pos) {
+			return false;
+		}
+		filename = filename.replace(pos2, pos- pos2 + 3, "");
+	}
+	if(filename.find("..") != std::string::npos) {
+		return false;
+	}
+	return true;
+}
+
+}

--- a/src/wml_path.cpp
+++ b/src/wml_path.cpp
@@ -1,6 +1,5 @@
 /*
-   Copyright (C) 2003 - 2012 by David White <dave@whitevine.net>
-   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+   Copyright (C) 2020 by the Battle for Wesnoth Project https://www.wesnoth.org/
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -12,30 +11,13 @@
    See the COPYING file for more details.
 */
 
-/**
- * @file
- * File-IO
- */
 #define GETTEXT_DOMAIN "wesnoth-lib"
 
 #include "wml_path.hpp"
 #include "filesystem.hpp"
 
 #include "config.hpp"
-#include "deprecation.hpp"
-#include "game_config.hpp"
-#include "game_version.hpp"
-#include "gettext.hpp"
 #include "log.hpp"
-#include "serialization/unicode.hpp"
-#include "serialization/unicode_cast.hpp"
-
-#include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
-#include <boost/iostreams/device/file_descriptor.hpp>
-#include <boost/iostreams/stream.hpp>
-#include <boost/system/windows_error.hpp>
 
 
 namespace {
@@ -67,6 +49,7 @@ wml_path wml_path::from_absolute(const std::string& path)
 	std::string dir = filesystem::directory_name(path);
 	std::string base = "./" +  filesystem::base_name(path);
 
+	std::cerr << "wml_path::from_absolute: " << path << " to " << dir << " and " << base << "\n";
 	return wml_path(utils::string_view(dir), utils::string_view(base));
 }
 
@@ -104,7 +87,9 @@ void wml_path::get_files_in_dir(std::vector<wml_path>* files, std::vector<wml_pa
 	filesystem::get_files_in_dir(get_abolute_path(), files ? &file_names : nullptr , dirs ? &dir_names : nullptr, FILE_NAME_ONLY, NO_FILTER, DO_REORDER);
 	std::cerr << "get_files_in_dir:\n";
 	for(const auto& str: file_names) {
-		std::cerr << "    " << str << "\n";
+		if(str == "_main.cfg") {
+			std::cerr << "    " << str << " " << get_abolute_path() << "\n";
+		}
 		files->push_back(append(str));
 	}
 	for(const auto& str: dir_names) {

--- a/src/wml_path.cpp
+++ b/src/wml_path.cpp
@@ -33,6 +33,8 @@ namespace {
 
 	}
 }
+
+
 namespace filesystem {
 
 

--- a/src/wml_path.hpp
+++ b/src/wml_path.hpp
@@ -1,0 +1,69 @@
+/*
+   Copyright (C) 2003 - 2018 by David White <dave@whitevine.net>
+   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+/**
+ * @file
+ * Declarations for File-IO.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <ctime>
+#include <functional>
+#include <iosfwd>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "exceptions.hpp"
+#include "serialization/string_utils.hpp"
+
+namespace filesystem {
+
+class wml_path {
+public:
+
+	wml_path()
+		: base_()
+		, path_()
+	{
+
+	}
+
+	explicit wml_path(const std::string& path)
+		: base_()
+		, path_(path)
+	{}
+	/// "unsafe" constructor
+	static wml_path from_absolute(const std::string& path);
+	/// helper function, also used by lua
+	static bool canonical_path(std::string& filename, utils::string_view currentdir);
+	/// returns an abolute path to open the file.
+	std::string get_abolute_path() const;
+	///
+	/// 
+	wml_path get_relative_path(const std::string& path) const;
+	wml_path append(const std::string& path) const;
+	void get_files_in_dir(std::vector<wml_path>* files, std::vector<wml_path>* dirs, bool do_reroder = true)  const;
+	const std::string& safe_path() const { return path_; }
+	///
+	bool exists() const;
+private:
+	wml_path(utils::string_view base, utils::string_view path);
+	std::string base_;
+	std::string path_;
+};
+}
+using wml_path = filesystem::wml_path;

--- a/src/wml_path.hpp
+++ b/src/wml_path.hpp
@@ -1,6 +1,5 @@
 /*
-   Copyright (C) 2003 - 2018 by David White <dave@whitevine.net>
-   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+   Copyright (C) 2020 by the Battle for Wesnoth Project https://www.wesnoth.org/
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -11,11 +10,6 @@
 
    See the COPYING file for more details.
 */
-
-/**
- * @file
- * Declarations for File-IO.
- */
 
 #pragma once
 
@@ -32,6 +26,9 @@
 
 namespace filesystem {
 
+/// This class descriobes a path in the fie system, its split in one 'base' part and one 'safe' part
+/// the safe part can be moves upwards the base part not. The 'base' part is irrelevent if the 'safe'
+/// part does not start with './'.
 class wml_path {
 public:
 
@@ -42,24 +39,47 @@ public:
 
 	}
 
+	/// default constructor, takes a wml path like for exmaple '~add-ons/test/_main.cfg'
 	explicit wml_path(const std::string& path)
 		: base_()
 		, path_(path)
 	{}
 	/// "unsafe" constructor
 	static wml_path from_absolute(const std::string& path);
-	/// helper function, also used by lua
+	/// helper function, also used by lua, brings @a filename to a canonical form, uses @a currentdir only if
+	/// @a filename starts with './'.
 	static bool canonical_path(std::string& filename, utils::string_view currentdir);
 	/// returns an abolute path to open the file.
 	std::string get_abolute_path() const;
-	///
-	/// 
 	wml_path get_relative_path(const std::string& path) const;
 	wml_path append(const std::string& path) const;
 	void get_files_in_dir(std::vector<wml_path>* files, std::vector<wml_path>* dirs, bool do_reroder = true)  const;
 	const std::string& safe_path() const { return path_; }
 	///
 	bool exists() const;
+	///
+	bool empty() const
+	{
+		return base_.empty() && path_.empty();
+	}
+
+	int compare(const wml_path& other) const
+	{
+		int res = 0;
+		if(!res) { res = base_.compare(other.base_); }
+		if(!res) { res = path_.compare(other.path_); }
+		return res;
+	}
+
+	friend bool operator<(const wml_path& a, const wml_path& b)
+	{
+		return a.compare(b) < 0;
+	}
+
+	bool has_abolute_part() const {
+		return !base_.empty();
+	}
+
 private:
 	wml_path(utils::string_view base, utils::string_view path);
 	std::string base_;


### PR DESCRIPTION
to do that the Preprocessor code was refactored to use the new "wml_path" class which basically splits the path into two parts of which the second might be traversed upwards but the first part not, security is guaranteed exactly the same way as before since we still call the same get_wml_location function.

This in particular allows s me  to make  the WC2 code easier by since i can hopefully do something like `#ifhave  ./../../campaigns to check whether the code  is currently inside the mainline directory or not. ` 