### PR TITLE
Disambiguate some python shebang lines to be "python3"

### DIFF
--- a/utils/dockerbuilds/mingw/get_dlls.py
+++ b/utils/dockerbuilds/mingw/get_dlls.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python3
 
 import pefile, pathlib, shutil
 

--- a/utils/update_appdata
+++ b/utils/update_appdata
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python3
 
 import sys, requests, argparse
 from xml.dom import minidom


### PR DESCRIPTION
I'm opening a PR to check that this builds on all of the platforms, but then plan
to merge without further review. @loonycyborg already uses these tools with
Python 3, and gave a green-light for this change in https://github.com/wesnoth/wesnoth/issues/1508#issuecomment-665119912 .

The python launcher tool for Windows has magic handling for some shebang lines,
however `#!/bin/env python` isn't recognised without the `/usr`. Had the `/usr`
been included with the old code then these scripts would likely have been run
with Python 2.
https://docs.python.org/dev/using/windows.html#shebang-lines