### PR TITLE
fix {WEAPON_SPECIAL_INITIATIVE_EVENTS} not in scepter_variation(1.14 version)

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/units/Battle_Princess.cfg
+++ b/data/campaigns/Heir_To_The_Throne/units/Battle_Princess.cfg
@@ -217,5 +217,6 @@
 
             {SOUND:HIT_AND_MISS {SOUND_LIST:SWORD_SWISH} {SOUND_LIST:MISS} -100}
         [/attack_anim]
+        {WEAPON_SPECIAL_INITIATIVE_EVENTS}
     [/variation]
 [/unit_type]

--- a/data/campaigns/Heir_To_The_Throne/units/Princess.cfg
+++ b/data/campaigns/Heir_To_The_Throne/units/Princess.cfg
@@ -136,5 +136,6 @@
 
             {SOUND:HIT_AND_MISS {SOUND_LIST:SWORD_SWISH} {SOUND_LIST:MISS} -75}
         [/attack_anim]
+        {WEAPON_SPECIAL_INITIATIVE_EVENTS}
     [/variation]
 [/unit_type]


### PR DESCRIPTION
this macro must be present in scepter_variation of Princess and Battle_Princess unit_type for what initiative abilitie function in 1.14 when Li'sar have the Scepter of fire