### PR TITLE
Add lua attack_type:active_specials() api

### DIFF
--- a/data/core/macros/abilities.cfg
+++ b/data/core/macros/abilities.cfg
@@ -320,15 +320,17 @@ Enemy units cannot see this unit while it is in deep water, except if they have 
 #enddef
 
 #define ABILITY_FEEDING
+    # technically this is a weapon special, but like all weaponspecials it can nowdays be used in [abilities] as well.
     # Canned definition of the Feeding ability to be included in an
     # [abilities] clause.
     # This works because of data/lua/feeding.lua
-    [dummy]
+    [feeding]
         id=feeding
+        value=1
         name= _ "feeding"
         female_name= _ "female^feeding"
         description=_ "This unit gains 1 hitpoint added to its maximum whenever it kills a unit, except units that are immune to plague."
-    [/dummy]
+    [/feeding]
 #enddef
 
 #weapons specials

--- a/data/lua/feeding.lua
+++ b/data/lua/feeding.lua
@@ -14,21 +14,36 @@ on_event("die", function()
 	local u_killer = wesnoth.units.get(ec.x2, ec.y2)
 	local u_victim = wesnoth.units.get(ec.x1, ec.y1)
 
-	if not u_killer or not u_killer:matches { ability = "feeding" } then
+	if not u_killer or not u_killer.active_attack then
 		return
 	end
+
+	local feeding = u_killer.active_attack:active_specials {
+		tag = "feeding",
+		base_value = 0,
+	}
+
+	if feeding.value <= 0 then
+		return
+	end
+
 	if not u_victim or u_victim:matches { status = "unplagueable" } then
 		return
 	end
+
+	-- po: Floating text shown when a unit with the "feeding" ability gets a kill
+	local text = _(_"+$value max HP", _"+$value max HP", feeding.value)
+	local text = text:vformat { value = feeding.value }
+
 	local u_killer_cfg = u_killer.__cfg
 	for i,v in ipairs(wml.get_child(u_killer_cfg, "modifications"))do
 		if v[1] == "object" and v[2].feeding == true then
 			local effect = wml.get_child(v[2], "effect")
-			effect.increase_total = effect.increase_total + 1
-			u_killer_cfg.max_hitpoints = u_killer_cfg.max_hitpoints + 1
-			u_killer_cfg.hitpoints = u_killer_cfg.hitpoints + 1
+			effect.increase_total = effect.increase_total + feeding.value
+			u_killer_cfg.max_hitpoints = u_killer_cfg.max_hitpoints + feeding.value
+			u_killer_cfg.hitpoints = u_killer_cfg.hitpoints + feeding.value
 			wesnoth.units.to_map(u_killer_cfg)
-			wesnoth.interface.float_label(ec.x2, ec.y2, _ "+1 max HP", "0,255,0")
+			wesnoth.interface.float_label(ec.x2, ec.y2, text, "0,255,0")
 			return
 		end
 	end
@@ -37,9 +52,9 @@ on_event("die", function()
 		feeding = true,
 		T.effect {
 			apply_to = "hitpoints",
-			increase_total = 1,
+			increase_total = feeding.value,
 		},
 	})
-	u_killer.hitpoints = u_killer.hitpoints + 1
-	wesnoth.interface.float_label(ec.x2, ec.y2, _ "+1 max HP", "0,255,0")
+	u_killer.hitpoints = u_killer.hitpoints + feeding.value
+	wesnoth.interface.float_label(ec.x2, ec.y2, text, "0,255,0")
 end)

--- a/data/test/scenarios/feeding.cfg
+++ b/data/test/scenarios/feeding.cfg
@@ -71,43 +71,7 @@
     {ASSERT ({VARIABLE_CONDITIONAL Killer.hitpoints equals $Killer_start_hp})}
 #enddef
 
-## TODO: the original feeding ability is implemented differently, maybe we should update this.
 {GENERIC_UNIT_TEST "feeding" (
-    [event]
-        id=ability_feeding_die
-        name=die
-        first_time_only=no
-        [filter]
-            [not]
-                [filter_wml]
-                    [status]
-                        not_living="yes"
-                    [/status]
-                [/filter_wml]
-            [/not]
-        [/filter]
-        [filter_second]
-            ability=feeding_Test
-        [/filter_second]
-        [unstore_unit]
-            variable=second_unit
-            {COLOR_HEAL}
-            text= {STR_FEEDING_EFFECT}
-            find_vacant=no
-        [/unstore_unit]
-        [object]
-            silent=yes
-            duration=forever
-            [filter]
-                x,y=$x2|,$y2|
-            [/filter]
-            [effect]
-                apply_to=hitpoints
-                increase_total=1
-                increase=1
-            [/effect]
-        [/object]
-    [/event]
     [event]
         name=start
         [object]
@@ -116,12 +80,13 @@
             [effect]
                 apply_to=new_ability
                 [abilities]
-                    [dummy]
+                    [feeding]
                         id=feeding_Test
+                        value=1
                         name= {STR_FEEDING}
                         female_name= {STR_FEEDING}
                         description= {STR_FEEDING_DESCRIPTION}
-                    [/dummy]
+                    [/feeding]
                 [/abilities]
             [/effect]
             [filter]

--- a/src/scripting/lua_unit.cpp
+++ b/src/scripting/lua_unit.cpp
@@ -343,6 +343,18 @@ static int impl_unit_get(lua_State *L)
 		return 1;
 	}
 
+	if(strcmp(m, "active_attack") == 0) {
+		attack_ptr att = lu->get()->get_active_attack();
+		if(att) {
+			luaW_pushweapon(L, att);
+			return 1;
+		}
+		else {
+			std::cerr << "no active attack!\n";
+			return 0;
+		}
+	}
+
 	if(strcmp(m, "upkeep") == 0) {
 		unit::upkeep_t upkeep = u.upkeep_raw();
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1111,11 +1111,33 @@ namespace { // Helpers for attack_type::special_active()
 
 unit_ability_list attack_type::list_ability(const std::string& ability) const
 {
+	const unit_map& units = display::get_singleton()->get_units();
+
+	unit_const_ptr self = self_;
+	unit_const_ptr other = other_;
+
+	if(self == nullptr) {
+		unit_map::const_iterator it = units.find(self_loc_);
+		if(it.valid()) {
+			self = it.get_shared_ptr().get();
+		}
+	}
+	if(other == nullptr) {
+		unit_map::const_iterator it = units.find(other_loc_);
+		if(it.valid()) {
+			other = it.get_shared_ptr().get();
+		}
+	}
+
+	// Make sure they're facing each other.
+	temporary_facing self_facing(self, self_loc_.get_relative_dir(other_loc_));
+	temporary_facing other_facing(other, other_loc_.get_relative_dir(self_loc_));
+
 	const map_location loc = self_ ? self_->get_location() : self_loc_;
 	unit_ability_list abil_list(loc);
 	unit_ability_list abil_other_list(loc);
-	if(self_) {
-		abil_list.append((*self_).get_abilities(ability, self_loc_));
+	if(self) {
+		abil_list.append((*self).get_abilities(ability, self_loc_));
 		for(unit_ability_list::iterator i = abil_list.begin(); i != abil_list.end();) {
 			if(!special_active(*i->ability_cfg, AFFECT_SELF, ability, true, "filter_student")) {
 				i = abil_list.erase(i);
@@ -1125,8 +1147,8 @@ unit_ability_list attack_type::list_ability(const std::string& ability) const
 		}
 	}
 
-	if(other_) {
-		abil_other_list.append((*other_).get_abilities(ability, other_loc_));
+	if(other) {
+		abil_other_list.append((*other).get_abilities(ability, other_loc_));
 		for(unit_ability_list::iterator i = abil_other_list.begin(); i != abil_other_list.end();) {
 			if(!special_active_impl(other_attack_, shared_from_this(), *i->ability_cfg, AFFECT_OTHER, ability, true, "filter_student")) {
 				i = abil_other_list.erase(i);

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -259,6 +259,10 @@ bool attack_type::matches_filter(const config& filter) const
 	return matches;
 }
 
+bool attack_type::is_active() const
+{
+	return self_ || other_ || self_loc_ != map_location::null_location() || other_loc_ != map_location::null_location();
+}
 /**
  * Modifies *this using the specifications in @a cfg, but only if *this matches
  * @a cfg viewed as a filter.

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -105,6 +105,9 @@ public:
 	inline config to_config() const { config c; write(c); return c; }
 
 	void add_formula_context(wfl::map_formula_callable&) const;
+
+
+	bool is_active() const;
 private:
 	// In unit_abilities.cpp:
 

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -2636,6 +2636,17 @@ bool unit::remove_attack(attack_ptr atk)
 	return true;
 }
 
+attack_ptr unit::get_active_attack()
+{
+	auto iter = std::find_if(attacks_.begin(), attacks_.end(), [&](attack_ptr ap) { return ap->is_active(); });
+	if(iter != attacks_.end()) {
+		return *iter;
+	}
+	else {
+		return attack_ptr();
+	}
+}
+
 void unit::remove_attacks_ai()
 {
 	if(attacks_left_ == max_attacks_) {

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -928,6 +928,8 @@ public:
 		return make_attack_itors(attacks_);
 	}
 
+	attack_ptr get_active_attack();
+
 	/**
 	 * Adds a new attack to the unit.
 	 * @param position An iterator pointing to the attack before which to insert the new one.

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -98,6 +98,7 @@ public:
 	const_iterator end()   const  { return cfgs_.end();   }
 
 	// Vector access
+	size_t              size()  const  { return cfgs_.size(); }
 	bool                empty() const  { return cfgs_.empty(); }
 	unit_ability&       front()        { return cfgs_.front(); }
 	const unit_ability& front() const  { return cfgs_.front(); }


### PR DESCRIPTION
this api can be used to query active attack and make them work 'just like mainline abilities'

This also contains a ability-related fix.

As a "testcase" this adds the new [feeding] ability implemented in lua:
> Now feeding is reconized by tagname instead of
id. This means in particular that umc authors
can use [feeding] abilities with filters now.
>
> Also [feeding] is now technicially a weapon
special, but sicne weapon speciasl can be used
in [abilities] it will work as before.
>
> Lastly [feeding] now takes a value, for example
`[feeding] value=(opponent.level)` should
increase the units max hp by the opponents level
(not tested).