### PR TITLE
Throw instead of crashing when handling extremely long text

### DIFF
--- a/src/sdl/surface.cpp
+++ b/src/sdl/surface.cpp
@@ -47,6 +47,10 @@ surface::surface(int w, int h)
 		neutral_pixel_format.Bmask,
 		neutral_pixel_format.Amask);
 #endif
+
+	if(!surface_) {
+		throw std::length_error("Failed to create an SDL surface, probably out of memory");
+	}
 }
 
 bool surface::is_neutral() const


### PR DESCRIPTION
Both of these still result in the program quitting, they just make it a graceful quit with a hopefully useful diagnostic. 

The length of text required to trigger these is excessive; in one case the trigger is to make (width * height * 32 bits per pixel) exceed 2 gigabytes, for debugging I added a comment to the credits with 30000 short lines and a single 12000 character line. These changes are inspired by bug #3265, but I think the already-merged fix to that bug handles all sane input, the changes in this PR handle edge cases that need deliberately crafted input to trigger them.