### PR TITLE
WIP fix crash when reading chinese -po files

### DIFF
--- a/src/gettext_boost.cpp
+++ b/src/gettext_boost.cpp
@@ -131,12 +131,11 @@ namespace
 				if(!filesystem::file_exists(path)) {
 					continue;
 				}
-				std::ifstream po_file;
-				po_file.exceptions(std::ios::badbit);
 				LOG_G << "Loading language file from " << path << '\n';
 				try {
-					po_file.open(path);
-					const po_catalog& cat = po_catalog::from_istream(po_file);
+					filesystem::scoped_istream po_file = filesystem::istream_file(path);
+					po_file->exceptions(std::ios::badbit);
+					const po_catalog& cat = po_catalog::from_istream(*po_file);
 					extra_messages_.emplace(get_base().domain(domain), cat);
 				} catch(const spirit_po::catalog_exception& e) {
 					throw_po_error(lang_name_long, domain, e.what());


### PR DESCRIPTION
you may _never_ use the std:: file io functions
in wesnoth since they only support acii characters.
wes have fixed this mayn times already but apparently
the preson that added -po file support didn't knew
that.