### PR TITLE
Add missing includes of units/types.hpp to the unit tests

### DIFF
--- a/src/tests/test_recall_list.cpp
+++ b/src/tests/test_recall_list.cpp
@@ -17,8 +17,9 @@
 #include "config.hpp"
 #include "recall_list_manager.hpp"
 #include "tests/utils/game_config_manager_tests.hpp"
-#include "units/unit.hpp"
 #include "units/ptr.hpp"
+#include "units/types.hpp"
+#include "units/unit.hpp"
 
 BOOST_AUTO_TEST_SUITE( recall_list_suite )
 

--- a/src/tests/test_unit_map.cpp
+++ b/src/tests/test_unit_map.cpp
@@ -16,12 +16,13 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include "log.hpp"
 #include "config.hpp"
-#include "units/unit.hpp"
+#include "log.hpp"
 #include "tests/utils/game_config_manager_tests.hpp"
-#include "units/map.hpp"
 #include "units/id.hpp"
+#include "units/map.hpp"
+#include "units/types.hpp"
+#include "units/unit.hpp"
 
 #include "utils/functional.hpp"
 


### PR DESCRIPTION
Some indirect inclusion paths were removed in 194b903918db4405862028ed4ab2eb2ae6fc91c2.

Creating a PR to check that this builds everywhere.