### PR TITLE
Create Unit UI improvements & unit type variation selection

### DIFF
--- a/data/gui/window/unit_create.cfg
+++ b/data/gui/window/unit_create.cfg
@@ -201,10 +201,32 @@
 
 										[column]
 											grow_factor = 1
-											horizontal_grow = true
+											horizontal_alignment = "right"
 											[grid]
 												[row]
 													grow_factor=0
+													[column]
+														border = "all"
+														border_size = 5
+														horizontal_alignment = "left"
+
+														[label]
+															definition = "default"
+															label= _ "Variation:"
+														[/label]
+													[/column]
+
+													[column]
+														border = "all"
+														border_size = 5
+														horizontal_alignment = "left"
+
+														[menu_button]
+															id = "variation_box"
+															definition = "default"
+														[/menu_button]
+													[/column]
+
 													[column]
 														border = "all"
 														border_size = 5

--- a/data/gui/window/unit_create.cfg
+++ b/data/gui/window/unit_create.cfg
@@ -52,7 +52,7 @@
 
 								[label]
 									definition = "title"
-									label = _ "Create Unit (Debug!)"
+									label = _ "Create Unit"
 								[/label]
 
 							[/column]

--- a/data/gui/window/unit_create.cfg
+++ b/data/gui/window/unit_create.cfg
@@ -201,25 +201,53 @@
 
 										[column]
 											grow_factor = 1
-											horizontal_alignment = "right"
+											horizontal_grow = true
+
 											[grid]
+
 												[row]
 													grow_factor=0
+
 													[column]
-														border = "all"
-														border_size = 5
 														horizontal_alignment = "left"
 
-														[label]
-															definition = "default"
-															label= _ "Variation:"
-														[/label]
+														[grid]
+
+															[row]
+
+																[column]
+																	border = "all"
+																	border_size = 5
+
+																	[toggle_button]
+																		id = "male_toggle"
+																		definition = "radio"
+																		label= _ "Male"
+																	[/toggle_button]
+																[/column]
+
+																[column]
+																	border = "all"
+																	border_size = 5
+
+																	[toggle_button]
+																		id = "female_toggle"
+																		definition = "radio"
+																		label= _ "Female"
+																	[/toggle_button]
+
+																[/column]
+
+															[/row]
+
+														[/grid]
+
 													[/column]
 
 													[column]
 														border = "all"
 														border_size = 5
-														horizontal_alignment = "left"
+														horizontal_alignment = "right"
 
 														[menu_button]
 															id = "variation_box"
@@ -227,41 +255,6 @@
 														[/menu_button]
 													[/column]
 
-													[column]
-														border = "all"
-														border_size = 5
-														horizontal_alignment = "left"
-
-														[label]
-															definition = "default"
-															label= _ "Gender:"
-														[/label]
-													[/column]
-
-													[column]
-														border = "all"
-														border_size = 5
-														horizontal_alignment = "right"
-
-														[toggle_button]
-															id = "male_toggle"
-															definition = "radio"
-															label= _ "Male"
-														[/toggle_button]
-													[/column]
-
-													[column]
-														border = "all"
-														border_size = 5
-														horizontal_alignment = "right"
-
-														[toggle_button]
-															id = "female_toggle"
-															definition = "radio"
-															label= _ "Female"
-														[/toggle_button]
-
-													[/column]
 												[/row]
 
 											[/grid]

--- a/src/gui/dialogs/unit_create.cpp
+++ b/src/gui/dialogs/unit_create.cpp
@@ -199,11 +199,9 @@ void unit_create::update_displayed_type() const
 	const unit_type* ut = &units_[selected_row]->get_gender_unit_type(gender_);
 
 	if(!variation_.empty()) {
-		const auto& variations = units_[selected_row]->variation_types();
-		auto vi = variations.find(variation_);
-		if(vi != variations.end()) {
-			ut = &vi->second.get_gender_unit_type(gender_);
-		}
+		// This effectively translates to `ut = ut` if somehow variation_ does
+		// not refer to a variation that the unit type supports.
+		ut = &ut->get_variation(variation_);
 	}
 
 	find_widget<unit_preview_pane>(w, "unit_details", false).set_displayed_type(*ut);

--- a/src/gui/dialogs/unit_create.cpp
+++ b/src/gui/dialogs/unit_create.cpp
@@ -240,7 +240,9 @@ void unit_create::list_item_clicked(window& window)
 		const unit_type& uv = pair.second;
 
 		std::string uv_label;
-		if(!uv.type_name().empty() && uv.type_name() != ut.type_name()) {
+		if(!uv.variation_name().empty()) {
+			uv_label = uv.variation_name() + " (" + uv_id + ")";
+		} else if(!uv.type_name().empty() && uv.type_name() != ut.type_name()) {
 			uv_label = uv.type_name() + " (" + uv_id + ")";
 		} else {
 			uv_label = uv_id;

--- a/src/gui/dialogs/unit_create.cpp
+++ b/src/gui/dialogs/unit_create.cpp
@@ -226,7 +226,7 @@ void unit_create::list_item_clicked(window& window)
 
 	menu_button& var_box = find_widget<menu_button>(&window, "variation_box", false);
 	std::vector<config> var_box_values;
-	var_box_values.emplace_back("label", _("unit_variation^Default"), "variation_id", "");
+	var_box_values.emplace_back("label", _("unit_variation^Default Variation"), "variation_id", "");
 
 	const auto& ut = *units_[selected_row];
 	const auto& uvars = ut.variation_types();

--- a/src/gui/dialogs/unit_create.hpp
+++ b/src/gui/dialogs/unit_create.hpp
@@ -27,6 +27,7 @@ class unit_type;
 namespace gui2
 {
 
+class menu_button;
 class text_box_base;
 
 namespace dialogs
@@ -55,12 +56,20 @@ public:
 		return gender_;
 	}
 
+	/** Variation choice from the user. */
+	std::string variation() const
+	{
+		return variation_;
+	}
+
 private:
 	std::vector<const unit_type*> units_;
 
 	unit_race::GENDER gender_;
 
 	std::string choice_;
+
+	std::string variation_;
 
 	std::vector<std::string> last_words_;
 
@@ -77,6 +86,7 @@ private:
 	void list_item_clicked(window& window);
 	void filter_text_changed(text_box_base* textbox, const std::string& text);
 	void gender_toggle_callback();
+	void variation_menu_callback();
 
 	void update_displayed_type() const;
 

--- a/src/synced_commands.cpp
+++ b/src/synced_commands.cpp
@@ -536,6 +536,7 @@ SYNCED_COMMAND_HANDLER_FUNCTION(debug_create_unit, child,  use_undo, /*show*/, e
 	debug_notification(N_("A unit was created using debug mode during $player’s turn"));
 	map_location loc(child);
 	resources::whiteboard->on_kill_unit();
+	const std::string& variation = child["variation"].str();
 	const unit_race::GENDER gender = string_gender(child["gender"], unit_race::NUM_GENDERS);
 	const unit_type *u_type = unit_types.find(child["type"]);
 	if (!u_type) {
@@ -547,7 +548,7 @@ SYNCED_COMMAND_HANDLER_FUNCTION(debug_create_unit, child,  use_undo, /*show*/, e
 			? resources::controller->current_side() : 1;
 
 	// Create the unit.
-	unit_ptr created = unit::create(*u_type, side_num, true, gender);
+	unit_ptr created = unit::create(*u_type, side_num, true, gender, variation);
 	created->new_turn();
 
 	unit_map::unit_iterator unit_it;

--- a/src/units/types.hpp
+++ b/src/units/types.hpp
@@ -308,7 +308,7 @@ private:
 	std::string debug_id_;  /// A suffix for id_, used when logging messages.
 	std::string parent_id_;   /// The id of the top ancestor of this unit_type.
 	/// from [base_unit]
-	std::string base_unit_id_;	
+	std::string base_unit_id_;
 	t_string type_name_;
 	t_string description_;
 	std::vector<t_string> special_notes_;

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -725,11 +725,11 @@ void unit::clear_status_caches()
 	units_with_cache.clear();
 }
 
-void unit::init(const unit_type& u_type, int side, bool real_unit, unit_race::GENDER gender)
+void unit::init(const unit_type& u_type, int side, bool real_unit, unit_race::GENDER gender, const std::string& variation)
 {
 	type_ = &u_type;
 	race_ = &unit_race::null_race;
-	variation_ = type_->default_variation();
+	variation_ = variation.empty() ? type_->default_variation() : variation;
 	side_ = side;
 	gender_ = gender != unit_race::NUM_GENDERS ? gender : generate_gender(u_type, real_unit);
 	facing_ = static_cast<map_location::DIRECTION>(randomness::rng::default_instance().get_random_int(0, map_location::NDIRECTIONS-1));

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1963,7 +1963,7 @@ void unit::apply_builtin_effect(std::string apply_to, const config& effect)
 		if(const config::attribute_value* v = effect.get("description")) {
 			description_ = *v;
 		}
-		
+
 		if(config::const_child_itors cfg_range = effect.child_range("special_note")) {
 			for(const config& c : cfg_range) {
 				if(!c["remove"].to_bool()) {

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -140,7 +140,7 @@ public:
 private:
 	void init(const config& cfg, bool use_traits = false, const vconfig* vcfg = nullptr);
 
-	void init(const unit_type& t, int side, bool real_unit, unit_race::GENDER gender = unit_race::NUM_GENDERS);
+	void init(const unit_type& t, int side, bool real_unit, unit_race::GENDER gender = unit_race::NUM_GENDERS, const std::string& variation = "");
 
 	// Copy constructor
 	unit(const unit& u);
@@ -194,10 +194,10 @@ public:
 	 *
 	 * Only real_unit-s should have random traits, name and gender (to prevent OOS caused by RNG calls)
 	 */
-	static unit_ptr create(const unit_type& t, int side, bool real_unit, unit_race::GENDER gender = unit_race::NUM_GENDERS)
+	static unit_ptr create(const unit_type& t, int side, bool real_unit, unit_race::GENDER gender = unit_race::NUM_GENDERS, const std::string& variation = "")
 	{
 		unit_ptr res(new unit());
-		res->init(t, side, real_unit, gender);
+		res->init(t, side, real_unit, gender, variation);
 		return res;
 	}
 

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -116,7 +116,7 @@ public:
 	{
 		std::copy( other.begin(), other.end(), std::back_inserter(cfgs_ ));
 	}
-	
+
 private:
 	// Data
 	std::vector<unit_ability> cfgs_;
@@ -448,7 +448,7 @@ public:
 	{
 		description_ = new_desc;
 	}
-	
+
 	/** The unit's special notes. */
 	const std::vector<t_string>& unit_special_notes() const
 	{
@@ -1167,7 +1167,7 @@ public:
 	};
 
 	using upkeep_t = boost::variant<upkeep_full, upkeep_loyal, int>;
-	
+
 	/** Visitor helper class to parse the upkeep value from a config. */
 	class upkeep_parser_visitor : public boost::static_visitor<upkeep_t>
 	{
@@ -1180,19 +1180,19 @@ public:
 			if(n < 0) throw std::invalid_argument(std::to_string(n));
 			return n;
 		}
-		
+
 		template<typename B>
 		std::enable_if_t<std::is_convertible<B, bool>::value && !std::is_arithmetic<B>::value, upkeep_t>
 		operator()(B b) const
 		{
 			throw std::invalid_argument(b.str());
 		}
-		
+
 		upkeep_t operator()(boost::blank) const
 		{
 			return upkeep_full();
 		}
-		
+
 		upkeep_t operator()(const std::string& s) const
 		{
 			if(s == "loyal" || s == "free")
@@ -1654,7 +1654,7 @@ public:
 	{
 		return get_abilities(tag_name, loc_);
 	}
-	
+
 	unit_ability_list get_abilities_weapons(const std::string& tag_name, const map_location& loc, const_attack_ptr weapon = nullptr, const_attack_ptr opp_weapon = nullptr) const;
 
 	unit_ability_list get_abilities_weapons(const std::string& tag_name, const_attack_ptr weapon = nullptr, const_attack_ptr opp_weapon = nullptr) const
@@ -1736,7 +1736,7 @@ private:
 	 * @param loc The location on which to resolve the ability
 	 */
 	bool ability_affects_self(const std::string& ability, const config& cfg, const map_location& loc) const;
-	
+
 	///filters the weapons that condition the use of abilities for combat ([resistance],[leadership] or abilities used like specials(deprecated in two last cases)
 	bool ability_affects_weapon(const config& cfg, const_attack_ptr weapon, bool is_opp) const;
 


### PR DESCRIPTION
This is a bit of a messy pull request that touches both backend code (the synced commands functionality) and UI code (context menu, Create Unit) bringing a few improvements to the Create Unit dialog.

Firstly, smaller aspects of Create Unit should be more streamlined by removing redundant labels and caption text.

Secondly, the dialog now supports selecting the unit type variation for the unit that will be created.

![image](https://user-images.githubusercontent.com/489895/86558510-85582e80-bf27-11ea-8b1b-cc4b9dce5859.png)

In order to implement this functionality I had to touch a surprising amount of code in `menu_events.cpp`, the synced commands functionality, as well as a couple key methods of the `unit` class. As far as I can tell there shouldn't be unexpected side-effects for these changes, but just in case I want @gfgtdf's review in addition to @Vultraz's anyway since it's not code I am well familiarized with at the moment.

(Also, hopefully the UI implementation side of things conforms to the current UI coding style.)