### PR TITLE
Scale fixed-size dialogue window capped by screen size percentage

### DIFF
--- a/data/gui/macros/_initial.cfg
+++ b/data/gui/macros/_initial.cfg
@@ -248,16 +248,6 @@
 	y = "(floor((screen_height - window_height) / 2))"
 #enddef
 
-#define GUI_WINDOW_PERC_FIXED_SIZE_CENTERED PERC_W PERC_H WIDTH HEIGHT
-	automatic_placement = false
-
-	width = "(max(screen_width * {PERC_W} / 100, min(screen_width, {WIDTH})))"
-	height = "(max(screen_height * {PERC_H} / 100, min(screen_height, {HEIGHT})))"
-
-	x = "(floor((screen_width  - window_width)  / 2))"
-	y = "(floor((screen_height - window_height) / 2))"
-#enddef
-
 #define GUI_CENTERED_IMAGE
 	x = "(max(pos, 0) where pos = floor((width  - image_width)  / 2))"
 	y = "(max(pos, 0) where pos = floor((height - image_height) / 2))"
@@ -366,10 +356,18 @@
 # dpi. It came out looking pretty decent on my 90-micron monitor.
 
 #define GUI_SCALE_RESOLUTION SIZE
-	"(max({SIZE}, floor({SIZE} * 265 * 2 / (3 * screen_pitch_microns))))"
+	(max({SIZE}, floor({SIZE} * 265 * 2 / (3 * screen_pitch_microns))))
 #enddef
 
+#define GUI_WINDOW_PERC_FIXED_SIZE_CENTERED PERC_W PERC_H WIDTH HEIGHT
+	automatic_placement = false
 
+	width  = "(max(min(screen_width,  {WIDTH} ), min(screen_width  * {PERC_W} / 100, {GUI_SCALE_RESOLUTION {WIDTH} })))"
+	height = "(max(min(screen_height, {HEIGHT}), min(screen_height * {PERC_H} / 100, {GUI_SCALE_RESOLUTION {HEIGHT}})))"
+
+	x = "(floor((screen_width  - window_width)  / 2))"
+	y = "(floor((screen_height - window_height) / 2))"
+#enddef
 
 ###############################################################################
 ###                                                                         ###


### PR DESCRIPTION
Changes the GUI_WINDOW_PERC_FIXED_SIZED_CENTERED macro used by the load game dialogue to scale the nominal pixel size of the window by exactly the same scaling used for font sizes at large pixel dimensions, but (a) capped by a percentage of the screen size and (b) no smaller that it would have been under older code. Provision (b) is important to avoid the dialogue becoming any smaller on lower-pixel-dimension screen sizes where the label font scaling is not in effect.

Resolves #4969 
