### PR TITLE
Avoid prematurely generating bad color range/palette definitions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@
    * Do not list nameless abilities in the Abilities and Ability Upgrades lists in unit
      descriptions in Help (issue #3060).
    * Fixed disabled buttons using the pressed highlight color.
+ ### WML engine
+   * Do not attempt to use names of [color_range]s as inline color range definitions if
+     they don't have commas, or names of [color_palette]s as inline palette definitions
+     if they have characters that aren't commas or hexadecimal digits.
  ### Miscellaneous and bug fixes
    * Made wmllint recognize [remove_time_area] in order to avoid spurious warnings about
      unit ids.

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -60,8 +60,8 @@ color_t color_t::from_rgb_string(const std::string& c)
 
 color_t color_t::from_hex_string(const std::string& c)
 {
-	if(c.length() != 6) {
-		throw std::invalid_argument("Color hex string should be exactly 6 digits");
+	if(c.length() != 6 || c.find_first_not_of("0123456789AaBbCcDdEeFf") != std::string::npos) {
+		throw std::invalid_argument("Color string must be exactly 6 hexadecimal digits");
 	}
 
 	unsigned long temp_c = std::strtol(c.c_str(), nullptr, 16);

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -530,6 +530,16 @@ const color_range& color_info(const std::string& name)
 		return i->second;
 	}
 
+	// If the name string has commas, it's an inline-defined color range. Otherwise
+	// it's the name of a color range that doesn't exist (e.g. looking at saves from
+	// an add-on that's not loaded yet).
+
+	if(name.find(',') == std::string::npos) {
+		throw config::error(_("Color range not defined: ") + name);
+	}
+
+	LOG_NG << "attempting to parse \"" << name << "\" as an inline color range definition\n";
+
 	std::vector<color_t> temp;
 	for(const auto& s : utils::split(name)) {
 		try {
@@ -549,6 +559,17 @@ const std::vector<color_t>& tc_info(const std::string& name)
 	if(i != team_rgb_colors.end()) {
 		return i->second;
 	}
+
+	// If the name string is only commas and hexadecimal digits, it's an
+	// inline-defined palette. Otherwise it's the name of a palette that
+	// doesn't exist (e.g. looking at saves from an add-on that's not
+	// loaded yet).
+
+	if(name.find_first_not_of("0123456789AaBbCcDdEeFf,") != std::string::npos) {
+		throw config::error(_("Color palette not defined: ") + name);
+	}
+
+	LOG_NG << "attempting to parse \"" << name << "\" as an inline color palette definition\n";
 
 	std::vector<color_t> temp;
 	for(const auto& s : utils::split(name)) {


### PR DESCRIPTION
(PR against 1.14 because master refuses to read custom colour range/palette definitions at all right now? The forward port is trivial, though.)

Previously it was possible for the game to try to coerce any named color range/palette that hasn't been defined by WML yet into a range/palette with RGB `#000000` as its first entry, since `strtol()` (used by the `color_t::from_hex_string()` function) will return 0 if the input is not a valid hexadecimal number.

Now, normally this condition was *not* reached because `color_t::from_hex_string()` throws `std::invalid_argument` if the input
isn't exactly 6 chars (as in char, not Unicode characters) long. The problem is, in English, "yellow" is exactly 6 chars long.

The existing code suggests that we should be throwing in this case, and this is exactly what was already being done in the general case, so just do that immediately when:

 1. A named color range doesn't exist and it doesn't have at least one comma.
 2. A named color palette doesn't exist and it has characters that aren't hexadecimal digits or commas.

Reasoning:

 1. While `color_range`'s type definition in the engine suggests that only the first colour value is needed, this doesn't make much sense from the WML API standpoint so we might as well be stricter than the `color_range` constructor here.

 2. As for palettes, there's a possibility that someone may want to perform a palette substitution with exactly one colour (e.g. `~PAL(FF00FF>000000)`), so we just make sure that all characters in the "name" are hexadecimal digits. This means that using "DEADED" as a name might be a bad idea if the palette somehow finds itself being used before being defined (it will effectively create a new palette with `#DEADED` as its only entry) but it's either that or making the single colour case surprisingly clunky to write.

Ideally, we should be resetting colour info entirely (the `game_config::reset_color_info()` function) every time we enter a game,
but for *some* reason that's not done at the moment. It would also make more sense to allow `[color_range]` and `[color_palette]` definitions to be overridden under certain circumstances, but currently that's not the case (the first defined element with a given id remains a constant for the entire game session) and it's also more work to change that.

(Wow, I'm doing a terrible job at selling this commit, aren't I?)