### PR TITLE
WIP only load active add-ons fixes #4832

### DIFF
--- a/source_lists/libwesnoth_core
+++ b/source_lists/libwesnoth_core
@@ -7,6 +7,7 @@ filesystem.cpp
 filesystem_common.cpp
 font/constants.cpp
 game_config.cpp
+game_config_view.cpp
 gettext.cpp
 hash.cpp
 log.cpp

--- a/src/about.cpp
+++ b/src/about.cpp
@@ -17,6 +17,7 @@
 #include "config.hpp"
 #include "gettext.hpp"
 #include "serialization/string_utils.hpp"
+#include "game_config_view.hpp"
 
 #include <map>
 
@@ -103,7 +104,7 @@ std::vector<std::string> get_background_images(const std::string& campaign)
 	return images_general;
 }
 
-void set_about(const config& cfg)
+void set_about(const game_config_view& cfg)
 {
 	parsed_credits_data.clear();
 

--- a/src/about.hpp
+++ b/src/about.hpp
@@ -20,6 +20,7 @@
 #include <string>
 
 class config;
+class game_config_view;
 
 namespace about
 {
@@ -62,6 +63,6 @@ std::vector<std::string> get_background_images(const std::string& campaign);
 /**
  * Regenerates the credits config
  */
-void set_about(const config& cfg);
+void set_about(const game_config_view& cfg);
 
 }

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -167,7 +167,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit& u,
 		plague_type = (*plague_specials.front().ability_cfg)["type"].str();
 
 		if(plague_type.empty()) {
-			plague_type = u.type().base_id();
+			plague_type = u.type().parent_id();
 		}
 	}
 
@@ -316,7 +316,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 	if(plagues) {
 		plague_type = (*plague_specials.front().ability_cfg)["type"].str();
 		if(plague_type.empty()) {
-			plague_type = u_type->base_id();
+			plague_type = u_type->parent_id();
 		}
 	}
 

--- a/src/actions/undo_recruit_action.cpp
+++ b/src/actions/undo_recruit_action.cpp
@@ -60,7 +60,7 @@ void recruit_action::write(config & cfg) const
 
 	recruit_from.write(cfg.add_child("leader"));
 	config & child = cfg.child("unit");
-	child["type"] = u_type.base_id();
+	child["type"] = u_type.parent_id();
 }
 
 /**

--- a/src/ai/configuration.cpp
+++ b/src/ai/configuration.cpp
@@ -24,7 +24,7 @@
 #include "log.hpp"
 #include "serialization/parser.hpp"
 #include "serialization/preprocessor.hpp"
-
+#include "game_config_view.hpp"
 #include <vector>
 #include <deque>
 #include <set>
@@ -37,7 +37,7 @@ static lg::log_domain log_ai_configuration("ai/config");
 #define WRN_AI_CONFIGURATION LOG_STREAM(warn, log_ai_configuration)
 #define ERR_AI_CONFIGURATION LOG_STREAM(err, log_ai_configuration)
 
-void configuration::init(const config &game_config)
+void configuration::init(const game_config_view &game_config)
 {
 	ai_configurations_.clear();
 	era_ai_configurations_.clear();

--- a/src/ai/configuration.hpp
+++ b/src/ai/configuration.hpp
@@ -21,6 +21,7 @@
 
 #include "config.hpp"
 #include "ai/game_info.hpp"
+#include "game_config_view.hpp"
 
 namespace ai {
 
@@ -64,7 +65,7 @@ public:
 	 * Init the parameters of ai configuration parser
 	 * @param game_config game config
 	 */
-	static void init(const config &game_config);
+	static void init(const game_config_view &game_config);
 	static void add_era_ai_from_config(const config &game_config);
 	static void add_mod_ai_from_config(config::const_child_itors configs);
 

--- a/src/controller_base.cpp
+++ b/src/controller_base.cpp
@@ -453,7 +453,7 @@ bool controller_base::in_context_menu(hotkey::HOTKEY_COMMAND /*command*/) const
 	return true;
 }
 
-const config& controller_base::get_theme(const config& game_config, std::string theme_name)
+const config& controller_base::get_theme(const game_config_view& game_config, std::string theme_name)
 {
 	if(theme_name.empty()) {
 		theme_name = preferences::theme();

--- a/src/controller_base.hpp
+++ b/src/controller_base.hpp
@@ -41,6 +41,7 @@
 #include "quit_confirmation.hpp"
 #include "video.hpp"
 
+class game_config_view;
 class display;
 class plugins_context;
 
@@ -67,7 +68,7 @@ public:
 
 	virtual void play_slice(bool is_delay_enabled = true);
 
-	static const config& get_theme(const config& game_config, std::string theme_name);
+	static const config& get_theme(const game_config_view& game_config, std::string theme_name);
 
 	void apply_keyboard_scroll(int x, int y);
 
@@ -180,7 +181,7 @@ protected:
 
 	void long_touch_callback(int x, int y);
 
-	const config& game_config_;
+	const game_config_view& game_config_;
 
 	CKey key_;
 

--- a/src/editor/controller/editor_controller.cpp
+++ b/src/editor/controller/editor_controller.cpp
@@ -50,7 +50,7 @@
 #include "sound.hpp"
 #include "units/unit.hpp"
 #include "units/animation_component.hpp"
-
+#include "game_config_manager.hpp"
 #include "quit_confirmation.hpp"
 
 #include "utils/functional.hpp"
@@ -109,7 +109,7 @@ void editor_controller::init_gui()
 //	without deleting it.
 }
 
-void editor_controller::init_tods(const config& game_config)
+void editor_controller::init_tods(const game_config_view& game_config)
 {
 	for (const config &schedule : game_config.child_range("editor_times")) {
 
@@ -142,11 +142,12 @@ void editor_controller::init_tods(const config& game_config)
 	}
 }
 
-void editor_controller::init_music(const config& game_config)
+void editor_controller::init_music(const game_config_view& game_config)
 {
 	const std::string tag_name = "editor_music";
-	if (!game_config.has_child(tag_name))
+	if (game_config.child_range(tag_name).size() == 0) {
 		ERR_ED << "No editor music defined" << std::endl;
+	}
 	else {
 		for (const config& editor_music : game_config.child_range(tag_name)) {
 			for (const config& music : editor_music.child_range("music")) {

--- a/src/editor/controller/editor_controller.hpp
+++ b/src/editor/controller/editor_controller.hpp
@@ -205,10 +205,10 @@ class editor_controller : public controller_base,
 		void init_gui();
 
 		/** init the available time-of-day settings */
-		void init_tods(const config& game_config);
+		void init_tods(const game_config_view& game_config);
 
 		/** init background music for the editor */
-		void init_music(const config& game_config);
+		void init_music(const game_config_view& game_config);
 
 		/** Load editor-specific tooltips */
 		void load_tooltips();

--- a/src/editor/map/context_manager.cpp
+++ b/src/editor/map/context_manager.cpp
@@ -41,6 +41,7 @@
 
 #include "gui/dialogs/editor/edit_scenario.hpp"
 #include "gui/dialogs/editor/edit_side.hpp"
+#include "game_config_view.hpp"
 
 #include "terrain/translation.hpp"
 
@@ -63,7 +64,7 @@ static const std::string get_menu_marker(const bool changed)
 	return ss.str();
 }
 
-context_manager::context_manager(editor_display& gui, const config& game_config)
+context_manager::context_manager(editor_display& gui, const game_config_view& game_config)
 	: locs_(nullptr)
 	, gui_(gui)
 	, game_config_(game_config)
@@ -672,7 +673,7 @@ void context_manager::save_scenario_as_dialog()
 	save_scenario_as(dlg.path());
 }
 
-void context_manager::init_map_generators(const config& game_config)
+void context_manager::init_map_generators(const game_config_view& game_config)
 {
 	for(const config& i : game_config.child_range("multiplayer")) {
 		if(i["map_generation"].empty() && i["scenario_generation"].empty()) {

--- a/src/editor/map/context_manager.hpp
+++ b/src/editor/map/context_manager.hpp
@@ -20,6 +20,7 @@
 #include "preferences/editor.hpp"
 
 class map_generator;
+class game_config_view;
 
 namespace editor
 {
@@ -29,7 +30,7 @@ class context_manager : public filter_context
 public:
 	using context_ptr = std::unique_ptr<map_context>;
 
-	context_manager(editor_display& gui, const config& game_config);
+	context_manager(editor_display& gui, const game_config_view& game_config);
 	~context_manager();
 
 	bool is_active_transitions_hotkey(const std::string& item);
@@ -195,7 +196,7 @@ public:
 	class location_palette* locs_;
 private:
 	/** init available random map generators */
-	void init_map_generators(const config& game_config);
+	void init_map_generators(const game_config_view& game_config);
 
 	/**
 	 * Shows an are-you-sure dialog if the map was modified.
@@ -312,7 +313,7 @@ public:
 private:
 	editor_display& gui_;
 
-	const config& game_config_;
+	const game_config_view& game_config_;
 
 	/** Default directory for map load/save as dialogs */
 	std::string default_dir_;

--- a/src/editor/map/editor_map.cpp
+++ b/src/editor/map/editor_map.cpp
@@ -39,20 +39,20 @@ editor_map_load_exception wrap_exc(const char* type, const std::string& e_msg, c
 	return editor_map_load_exception(filename, msg);
 }
 
-editor_map::editor_map(const config& terrain_cfg)
+editor_map::editor_map(const game_config_view& terrain_cfg)
 	: gamemap(std::make_shared<terrain_type_data>(terrain_cfg), "")
 	, selection_()
 {
 }
 
-editor_map::editor_map(const config& terrain_cfg, const std::string& data)
+editor_map::editor_map(const game_config_view& terrain_cfg, const std::string& data)
 	: gamemap(std::make_shared<terrain_type_data>(terrain_cfg), data)
 	, selection_()
 {
 	sanity_check();
 }
 
-editor_map editor_map::from_string(const config& terrain_cfg, const std::string& data)
+editor_map editor_map::from_string(const game_config_view&  terrain_cfg, const std::string& data)
 {
 	try {
 		return editor_map(terrain_cfg, data);
@@ -65,7 +65,7 @@ editor_map editor_map::from_string(const config& terrain_cfg, const std::string&
 	}
 }
 
-editor_map::editor_map(const config& terrain_cfg, std::size_t width, std::size_t height, const t_translation::terrain_code & filler)
+editor_map::editor_map(const game_config_view& terrain_cfg, std::size_t width, std::size_t height, const t_translation::terrain_code & filler)
 	: gamemap(std::make_shared<terrain_type_data>(terrain_cfg), t_translation::write_game_map(t_translation::ter_map(width + 2, height + 2, filler)))
 	, selection_()
 {

--- a/src/editor/map/editor_map.hpp
+++ b/src/editor/map/editor_map.hpp
@@ -73,23 +73,23 @@ public:
 	/**
 	 * Empty map constructor
 	 */
-	explicit editor_map(const config& terrain_cfg);
+	explicit editor_map(const game_config_view& terrain_cfg);
 
 	/**
 	 * Create an editor map from a map data string
 	 */
-	editor_map(const config& terrain_cfg, const std::string& data);
+	editor_map(const game_config_view& terrain_cfg, const std::string& data);
 
 	/**
 	 * Wrapper around editor_map(cfg, data) that catches possible exceptions
 	 * and wraps them in a editor_map_load_exception
 	 */
-	static editor_map from_string(const config& terrain_cfg, const std::string& data);
+	static editor_map from_string(const game_config_view& terrain_cfg, const std::string& data);
 
 	/**
 	 * Create an editor map with the given dimensions and filler terrain
 	 */
-	editor_map(const config& terrain_cfg, std::size_t width, std::size_t height, const t_translation::terrain_code & filler);
+	editor_map(const game_config_view& terrain_cfg, std::size_t width, std::size_t height, const t_translation::terrain_code & filler);
 
 	/**
 	 * Create an editor_map by upgrading an existing gamemap. The map data is

--- a/src/editor/map/map_context.cpp
+++ b/src/editor/map/map_context.cpp
@@ -29,6 +29,7 @@
 #include "team.hpp"
 #include "terrain/type_data.hpp"
 #include "units/unit.hpp"
+#include "game_config_view.hpp"
 
 #include <boost/regex.hpp>
 
@@ -85,7 +86,7 @@ map_context::map_context(const editor_map& map, bool pure_map, const config& sch
 {
 }
 
-map_context::map_context(const config& game_config, const std::string& filename)
+map_context::map_context(const game_config_view& game_config, const std::string& filename)
 	: filename_(filename)
 	, map_data_key_()
 	, embedded_(false)
@@ -312,7 +313,7 @@ void map_context::replace_local_schedule(const std::vector<time_of_day>& schedul
 	}
 }
 
-void map_context::load_scenario(const config& game_config)
+void map_context::load_scenario(const game_config_view& game_config)
 {
 	config scenario;
 

--- a/src/editor/map/map_context.hpp
+++ b/src/editor/map/map_context.hpp
@@ -26,6 +26,7 @@
 #include "display_context.hpp"
 
 #include <vector>
+class game_config_view;
 
 namespace editor {
 
@@ -75,7 +76,7 @@ public:
 	 * inside scenarios do not change the filename, but set the "embedded" flag
 	 * instead.
 	 */
-	map_context(const config& game_config, const std::string& filename);
+	map_context(const game_config_view& game_config, const std::string& filename);
 
 	/**
 	 * Map context destructor
@@ -335,7 +336,7 @@ public:
 	bool save_scenario();
 
 
-	void load_scenario(const config& game_config);
+	void load_scenario(const game_config_view& game_config);
 
 	config to_config();
 

--- a/src/editor/palette/editor_palettes.hpp
+++ b/src/editor/palette/editor_palettes.hpp
@@ -27,7 +27,7 @@ class editor_palette : public tristate_palette {
 
 public:
 
-	editor_palette(editor_display &gui, const config& /*cfg*/
+	editor_palette(editor_display &gui, const game_config_view& /*cfg*/
 	             , std::size_t item_size, std::size_t item_width, editor_toolkit &toolkit)
 		: tristate_palette(gui.video())
 		, groups_()
@@ -110,7 +110,7 @@ private:
 	virtual const std::string& get_id(const Item& item) = 0;
 
 	/** Setup the internal data structure. */
-	virtual void setup(const config& cfg) = 0;
+	virtual void setup(const game_config_view& cfg) = 0;
 
 	virtual const std::string& active_group_id() {return active_group_;}
 

--- a/src/editor/palette/item_palette.cpp
+++ b/src/editor/palette/item_palette.cpp
@@ -20,6 +20,7 @@
 
 #include "editor/palette/item_palette.hpp"
 #include "gettext.hpp"
+#include "game_config_view.hpp"
 
 #include <string>
 
@@ -30,7 +31,7 @@ std::string item_palette::get_help_string()
 	return selected_fg_item().name;
 }
 
-void item_palette::setup(const config& cfg)
+void item_palette::setup(const game_config_view& cfg)
 {
 	for(const config& group : cfg.child_range("item_group")) {
 		groups_.emplace_back(group);
@@ -81,7 +82,7 @@ void item_palette::draw_item(const overlay& item, surface& image, std::stringstr
 	tooltip_text << item.name;
 }
 
-item_palette::item_palette(editor_display &gui, const config& cfg,
+item_palette::item_palette(editor_display &gui, const game_config_view& cfg,
                            editor_toolkit &toolkit)
 //TODO avoid magic numbers
 	:	editor_palette<overlay>(gui, cfg, 36, 4, toolkit)

--- a/src/editor/palette/item_palette.hpp
+++ b/src/editor/palette/item_palette.hpp
@@ -20,6 +20,7 @@
 
 #include "editor/palette/editor_palettes.hpp"
 #include "overlay.hpp"
+class game_config_view;
 
 namespace editor {
 
@@ -32,10 +33,10 @@ class item_palette : public editor_palette<overlay> {
 public:
 
 	item_palette(editor_display &gui,
-	             const config& cfg,
+	             const game_config_view& cfg,
 	             editor_toolkit &toolkit);
 
-	virtual void setup(const config& cfg);
+	virtual void setup(const game_config_view& cfg);
 
 	virtual std::string get_help_string();
 

--- a/src/editor/palette/location_palette.cpp
+++ b/src/editor/palette/location_palette.cpp
@@ -158,7 +158,7 @@ protected:
 
 };
 namespace editor {
-location_palette::location_palette(editor_display &gui, const config& /*cfg*/,
+location_palette::location_palette(editor_display &gui, const game_config_view& /*cfg*/,
                                    editor_toolkit &toolkit)
 		: common_palette(gui.video())
 		, item_size_(20)

--- a/src/editor/palette/location_palette.hpp
+++ b/src/editor/palette/location_palette.hpp
@@ -22,7 +22,7 @@
 
 class location_palette_item;
 class location_palette_button;
-
+class game_config_view;
 namespace editor {
 
 class editor_toolkit;
@@ -31,7 +31,7 @@ class location_palette : public common_palette {
 
 public:
 
-	location_palette(editor_display &gui, const config& /*cfg*/,
+	location_palette(editor_display &gui, const game_config_view& /*cfg*/,
 	                 editor_toolkit &toolkit);
 
 

--- a/src/editor/palette/palette_manager.cpp
+++ b/src/editor/palette/palette_manager.cpp
@@ -22,7 +22,7 @@
 
 namespace editor {
 
-palette_manager::palette_manager(editor_display& gui, const config& cfg
+palette_manager::palette_manager(editor_display& gui, const game_config_view& cfg
                                , editor_toolkit& toolkit)
 		: gui::widget(gui.video()),
 		  gui_(gui),

--- a/src/editor/palette/palette_manager.hpp
+++ b/src/editor/palette/palette_manager.hpp
@@ -35,7 +35,7 @@ class palette_manager : public gui::widget {
 
 public:
 
-	palette_manager(editor_display &gui, const config& cfg
+	palette_manager(editor_display &gui, const game_config_view& cfg
 	              , editor_toolkit &toolkit);
 
 	void set_group(std::size_t index);

--- a/src/editor/palette/terrain_palettes.cpp
+++ b/src/editor/palette/terrain_palettes.cpp
@@ -22,6 +22,7 @@
 
 #include "gettext.hpp"
 #include "serialization/string_utils.hpp"
+#include "game_config_view.hpp"
 
 namespace {
 	static t_translation::terrain_code fg_terrain;
@@ -67,7 +68,7 @@ void terrain_palette::select_fg_item(const t_translation::terrain_code& terrain)
 }
 
 
-void terrain_palette::setup(const config& cfg)
+void terrain_palette::setup(const game_config_view& cfg)
 {
 	// Get the available terrains temporary in items
 	t_translation::ter_list items = map().get_terrain_list();
@@ -212,7 +213,7 @@ void terrain_palette::draw_item(const t_translation::terrain_code& terrain,
 	}
 }
 
-terrain_palette::terrain_palette(editor_display &gui, const config& cfg, editor_toolkit &toolkit)
+terrain_palette::terrain_palette(editor_display &gui, const game_config_view& cfg, editor_toolkit &toolkit)
 //TODO avoid magic numbers
 	:	editor_palette<t_translation::terrain_code>(gui, cfg, 36, 4, toolkit)
 {

--- a/src/editor/palette/terrain_palettes.hpp
+++ b/src/editor/palette/terrain_palettes.hpp
@@ -33,12 +33,12 @@ class terrain_palette : public editor_palette<t_translation::terrain_code> {
 
 public:
 
-	terrain_palette(editor_display &gui, const config& cfg,
+	terrain_palette(editor_display &gui, const game_config_view& cfg,
 	                editor_toolkit &toolkit);
 
 	const gamemap& map() const { return gui_.get_map(); }
 
-	virtual void setup(const config& cfg);
+	virtual void setup(const game_config_view& cfg);
 
 	void select_bg_item(const t_translation::terrain_code& terrain);
 	void select_fg_item(const t_translation::terrain_code& terrain);

--- a/src/editor/palette/unit_palette.cpp
+++ b/src/editor/palette/unit_palette.cpp
@@ -31,7 +31,7 @@ std::string unit_palette::get_help_string() {
 	return selected_fg_item().type_name();
 }
 
-void unit_palette::setup(const config& /*cfg*/)
+void unit_palette::setup(const game_config_view& /*cfg*/)
 {
 	for(const unit_type_data::unit_type_map::value_type &i : unit_types.types()) {
 		if(i.second.do_not_list())
@@ -94,7 +94,7 @@ void unit_palette::draw_item(const unit_type& u, surface& image, std::stringstre
 	tooltip_text << u.type_name();
 }
 
-unit_palette::unit_palette(editor_display &gui, const config& cfg,
+unit_palette::unit_palette(editor_display &gui, const game_config_view& cfg,
                            editor_toolkit &toolkit)
 //TODO avoid magic numbers
 	: editor_palette<const unit_type&>(gui, cfg, 36, 4, toolkit)

--- a/src/editor/palette/unit_palette.hpp
+++ b/src/editor/palette/unit_palette.hpp
@@ -33,10 +33,10 @@ class unit_palette : public editor_palette<const unit_type&> {
 public:
 
 	unit_palette(editor_display &gui,
-	             const config& cfg,
+	             const game_config_view& cfg,
 	             editor_toolkit &toolkit);
 
-	virtual void setup(const config& cfg);
+	virtual void setup(const game_config_view& cfg);
 
 	virtual std::string get_help_string();
 

--- a/src/editor/toolkit/editor_toolkit.cpp
+++ b/src/editor/toolkit/editor_toolkit.cpp
@@ -22,10 +22,12 @@
 #include "editor/action/mouse/mouse_action_item.hpp"
 #include "editor/action/mouse/mouse_action_select.hpp"
 
+#include "game_config_view.hpp"
+
 namespace editor {
 
 editor_toolkit::editor_toolkit(editor_display& gui, const CKey& key,
-		const config& game_config, context_manager& c_manager)
+		const game_config_view& game_config, context_manager& c_manager)
 	: gui_(gui)
 	, key_(key)
 	, palette_manager_()
@@ -41,7 +43,7 @@ editor_toolkit::editor_toolkit(editor_display& gui, const CKey& key,
 
 editor_toolkit::~editor_toolkit() = default;
 
-void editor_toolkit::init_brushes(const config& game_config)
+void editor_toolkit::init_brushes(const game_config_view& game_config)
 {
 	for (const config &i : game_config.child_range("brush")) {
 		brushes_.emplace_back(i);
@@ -54,7 +56,7 @@ void editor_toolkit::init_brushes(const config& game_config)
 	brush_ = &brushes_[0];
 }
 
-void editor_toolkit::init_sidebar(const config& game_config)
+void editor_toolkit::init_sidebar(const game_config_view& game_config)
 {
 	palette_manager_.reset(new palette_manager(gui_, game_config, *this));
 }

--- a/src/editor/toolkit/editor_toolkit.hpp
+++ b/src/editor/toolkit/editor_toolkit.hpp
@@ -20,7 +20,7 @@
 #include "hotkey/hotkey_command.hpp"
 
 class config;
-
+class game_config_view;
 namespace editor {
 
 
@@ -28,7 +28,7 @@ class editor_toolkit {
 
 public:
 	editor_toolkit(editor_display& gui, const CKey& key,
-			const config& game_config, context_manager& c_manager);
+			const game_config_view& game_config, context_manager& c_manager);
 
 	~editor_toolkit();
 
@@ -38,10 +38,10 @@ public:
 
 private:
 	/** init the sidebar objects */
-	void init_sidebar(const config& game_config);
+	void init_sidebar(const game_config_view& game_config);
 
 	/** init the brushes */
-	void init_brushes(const config& game_config);
+	void init_brushes(const game_config_view& game_config);
 
 	/** init the mouse actions (tools) */
 	void init_mouse_actions(context_manager& c_manager);

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -35,6 +35,7 @@
 #include <boost/iostreams/device/file_descriptor.hpp>
 #include <boost/iostreams/stream.hpp>
 #include <boost/system/windows_error.hpp>
+#include "game_config_view.hpp"
 
 #ifdef _WIN32
 #include "log_windows.hpp"
@@ -1287,7 +1288,7 @@ binary_paths_manager::binary_paths_manager()
 {
 }
 
-binary_paths_manager::binary_paths_manager(const config& cfg)
+binary_paths_manager::binary_paths_manager(const game_config_view& cfg)
 	: paths_()
 {
 	set_paths(cfg);
@@ -1298,7 +1299,7 @@ binary_paths_manager::~binary_paths_manager()
 	cleanup();
 }
 
-void binary_paths_manager::set_paths(const config& cfg)
+void binary_paths_manager::set_paths(const game_config_view& cfg)
 {
 	cleanup();
 	init_binary_paths();

--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -31,7 +31,7 @@
 #include "serialization/string_utils.hpp"
 
 class config;
-
+class game_config_view;
 struct SDL_RWops;
 
 namespace filesystem {
@@ -384,10 +384,10 @@ char path_separator();
 struct binary_paths_manager
 {
 	binary_paths_manager();
-	binary_paths_manager(const config& cfg);
+	binary_paths_manager(const game_config_view& cfg);
 	~binary_paths_manager();
 
-	void set_paths(const config& cfg);
+	void set_paths(const game_config_view& cfg);
 
 private:
 	binary_paths_manager(const binary_paths_manager& o);

--- a/src/game_classification.cpp
+++ b/src/game_classification.cpp
@@ -38,6 +38,8 @@ game_classification::game_classification(const config& cfg)
 	, scenario_define(cfg["scenario_define"])
 	, era_define(cfg["era_define"])
 	, mod_defines(utils::split(cfg["mod_defines"]))
+	, active_mods(utils::split(cfg["active_mods"]))
+	, era_id(cfg["era_id"])
 	, campaign(cfg["campaign"])
 	, campaign_name(cfg["campaign_name"])
 	, abbrev(cfg["abbrev"])
@@ -61,6 +63,8 @@ config game_classification::to_config() const
 	cfg["scenario_define"] = scenario_define;
 	cfg["era_define"] = era_define;
 	cfg["mod_defines"] = utils::join(mod_defines);
+	cfg["active_mods"] = utils::join(active_mods);
+	cfg["era_id"] = era_id;
 	cfg["campaign"] = campaign;
 	cfg["campaign_name"] = campaign_name;
 	cfg["abbrev"] = abbrev;

--- a/src/game_classification.hpp
+++ b/src/game_classification.hpp
@@ -49,6 +49,9 @@ public:
 	std::string era_define;                          /**< If there is a define the era uses to customize data */
 	std::vector<std::string> mod_defines;            /**< If there are defines the modifications use to customize data */
 
+	std::vector<std::string> active_mods;
+	std::string era_id;
+
 	std::string campaign;                            /**< The id of the campaign being played */
 	std::string campaign_name;                       /**< The name of the campaign being played. */
 

--- a/src/game_classification.hpp
+++ b/src/game_classification.hpp
@@ -17,6 +17,7 @@
 #include "utils/make_enum.hpp"
 
 #include <vector>
+#include <set>
 
 class config;
 
@@ -33,6 +34,7 @@ public:
 	config to_config() const;
 	std::string get_tagname() const;
 	bool is_normal_mp_game() const;
+	std::set<std::string> active_addons(const std::string& scenario_id) const;
 
 	std::string label;                               /**< Name of the game (e.g. name of save file). */
 	std::string version;                             /**< Version game was created with. */

--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -274,34 +274,12 @@ void game_config_manager::load_game_config(FORCE_RELOAD_CONFIG force_reload,
 
 		main_transaction.lock();
 
-		// Put the gfx rules aside so that we can prepend the add-on
-		// rules to them.
-		config core_terrain_rules;
-		core_terrain_rules.splice_children(game_config_, "terrain_graphics");
-
 		if (!game_config::no_addons && !cmdline_opts_.noaddons)
 			load_addons_cfg();
 
-		// If multiplayer campaign is being loaded, [scenario] tags should
-		// become [multiplayer] tags and campaign's id should be added to them
-		// to allow to recognize which scenarios belongs to a loaded campaign.
-		if (classification != nullptr) {
-			if (const config& campaign = game_config().find_child("campaign", "id", classification->campaign))
-			{
-				const bool require_campaign = campaign["require_campaign"].to_bool(true);
-				for (config& scenario : game_config_.child_range("scenario"))
-				{
-					scenario["require_scenario"] = require_campaign;
-				}
-			}
-		}
 
 		// Extract the Lua scripts at toplevel.
 		game_lua_kernel::extract_preload_scripts(game_config());
-		game_config_.clear_children("lua");
-
-		// Put the gfx rules back to game config.
-		game_config_.splice_children(core_terrain_rules, "terrain_graphics");
 
 		set_multiplayer_hashes();
 		set_unit_data();

--- a/src/game_config_manager.hpp
+++ b/src/game_config_manager.hpp
@@ -14,17 +14,19 @@
 
 #pragma once
 
+#include <boost/optional.hpp>
+
 #include "commandline_options.hpp"
 #include "config_cache.hpp"
 #include "filesystem.hpp"
 #include "terrain/type_data.hpp"
+#include "config.hpp"
 #include "game_config_view.hpp"
 
-class config;
 class game_classification;
-
 class game_config_manager
 {
+	friend class game_config_view;
 public:
 	game_config_manager(const commandline_options& cmdline_opts, const bool jump_to_editor);
 	~game_config_manager();
@@ -46,20 +48,22 @@ public:
 	void reload_changed_game_config();
 
 	void load_game_config_for_editor();
-	void load_game_config_for_game(const game_classification& classification);
+	void load_game_config_for_game(const game_classification& classification, const std::string& scenario_id);
 	void load_game_config_for_create(bool is_mp, bool is_test = false);
 
 	static game_config_manager * get();
 
+
 private:
+	void set_enabled_addon(std::set<std::string> addon_ids);
+	void set_enabled_addon_all();
 	game_config_manager(const game_config_manager&);
 	void operator=(const game_config_manager&);
 
-	void load_game_config(FORCE_RELOAD_CONFIG force_reload,
-		game_classification const* classification = nullptr);
+	void load_game_config(bool reload_everything);
 
 	void load_game_config_with_loadscreen(FORCE_RELOAD_CONFIG force_reload,
-		game_classification const* classification = nullptr);
+		game_classification const* classification = nullptr, boost::optional<std::set<std::string>> active_addons = boost::optional<std::set<std::string>>());
 
 	// load_game_config() helper functions.
 	void load_addons_cfg();
@@ -72,6 +76,9 @@ private:
 	config game_config_;
 	game_config_view game_config_view_;
 
+	std::map<std::string, config> addon_cfgs_;
+	boost::optional<std::set<std::string>> active_addons_;
+	
 	preproc_map old_defines_map_;
 
 	filesystem::binary_paths_manager paths_manager_;

--- a/src/game_config_manager.hpp
+++ b/src/game_config_manager.hpp
@@ -18,6 +18,7 @@
 #include "config_cache.hpp"
 #include "filesystem.hpp"
 #include "terrain/type_data.hpp"
+#include "game_config_view.hpp"
 
 class config;
 class game_classification;
@@ -37,7 +38,7 @@ public:
 		NO_INCLUDE_RELOAD,
 	};
 
-	const config& game_config() const { return game_config_; }
+	const game_config_view& game_config() const { return game_config_view_; }
 	const preproc_map& old_defines_map() const { return old_defines_map_; }
 	const ter_data_cache & terrain_types() const { return tdata_; }
 
@@ -69,6 +70,7 @@ private:
 	const bool jump_to_editor_;
 
 	config game_config_;
+	game_config_view game_config_view_;
 
 	preproc_map old_defines_map_;
 

--- a/src/game_config_view.cpp
+++ b/src/game_config_view.cpp
@@ -1,0 +1,80 @@
+/*
+   Copyright (C) 2013 - 2018 by Andrius Silinskas <silinskas.andrius@gmail.com>
+   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+#include "game_config_view.hpp"
+#include "config.hpp"
+#include "log.hpp"
+
+static lg::log_domain log_config("config");
+#define ERR_CONFIG LOG_STREAM(err, log_config)
+#define WRN_CONFIG LOG_STREAM(warn, log_config)
+#define LOG_CONFIG LOG_STREAM(info, log_config)
+
+
+config_array_view game_config_view::child_range(config_key_type key) const
+{
+	config_array_view res;
+	for(const config& cfg : cfgs_) {
+		for (const config& child : cfg.child_range(key)) {
+			res.push_back(child);
+		}
+	}
+	return res;
+}
+
+const config& game_config_view::find_child(config_key_type key, const std::string &name, const std::string &value) const
+{
+	for(const config& cfg : cfgs_) {
+		if(const config& res = cfg.find_child(key, name, value)) {
+			return res;
+		}
+	}
+	LOG_CONFIG << "gcv : cannot find [" << key <<  "] with " << name  << "=" << value << ", count = " << cfgs_.size() <<"\n";
+	const config cfg;
+	return cfg.child("invalid");
+}
+
+const config& game_config_view::child(config_key_type key) const
+{
+	for(const config& cfg : cfgs_) {
+		if(const config& res = cfg.child(key)) {
+			return res;
+		}
+	}
+	const config cfg;
+	return cfg.child("invalid");
+}
+
+
+const config& game_config_view::child_or_empty(config_key_type key) const
+{
+	for(const config& cfg : cfgs_) {
+		if(const config& res = cfg.child(key)) {
+			return res;
+		}
+	}
+	static const config cfg;
+	return cfg;
+}
+
+game_config_view game_config_view::merged_children_view(config_key_type key) const
+{
+	game_config_view res;
+	for(const config& cfg : cfgs_) {
+
+		for(const config& child : cfg.child_range(key)) {
+			res.cfgs_.push_back(child);
+		}
+	}
+	return res;
+}

--- a/src/game_config_view.hpp
+++ b/src/game_config_view.hpp
@@ -1,0 +1,61 @@
+/*
+   Copyright (C) 2013 - 2018 by Andrius Silinskas <silinskas.andrius@gmail.com>
+   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#pragma once
+
+#include "config.hpp"
+
+#include <functional>
+#include <vector>
+
+using config_array_view = std::vector<std::reference_wrapper<const config>>;
+
+class game_config_view
+{
+
+public:
+	game_config_view()
+   {
+
+   }
+
+   static game_config_view wrap(const config& cfg) {
+      return game_config_view(cfg);
+   }
+
+	config_array_view child_range(config_key_type key) const;
+
+	const config& find_child(config_key_type key, const std::string &name, const std::string &value) const;
+
+	const config& child(config_key_type key) const;
+
+	const config& child_or_empty(config_key_type key) const;
+
+	game_config_view merged_children_view(config_key_type key) const;
+
+   
+   config_array_view& data()
+   {
+      return cfgs_;
+   }
+
+private:
+
+	explicit game_config_view(const config& cfg)
+      : cfgs_()
+   {
+      cfgs_.push_back(cfg);
+   }
+   config_array_view cfgs_;
+};

--- a/src/game_initialization/connect_engine.cpp
+++ b/src/game_initialization/connect_engine.cpp
@@ -491,7 +491,7 @@ void connect_engine::start_game()
 	send_to_server(config("start_game"));
 }
 
-void connect_engine::start_game_commandline(const commandline_options& cmdline_opts, const config& game_config)
+void connect_engine::start_game_commandline(const commandline_options& cmdline_opts, const game_config_view& game_config)
 {
 	DBG_MP << "starting a new game in commandline mode" << std::endl;
 

--- a/src/game_initialization/connect_engine.cpp
+++ b/src/game_initialization/connect_engine.cpp
@@ -79,7 +79,9 @@ connect_engine::connect_engine(saved_game& state, const bool first_scenario, mp_
 	config::child_itors sides = current_config()->child_range("side");
 
 	// AI algorithms.
-	ai::configuration::add_era_ai_from_config(level_.child("era"));
+	if(const config& era = level_.child("era")) {
+		ai::configuration::add_era_ai_from_config(era);
+	}
 	ai::configuration::add_mod_ai_from_config(level_.child_range("modification"));
 
 	// Set the team name lists and modify the original level sides if necessary.

--- a/src/game_initialization/connect_engine.hpp
+++ b/src/game_initialization/connect_engine.hpp
@@ -22,6 +22,7 @@
 
 namespace randomness { class mt_rng; }
 struct mp_campaign_info;
+class game_config_view;
 
 namespace ng {
 
@@ -63,7 +64,7 @@ public:
 
 	bool can_start_game() const;
 	void start_game();
-	void start_game_commandline(const commandline_options& cmdline_opts, const config& game_config);
+	void start_game_commandline(const commandline_options& cmdline_opts, const game_config_view& game_config);
 
 	void leave_game();
 

--- a/src/game_initialization/create_engine.cpp
+++ b/src/game_initialization/create_engine.cpp
@@ -467,7 +467,7 @@ void create_engine::prepare_for_saved_game()
 {
 	DBG_MP << "preparing mp_game_settings for saved game\n";
 
-	game_config_manager::get()->load_game_config_for_game(state_.classification());
+	game_config_manager::get()->load_game_config_for_game(state_.classification(), state_.get_scenario_id());
 
 	// The save might be a start-of-scenario save so make sure we have the scenario data loaded.
 	state_.expand_scenario();

--- a/src/game_initialization/create_engine.hpp
+++ b/src/game_initialization/create_engine.hpp
@@ -28,6 +28,7 @@
 
 class saved_game;
 class gamemap;
+class game_config_view;
 
 namespace ng {
 
@@ -463,7 +464,7 @@ private:
 	std::string selected_campaign_difficulty_;
 
 	/** Reference to the main game config. */
-	const config& game_config_;
+	const game_config_view& game_config_;
 };
 
 } // end namespace ng

--- a/src/game_initialization/depcheck.cpp
+++ b/src/game_initialization/depcheck.cpp
@@ -24,6 +24,7 @@
 #include "gui/dialogs/depcheck_confirm_change.hpp"
 #include "gui/dialogs/depcheck_select_new.hpp"
 #include "gui/dialogs/message.hpp"
+#include "game_config_view.hpp"
 
 static lg::log_domain log_mp_create_depcheck("mp/create/depcheck");
 #define DBG_MP LOG_STREAM(debug, log_mp_create_depcheck)
@@ -55,7 +56,7 @@ namespace ng
 {
 namespace depcheck
 {
-manager::manager(const config& gamecfg, bool mp)
+manager::manager(const game_config_view& gamecfg, bool mp)
 	: depinfo_()
 	, era_()
 	, scenario_()

--- a/src/game_initialization/depcheck.hpp
+++ b/src/game_initialization/depcheck.hpp
@@ -20,6 +20,8 @@
 #include "gettext.hpp"
 #include "utils/make_enum.hpp"
 
+class game_config_view;
+
 namespace ng
 {
 
@@ -52,7 +54,7 @@ MAKE_ENUM(component_availability,
 class manager
 {
 public:
-	manager(const config& gamecfg, bool mp);
+	manager(const game_config_view& gamecfg, bool mp);
 
 	/**
 	 * Tries to set the selected era

--- a/src/game_initialization/lobby_data.cpp
+++ b/src/game_initialization/lobby_data.cpp
@@ -32,6 +32,7 @@
 #include "wml_exception.hpp"
 #include "game_version.hpp"
 #include "mp_game_settings.hpp"
+#include "game_config_view.hpp"
 
 #include <iterator>
 
@@ -209,7 +210,7 @@ game_info::game_info(const config& game, const std::vector<std::string>& install
 	, required_addons()
 	, addons_outcome(SATISFIED)
 {
-	const config& game_config = game_config_manager::get()->game_config();
+	const game_config_view& game_config = game_config_manager::get()->game_config();
 
 	// Parse the list of addons required to join this game.
 	for(const config& addon : game.child_range("addon")) {

--- a/src/game_initialization/mp_game_utils.cpp
+++ b/src/game_initialization/mp_game_utils.cpp
@@ -109,8 +109,6 @@ config initial_level_config(saved_game& state)
 		// FIXME: @todo We should tell user about missing era but still load game...
 		WRN_CF << "Missing era in MP load game " << era << std::endl;
 
-		// Otherwise we get an error when when we try to add ai algorithms in mp_staging.
-		level.add_child("era");
 	} else {
 		level.add_child("era", era_cfg);
 

--- a/src/game_initialization/mp_game_utils.cpp
+++ b/src/game_initialization/mp_game_utils.cpp
@@ -45,6 +45,9 @@ static void add_multiplayer_classification(config& multiplayer, saved_game& stat
 	multiplayer["difficulty_define"] = state.classification().difficulty;
 	multiplayer["mp_campaign"] = state.classification().campaign;
 	multiplayer["mp_campaign_name"] = state.classification().campaign_name;
+	multiplayer["mp_era"] = state.classification().era_id;
+	multiplayer["active_mods"] = utils::join(state.classification().active_mods, ",");
+	
 }
 
 config initial_level_config(saved_game& state)
@@ -84,7 +87,7 @@ config initial_level_config(saved_game& state)
 	level.child("multiplayer")["mp_scenario_addon_version"] = state.to_config().child("scenario")["addon_version"].str();
 
 	// [multiplayer] mp_era= should be persistent over saves.
-	std::string era = params.mp_era;
+	std::string era = state.classification().era_id;
 
 	/**
 	 * [era] and [modification]s are toplevel tags here.
@@ -121,7 +124,7 @@ config initial_level_config(saved_game& state)
 	}
 
 	// Add modifications, needed for ai algorithms which are applied in mp_staging.
-	const std::vector<std::string>& mods = params.active_mods;
+	const std::vector<std::string>& mods = state.classification().active_mods;
 	std::vector<std::string> mod_versions;
 	std::vector<std::string> mod_addon_ids;
 

--- a/src/game_initialization/mp_game_utils.cpp
+++ b/src/game_initialization/mp_game_utils.cpp
@@ -98,7 +98,7 @@ config initial_level_config(saved_game& state)
 	 * -- vultraz, 2017-11-24
 	 */
 
-	const config& game_config = game_config_manager::get()->game_config();
+	const game_config_view& game_config = game_config_manager::get()->game_config();
 	const config& era_cfg = game_config.find_child("era", "id", era);
 
 	if(!era_cfg) {

--- a/src/game_initialization/multiplayer.cpp
+++ b/src/game_initialization/multiplayer.cpp
@@ -640,7 +640,7 @@ void start_client(const game_config_view& game_config,	saved_game& state, const 
 		if(re_enter) {
 			game_config_manager* gcm = game_config_manager::get();
 			gcm->reload_changed_game_config();
-			gcm->load_game_config_for_game(state.classification()); // NOTE: Using reload_changed_game_config only doesn't seem to work here
+			gcm->load_game_config_for_create(true); // NOTE: Using reload_changed_game_config only doesn't seem to work here
 
 			game_config_ptr = &gcm->game_config();
 
@@ -751,10 +751,11 @@ void start_local_game_commandline(const game_config_view& game_config, saved_gam
 		return;
 	}
 
-	game_config_manager::get()->load_game_config_for_game(state.classification());
 	state.set_carryover_sides_start(
 		config {"next_scenario", parameters.name}
 	);
+
+	game_config_manager::get()->load_game_config_for_game(state.classification(), state.get_scenario_id());
 
 	state.expand_random_scenario();
 	state.expand_mp_events();

--- a/src/game_initialization/multiplayer.cpp
+++ b/src/game_initialization/multiplayer.cpp
@@ -705,7 +705,7 @@ void start_local_game_commandline(const config& game_config, saved_game& state, 
 	mp_game_settings& parameters = state.mp_settings();
 
 	// Hardcoded default values
-	parameters.mp_era = "era_default";
+	state.classification().era_id = "era_default";
 	parameters.name = "multiplayer_The_Freelands";
 
 	// Default values for which at getter function exists
@@ -729,13 +729,13 @@ void start_local_game_commandline(const config& game_config, saved_game& state, 
 
 	// [era] define.
 	if(cmdline_opts.multiplayer_era) {
-		parameters.mp_era = *cmdline_opts.multiplayer_era;
+		state.classification().era_id = *cmdline_opts.multiplayer_era;
 	}
 
-	if(const config& cfg_era = game_config.find_child("era", "id", parameters.mp_era)) {
+	if(const config& cfg_era = game_config.find_child("era", "id", state.classification().era_id)) {
 		state.classification().era_define = cfg_era["define"].str();
 	} else {
-		std::cerr << "Could not find era '" << parameters.mp_era << "'\n";
+		std::cerr << "Could not find era '" << state.classification().era_id << "'\n";
 		return;
 	}
 

--- a/src/game_initialization/multiplayer.cpp
+++ b/src/game_initialization/multiplayer.cpp
@@ -393,14 +393,14 @@ std::pair<wesnothd_connection_ptr, config> open_connection(std::string host)
 /** Helper struct to manage the MP workflow arguments. */
 struct mp_workflow_helper
 {
-	mp_workflow_helper(const config& gc, saved_game& state, wesnothd_connection* connection, mp::lobby_info* li)
+	mp_workflow_helper(const game_config_view& gc, saved_game& state, wesnothd_connection* connection, mp::lobby_info* li)
 		: game_config(gc)
 		, state(state)
 		, connection(connection)
 		, lobby_info(li)
 	{}
 
-	const config& game_config;
+	const game_config_view& game_config;
 
 	saved_game& state;
 
@@ -604,9 +604,9 @@ bool enter_lobby_mode(mp_workflow_helper_ptr helper, const std::vector<std::stri
 /** Pubic entry points for the MP workflow */
 namespace mp
 {
-void start_client(const config& game_config,	saved_game& state, const std::string& host)
+void start_client(const game_config_view& game_config,	saved_game& state, const std::string& host)
 {
-	const config* game_config_ptr = &game_config;
+	const game_config_view* game_config_ptr = &game_config;
 
 	// This function does not refer to an addon database, it calls filesystem functions.
 	// For the sanity of the mp lobby, this list should be fixed for the entire lobby session,
@@ -676,7 +676,7 @@ bool goto_mp_wait(saved_game& state, wesnothd_connection* connection, bool obser
 	return dlg.show();
 }
 
-void start_local_game(const config& game_config, saved_game& state)
+void start_local_game(const game_config_view& game_config, saved_game& state)
 {
 	DBG_MP << "starting local game" << std::endl;
 
@@ -689,7 +689,7 @@ void start_local_game(const config& game_config, saved_game& state)
 	enter_create_mode(workflow_helper);
 }
 
-void start_local_game_commandline(const config& game_config, saved_game& state, const commandline_options& cmdline_opts)
+void start_local_game_commandline(const game_config_view& game_config, saved_game& state, const commandline_options& cmdline_opts)
 {
 	DBG_MP << "starting local MP game from commandline" << std::endl;
 

--- a/src/game_initialization/multiplayer.hpp
+++ b/src/game_initialization/multiplayer.hpp
@@ -21,6 +21,8 @@
 
 class config;
 class wesnothd_connection;
+class game_config_view;
+
 namespace mp {
 
 // max. length of a player name
@@ -34,7 +36,7 @@ const std::size_t max_login_size = 20;
  *
  * @param game_config The global, top-level WML configuration for the game
  */
-void start_local_game(const config& game_config,
+void start_local_game(const game_config_view& game_config,
 	saved_game& state);
 
 /** Starts a multiplayer game in single-user mode.
@@ -42,7 +44,7 @@ void start_local_game(const config& game_config,
  * Same parameters as start_local_game plus:
  * cmdline_opts The commandline options
  */
-void start_local_game_commandline(const config& game_config,
+void start_local_game_commandline(const game_config_view& game_config,
 	saved_game& state, const commandline_options& cmdline_opts);
 
 /** Starts a multiplayer game in client mode.
@@ -50,7 +52,7 @@ void start_local_game_commandline(const config& game_config,
  * @param game_config The global, top-level WML configuration for the game
  * @param host        The host to connect to.
  */
-void start_client(const config& game_config,
+void start_client(const game_config_view& game_config,
 	saved_game& state, const std::string& host);
 
 /**

--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -440,8 +440,8 @@ void game_launcher::set_test(const std::string& id)
 	state_.clear();
 	state_.classification().campaign_type = game_classification::CAMPAIGN_TYPE::TEST;
 	state_.classification().campaign_define = "TEST";
+	state_.classification().era_id = "era_default";
 
-	state_.mp_settings().mp_era = "era_default";
 
 	state_.set_carryover_sides_start(
 		config {"next_scenario", id}
@@ -738,7 +738,8 @@ void game_launcher::set_tutorial()
 	state_.classification().campaign_type = game_classification::CAMPAIGN_TYPE::TUTORIAL;
 	state_.classification().campaign_define = "TUTORIAL";
 	state_.classification().campaign = "Tutorial";
-	state_.mp_settings().mp_era = "era_default";
+	state_.classification().era_id = "era_default";
+
 	state_.set_carryover_sides_start(
 		config {"next_scenario", "tutorial"}
 	);

--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -474,7 +474,7 @@ bool game_launcher::play_test()
 	set_test(test_scenarios_.at(0));
 
 	game_config_manager::get()->
-		load_game_config_for_game(state_.classification());
+		load_game_config_for_game(state_.classification(), state_.get_scenario_id());
 
 	try {
 		campaign_controller ccontroller(state_, game_config_manager::get()->terrain_types());
@@ -545,7 +545,7 @@ game_launcher::unit_test_result game_launcher::unit_test()
 game_launcher::unit_test_result game_launcher::single_unit_test()
 {
 	game_config_manager::get()->
-		load_game_config_for_game(state_.classification());
+		load_game_config_for_game(state_.classification(), state_.get_scenario_id());
 
 	LEVEL_RESULT game_res = LEVEL_RESULT::TEST_FAIL;
 	try {
@@ -629,7 +629,7 @@ bool game_launcher::play_render_image_mode()
 
 	try {
 		game_config_manager::get()->
-			load_game_config_for_game(state_.classification());
+			load_game_config_for_game(state_.classification(), state_.get_scenario_id());
 	} catch(const config::error& e) {
 		std::cerr << "Error loading game config: " << e.what() << std::endl;
 		return false;
@@ -674,7 +674,7 @@ bool game_launcher::load_game()
 
 		try {
 			game_config_manager::get()->
-				load_game_config_for_game(state_.classification());
+				load_game_config_for_game(state_.classification(), state_.get_scenario_id());
 		} catch(const config::error&) {
 			return false;
 		}
@@ -970,7 +970,7 @@ bool game_launcher::play_multiplayer_commandline()
 	state_.classification().campaign_type = game_classification::CAMPAIGN_TYPE::MULTIPLAYER;
 
 	game_config_manager::get()->
-		load_game_config_for_game(state_.classification());
+		load_game_config_for_create(true);
 
 	events::discard_input(); // prevent the "keylogger" effect
 	cursor::set(cursor::NORMAL);
@@ -1014,7 +1014,7 @@ void game_launcher::launch_game(RELOAD_GAME_DATA reload)
 		if(reload == RELOAD_DATA) {
 			try {
 				game_config_manager::get()->
-					load_game_config_for_game(state_.classification());
+					load_game_config_for_game(state_.classification(), state_.get_scenario_id());
 			} catch(const config::error&) {
 				return;
 			}

--- a/src/generators/default_map_generator_job.hpp
+++ b/src/generators/default_map_generator_job.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 class config;
+class game_config_view;
 
 #include "default_map_generator.hpp"
 #include "map/location.hpp"
@@ -62,6 +63,6 @@ private:
 	map_location random_point_at_side(std::size_t width, std::size_t height);
 
 	std::mt19937 rng_;
-	const config& game_config_;
+	const game_config_view& game_config_;
 
 };

--- a/src/gui/dialogs/game_load.cpp
+++ b/src/gui/dialogs/game_load.cpp
@@ -43,6 +43,7 @@
 #include "serialization/string_utils.hpp"
 #include "utils/general.hpp"
 #include "utils/functional.hpp"
+#include "game_config_view.hpp"
 
 #include <cctype>
 
@@ -102,7 +103,7 @@ namespace dialogs
 
 REGISTER_DIALOG(game_load)
 
-game_load::game_load(const config& cache_config, savegame::load_game_metadata& data)
+game_load::game_load(const game_config_view& cache_config, savegame::load_game_metadata& data)
 	: filename_(data.filename)
 	, save_index_manager_(data.manager)
 	, change_difficulty_(register_bool("change_difficulty", true, data.select_difficulty))

--- a/src/gui/dialogs/game_load.hpp
+++ b/src/gui/dialogs/game_load.hpp
@@ -32,9 +32,9 @@ namespace dialogs
 class game_load : public modal_dialog
 {
 public:
-	game_load(const config& cache_config, savegame::load_game_metadata& data);
+	game_load(const game_config_view& cache_config, savegame::load_game_metadata& data);
 
-	static bool execute(const config& cache_config, savegame::load_game_metadata& data)
+	static bool execute(const game_config_view& cache_config, savegame::load_game_metadata& data)
 	{
 		return game_load(cache_config, data).show();
 	}
@@ -72,7 +72,7 @@ private:
 	config& summary_;
 
 	std::vector<savegame::save_info> games_;
-	const config& cache_config_;
+	const game_config_view& cache_config_;
 
 	std::vector<std::string> last_words_;
 };

--- a/src/gui/dialogs/help_browser.hpp
+++ b/src/gui/dialogs/help_browser.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "gui/dialogs/modal_dialog.hpp"
+class game_config_view;
 
 namespace gui2
 {

--- a/src/gui/dialogs/multiplayer/lobby.cpp
+++ b/src/gui/dialogs/multiplayer/lobby.cpp
@@ -115,7 +115,7 @@ bool mp_lobby::logout_prompt()
 	return show_prompt(_("Do you really want to log out?"));
 }
 
-mp_lobby::mp_lobby(const config& game_config, mp::lobby_info& info, wesnothd_connection &connection)
+mp_lobby::mp_lobby(const game_config_view& game_config, mp::lobby_info& info, wesnothd_connection &connection)
 	: quit_confirmation(&mp_lobby::logout_prompt)
 	, game_config_(game_config)
 	, gamelistbox_(nullptr)
@@ -832,7 +832,7 @@ void mp_lobby::pre_show(window& window)
 	}, true);
 
 	plugins_context_->set_accessor("game_list",   [this](const config&) { return lobby_info_.gamelist(); });
-	plugins_context_->set_accessor("game_config", [this](const config&) { return game_config_; });
+	//plugins_context_->set_accessor("game_config", [this](const config&) { return game_config_; });
 }
 
 void mp_lobby::post_show(window& /*window*/)

--- a/src/gui/dialogs/multiplayer/lobby.hpp
+++ b/src/gui/dialogs/multiplayer/lobby.hpp
@@ -23,6 +23,8 @@
 #include "quit_confirmation.hpp"
 
 class wesnothd_connection;
+class game_config_view;
+
 namespace gui2
 {
 
@@ -62,7 +64,7 @@ struct player_list
 class mp_lobby : public modal_dialog, public quit_confirmation, private plugin_executor
 {
 public:
-	mp_lobby(const config& game_config, mp::lobby_info& info, wesnothd_connection &connection);
+	mp_lobby(const game_config_view& game_config, mp::lobby_info& info, wesnothd_connection &connection);
 
 	~mp_lobby();
 
@@ -168,7 +170,7 @@ private:
 	/** Inherited from modal_dialog. */
 	virtual void post_show(window& window) override;
 
-	const config& game_config_;
+	const game_config_view& game_config_;
 
 	listbox* gamelistbox_;
 

--- a/src/gui/dialogs/multiplayer/mp_create_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.cpp
@@ -45,6 +45,7 @@
 #include "preferences/game.hpp"
 #include "save_index.hpp"
 #include "savegame.hpp"
+#include "game_config_view.hpp"
 
 #include <boost/algorithm/string.hpp>
 
@@ -67,7 +68,7 @@ namespace prefs = preferences;
 
 REGISTER_DIALOG(mp_create_game)
 
-mp_create_game::mp_create_game(const config& cfg, saved_game& state, bool local_mode, mp::user_info* host_info)
+mp_create_game::mp_create_game(const game_config_view& cfg, saved_game& state, bool local_mode, mp::user_info* host_info)
 	: cfg_(cfg)
 	, create_engine_(state)
 	, config_engine_()
@@ -410,7 +411,7 @@ void mp_create_game::pre_show(window& win)
 		on_mod_toggle(win, cfg["index"].to_int(), nullptr);
 	}, true);
 
-	plugins_context_->set_accessor("game_config",  [this](const config&) {return cfg_; });
+	//plugins_context_->set_accessor("game_config",  [this](const config&) {return cfg_; });
 	plugins_context_->set_accessor("get_selected", [this](const config&) {
 		const ng::level& current_level = create_engine_.current_level();
 		return config {

--- a/src/gui/dialogs/multiplayer/mp_create_game.hpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.hpp
@@ -24,6 +24,7 @@
 #include "mp_game_settings.hpp"
 
 class config;
+class game_config_view;
 
 namespace mp
 {
@@ -44,7 +45,7 @@ class mp_create_game : public modal_dialog, private plugin_executor
 	typedef std::pair<ng::level::TYPE, std::string> level_type_info;
 
 public:
-	mp_create_game(const config& cfg, saved_game& state, bool local_mode, mp::user_info* host_info = nullptr);
+	mp_create_game(const game_config_view& cfg, saved_game& state, bool local_mode, mp::user_info* host_info = nullptr);
 
 private:
 	/** Inherited from modal_dialog, implemented by REGISTER_DIALOG. */
@@ -56,7 +57,7 @@ private:
 	/** Inherited from modal_dialog. */
 	virtual void post_show(window& window) override;
 
-	const config& cfg_;
+	const game_config_view& cfg_;
 
 	ng::create_engine create_engine_;
 	std::unique_ptr<ng::configure_engine> config_engine_;

--- a/src/gui/dialogs/multiplayer/mp_join_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_join_game.cpp
@@ -134,7 +134,7 @@ bool mp_join_game::fetch_game_config()
 		state_.classification() = game_classification(level_);
 
 		// Make sure that we have the same config as host, if possible.
-		game_config_manager::get()->load_game_config_for_game(state_.classification());
+		game_config_manager::get()->load_game_config_for_game(state_.classification(), state_.get_scenario_id());
 	}
 
 	game_config::add_color_info(get_scenario());

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -58,6 +58,7 @@
 #include "gui/widgets/toggle_button.hpp"
 #include "gui/widgets/window.hpp"
 #include "lexical_cast.hpp"
+#include "game_config_view.hpp"
 
 #if BOOST_VERSION >= 106700
 #include <boost/integer/common_factor_rt.hpp>
@@ -114,7 +115,7 @@ using namespace preferences;
 
 REGISTER_DIALOG(preferences_dialog)
 
-preferences_dialog::preferences_dialog(const config& game_cfg, const PREFERENCE_VIEW& initial_view)
+preferences_dialog::preferences_dialog(const game_config_view& game_cfg, const PREFERENCE_VIEW& initial_view)
 	: resolutions_() // should be populated by set_resolution_list before use
 	, adv_preferences_cfg_()
 	, last_selected_item_(0)

--- a/src/gui/dialogs/preferences_dialog.hpp
+++ b/src/gui/dialogs/preferences_dialog.hpp
@@ -25,6 +25,7 @@
 
 #include <boost/dynamic_bitset.hpp>
 
+class game_config_view;
 // This file is not named preferences.hpp in order -I conflicts with
 // src/preferences.hpp.
 
@@ -71,10 +72,10 @@ namespace dialogs
 class preferences_dialog : public modal_dialog
 {
 public:
-	preferences_dialog(const config& game_cfg, const preferences::PREFERENCE_VIEW& initial_view);
+	preferences_dialog(const game_config_view& game_cfg, const preferences::PREFERENCE_VIEW& initial_view);
 
 	/** The display function -- see @ref modal_dialog for more information. */
-	static void display(const config& game_cfg, const preferences::PREFERENCE_VIEW initial_view = preferences::VIEW_DEFAULT)
+	static void display(const game_config_view& game_cfg, const preferences::PREFERENCE_VIEW initial_view = preferences::VIEW_DEFAULT)
 	{
 		preferences_dialog(game_cfg, initial_view).show();
 	}

--- a/src/gui/widgets/minimap.cpp
+++ b/src/gui/widgets/minimap.cpp
@@ -127,7 +127,7 @@ static const size_t cache_max_size = 100;
  * normally doesn't happen a lot so the clearing of the cache is rather
  * unusual.
  */
-static const ::config* terrain = nullptr;
+static const ::game_config_view* terrain = nullptr;
 
 /** The cache. */
 typedef std::map<key_type, value_type> tcache;

--- a/src/gui/widgets/minimap.hpp
+++ b/src/gui/widgets/minimap.hpp
@@ -20,7 +20,7 @@
 #include "gui/core/window_builder.hpp"
 
 class config;
-
+class game_config_view;
 namespace gui2
 {
 namespace implementation
@@ -75,7 +75,7 @@ public:
 		return map_data_;
 	}
 
-	void set_config(const ::config* terrain)
+	void set_config(const ::game_config_view* terrain)
 	{
 		terrain_ = terrain;
 	}
@@ -89,7 +89,7 @@ private:
 	 *
 	 * This config must be set before the object can be drawn.
 	 */
-	const ::config* terrain_;
+	const ::game_config_view* terrain_;
 
 	/**
 	 * Gets the image for the minimap.

--- a/src/help/help.cpp
+++ b/src/help/help.cpp
@@ -87,11 +87,10 @@ void show_unit_description(const unit_type &t)
 		help::show_unit_help(t.id(), t.show_variations_in_help(), hide_help);
 }
 
-extern config dummy_cfg;
-
-help_manager::help_manager(const config *cfg) //, gamemap *_map)
+help_manager::help_manager(const game_config_view *cfg) //, gamemap *_map)
 {
-	game_cfg = cfg == nullptr ? &dummy_cfg : cfg;
+	static game_config_view dummy_view;
+	game_cfg = cfg == nullptr ? &dummy_view : cfg;
 //	map = _map;
 }
 

--- a/src/help/help.hpp
+++ b/src/help/help.hpp
@@ -19,12 +19,14 @@ class terrain_type;
 class unit;
 class unit_type;
 class CVideo;
+class game_config_view;
+
 #include <string>
 
 namespace help {
 
 struct help_manager {
-	help_manager(const config *game_config);
+	help_manager(const game_config_view *game_config);
 	~help_manager();
 };
 

--- a/src/help/help_impl.cpp
+++ b/src/help/help_impl.cpp
@@ -63,7 +63,7 @@ static lg::log_domain log_help("help");
 
 namespace help {
 
-const config *game_cfg = nullptr;
+const game_config_view *game_cfg = nullptr;
 // The default toplevel.
 help::section default_toplevel;
 // All sections and topics not referenced from the default toplevel.
@@ -73,7 +73,6 @@ int last_num_encountered_units = -1;
 int last_num_encountered_terrains = -1;
 boost::tribool last_debug_state = boost::indeterminate;
 
-config dummy_cfg;
 std::vector<std::string> empty_string_vector;
 const int max_section_level = 15;
 const int title_size = font::SIZE_LARGE;
@@ -293,7 +292,7 @@ void generate_sections(const config *help_cfg, const std::string &generator, sec
 	if (generator == "races") {
 		generate_races_sections(help_cfg, sec, level);
 	} else if (generator == "terrains") {
-		generate_terrain_sections(help_cfg, sec, level);
+		generate_terrain_sections(sec, level);
 	} else if (generator == "eras") {
 		DBG_HP << "Generating eras...\n";
 		generate_era_sections(help_cfg, sec, level);
@@ -834,7 +833,7 @@ void generate_era_sections(const config* help_cfg, section & sec, int level)
 	}
 }
 
-void generate_terrain_sections(const config* /*help_cfg*/, section& sec, int /*level*/)
+void generate_terrain_sections(section& sec, int /*level*/)
 {
 	ter_data_cache tdata = load_terrain_types_data();
 
@@ -1350,10 +1349,7 @@ void generate_contents()
 	default_toplevel.clear();
 	hidden_sections.clear();
 	if (game_cfg != nullptr) {
-		const config *help_config = &game_cfg->child("help");
-		if (!*help_config) {
-			help_config = &dummy_cfg;
-		}
+		const config *help_config = &game_cfg->child_or_empty("help");
 		try {
 			default_toplevel = parse_config(help_config);
 			// Create a config object that contains everything that is

--- a/src/help/help_impl.hpp
+++ b/src/help/help_impl.hpp
@@ -45,6 +45,7 @@
 #include <boost/logic/tribool.hpp>
 #include <boost/optional.hpp>
 
+class game_config_view;
 class config;
 class unit_type;
 class terrain_type_data;
@@ -216,7 +217,7 @@ void generate_sections(const config *help_cfg, const std::string &generator, sec
 std::vector<topic> generate_topics(const bool sort_topics,const std::string &generator);
 std::string generate_topic_text(const std::string &generator, const config *help_cfg,
 const section &sec, const std::vector<topic>& generated_topics);
-std::string generate_contents_links(const std::string& section_name, config const *help_cfg);
+std::string generate_contents_links(const std::string& section_name, const config *help_cfg);
 std::string generate_contents_links(const section &sec, const std::vector<topic>& topics);
 
 /// return a hyperlink with the unit's name and pointing to the unit page
@@ -227,7 +228,7 @@ std::vector<std::string> make_unit_links_list(
 		const std::vector<std::string>& type_id_list, bool ordered = false);
 
 void generate_races_sections(const config *help_cfg, section &sec, int level);
-void generate_terrain_sections(const config* help_cfg, section &sec, int level);
+void generate_terrain_sections(section &sec, int level);
 std::vector<topic> generate_unit_topics(const bool, const std::string& race);
 void generate_unit_sections(const config *help_cfg, section &sec, int level, const bool, const std::string& race);
 enum UNIT_DESCRIPTION_TYPE {FULL_DESCRIPTION, NO_DESCRIPTION, NON_REVEALING_DESCRIPTION};
@@ -297,7 +298,7 @@ std::string get_first_word(const std::string &s);
 /// Load the appropriate terrain types data to use
 ter_data_cache load_terrain_types_data();
 
-extern const config *game_cfg;
+extern const game_config_view *game_cfg;
 // The default toplevel.
 extern help::section default_toplevel;
 // All sections and topics not referenced from the default toplevel.

--- a/src/hotkey/hotkey_item.cpp
+++ b/src/hotkey/hotkey_item.cpp
@@ -23,7 +23,7 @@
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string.hpp>
 #include "utils/functional.hpp"
-
+#include "game_config_view.hpp"
 #include <SDL2/SDL.h>
 #include <key.hpp>
 #include <serialization/unicode.hpp>
@@ -38,7 +38,7 @@ static lg::log_domain log_config("config");
 namespace hotkey {
 
 hotkey_list hotkeys_;
-config default_hotkey_cfg_;
+game_config_view default_hotkey_cfg_;
 
 namespace {
 	const int TOUCH_MOUSE_INDEX = 255;
@@ -401,7 +401,7 @@ const hotkey_ptr get_hotkey(const SDL_Event &event)
 	return hotkey_ptr(new hotkey_void());
 }
 
-void load_hotkeys(const config& cfg, bool set_as_default)
+void load_hotkeys(const game_config_view& cfg, bool set_as_default)
 {
 	for (const config &hk : cfg.child_range("hotkey")) {
 
@@ -424,7 +424,7 @@ void reset_default_hotkeys()
 {
 	hotkeys_.clear();
 
-	if (!default_hotkey_cfg_.empty()) {
+	if (!default_hotkey_cfg_.child_range("hotkey").empty()) {
 		load_hotkeys(default_hotkey_cfg_, true);
 	} else {
 		ERR_G<< "no default hotkeys set yet; all hotkeys are now unassigned!" << std::endl;

--- a/src/hotkey/hotkey_item.hpp
+++ b/src/hotkey/hotkey_item.hpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <boost/algorithm/string.hpp>
 
+class game_config_view;
 class config;
 namespace hotkey {
 
@@ -389,7 +390,7 @@ const hotkey_ptr get_hotkey(const SDL_Event &event);
  * @param set_as_default Indicates whether the config struct should be treated as the
  * default game settings.
  */
-void load_hotkeys(const config& cfg, bool set_as_default = false);
+void load_hotkeys(const game_config_view& cfg, bool set_as_default = false);
 
 /**
  * Reset all hotkeys to the defaults.

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -19,6 +19,7 @@
 #include "preferences/general.hpp"
 #include "serialization/parser.hpp"
 #include "serialization/preprocessor.hpp"
+#include "game_config_manager.hpp"
 
 #include <stdexcept>
 #include <clocale>
@@ -352,7 +353,7 @@ const language_def& get_locale()
 	return known_languages[0];
 }
 
-void init_textdomains(const config& cfg)
+void init_textdomains(const game_config_view& cfg)
 {
 	for (const config &t : cfg.child_range("textdomain"))
 	{
@@ -375,7 +376,7 @@ void init_textdomains(const config& cfg)
 	}
 }
 
-bool init_strings(const config& cfg)
+bool init_strings(const game_config_view& cfg)
 {
 	languages_.clear();
 	for (const config &l : cfg.child_range("language")) {

--- a/src/language.hpp
+++ b/src/language.hpp
@@ -19,6 +19,8 @@
 
 #include <iterator>
 
+class game_config_view;
+
 //this module controls internationalization.
 
 class config;
@@ -94,10 +96,10 @@ bool current_language_rtl();
 const language_def& get_locale();
 
 /** Initializes the list of textdomains from a configuration object */
-void init_textdomains(const config& cfg);
+void init_textdomains(const game_config_view& cfg);
 
 /** Initializes certain English strings */
-bool init_strings(const config& cfg);
+bool init_strings(const game_config_view& cfg);
 
 bool load_language_list();
 

--- a/src/menu_events.hpp
+++ b/src/menu_events.hpp
@@ -26,6 +26,7 @@ class game_state;
 class gamemap;
 class game_data;
 class game_board;
+class game_config_view;
 class play_controller;
 class team;
 class unit_map;
@@ -146,7 +147,7 @@ private:
 	game_display* gui_;
 	play_controller& pc_;
 
-	const config& game_config_;
+	const game_config_view& game_config_;
 
 	gui::floating_textbox textbox_info_;
 	std::string last_search_;

--- a/src/mp_game_settings.cpp
+++ b/src/mp_game_settings.cpp
@@ -32,12 +32,10 @@ mp_game_settings::mp_game_settings() :
 	name(),
 	password(),
 	hash(),
-	mp_era(),
 	mp_era_name(),
 	mp_scenario(),
 	mp_scenario_name(),
 	mp_campaign(),
-	active_mods(),
 	side_users(),
 	num_turns(0),
 	village_gold(0),
@@ -66,12 +64,10 @@ mp_game_settings::mp_game_settings(const config& cfg)
 	: name(cfg["scenario"].str())
 	, password()
 	, hash(cfg["hash"].str())
-	, mp_era(cfg["mp_era"].str())
 	, mp_era_name(cfg["mp_era_name"].str())
 	, mp_scenario(cfg["mp_scenario"].str())
 	, mp_scenario_name(cfg["mp_scenario_name"].str())
 	, mp_campaign(cfg["mp_campaign"].str())
-	, active_mods(utils::split(cfg["active_mods"], ','))
 	, side_users(utils::map_split(cfg["side_users"]))
 	, num_turns(cfg["mp_num_turns"])
 	, village_gold(cfg["mp_village_gold"])
@@ -108,12 +104,10 @@ config mp_game_settings::to_config() const
 
 	cfg["scenario"] = name;
 	cfg["hash"] = hash;
-	cfg["mp_era"] = mp_era;
 	cfg["mp_era_name"] = mp_era_name;
 	cfg["mp_scenario"] = mp_scenario;
 	cfg["mp_scenario_name"] = mp_scenario_name;
 	cfg["mp_campaign"] = mp_campaign;
-	cfg["active_mods"] = utils::join(active_mods, ",");
 	cfg["side_users"] = utils::join_map(side_users);
 	cfg["experience_modifier"] = xp_modifier;
 	cfg["mp_countdown"] = mp_countdown;

--- a/src/mp_game_settings.hpp
+++ b/src/mp_game_settings.hpp
@@ -35,12 +35,10 @@ struct mp_game_settings
 	std::string name;
 	std::string password;
 	std::string hash;
-	std::string mp_era;
 	std::string mp_era_name;
 	std::string mp_scenario;
 	std::string mp_scenario_name;
 	std::string mp_campaign;
-	std::vector<std::string> active_mods;
 	std::map<std::string, std::string> side_users;
 
 	int num_turns;

--- a/src/preferences/general.cpp
+++ b/src/preferences/general.cpp
@@ -33,6 +33,7 @@
 #include "sound.hpp"
 #include "utils/general.hpp"
 #include "video.hpp" // non_interactive()
+#include "game_config_view.hpp"
 
 #include <sys/stat.h> // for setting the permissions of the preferences file
 #ifndef _WIN32
@@ -864,7 +865,7 @@ void _set_color_cursors(bool value)
 
 void load_hotkeys()
 {
-	hotkey::load_hotkeys(prefs, false);
+	hotkey::load_hotkeys(game_config_view::wrap(prefs), false);
 }
 
 void save_hotkeys()

--- a/src/saved_game.cpp
+++ b/src/saved_game.cpp
@@ -217,12 +217,19 @@ void saved_game::set_defaults()
 {
 	const bool is_loaded_game = this->starting_point_type_ != STARTING_POINT_SCENARIO;
 	const bool is_multiplayer_tag = classification().get_tagname() == "multiplayer";
-
+	const game_config_view& game_config = game_config_manager::get()->game_config();
 	static const std::vector<std::string> team_defaults {
 		"carryover_percentage",
 		"carryover_add",
 	};
 
+
+	if (const config& campaign = game_config.find_child("campaign", "id", classification_.campaign))
+	{
+		bool require_campaign = campaign["require_campaign"].to_bool(true);
+		starting_point_["require_scenario"] = require_campaign;
+	}
+	
 	for(config& side : starting_point_.child_range("side")) {
 		// Set save_id default value directly after loading to its default to prevent different default behaviour in
 		// mp_connect code and sp code.

--- a/src/saved_game.cpp
+++ b/src/saved_game.cpp
@@ -264,7 +264,7 @@ void saved_game::expand_scenario()
 	if(this->starting_point_type_ == STARTING_POINT_NONE && !has_carryover_expanded_) {
 		game_config_manager::get()->load_game_config_for_game(this->classification());
 
-		const config& game_config = game_config_manager::get()->game_config();
+		const game_config_view& game_config = game_config_manager::get()->game_config();
 		const config& scenario =
 			game_config.find_child(classification().get_tagname(), "id", carryover_["next_scenario"]);
 

--- a/src/saved_game.cpp
+++ b/src/saved_game.cpp
@@ -269,7 +269,7 @@ void saved_game::set_defaults()
 void saved_game::expand_scenario()
 {
 	if(this->starting_point_type_ == STARTING_POINT_NONE && !has_carryover_expanded_) {
-		game_config_manager::get()->load_game_config_for_game(this->classification());
+		game_config_manager::get()->load_game_config_for_game(this->classification(), this->get_scenario_id());
 
 		const game_config_view& game_config = game_config_manager::get()->game_config();
 		const config& scenario =

--- a/src/saved_game.cpp
+++ b/src/saved_game.cpp
@@ -369,13 +369,13 @@ void saved_game::expand_mp_events()
 		std::vector<modevents_entry> mods;
 		std::set<std::string> loaded_resources;
 
-		std::transform(mp_settings_.active_mods.begin(), mp_settings_.active_mods.end(), std::back_inserter(mods),
+		std::transform(classification_.active_mods.begin(), classification_.active_mods.end(), std::back_inserter(mods),
 			[](const std::string& id) { return modevents_entry("modification", id); }
 		);
 
 		// We don't want the error message below if there is no era (= if this is a sp game).
-		if(!mp_settings_.mp_era .empty()) {
-			mods.emplace_back("era", mp_settings_.mp_era);
+		if(!classification_.era_id .empty()) {
+			mods.emplace_back("era", classification_.era_id);
 		}
 
 		if(!classification_.campaign.empty()) {
@@ -407,11 +407,11 @@ void saved_game::expand_mp_options()
 	if(starting_point_type_ == STARTING_POINT_SCENARIO && !has_carryover_expanded_) {
 		std::vector<modevents_entry> mods;
 
-		std::transform(mp_settings_.active_mods.begin(), mp_settings_.active_mods.end(), std::back_inserter(mods),
+		std::transform(classification_.active_mods.begin(), classification_.active_mods.end(), std::back_inserter(mods),
 			[](const std::string& id) { return modevents_entry("modification", id); }
 		);
 
-		mods.emplace_back("era", mp_settings_.mp_era);
+		mods.emplace_back("era", classification_.era_id);
 		mods.emplace_back("multiplayer", get_scenario_id());
 		mods.emplace_back("campaign", classification().campaign);
 

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -840,6 +840,16 @@ static void convert_old_saves_1_13_1(config& cfg)
 		}
 	}
 }
+//changes done during 1.15.3+dev
+static void convert_old_saves_1_15_3(config& cfg)
+{
+	if(cfg["era_id"].empty()) {
+		cfg["era_id"] = cfg.child_or_empty("multiplayer")["mp_era"];
+	}
+	if(cfg["active_mods"].empty()) {
+		cfg["active_mods"] = cfg.child_or_empty("multiplayer")["active_mods"];
+	}
+}
 
 void convert_old_saves(config& cfg)
 {
@@ -857,6 +867,10 @@ void convert_old_saves(config& cfg)
 	if(loaded_version <= version_info("1.13.1"))
 	{
 		convert_old_saves_1_13_1(cfg);
+	}
+	if(loaded_version < version_info("1.15.4"))
+	{
+		convert_old_saves_1_15_3(cfg);
 	}
 	LOG_RG<<"cfg after conversion "<<cfg<<"\n";
 }

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -45,6 +45,7 @@
 #include "statistics.hpp"
 #include "game_version.hpp"
 #include "video.hpp"
+#include "game_config_view.hpp"
 
 #include <algorithm>
 #include <iomanip>
@@ -80,7 +81,7 @@ void clean_saves(const std::string& label)
 	}
 }
 
-loadgame::loadgame(const std::shared_ptr<save_index_class>& index, const config& game_config, saved_game& gamestate)
+loadgame::loadgame(const std::shared_ptr<save_index_class>& index, const game_config_view& game_config, saved_game& gamestate)
 	: game_config_(game_config)
 	, gamestate_(gamestate)
 	, load_data_(index)

--- a/src/savegame.hpp
+++ b/src/savegame.hpp
@@ -25,6 +25,7 @@
 #include <exception>
 
 class config_writer;
+class game_config_view;
 class version_info;
 
 namespace savegame
@@ -108,7 +109,7 @@ private:
 class loadgame
 {
 public:
-	loadgame(const std::shared_ptr<save_index_class>& index, const config& game_config, saved_game& gamestate);
+	loadgame(const std::shared_ptr<save_index_class>& index, const game_config_view& game_config, saved_game& gamestate);
 	virtual ~loadgame() {}
 
 	/* In any of the following three function, a bool value of false indicates
@@ -145,7 +146,7 @@ private:
 	/** Copy era information into the snapshot. */
 	void copy_era(config& cfg);
 
-	const config& game_config_;
+	const game_config_view& game_config_;
 
 	saved_game& gamestate_; /** Primary output information. */
 

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -1385,7 +1385,7 @@ int game_lua_kernel::impl_game_config_get(lua_State *L)
 	return_string_attrib("campaign_type", classification.campaign_type.to_string());
 	if(classification.campaign_type==game_classification::CAMPAIGN_TYPE::MULTIPLAYER) {
 		return_cfgref_attrib("mp_settings", mp_settings.to_config());
-		return_cfgref_attrib("era", game_config_manager::get()->game_config().find_child("era","id",mp_settings.mp_era));
+		return_cfgref_attrib("era", game_config_manager::get()->game_config().find_child("era","id",classification.era_id));
 		//^ finds the era with name matching mp_era, and creates a lua reference from the config of that era.
 
 		//This code for SigurdFD, not the cleanest implementation but seems to work just fine.

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -172,7 +172,7 @@ struct map_locker
 };
 
 
-void game_lua_kernel::extract_preload_scripts(const config& game_config)
+void game_lua_kernel::extract_preload_scripts(const game_config_view& game_config)
 {
 	game_lua_kernel::preload_scripts.clear();
 	for (const config& cfg : game_config.child_range("lua")) {
@@ -1389,13 +1389,11 @@ int game_lua_kernel::impl_game_config_get(lua_State *L)
 		//^ finds the era with name matching mp_era, and creates a lua reference from the config of that era.
 
 		//This code for SigurdFD, not the cleanest implementation but seems to work just fine.
-		config::const_child_itors its = game_config_manager::get()->game_config().child_range("era");
-		std::string eras_list(its.front()["id"]);
-		its.pop_front();
-		for(const auto& cfg : its) {
-			eras_list = eras_list + "," + cfg["id"];
+		std::vector<std::string> eras_list;
+		for (const config& era : game_config_manager::get()->game_config().child_range("era") ) {
+			eras_list.push_back(era["id"].str());
 		}
-		return_string_attrib("eras", eras_list);
+		return_string_attrib("eras", utils::join(eras_list));
 	}
 	return lua_kernel_base::impl_game_config_get(L);
 }
@@ -1425,7 +1423,7 @@ int game_lua_kernel::impl_game_config_set(lua_State *L)
 	modify_string_attrib("next_scenario", gamedata().set_next_scenario(value));
 	modify_string_attrib("theme",
 		gamedata().set_theme(value);
-		const config& game_config = game_config_manager::get()->game_config();
+		const game_config_view& game_config = game_config_manager::get()->game_config();
 		game_display_->set_theme(play_controller_.get_theme(game_config, value));
 	);
 	modify_vector_string_attrib("defeat_music", gamedata().set_defeat_music(std::move(value)));

--- a/src/scripting/game_lua_kernel.hpp
+++ b/src/scripting/game_lua_kernel.hpp
@@ -22,6 +22,7 @@
 #include <string>                       // for string
 
 class config;
+class game_config_view;
 class unit;
 class vconfig;
 namespace ai { class engine_lua; }
@@ -61,7 +62,7 @@ class game_lua_kernel : public lua_kernel_base
 
 	const game_events::queued_event & get_event_info();
 
-	static void extract_preload_scripts(const config& game_config);
+	static void extract_preload_scripts(const game_config_view& game_config);
 	static std::vector<config> preload_scripts;
 	static config preload_config;
 

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -644,7 +644,7 @@ void attack_context::defend_result(hit_result res, int cth, int damage, int drai
 void recruit_unit(const unit& u)
 {
 	stats& s = get_stats(get_team_save_id(u));
-	s.recruits[u.type().base_id()]++;
+	s.recruits[u.type().parent_id()]++;
 	s.recruit_cost += u.cost();
 }
 
@@ -665,7 +665,7 @@ void un_recall_unit(const unit& u)
 void un_recruit_unit(const unit& u)
 {
 	stats& s = get_stats(get_team_save_id(u));
-	s.recruits[u.type().base_id()]--;
+	s.recruits[u.type().parent_id()]--;
 	s.recruit_cost -= u.cost();
 }
 

--- a/src/terrain/builder.cpp
+++ b/src/terrain/builder.cpp
@@ -25,6 +25,7 @@
 #include "map/map.hpp"
 #include "preferences/game.hpp"
 #include "serialization/string_utils.hpp"
+#include "game_config_view.hpp"
 
 static lg::log_domain log_engine("engine");
 #define ERR_NG LOG_STREAM(err, log_engine)
@@ -85,7 +86,7 @@ static map_location legacy_difference(const map_location& me, const map_location
  */
 
 terrain_builder::building_ruleset terrain_builder::building_rules_;
-const config* terrain_builder::rules_cfg_ = nullptr;
+const game_config_view* terrain_builder::rules_cfg_ = nullptr;
 
 terrain_builder::rule_image::rule_image(int layer, int x, int y, bool global_image, int cx, int cy, bool is_water)
 	: layer(layer)
@@ -287,7 +288,7 @@ void terrain_builder::flush_local_rules()
 	}
 }
 
-void terrain_builder::set_terrain_rules_cfg(const config& cfg)
+void terrain_builder::set_terrain_rules_cfg(const game_config_view& cfg)
 {
 	rules_cfg_ = &cfg;
 	// use the swap trick to clear the rules cache and get a fresh one.
@@ -882,6 +883,11 @@ void terrain_builder::add_rotated_rules(building_ruleset& rules, building_rule& 
 
 void terrain_builder::parse_config(const config& cfg, bool local)
 {
+	return parse_config(game_config_view::wrap(cfg), local);
+}
+
+void terrain_builder::parse_config(const game_config_view& cfg, bool local)
+{
 	log_scope("terrain_builder::parse_config");
 	int n = 0;
 
@@ -1012,7 +1018,7 @@ void terrain_builder::add_off_map_rule(const std::string& image)
 	item["set_flag"] = "base";
 
 	// Parse the object
-	parse_global_config(cfg);
+	parse_global_config(game_config_view::wrap(cfg));
 }
 
 bool terrain_builder::rule_matches(const terrain_builder::building_rule& rule,

--- a/src/terrain/builder.hpp
+++ b/src/terrain/builder.hpp
@@ -25,6 +25,8 @@
 #include "terrain/translation.hpp"
 
 class config;
+class game_config_view;
+
 class gamemap;
 namespace image
 {
@@ -92,7 +94,7 @@ public:
 	 * @param cfg			The main game configuration object, where the
 	 *						[terrain_graphics] rule reside.
 	 */
-	static void set_terrain_rules_cfg(const config& cfg);
+	static void set_terrain_rules_cfg(const game_config_view& cfg);
 
 	const gamemap& map() const
 	{
@@ -755,8 +757,9 @@ private:
 	 * @param local     Mark the rules as local only.
 	 */
 	void parse_config(const config& cfg, bool local = true);
+	void parse_config(const game_config_view& cfg, bool local = true);
 
-	void parse_global_config(const config& cfg)
+	void parse_global_config(const game_config_view& cfg)
 	{
 		parse_config(cfg, false);
 	}
@@ -858,5 +861,5 @@ private:
 	static building_ruleset building_rules_;
 
 	/** Config used to parse global terrain rules */
-	static const config* rules_cfg_;
+	static const game_config_view* rules_cfg_;
 };

--- a/src/terrain/type_data.cpp
+++ b/src/terrain/type_data.cpp
@@ -15,6 +15,7 @@
 #include "terrain/type_data.hpp"
 
 #include "serialization/string_utils.hpp"
+#include "game_config_view.hpp"
 
 #include <map>
 
@@ -23,7 +24,7 @@
 #define LOG_G LOG_STREAM(info, lg::general())
 #define DBG_G LOG_STREAM(debug, lg::general())
 
-terrain_type_data::terrain_type_data(const config & game_config)
+terrain_type_data::terrain_type_data(const game_config_view & game_config)
 	: terrainList_()
 	, tcodeToTerrain_()
 	, initialized_(false)

--- a/src/terrain/type_data.hpp
+++ b/src/terrain/type_data.hpp
@@ -18,6 +18,8 @@
 
 #include <map>
 
+class game_config_view;
+
 /**
  * Contains the database of all known terrain types, both those defined
  * explicitly by WML [terrain_type]s and those made by combining pairs of
@@ -40,10 +42,10 @@ private:
 	using tcodeToTerrain_t = std::map<t_translation::terrain_code, terrain_type>;
 	mutable tcodeToTerrain_t tcodeToTerrain_;
 	mutable bool initialized_;
-	const config & game_config_;
+	const game_config_view & game_config_;
 
 public:
-	terrain_type_data(const config & game_config);
+	terrain_type_data(const game_config_view & game_config);
 
 	/**
 	 * On the first call to this function, parse all of the [terrain_type]s

--- a/src/tests/test_image_modifications.cpp
+++ b/src/tests/test_image_modifications.cpp
@@ -18,6 +18,7 @@
 #include <sstream>
 
 #include "game_config.hpp"
+#include "game_config_view.hpp"
 #include "config_cache.hpp"
 #include "config.hpp"
 #include "color_range.hpp"
@@ -86,11 +87,12 @@ private:
 	void set_up_image_paths()
 	{
 		config cfg;
-
+		game_config_view v = game_config_view::wrap(cfg);
 		cfg.add_child("binary_path",
 			      create_path_config("data/core"));
 
-		paths_manager_.set_paths(cfg);
+
+		paths_manager_.set_paths(v);
 	}
 
 	static config create_color_range(const std::string& id,

--- a/src/tests/test_mp_connect.cpp
+++ b/src/tests/test_mp_connect.cpp
@@ -59,9 +59,9 @@ struct mp_connect_fixture {
 
 		state.reset(new saved_game());
 		state->classification().campaign_type = game_classification::CAMPAIGN_TYPE::MULTIPLAYER;
+		state->classification().era_id = "era_default";
 		config_manager->load_game_config_for_game(state->classification());
 
-		state->mp_settings().mp_era = "era_default";
 		state->mp_settings().name = "multiplayer_The_Freelands";
 		state->mp_settings().use_map_settings = true;
 		state->mp_settings().saved_game = mp_game_settings::SAVED_GAME_MODE::NONE;

--- a/src/tests/test_mp_connect.cpp
+++ b/src/tests/test_mp_connect.cpp
@@ -60,7 +60,7 @@ struct mp_connect_fixture {
 		state.reset(new saved_game());
 		state->classification().campaign_type = game_classification::CAMPAIGN_TYPE::MULTIPLAYER;
 		state->classification().era_id = "era_default";
-		config_manager->load_game_config_for_game(state->classification());
+		config_manager->load_game_config_for_game(state->classification(), state->get_scenario_id());
 
 		state->mp_settings().name = "multiplayer_The_Freelands";
 		state->mp_settings().use_map_settings = true;

--- a/src/tests/utils/fake_display.cpp
+++ b/src/tests/utils/fake_display.cpp
@@ -17,6 +17,7 @@
 #include "tests/utils/fake_display.hpp"
 
 #include "game_board.hpp"
+#include "game_config_view.hpp"
 #include "game_display.hpp"
 #include "terrain/type_data.hpp"
 #include "reports.hpp"
@@ -32,6 +33,7 @@ namespace test_utils {
 
 		CVideo video_;
 		config dummy_cfg_;
+		game_config_view dummy_cfg_view_;
 		config dummy_cfg2_;
 		game_board dummy_board_;
 		reports dummy_reports;
@@ -62,8 +64,9 @@ namespace test_utils {
 	fake_display_manager::fake_display_manager() :
 		video_(CVideo::FAKE_TEST),
 		dummy_cfg_(),
+		dummy_cfg_view_(game_config_view::wrap(dummy_cfg_)),
 		dummy_cfg2_(),
-		dummy_board_(std::make_shared<terrain_type_data>(dummy_cfg_), dummy_cfg2_),
+		dummy_board_(std::make_shared<terrain_type_data>(dummy_cfg_view_), dummy_cfg2_),
 		main_event_context_(),
 		disp_(dummy_board_, std::shared_ptr<wb::manager> (), dummy_reports, dummy_cfg_, dummy_cfg_)
 	{

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -25,7 +25,7 @@
 #include "sdl/rect.hpp"
 #include "serialization/string_utils.hpp"
 #include "wml_exception.hpp"
-
+#include "game_config_view.hpp"
 #include <sstream>
 #include <utility>
 
@@ -938,7 +938,7 @@ const theme::status_item* theme::get_status_item(const std::string& key) const
 typedef std::map<std::string, config> known_themes_map;
 known_themes_map theme::known_themes;
 
-void theme::set_known_themes(const config* cfg)
+void theme::set_known_themes(const game_config_view* cfg)
 {
 	known_themes.clear();
 	if(!cfg)

--- a/src/theme.hpp
+++ b/src/theme.hpp
@@ -26,6 +26,8 @@
 #include <memory>
 #include <SDL2/SDL_rect.h>
 
+class game_config_view;
+
 struct _rect { std::size_t x1,y1,x2,y2; };
 
 struct theme_info
@@ -275,7 +277,7 @@ public:
 	const SDL_Rect& palette_location(const SDL_Rect& screen) const
 		{ return palette_.location(screen); }
 
-    static void set_known_themes(const config* cfg);
+    static void set_known_themes(const game_config_view* cfg);
     static std::vector<theme_info> get_known_themes();
 
 	const border_t& border() const { return border_; }

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -348,7 +348,7 @@ void unit_filter_compound::fill(vconfig cfg)
 			[](const std::vector<std::string>& types, const unit_filter_args& args)
 			{
 				// If this unit is a variation itself then search in the base unit's variations.
-				const unit_type* const type = args.u.variation().empty() ? &args.u.type() : unit_types.find(args.u.type().base_id());
+				const unit_type* const type = args.u.variation().empty() ? &args.u.type() : unit_types.find(args.u.type().parent_id());
 				assert(type);
 
 				for(const std::string& variation_id : types) {

--- a/src/units/types.cpp
+++ b/src/units/types.cpp
@@ -116,22 +116,22 @@ unit_type::unit_type(const config& cfg, const std::string& parent_id)
 	, cost_(0)
 	, usage_()
 	, undead_variation_()
-	, image_(cfg_["image"].str())
+	, image_()
 	, icon_()
 	, small_profile_()
 	, profile_()
-	, flag_rgb_(cfg_["flag_rgb"].str())
+	, flag_rgb_()
 	, num_traits_(0)
 	, gender_types_()
 	, variations_()
-	, default_variation_(cfg_["variation"])
+	, default_variation_()
 	, variation_name_(cfg_["variation_name"].t_str())
 	, race_(&unit_race::null_race)
 	, abilities_()
 	, adv_abilities_()
 	, zoc_(false)
 	, hide_help_(false)
-	, do_not_list_(cfg_["do_not_list"].to_bool(false))
+	, do_not_list_()
 	, advances_to_()
 	, experience_needed_(0)
 	, alignment_(unit_type::ALIGNMENT::NEUTRAL)
@@ -232,11 +232,14 @@ void unit_type::build_help_index(
 	max_attacks_ = cfg_["attacks"].to_int(1);
 	usage_ = cfg_["usage"].str();
 	undead_variation_ = cfg_["undead_variation"].str();
+	default_variation_ = cfg_["variation"].str();
 	image_ = cfg_["image"].str();
 	icon_ = cfg_["image_icon"].str();
 	small_profile_ = cfg_["small_profile"].str();
 	profile_ = cfg_["profile"].str();
-	
+	flag_rgb_ = cfg_["flag_rgb"].str();
+	do_not_list_ = cfg_["do_not_list"].to_bool(false);
+
 	for(const config& sn : cfg_.child_range("special_note")) {
 		special_notes_.push_back(sn["note"]);
 	}

--- a/src/units/types.cpp
+++ b/src/units/types.cpp
@@ -54,7 +54,7 @@ unit_type::unit_type(const unit_type& o)
 	: cfg_(o.cfg_)
 	, id_(o.id_)
 	, debug_id_(o.debug_id_)
-	, base_id_(o.base_id_)
+	, parent_id_(o.parent_id_)
 	, type_name_(o.type_name_)
 	, description_(o.description_)
 	, hitpoints_(o.hitpoints_)
@@ -99,9 +99,11 @@ unit_type::unit_type(const unit_type& o)
 
 unit_type::unit_type(const config& cfg, const std::string& parent_id)
 	: cfg_(cfg)
+	, built_cfg_()
+	, has_cfg_build_()
 	, id_(cfg_.has_attribute("id") ? cfg_["id"].str() : parent_id)
 	, debug_id_()
-	, base_id_(!parent_id.empty() ? parent_id : id_)
+	, parent_id_(!parent_id.empty() ? parent_id : id_)
 	, type_name_(cfg_["name"].t_str())
 	, description_()
 	, hitpoints_(0)
@@ -142,7 +144,7 @@ unit_type::unit_type(const config& cfg, const std::string& parent_id)
 	, build_status_(NOT_BUILT)
 {
 	check_id(id_);
-	check_id(base_id_);
+	check_id(parent_id_);
 }
 
 unit_type::~unit_type()
@@ -347,7 +349,7 @@ void unit_type::build_help_index(
 
 		if(success) {
 			ut->second.debug_id_ = debug_id_ + " [" + var_id + "]";
-			ut->second.base_id_ = base_id_; // In case this is not id_.
+			ut->second.parent_id_ = parent_id_; // In case this is not id_.
 			ut->second.variation_id_ = var_id;
 			ut->second.build_help_index(mv_types, races, traits);
 		} else {

--- a/src/units/types.hpp
+++ b/src/units/types.hpp
@@ -22,7 +22,7 @@
 #include "units/attack_type.hpp"
 #include "units/alignment.hpp"
 #include "units/type_error.hpp"
-
+#include "game_config_view.hpp"
 #include <memory>
 #include <array>
 #include <map>
@@ -32,7 +32,7 @@
 
 class unit_ability_list;
 class unit_animation;
-
+class game_config_view;
 
 typedef std::map<std::string, movetype> movement_type_map;
 
@@ -84,10 +84,10 @@ public:
 private: // These will be called by build().
 	/// Load data into an empty unit_type (build to FULL).
 	void build_full(const movement_type_map &movement_types,
-		const race_map &races, const config::const_child_itors &traits);
+		const race_map &races, const config_array_view &traits);
 	/// Partially load data into an empty unit_type (build to HELP_INDEXED).
 	void build_help_index(const movement_type_map &movement_types,
-		const race_map &races, const config::const_child_itors &traits);
+		const race_map &races, const config_array_view &traits);
 	/// Load the most needed data into an empty unit_type (build to CREATE).
 	void build_created();
 
@@ -95,11 +95,11 @@ private: // These will be called by build().
 public:
 	/// Performs a build of this to the indicated stage.
 	void build(BUILD_STATUS status, const movement_type_map &movement_types,
-	           const race_map &races, const config::const_child_itors &traits);
+	           const race_map &races, const config_array_view &traits);
 	/// Performs a build of this to the indicated stage.
 	/// (This does not logically change the unit type, so allow const access.)
 	void build(BUILD_STATUS status, const movement_type_map &movement_types,
-	           const race_map &races, const config::const_child_itors &traits) const
+	           const race_map &races, const config_array_view &traits) const
 	{ const_cast<unit_type *>(this)->build(status, movement_types, races, traits); }
 
 
@@ -375,8 +375,8 @@ public:
 
 	const unit_type_map &types() const { return types_; }
 	const race_map &races() const { return races_; }
-	const config::const_child_itors traits() const { return unit_cfg_->child_range("trait"); }
-	void set_config(const config &cfg);
+	config_array_view traits() const { return units_cfg().child_range("trait"); }
+	void set_config(const game_config_view &cfg);
 
 	/// Finds a unit_type by its id() and makes sure it is built to the specified level.
 	const unit_type *find(const std::string &key, unit_type::BUILD_STATUS status = unit_type::FULL) const;
@@ -386,8 +386,7 @@ public:
 	/// Makes sure the all unit_types are built to the specified level.
 	void build_all(unit_type::BUILD_STATUS status);
 	/// Makes sure the provided unit_type is built to the specified level.
-	void build_unit_type(const unit_type & ut, unit_type::BUILD_STATUS status) const
-	{ ut.build(status, movement_types_, races_, unit_cfg_->child_range("trait")); }
+	void build_unit_type(const unit_type & ut, unit_type::BUILD_STATUS status) const;
 
 	/** Checks if the [hide_help] tag contains these IDs. */
 	bool hide_help(const std::string &type_id, const std::string &race_id) const;
@@ -412,7 +411,8 @@ private:
 	std::vector< std::set<std::string>> hide_help_type_;
 	std::vector< std::set<std::string>> hide_help_race_;
 
-	const config *unit_cfg_;
+	const game_config_view& units_cfg() const { return units_cfg_; }
+	game_config_view units_cfg_;
 	unit_type::BUILD_STATUS build_status_;
 };
 

--- a/src/units/types.hpp
+++ b/src/units/types.hpp
@@ -128,7 +128,7 @@ public:
 	/// A variant on id() that is more descriptive, for use with message logging.
 	const std::string log_id() const { return id_ + debug_id_; }
 	/// The id of the original type from which this (variation) descended.
-	const std::string& base_id() const { return base_id_; }
+	const std::string& parent_id() const { return parent_id_; }
 	/// The id of this variation; empty if it's a gender variation or a base unit.
 	const std::string& variation_id() const { return variation_id_; }
 	// NOTE: this used to be a const object reference, but it messed up with the
@@ -270,11 +270,16 @@ private:
 	void operator=(const unit_type& o);
 
 	const config &cfg_;
+	friend class unit_type_data;
+	mutable config built_cfg_;
+	mutable bool has_cfg_build_;
 	mutable attack_list attacks_cache_;
 
 	std::string id_;
 	std::string debug_id_;  /// A suffix for id_, used when logging messages.
-	std::string base_id_;   /// The id of the top ancestor of this unit_type.
+	std::string parent_id_;   /// The id of the top ancestor of this unit_type.
+	/// from [base_unit]
+	std::string base_ids_;	
 	t_string type_name_;
 	t_string description_;
 	std::vector<t_string> special_notes_;

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1519,8 +1519,8 @@ void unit::write(config& cfg, bool write_all) const
 
 	cfg["type"] = type_id();
 
-	if(type_id() != type().base_id()) {
-		cfg["parent_type"] = type().base_id();
+	if(type_id() != type().parent_id()) {
+		cfg["parent_type"] = type().parent_id();
 	}
 
 	// Support for unit formulas in [ai] and unit-specific variables in [ai] [vars]
@@ -2258,7 +2258,7 @@ void unit::apply_builtin_effect(std::string apply_to, const config& effect)
 		}
 	} else if(effect["apply_to"] == "variation") {
 		variation_ = effect["name"].str();
-		const unit_type*  base_type = unit_types.find(type().base_id());
+		const unit_type*  base_type = unit_types.find(type().parent_id());
 		assert(base_type != nullptr);
 		advance_to(*base_type);
 		if(effect["heal_full"].to_bool(false)) {
@@ -2267,7 +2267,7 @@ void unit::apply_builtin_effect(std::string apply_to, const config& effect)
 	} else if(effect["apply_to"] == "type") {
 		std::string prev_type = effect["prev_type"];
 		if(prev_type.empty()) {
-			prev_type = type().base_id();
+			prev_type = type().parent_id();
 		}
 		const std::string& new_type_id = effect["name"];
 		const unit_type* new_type = unit_types.find(new_type_id);

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -352,7 +352,7 @@ public:
 	 * The id of this unit's type.
 	 *
 	 * If you are dealing with creating units (e.g. recruitment), this is not what you want, as a
-	 * variation can change this; use type().base_id() instead.
+	 * variation can change this; use type().parent_id() instead.
 	 */
 	const std::string& type_id() const;
 


### PR DESCRIPTION
With this, the engine will ignore all global tags defined by addons that are not used in the current game, The main purpose is to solve OOS. The addons that are uses in the current gam are the addons that defines one the the [campaign],[modification] etc. tags that are uses in the current game.