### PR TITLE
Addon titles and descriptions made translatable

### DIFF
--- a/data/core/about.cfg
+++ b/data/core/about.cfg
@@ -1132,6 +1132,9 @@
         name = "Anja Keicher (ayne)"
     [/entry]
     [entry]
+        name = "Artem Khrapov (kabachuha)"
+    [/entry]
+    [entry]
         name = "Astrid Halberkamp"
     [/entry]
     [entry]

--- a/src/addon/client.cpp
+++ b/src/addon/client.cpp
@@ -308,7 +308,7 @@ bool addons_client::try_fetch_addon(const addon_info & addon)
 	config archive;
 
 	if(!(
-		download_addon(archive, addon.id, addon.title, !is_addon_installed(addon.id)) &&
+		download_addon(archive, addon.id, addon.display_title_full(), !is_addon_installed(addon.id)) &&
 		install_addon(archive, addon)
 		)) {
 		const std::string& server_error = get_last_server_error();

--- a/src/addon/info.cpp
+++ b/src/addon/info.cpp
@@ -117,10 +117,10 @@ void addon_info::write(config& cfg) const
 	cfg["uploads"] = this->uploads;
 	cfg["type"] = get_addon_type_string(this->type);
 
-	for(std::pair<std::string, addon_info_translation> element : this->info_translations) {
-		config* locale = &cfg.add_child("translation");
-		(*locale)["language"] = element.first;
-		element.second.write(*locale);
+	for(const auto& element : this->info_translations) {
+		config& locale = cfg.add_child("translation");
+		locale["language"] = element.first;
+		element.second.write(locale);
 	}
 
 	cfg["core"] = this->core;
@@ -158,9 +158,7 @@ addon_info_translation addon_info::translated_info() const
 	std::string locale = get_language().localename;
 
 	if(locale != "en_US") {
-		std::map<std::string, addon_info_translation>::const_iterator info;
-
-		info = info_translations.find(locale);
+		auto info = info_translations.find(locale);
 		if(info != info_translations.end()) {
 			return info->second;
 		}

--- a/src/addon/info.cpp
+++ b/src/addon/info.cpp
@@ -117,7 +117,7 @@ void addon_info::write(config& cfg) const
 	cfg["uploads"] = this->uploads;
 	cfg["type"] = get_addon_type_string(this->type);
 
-	for(const std::pair<std::string, addon_info_translation> &element : this->info_translations) {
+	for(std::pair<std::string, addon_info_translation> element : this->info_translations) {
 		config* locale = &cfg.add_child("translation");
 		(*locale)["language"] = element.first;
 		element.second.write(*locale);

--- a/src/addon/info.hpp
+++ b/src/addon/info.hpp
@@ -22,9 +22,66 @@
 #include <set>
 #include <map>
 
+struct addon_info_translation;
 struct addon_info;
 class config;
 typedef std::map<std::string, addon_info> addons_list;
+
+struct addon_info_translation
+{
+	static addon_info_translation invalid;
+
+	std::string language;
+	bool supported;
+	std::string title;
+	std::string description;
+
+	addon_info_translation()
+		: language()
+		, supported(true)
+		, title()
+		, description()
+	{}
+
+	addon_info_translation(std::string lang, bool sup, std::string titl, std::string desc)
+		: language(lang)
+		, supported(sup)
+		, title(titl)
+		, description(desc)
+	{
+	}
+
+	explicit addon_info_translation(const config& cfg)
+		: language()
+		, supported(true)
+		, title()
+		, description()
+	{
+		this->read(cfg);
+	}
+
+	addon_info_translation(const addon_info_translation&) = default;
+
+	addon_info_translation& operator=(const addon_info_translation& o)
+	{
+		if(this != &o) {
+			this->language = o.language;
+			this->supported = o.supported;
+			this->title = o.title;
+			this->description = o.description;
+		}
+		return *this;
+	}
+
+	void read(const config& cfg);
+
+	void write(config& cfg) const;
+
+	bool valid()
+	{
+		return title != "invalid_addon!";
+	}
+};
 
 struct addon_info
 {
@@ -61,6 +118,8 @@ struct addon_info
 	// not previously published.
 	bool local_only;
 
+	std::vector<addon_info_translation> info_translations;
+
 	addon_info()
 		: id(), title(), description(), icon()
 		, version(), author(), size(), downloads()
@@ -71,6 +130,7 @@ struct addon_info
 		, updated()
 		, created()
 		, local_only(false)
+		, info_translations()
 	{}
 
 	explicit addon_info(const config& cfg)
@@ -83,6 +143,7 @@ struct addon_info
 		, updated()
 		, created()
 		, local_only(false)
+		, info_translations()
 	{
 		this->read(cfg);
 	}
@@ -109,6 +170,7 @@ struct addon_info
 			this->updated = o.updated;
 			this->created = o.created;
 			this->local_only = o.local_only;
+			this->info_translations = o.info_translations;
 		}
 		return *this;
 	}
@@ -137,6 +199,18 @@ struct addon_info
 	 *       add-ons in its reply anymore? Titles seem to be required at upload time.
 	 */
 	std::string display_title() const;
+
+	addon_info_translation translated_info() const;
+
+	std::string display_title_translated() const;
+
+	std::string display_title_translated_or_original() const;
+
+	std::string display_title_full() const;
+
+	std::string display_title_full_shift() const;
+
+	std::string description_translated() const;
 
 	/** Get an icon path fixed for display (e.g. when TC is missing, or the image doesn't exist). */
 	std::string display_icon() const;

--- a/src/addon/info.hpp
+++ b/src/addon/info.hpp
@@ -31,29 +31,25 @@ struct addon_info_translation
 {
 	static addon_info_translation invalid;
 
-	std::string language;
 	bool supported;
 	std::string title;
 	std::string description;
 
 	addon_info_translation()
-		: language()
-		, supported(true)
+		: supported(true)
 		, title()
 		, description()
 	{}
 
-	addon_info_translation(std::string lang, bool sup, std::string titl, std::string desc)
-		: language(lang)
-		, supported(sup)
+	addon_info_translation(bool sup, std::string titl, std::string desc)
+		: supported(sup)
 		, title(titl)
 		, description(desc)
 	{
 	}
 
 	explicit addon_info_translation(const config& cfg)
-		: language()
-		, supported(true)
+		: supported(true)
 		, title()
 		, description()
 	{
@@ -65,7 +61,6 @@ struct addon_info_translation
 	addon_info_translation& operator=(const addon_info_translation& o)
 	{
 		if(this != &o) {
-			this->language = o.language;
 			this->supported = o.supported;
 			this->title = o.title;
 			this->description = o.description;
@@ -79,7 +74,7 @@ struct addon_info_translation
 
 	bool valid()
 	{
-		return title != "invalid_addon!";
+		return !title.empty();
 	}
 };
 
@@ -118,7 +113,7 @@ struct addon_info
 	// not previously published.
 	bool local_only;
 
-	std::vector<addon_info_translation> info_translations;
+	std::map<std::string, addon_info_translation> info_translations;
 
 	addon_info()
 		: id(), title(), description(), icon()
@@ -207,8 +202,6 @@ struct addon_info
 	std::string display_title_translated_or_original() const;
 
 	std::string display_title_full() const;
-
-	std::string display_title_full_shift() const;
 
 	std::string description_translated() const;
 

--- a/src/campaign_server/addon_utils.cpp
+++ b/src/campaign_server/addon_utils.cpp
@@ -92,18 +92,14 @@ std::string format_addon_feedback_url(const std::string& format, const config& p
 	return std::string();
 }
 
-void support_translation(config& addon, std::string locale_id)
+void support_translation(config& addon, const std::string locale_id)
 {
-	if(!locale_id.empty()) {
-		config& locale = addon.find_child("translation", "language", locale_id);
-		if(locale) {
-			locale["supported"] = true;
-		}
-		else {
-			addon.add_child("translation")["language"] = locale_id; //Doing this to circumvent a weird validation bug
-			addon.find_child("translation", "language", locale_id)["supported"] = true;
-		}
+	config* locale = &addon.find_child("translation", "language", locale_id);
+	if(!*locale) {
+		locale = &addon.add_child("translation");
+		(*locale)["language"] = locale_id;
 	}
+	(*locale)["supported"] = true;
 }
 
 void find_translations(const config& base_dir, config& addon)
@@ -121,12 +117,6 @@ void find_translations(const config& base_dir, config& addon)
 			support_translation(addon, base_dir["name"]);
 		} else {
 			find_translations(dir, addon);
-		}
-	}
-
-	for(config& locale : addon.child_range("translation")) {
-		if(!locale["supported"].to_bool(false)) {
-			locale["supported"] = false;
 		}
 	}
 }

--- a/src/campaign_server/addon_utils.cpp
+++ b/src/campaign_server/addon_utils.cpp
@@ -92,7 +92,7 @@ std::string format_addon_feedback_url(const std::string& format, const config& p
 	return std::string();
 }
 
-void support_translation(config& addon, const std::string locale_id)
+void support_translation(config& addon, const std::string& locale_id)
 {
 	config* locale = &addon.find_child("translation", "language", locale_id);
 	if(!*locale) {

--- a/src/campaign_server/addon_utils.hpp
+++ b/src/campaign_server/addon_utils.hpp
@@ -49,7 +49,7 @@ inline bool is_text_markup_char(char c)
  */
 std::string format_addon_feedback_url(const std::string& format, const config& params);
 
-void support_translation(config& addon, std::string locale_id);
+void support_translation(config& addon, const std::string& locale_id);
 
 /**
  * Scans an add-on archive directory for translations.

--- a/src/campaign_server/addon_utils.hpp
+++ b/src/campaign_server/addon_utils.hpp
@@ -49,6 +49,7 @@ inline bool is_text_markup_char(char c)
  */
 std::string format_addon_feedback_url(const std::string& format, const config& params);
 
+void support_translation(config& addon, std::string locale_id);
 
 /**
  * Scans an add-on archive directory for translations.

--- a/src/campaign_server/campaign_server.cpp
+++ b/src/campaign_server/campaign_server.cpp
@@ -623,7 +623,7 @@ void server::handle_request_campaign_list(const server::request& req)
 
 			for(const config& j : i.child_range("translation"))
 			{
-				if(j["language"] == lang) {
+				if(j["language"] == lang && j["supported"].to_bool(true)) {
 					found = true;
 					break;
 				}
@@ -881,6 +881,11 @@ void server::handle_upload(const server::request& req)
 			(*campaign).add_child("feedback", url_params);
 		}
 
+		(*campaign).clear_children("translation");
+		for(const config& locale_params : upload.child_range("translation")) {
+			(*campaign).add_child("translation", locale_params);
+		}
+
 		const std::string& filename = (*campaign)["filename"].str();
 		data["title"] = (*campaign)["title"];
 		data["name"] = "";
@@ -893,8 +898,11 @@ void server::handle_upload(const server::request& req)
 		data["icon"] = (*campaign)["icon"];
 		data["type"] = (*campaign)["type"];
 		data["tags"] = (*campaign)["tags"];
-		(*campaign).clear_children("translation");
 		find_translations(data, *campaign);
+
+		for(const config& locale_params : (*campaign).child_range("translation")) {
+			data.add_child("translation", locale_params);//Do we need it?
+		}
 
 		add_license(data);
 

--- a/src/campaign_server/campaign_server.cpp
+++ b/src/campaign_server/campaign_server.cpp
@@ -623,7 +623,7 @@ void server::handle_request_campaign_list(const server::request& req)
 
 			for(const config& j : i.child_range("translation"))
 			{
-				if(j["language"] == lang && j["supported"].to_bool(true)) {
+				if(j["language"] == lang && j["supported"].to_bool(true)) {//for old addons
 					found = true;
 					break;
 				}
@@ -883,7 +883,18 @@ void server::handle_upload(const server::request& req)
 
 		(*campaign).clear_children("translation");
 		for(const config& locale_params : upload.child_range("translation")) {
-			(*campaign).add_child("translation", locale_params);
+			if(!locale_params["language"].empty()) {
+				config* locale = &(*campaign).add_child("translation");
+				(*locale)["language"] = locale_params["language"].str();
+				(*locale)["supported"] = false;
+
+				if(!locale_params["title"].empty()) {
+					(*locale)["title"] = locale_params["title"].str();
+				}
+				if(!locale_params["description"].empty()) {
+					(*locale)["description"] = locale_params["description"].str();
+				}
+			}
 		}
 
 		const std::string& filename = (*campaign)["filename"].str();
@@ -899,10 +910,6 @@ void server::handle_upload(const server::request& req)
 		data["type"] = (*campaign)["type"];
 		data["tags"] = (*campaign)["tags"];
 		find_translations(data, *campaign);
-
-		for(const config& locale_params : (*campaign).child_range("translation")) {
-			data.add_child("translation", locale_params);
-		}
 
 		add_license(data);
 

--- a/src/campaign_server/campaign_server.cpp
+++ b/src/campaign_server/campaign_server.cpp
@@ -884,15 +884,15 @@ void server::handle_upload(const server::request& req)
 		(*campaign).clear_children("translation");
 		for(const config& locale_params : upload.child_range("translation")) {
 			if(!locale_params["language"].empty()) {
-				config* locale = &(*campaign).add_child("translation");
-				(*locale)["language"] = locale_params["language"].str();
-				(*locale)["supported"] = false;
+				config& locale = (*campaign).add_child("translation");
+				locale["language"] = locale_params["language"].str();
+				locale["supported"] = false;
 
 				if(!locale_params["title"].empty()) {
-					(*locale)["title"] = locale_params["title"].str();
+					locale["title"] = locale_params["title"].str();
 				}
 				if(!locale_params["description"].empty()) {
-					(*locale)["description"] = locale_params["description"].str();
+					locale["description"] = locale_params["description"].str();
 				}
 			}
 		}

--- a/src/campaign_server/campaign_server.cpp
+++ b/src/campaign_server/campaign_server.cpp
@@ -901,7 +901,7 @@ void server::handle_upload(const server::request& req)
 		find_translations(data, *campaign);
 
 		for(const config& locale_params : (*campaign).child_range("translation")) {
-			data.add_child("translation", locale_params);//Do we need it?
+			data.add_child("translation", locale_params);
 		}
 
 		add_license(data);

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -117,6 +117,15 @@ namespace {
 						break;
 					}
 				}
+				for(const config& child : cfg.child_range("translation")) {
+					for(const auto& attribute : child.attribute_range()) {
+						std::string val = attribute.second.str();
+						if(translation::ci_search(val, filter)) {
+							found = true;
+							break;
+						}
+					}
+				}
 				if(!found) {
 					return false;
 				}
@@ -159,7 +168,7 @@ namespace {
 				str += ", ";
 			}
 
-			str += addon_list::colorize_addon_state_string(dep.display_title(), depstate.state);
+			str += addon_list::colorize_addon_state_string(dep.display_title_translated_or_original(), depstate.state);
 		}
 
 		return str;
@@ -672,14 +681,14 @@ void addon_manager::uninstall_addon(const addon_info& addon, window& window)
 	if(have_addon_pbl_info(addon.id) || have_addon_in_vcs_tree(addon.id)) {
 		show_error_message(
 			_("The following add-on appears to have publishing or version control information stored locally, and will not be removed:") + " " +
-				addon.display_title());
+				addon.display_title_full());
 		return;
 	}
 
 	bool success = remove_local_addon(addon.id);
 
 	if(!success) {
-		gui2::show_error_message(_("The following add-on could not be deleted properly:") + " " + addon.display_title());
+		gui2::show_error_message(_("The following add-on could not be deleted properly:") + " " + addon.display_title_full());
 	} else {
 		need_wml_cache_refresh_ = true;
 
@@ -805,7 +814,7 @@ void addon_manager::execute_default_action(const addon_info& addon, window& wind
 			break;
 		case ADDON_INSTALLED:
 			if(!tracking_info_[addon.id].can_publish) {
-				utils::string_map symbols{ { "addon", addon.display_title() } };
+				utils::string_map symbols{ { "addon", addon.display_title_full() } };
 				int res = gui2::show_message(_("Uninstall add-on"),
 					VGETTEXT("Do you want to uninstall '$addon|'?", symbols),
 					gui2::dialogs::message::ok_cancel_buttons);
@@ -874,8 +883,8 @@ void addon_manager::on_addon_select(window& window)
 
 	find_widget<drawing>(parent, "image", false).set_label(info->display_icon());
 
-	find_widget<styled_widget>(parent, "title", false).set_label(info->display_title());
-	find_widget<styled_widget>(parent, "description", false).set_label(info->description);
+	find_widget<styled_widget>(parent, "title", false).set_label(info->display_title_translated_or_original());
+	find_widget<styled_widget>(parent, "description", false).set_label(info->description_translated());
 	find_widget<styled_widget>(parent, "version", false).set_label(info->version.str());
 	find_widget<styled_widget>(parent, "author", false).set_label(info->author);
 	find_widget<styled_widget>(parent, "type", false).set_label(info->display_type());

--- a/src/gui/widgets/addon_list.cpp
+++ b/src/gui/widgets/addon_list.cpp
@@ -164,7 +164,7 @@ void addon_list::set_addons(const addons_list& addons)
 			item["label"] = addon.display_icon();
 			data.emplace("icon", item);
 
-			item["label"] = addon.display_title();
+			item["label"] = addon.display_title_full_shift();
 			data.emplace("name", item);
 		} else {
 			item["label"] = addon.display_icon() + "~SCALE(72,72)~BLIT(icons/icon-addon-publish.png,8,8)";
@@ -172,7 +172,7 @@ void addon_list::set_addons(const addons_list& addons)
 
 			const std::string publish_name = formatter()
 				<< font::span_color(font::GOOD_COLOR)
-				<< addon.display_title()
+				<< addon.display_title_full_shift()
 				<< "</span>";
 
 			item["label"] = publish_name;
@@ -347,7 +347,7 @@ void addon_list::select_addon(const std::string& id)
 		grid* row = list.get_row_grid(i);
 
 		const label& name_label = find_widget<label>(row, "name", false);
-		if(name_label.get_label().base_str() == info.display_title()) {
+		if(name_label.get_label().base_str() == info.display_title_full_shift()) {
 			list.select_row(i);
 		}
 	}
@@ -369,7 +369,7 @@ void addon_list::finalize_setup()
 {
 	listbox& list = get_listbox();
 
-	list.register_translatable_sorting_option(0, [this](const int i) { return addon_vector_[i]->title; });
+	list.register_translatable_sorting_option(0, [this](const int i) { return addon_vector_[i]->display_title_full(); });
 	list.register_sorting_option(1, [this](const int i) { return addon_vector_[i]->author; });
 	list.register_sorting_option(2, [this](const int i) { return addon_vector_[i]->size; });
 	list.register_sorting_option(3, [this](const int i) { return addon_vector_[i]->downloads; });
@@ -402,7 +402,7 @@ void addon_list::select_first_addon()
 	const addon_info* first_addon = addon_vector_[0];
 
 	for(const addon_info* a : addon_vector_) {
-		if(a->display_title().compare(first_addon->display_title()) < 0) {
+		if(translation::icompare(a->display_title_full(), first_addon->display_title_full()) < 0) {
 			first_addon = a;
 		}
 	}

--- a/src/gui/widgets/addon_list.cpp
+++ b/src/gui/widgets/addon_list.cpp
@@ -144,6 +144,16 @@ void addon_list::addon_action_wrapper(addon_op_func_t& func, const addon_info& a
 	}
 }
 
+const std::string addon_list::display_title_full_shift(const addon_info& addon) const
+{
+	const std::string& local_title = addon.display_title_translated();
+	const std::string& display_title = addon.display_title();
+	if(local_title.empty())
+		return display_title;
+	return local_title + "\n"
+		+ "<small>(" + display_title + ")</small>";
+}
+
 void addon_list::set_addons(const addons_list& addons)
 {
 	listbox& list = get_listbox();
@@ -164,7 +174,7 @@ void addon_list::set_addons(const addons_list& addons)
 			item["label"] = addon.display_icon();
 			data.emplace("icon", item);
 
-			item["label"] = addon.display_title_full_shift();
+			item["label"] = display_title_full_shift(addon);
 			data.emplace("name", item);
 		} else {
 			item["label"] = addon.display_icon() + "~SCALE(72,72)~BLIT(icons/icon-addon-publish.png,8,8)";
@@ -172,7 +182,7 @@ void addon_list::set_addons(const addons_list& addons)
 
 			const std::string publish_name = formatter()
 				<< font::span_color(font::GOOD_COLOR)
-				<< addon.display_title_full_shift()
+				<< display_title_full_shift(addon)
 				<< "</span>";
 
 			item["label"] = publish_name;
@@ -347,7 +357,7 @@ void addon_list::select_addon(const std::string& id)
 		grid* row = list.get_row_grid(i);
 
 		const label& name_label = find_widget<label>(row, "name", false);
-		if(name_label.get_label().base_str() == info.display_title_full_shift()) {
+		if(name_label.get_label().base_str() == display_title_full_shift(info)) {
 			list.select_row(i);
 		}
 	}

--- a/src/gui/widgets/addon_list.hpp
+++ b/src/gui/widgets/addon_list.hpp
@@ -45,6 +45,8 @@ public:
 	/** Special retval for the toggle panels in the addons list */
 	static const int DEFAULT_ACTION_RETVAL = 200;
 
+	const std::string display_title_full_shift(const addon_info& addon) const;
+
 	/** Sets the add-ons to show. */
 	void set_addons(const addons_list& addons);
 


### PR DESCRIPTION
**Addon titles and descriptions made translatable**

Hello, wesnoth devs!

The international wesnoth players had long been troubled by not being able to see what the addon is about without installing it or using external tools. So I decided to make it possible to see addon titles and descriptions in the addon manager.

I've done through `[translation]` tag modification because sending .mo file for the entire campaign is unnecesearily, and .mo and .po workflow just for .pbl file is redundant.

The feature is done on the `master` branch, but I'd like backporting it to 1.14 in after it's tested.

The original tag contains only the `language` attribute, the new one has the following structure. (If the declaration is abscent, but the .mo file is present, it'll be added with `supported=yes` attribute.):
```
[translation]
	description="localized description"
	language="ru" #locale code
	supported=yes #is set to yes if the corresponding .mo file has been found, otherwise no. If the client receives the tag without the `supported` attribute, it's assumed as `yes` for backward compatibility.
	title="localized title"
[/translation]
```

To upload the description translation insert it into the .pbl file.

<details>
  <summary>The example .pbl file</summary>
  
  ```
	author="kabachuha"
	title="Hello World"
	icon="units/monsters/gryphon.png"
	version="0.1.0"
	description="Checking the translation of the addon!"
	type="campaign"
	email="artemkhrapov2001@yandex.ru"
	passphrase="iloveasaltycucumber"
	translate=true

	[translation]
		language="ru"
		title="Здравствуй, мир!"
		description="Проверка перевода описания аддона"
	[/translation]

	[translation]
		language="zh_CN"
		title="你好，世界!"
		description="检查插件的翻译 (translated online)"
	[/translation]
  ```
  Notice: My testing addon also has a .mo file for the Japanese translation which isn't declared in this file. But you'll see it in the server database with `supported=yes`.
  
</details>

The deal with the `supported` attribute is to protect against an edge case when the translation is declared without the .mo file (as pointed out by Iris (@shikadiqueen) and against duplicate translations.

The server stores the addon info as usual except for the appended `translation` tags.

<details>
  <summary>The server.cfg from my testing addon server</summary>
  
  ```
	compress_level=6
	[campaigns]
		[campaign]
			author="kabachuha"
			description="Checking the translation of the addon!"
			downloads=1
			email="artemkhrapov2001@yandex.ru"
			filename="data/Hello_World"
			icon="units/monsters/gryphon.png"
			name="Hello_World"
			original_timestamp=1593893863
			passhash="hs3F0Q1wNL2b2xWTn5ODS1"
			passsalt="nfOLTKWsrjS/s6v2"
			size=776987
			timestamp=1593899194
			title="Hello World"
			translate=true
			type="campaign"
			upload_ip="127.0.0.1"
			uploads=7
			version="0.1.0"
			[translation]
				description="Проверка перевода описания аддона"
				language="ru"
				supported=yes
				title="Здравствуй, мир!"
			[/translation]
			[translation]
				description="检查插件的翻译 (translated online)"
				language="zh_CN"
				supported=no
				title="你好，世界!"
			[/translation]
			[translation]
				language="ja"
				supported=yes
			[/translation]
		[/campaign]
		[campaign]
			author="kabachuha"
			description="Addon with no translation for Russian!"
			downloads=0
			email="artemkhrapov2001@yandex.ru"
			filename="data/Status_Quo_Addon"
			icon="units/monsters/gryphon.png"
			name="Status_Quo_Addon"
			original_timestamp=1593894760
			passhash="E6D1VGjAb5bXqxK/KAWKH0"
			passsalt="oMGowk3uSHic9QY0"
			size=3656
			timestamp=1593894760
			title="Status Quo"
			translate=true
			type="campaign"
			upload_ip="127.0.0.1"
			uploads=1
			version="0.1.0"
			[translation]
				description="检查插件的翻译 (translated online)"
				language="zh_CN"
				supported=no
				title="你好，世界!"
			[/translation]
		[/campaign]
	[/campaigns]
  ```
  
</details>

The client side will check if the translation exists for the current locale and will use the translated title (the original title is shown slightly below the title for players who had known the addon by the English name) and the translated description in that case.

Also, I made possible to search both for the original and the translated strings in the manager.

***Demos***

<details>
  <summary>Pictures</summary>

The changes are fully backwards compatible with the old server/client.

![backward_compatible](https://user-images.githubusercontent.com/14872007/86541427-7e282500-bf15-11ea-9c60-dc27ee661df2.png)

Addons on my pet server.

![2020-07-05-005141_1920x1080_scrot](https://user-images.githubusercontent.com/14872007/86541455-c2b3c080-bf15-11ea-9743-5cdd07145fb5.png)

Chinese translation is rendered fine too.

![2020-07-05-005233_1920x1080_scrot](https://user-images.githubusercontent.com/14872007/86541462-d65f2700-bf15-11ea-8650-56a8f96e28db.png)

Uploadable addons are also translated and the search is possible.

![2020-07-05-004724_1920x1080_scrot](https://user-images.githubusercontent.com/14872007/86541486-060e2f00-bf16-11ea-8f79-0745f77fb39f.png)

</details>

***Known issue***

The addon's name may not be fully shown in the dependecies window if it's very long. (According to Iris and Vultraz, its the fault of the gui even without the translation, so it belongs to another issue).