### PR TITLE
Add help topics for the Editor (as it stands in the 1.14 branch)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
  ### Add-ons client
  ### Add-ons server
  ### Campaigns
+ ### Editor
+   * Added help topics for the scenario editor's tools
+   * Added documentation about the files written by the editor
  ### Multiplayer
  ### Packaging
   * Boost 1.65 is now required (was 1.59).

--- a/data/core/editor/help.cfg
+++ b/data/core/editor/help.cfg
@@ -3,7 +3,7 @@
 [section]
     id=editor
     title= _ "Map and Scenario Editor"
-    topics=..editor, editor_modes, editor_toolkit, map_format
+    topics=..editor, editor_map_format, editor_separate_events_file
     sections=editor_mode_terrain, editor_mode_scenario
     sort_topics=no
 [/section]
@@ -18,7 +18,7 @@
 [section]
     id=editor_mode_scenario
     title= _ "Scenario Editor"
-    topics=editor_named_area, editor_playlist, editor_tool_label, editor_tool_item, editor_tool_village, editor_tool_unit
+    topics=..editor_mode_scenario, editor_tool_label, editor_tool_scenery, editor_tool_unit, editor_tool_village, editor_time_schedule, editor_playlist
     sort_topics=no
 [/section]
 
@@ -105,7 +105,7 @@ The paste tool also has some clipboard-manipulation functions:" +
 [topic]
     id=editor_tool_starting
     title= _ "Starting Locations Tool"
-    text= "<img>src=icons/action/editor-tool-starting-position_60.png align=left box=yes</img>" + _"Defines the side leader starting position
+    text= "<img>src=icons/action/editor-tool-starting-position_60.png align=left box=yes</img>" + _ "Defines the side leader starting position.
 
 This tool sets the side leaders’ default starting locations, and named special locations. Both types of location are enabled in both <ref>dst='..editor_mode_terrain' text='Terrain Editor'</ref> and Scenario Editor modes. The location names are shown as a list in the editor palette, clicking on the map will place that name on a hex, each location can only be placed on a single hex, and the editor will only allow one location per hex.
 
@@ -122,140 +122,133 @@ Named locations can be accessed from WML using the Standard Location Filter’s 
 # wmllint: markcheck on
 
 # wmllint: markcheck off
+# wmllint: unbalanced-on
 [topic]
     id=editor_tool_label
     title= _ "Label Tool"
-    text= "<img>src=icons/action/editor-tool-label_60.png align=left box=yes</img>" + _"TODO"
+    text= "<img>src=icons/action/editor-tool-label_60.png align=left box=yes</img>" + _ "Put text labels on the map.
+
+• Left-click will open a dialog box to create a new label or edit an existing one.
+• Right-click deletes.
+• Drag-and-drop with the left mouse button moves labels.
+
+This tool is only available in Scenario Mode; the decorations are implemented in the scenario using WML’s <italic>text='[label]'</italic> tag."
 [/topic]
+# wmllint: unbalanced-off
 # wmllint: markcheck on
 
 # wmllint: markcheck off
+# wmllint: unbalanced-on
 [topic]
-    id=editor_tool_item
-    title= _ "Item Tool"
-    text= "<img>src=icons/action/editor-tool-item_60.png align=left box=yes</img>" + _"TODO"
+    id=editor_tool_scenery
+    title= _ "Item Tool (Scenery Tool)"
+    text= "<img>src=icons/action/editor-tool-item_60.png align=left box=yes</img>" + _ "The Item Tool allows placing decorations such as windmills, bookcases and monoliths. Multiple items can be placed on the same hex.
+
+<bold>text='Note:'</bold> the tool doesn’t support deleting items once placed, nor does it support undo. Mistakes can currently only be fixed by editing the generated WML file.
+
+This tool is only available in Scenario Mode; the decorations are not part of the terrain and are implemented in the scenario using WML’s <italic>text='[item]'</italic> tag."
 [/topic]
+# wmllint: unbalanced-off
 # wmllint: markcheck on
 
 # wmllint: markcheck off
+# wmllint: unbalanced-on
 [topic]
     id=editor_tool_village
     title= _ "Village Ownership Tool"
-    text= "<img>src=icons/action/editor-tool-village_60.png align=left box=yes</img>" + _"TODO"
+    text= "<img>src=icons/action/editor-tool-village_60.png align=left box=yes</img>" + _ "This tool assigns ownership of villages at the start of a scenario. The villages must first be placed on the terrain with the <ref>dst='editor_tool_paint' text='Paint Tool'</ref>.
+
+• Left-click will assign the village to the currently-selected side.
+• Right-click will set the village back to unowned.
+
+This tool is only available in Scenario Mode; ownership information is stored by adding WML <italic>text='[village]'</italic> tags to the appropriate <italic>text='[side]'</italic>."
 [/topic]
+# wmllint: unbalanced-off
 # wmllint: markcheck on
 
 # wmllint: markcheck off
+# wmllint: unbalanced-on
 [topic]
     id=editor_tool_unit
     title= _ "Unit Tool"
-    text= "<img>src=icons/action/editor-tool-unit_60.png align=left box=yes</img>" + _"TODO"
+    text= "<img>src=icons/action/editor-tool-unit_60.png align=left box=yes</img>" + _ "Place units belonging to the currently-selected side.
+
+• Left-click will place a unit.
+• Left drag-and-drop will move an already-placed unit.
+• Various operations are added to the right-click menu when the hex contains a unit.
+
+This tool is only available in Scenario Mode; it adds WML <italic>text='[unit]'</italic> tags to the appropriate <italic>text='[side]'</italic>."
 [/topic]
+# wmllint: unbalanced-off
 # wmllint: markcheck on
 
 # wmllint: markcheck off
+# wmllint: unbalanced-on
 [topic]
     id=editor_named_area
     title= _ "Named Areas"
-    text= _ "This tool can create [time_area]s, unlike the name suggests these do not need to have a specific time zone assigned to them.
-    [time_area]s are sets of tiles which can be addressed during scenario scripting by their id. [time_area]s can optionally have a custom
-    time zone assigned to them. The simplest way to address a [time_area] via scenario scripting is the `area=` attribute in standard location filters.
+    text= _ "This tool create sets of tiles that can be used in WML scripts’ Standard Location Filters (a concept explained in detail on the Wiki), by using the area’s id in the filter’s <italic>text='area='</italic> attribute. For example:
 
-This tool can be used to abstract between the implementation of an effect and the map specific setting.
-This is a very powerful mechanism since it allows generic scenario code to work with different maps providing the needed named locations."
+• assigning a local time zone to this set of hexes
+• filtering the set of hexes which trigger an event when a unit moves on to them
+
+To use the tool:
+
+• select hexes using the <ref>dst='editor_tool_select' text='select tool'</ref>
+• in the Areas menu, select Add New Area
+• then in the Areas menu, select Save Selection to Area
+• then in the Areas menu, select Rename Selected Area and choose a name for the area
+
+This tool is only available in Scenario Mode; it adds WML <italic>text='[time_area]'</italic> tags to the scenario. Although the tag’s name implies time, it is now more generic and can be used for other purposes without needing to change the time-of-day schedule in the area."
 [/topic]
+# wmllint: unbalanced-off
 # wmllint: markcheck on
 
 # wmllint: markcheck off
+# wmllint: unbalanced-on
 [topic]
     id=editor_playlist
     title= _ "Playlist Manager"
-    text= "<img>src=icons/action/playlist_30.png align=left box=yes</img>" + _ "Saves a list of music tracks defining a random playlist to the scenario.
+    text= "<img>src=icons/action/playlist_30.png align=left box=yes</img>" + _ "Shows a list of music tracks known to the editor, with toggle-boxes to enable them.
 
-Have a look at the addon server for easy to use additional music tracks."
+This tool is only available in Scenario Mode; it adds WML <italic>text='[music]'</italic> tags to the scenario."
 [/topic]
+# wmllint: unbalanced-off
 # wmllint: markcheck on
 
 # wmllint: markcheck off
 [topic]
     id=..editor
     title= _ "Map/Scenario Editor"
-    # generator="contents:editor"
     text= "<img>src=icons/icon-editor.png align=left box=no float=yes</img>" + _ "Wesnoth’s Map and Scenario Editor allows users to create and edit the maps on which every Wesnoth scenario takes place. It also provides a limited set of features for setting up a basic scenario.
 
 The editor can be launched from the <italic>text='Map Editor'</italic> option at the title screen.
 
-<header>text='What you get'</header>
+<header>text='Editing Modes'</header>
 
-• <ref>dst='..editor_mode_terrain' text='Terrain Editor'</ref>
-An easy to use map editor, similar to simple paint applications.
+The editor features two modes of operation: terrain mode and scenario mode.
 
-• Scenario Editor
+The <ref>dst='..editor_mode_terrain' text='Terrain Mode'</ref> is similar to a simple paint application, with tools to <ref>dst='editor_tool_paint' text='paint'</ref>, <ref>dst='editor_tool_fill' text='fill'</ref>, <ref>dst='editor_tool_select' text='select (and copy)'</ref>, and <ref>dst='editor_tool_paste' text='paste'</ref>. It also has the tool for setting the leaders’ <ref>dst='editor_tool_starting' text='starting locations'</ref>.
 
-• <ref>dst='editor_playlist' text='Playlist Manager'</ref>
-Predefine the scenario’s music track playlist.
+The <ref>dst='..editor_mode_scenario' text='Scenario Mode'</ref>, in addition to the tools available in terrain mode, adds support for adding <ref>dst='editor_tool_label' text='labels'</ref>, <ref>dst='editor_tool_scenery' text='scenery items'</ref>, <ref>dst='editor_tool_unit' text='units'</ref> in addition to the leader, and assigning <ref>dst='editor_tool_village' text='village ownership'</ref> at the start of the scenario. There’s also a <ref>dst='editor_playlist' text='playlist manager'</ref> for the music.
 
-• Time Schedule Editor
+<bold>text='Warning: the Scenario Mode is buggy in 1.14.'</bold> Improving it is one of the main blockers for the 1.16 release, however in 1.14 its quality is far below that of the game and the terrain mode." + "
 
-<header>text='What you do *not* get'</header>
+" + _ "<header>text='What you do *not* get'</header>
 
-• What-you-see-is-what-you-get
-The editor is not a WYSIWYG application.
+• Exactly the same map rendering as in-game
 
-Because which exact graphic tile represents a terrain in the map depends on all terrain rules loaded (which is different between the editor and each other use case) the map won’t look exactly the same.
+The map won’t look exactly the same in the game as it does in the editor, because this depends on the terrain rules. For example, when many mountain hexes are clustered together the terrain rules will try to combine them into mountain ranges and large graphics spanning multiple hexes.
 
 • Event handlers and scripting
+
 The editor is not a tool to help you scripting the scenario’s event handlers.
 
 • Infinite Backwards Compatibility
-The editor can load most maps from older versions of Wesnoth, but not all. Maps from 1.3.2 and later will normally be supported, unless they use terrains which are no longer in mainline Wesnoth. Maps from add-ons which have their own terrains will need that add-on to tell the editor about their terrains." + "
 
-" + _ "<header>text='Basic Concepts'</header>
-• <ref>dst='editor_modes' text='Editing Modes'</ref>
-• <ref>dst='editor_toolkit' text='Editor Toolkit'</ref>
-• <ref>dst='editor_palette' text='Editor Palette'</ref>
-• The clipboard is described in the <ref>dst='editor_tool_paste' text='Paste Tool'</ref>"
+The editor can load most maps from older versions of Wesnoth, but not all. Maps from 1.3.2 and later will normally be supported, unless they use terrains which are no longer in mainline Wesnoth. Maps from add-ons which have their own terrains will need that add-on to tell the editor about their terrains."
 [/topic]
 # wmllint: markcheck on
-
-[topic]
-    id=editor_modes
-    title= _ "Editing Modes"
-    text= _ "The editor features two modes of operation:
-
-<header>text='Terrain-only Mode'</header>
-
-Allows only the composing of the terrain map itself and the definition of leader starting positions.
-
-When saved using “Save Map As” and saving to the default directory, the produced map can be found in the “User Maps” game type of the create multiplayer game dialog.
-
-<header>text='Scenario Mode'</header>
-
-The Scenario mode allows several extra tools to be used, such as the Unit tool. At least one side must be defined in order to use these tools, however.
-
-In this mode, terrain data is stored in the map_data attribute and saved into a file with any applicable WML."
-[/topic]
-
-[topic]
-    id=editor_toolkit
-    title= _ "Editor Tools"
-    text= _ "The editor provides several tools for editing your maps and scenarios. At all times, one of the editor tools is active. The active tool’s context determines the content of the editor palette and context menu.
-
-These tools are available in both terrain-only mode and scenario mode:
-
-• <ref>dst='editor_tool_paint' text='Paint Tool'</ref>
-• <ref>dst='editor_tool_fill' text='Fill Tool'</ref>
-• <ref>dst='editor_tool_select' text='Select Tool'</ref>
-• <ref>dst='editor_tool_paste' text='Paste Tool'</ref>
-• <ref>dst='editor_tool_starting' text='Starting Locations Tool'</ref>
-
-These tools are only available in scenario mode:
-
-• <ref>dst='editor_tool_label' text='Label Tool'</ref>
-• <ref>dst='editor_tool_item' text='Item Tool'</ref>
-• <ref>dst='editor_tool_village' text='Village Tool'</ref>
-• <ref>dst='editor_tool_unit' text='Unit Tool'</ref>"
-[/topic]
 
 # wmllint: markcheck off
 [topic]
@@ -263,10 +256,74 @@ These tools are only available in scenario mode:
     title= _ "Terrain Editor"
     text= _ "The terrain editor’s functionality is similar to a simple paint application.
 
-The right-hand sidebar contains, from top to bottom, the mini-map, <ref>dst='editor_toolkit' text='Toolkit'</ref>, tool options, and <ref>dst='editor_palette' text='Palette'</ref>.
+The right-hand sidebar contains, from top to bottom, the mini-map, the toolkit (see the pages for each tool), tool options, and <ref>dst='editor_palette' text='Palette'</ref>.
 
-To get started, refer to the <ref>dst='editor_tool_paint' text='Paint Tool'</ref>’s page."
+When saved using “Save Map As” and saving to the default directory, the resulting map can be found in the “User Maps” game type of the multiplayer “Create Game” dialog."
 [/topic]
+# wmllint: markcheck on
+
+# wmllint: markcheck off
+[topic]
+    id=..editor_mode_scenario
+    title= _ "Scenario Editor"
+    text= _ "The scenario editor mode adds support for some map-related WML features, such as areas and scenery items. Most scenarios will still require additional WML to be written using a different tool; the scenario editor does not support scripting the scenario’s events." + "
+
+" + _ "<header>text='Checking whether the editor is in scenario mode'</header>
+
+You can check which mode the editor is in by looking at the menu bar.
+
+• In scenario mode the “Areas” and “Side” menus are enabled.
+• In terrain-only mode the “Areas” and “Side” menus are grayed-out." + "
+
+" + _ "<header>text='Entering scenario mode'</header>
+
+To start a new map in scenario mode, choose “New Scenario” from the “File” menu.
+
+If you’re already editing a map in terrain mode, use “Save Scenario As” from the “File” menu; this will switch to scenario mode." + "
+
+To load a map that was created in the scenario editor, use “Load Map” from the “File” menu, and select the .cfg file (not a .map file)." + "
+
+" + _ "<header>text='The files: .map and .cfg'</header>
+
+The map editor saves exactly one file, either a .map (for terrain mode) or a .cfg (for scenario mode). In scenario mode the terrain map is saved inside the .cfg file; there is no separate .map file. If you start editing in terrain mode and then switch to scenaro mode then an old .map file might remain, but this is not updated by the scenario editor.
+
+Loading a .cfg file has different results depending on the contents of the .cfg file. For .cfg files that were created by the scenario editor, it will open the .cfg in the scenario editor. However, for .cfg files that use a separate .map file (which can't be created by the scenario editor), the editor may follow the link and open the corresponding .map in terrain-only mode, as if the .map file was chosen in the file selector."
+[/topic]
+# wmllint: markcheck on
+
+# wmllint: markcheck off
+# wmllint: unbalanced-on
+[topic]
+    id=editor_separate_events_file
+    title= _ "Using a separate file for WML events"
+    text= _ <<When loading a .cfg file, the scenario editor understands files created by the scenario editor, but is likely to have difficulty with files that have been edited by hand.
+
+Files created by the scenario editor omit the opening [scenario] and closing [/scenario] tags. If you are creating a campaign (or other add-on), then those tags need to be added; there is more detail about this in the <ref>dst='editor_map_format' text='map file format'</ref> documentation.
+
+One workflow is to create a separate WML file, also with the .cfg extension, which uses the WML preprocessor to include the editor-created file. This separate file contains both the [scenario] tag and any hand-edited WML such as events. With this workflow, the add-on’s file structure could look like this:
+
+<header>text='If your add-on needs to support 1.14'</header>
+
+• _main.cfg:
+  ◦ use “{./scenarios}” to include the “scenarios” directory
+• maps/map_from_01.cfg
+  ◦ this is the file created by the scenario editor
+• scenarios/01_Forest.cfg
+  ◦ inside the [scenario] element, use “map_file="~add-ons/NAME_OF_ADD_ON/maps/map_from_01.cfg"” to load that file
+
+<header>text='1.16 and later'</header>
+
+If your add-on will only be used on 1.16 and later, there’s a new feature to avoid repeating the add-on’s name within the .cfg files:
+
+• _main.cfg:
+  ◦ use “[binary_path]” to add add-on’s directories to the binary path, which makes “map_file” search the “maps” directory.
+  ◦ use “{./scenarios}” to include the “scenarios” directory
+• maps/map_from_01.cfg
+  ◦ this is the file created by the scenario editor
+• scenarios/01_Forest.cfg
+  ◦ inside the [scenario] element, use “map_file="~add-ons/NAME_OF_ADDON/maps/map_from_01.cfg"” to load that file>>
+[/topic]
+# wmllint: unbalanced-off
 # wmllint: markcheck on
 
 # wmllint: markcheck off
@@ -280,8 +337,13 @@ To get started, refer to the <ref>dst='editor_tool_paint' text='Paint Tool'</ref
 # wmllint: markcheck off
 [topic]
     id=editor_time_schedule
-    title= _ "Time Schedule Editor"
-    text= _ "TODO"
+    # po: Time of Day and Schedule Editor, please use a short string as it will be used in the left-hand pane of the help browser
+    title= _ "ToD and Schedule Editor"
+    text= "<img>src='icons/action/editor-switch-time_30.png' align=left box=yes</img>" + _ "This button at the top-right of the screen accesses the time-of-day preview and the schedule editor.
+
+In terrain mode, this displays the map as it will be recolored at different times of day.
+
+In scenario mode, the button accesses an editor for individual schedules for <ref>dst='editor_named_area' text='time areas'</ref>."
 [/topic]
 # wmllint: markcheck on
 
@@ -301,17 +363,18 @@ There is a filter function to show only a subset of the available items — this
 # wmllint: markcheck on
 
 # wmllint: markcheck off
+# wmllint: unbalanced-on
 # wmlindent: start ignoring
 # This section uses << >> quotes so that curly brackets can be used without being interpreted by the preprocessor
 # Note: If you change the following description string or this comment line, run wmllint on this file afterwards and make sure wmllint doesn't "improve" the map_data={...} lines.
 [topic]
-    id=map_format
+    id=editor_map_format
     title= _ "Wesnoth Map Format"
     text= _ "Wesnoth stores its maps in human readable plain text files." + "
 
 " + _ <<<header>text='Native'</header>
 
-A map file consists of rows with comma separated terrain code strings. The only non-terrain information provided by the map syntax are the locations created by the <ref>dst='editor_tool_starting' text='Starting Locations Tool'</ref>. The files can be edited with a general purpose text editor like notepad.
+A map file consists of rows with comma separated terrain code strings. The only non-terrain information provided by the map syntax is the set of locations created by the <ref>dst='editor_tool_starting' text='Starting Locations Tool'</ref>. The files can be edited with a general purpose text editor like notepad.
 
 These files can be used directly for multiplayer games, the number of players is automatically determined by the number of starting positions. When saved in the default directory, the map can be found in the “Custom Maps” game type of the multiplayer “Create Game” dialog; you may need to refresh the cache (press F5 on the title screen) before a newly-created map appears.
 
@@ -326,13 +389,20 @@ The <italic>text='map_file'</italic> method is preferred over using a preprocess
 
 The map data can stored as part of a scenario’s .cfg file, directly in the <italic>text='map_data'</italic> attribute. In other words, in the place that the preprocessor would include it when using the preprocessor-include method.
 
-<bold>text='Using Embedded Format in Terrain Mode'</bold>
+<header>text='Using Embedded Format in Terrain Mode'</header>
 
 If you are editing the map and not using the Scenario Mode support, then it’s trivial to move the data to a native map file before opening it in the editor. This conversion is recommended — the editor supports editing the content of map_data while leaving everything else in the file untouched, but this is rarely-used code. Maps opened this way are marked (E) in the Window menu.>> + "
 
-" + _ <<<bold>text='Using Embedded Format in Scenario Mode'</bold>
+" + _ <<<header>text='Files created by the Scenario Editor'</header>
 
-TODO: add documentation about the scenario mode.>>
+In scenario mode, the editor saves the data as a .cfg file with embedded map data. When loading a .cfg file, the scenario editor understands files created by the scenario editor itself, but is likely to have difficulty with files that have been edited by hand; problems can be avoided by <ref>dst='editor_separate_events_file' text='using a separate .cfg file'</ref> for the hand-edited parts.>> + "
+
+" + _ <<<header>text='Which scenario files use the [scenario] tag'</header>
+
+Files created by the scenario editor have the contents of a WML scenario element, but don’t include the opening [scenario] and closing [/scenario] tags. For each .cfg file in the userdata folder’s editor/scenarios subfolder, the game will automatically try to load a scenario from it to include in the “Custom Scenarios” list (files that fail to load are ignored). In this folder each file is a separate item - files that fail to parse as a scenario are ignored, and files must not contain the [scenario][/scenario] tags.
+
+The opposite applies when a scenario is part of a campaign or other add-on. Typically each scenario has its own .cfg file, however this is unnecessary - all of the WML in an add-on will be combined by the preprocessor, it doesn’t matter whether the add-on is written as separate files or not. The engine needs the [scenario]...[/scenario] (or [multiplayer]...[/multiplayer]) tags to know which WML is part of each scenario.>>
 [/topic]
 # wmlindent: stop ignoring
+# wmllint: unbalanced-off
 # wmllint: markcheck on


### PR DESCRIPTION
Add help topics for the Editor, as it stands in the 1.14 branch

This commit is on the master branch. There have been no changes at all to the editor documentation in the 1.14 branch, while there have been several updates to the master branch that would be good to backport if the help is displayed in the 1.14 branch - therefore my plan is to get this set of changes reviewed in the master branch, and then simply pull the entire file into the 1.14 branch along with enabling the editor documentation (a small change to data/core/help.cfg, as done in commit ed611f94385f608512da55d691d3c9753240d5d5).

A couple of warnings about the scenario mode being buggy are added to the user-visible text, find these by looking for <bold> tags within the text.

<strike>Original draft PR description follows:

I'm hoping that someone who uses the scenario editor will take over and write
the documentation. Without the knowledge of someone who uses the editor, the
only option is to leave a gap in the documentation; this commit is merely
hiding the problem to remove the "Blocker" tag from issue #2964.

This leaves dead links in the "Editor Tools" page, which I hope will be fixed
by someone else adding the relevant pages, rather than having to just remove
that section.</strike>