### PR TITLE
Replace aitesting log domain with ai/testing

### DIFF
--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -68,7 +68,7 @@
 
 #include "utils/functional.hpp"
 
-static lg::log_domain log_aitesting("aitesting");
+static lg::log_domain log_aitesting("ai/testing");
 #define LOG_AIT LOG_STREAM(info, log_aitesting)
 //If necessary, this define can be replaced with `#define LOG_AIT std::cout` to restore previous behavior
 

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -53,7 +53,7 @@
 #include "hotkey/hotkey_item.hpp"
 #include <boost/dynamic_bitset.hpp>
 
-static lg::log_domain log_aitesting("aitesting");
+static lg::log_domain log_aitesting("ai/testing");
 #define LOG_AIT LOG_STREAM(info, log_aitesting)
 //If necessary, this define can be replaced with `#define LOG_AIT std::cout` to restore previous behavior
 


### PR DESCRIPTION
The former was added in commit 40a1e7d3fa74d59e7bba2d23fc535d9aa0a7f499. However, `ai/testing` predates it by several years (added in commit ab540dca1517e82d0f93153604cdb00f256becd6) and also follows the existing naming convention better.

I don't think this should break anything, but just in case I'm creating a PR for it to run unit tests, since apparently `aitesting` was at some point relevant for those.