### PR TITLE
text.cpp: throw if rendering needs more than 2GB, fix antialiasing with stride > width

### DIFF
--- a/src/font/text.hpp
+++ b/src/font/text.hpp
@@ -389,20 +389,6 @@ private:
 	mutable std::vector<uint8_t> surface_buffer_;
 
 	/**
-	 * Creates a new buffer.
-	 *
-	 * If needed frees the other surface and then creates a new buffer and
-	 * initializes the entire buffer with values 0.
-	 *
-	 * NOTE even though we're clearly modifying function we don't change the
-	 * state of the object. The const is needed so other functions can also be
-	 * marked const (those also don't change the state of the object.
-	 *
-	 * @param size                The required size of the buffer.
-	 */
-	void create_surface_buffer(const std::size_t size) const;
-
-	/**
 	 * Sets the markup'ed text.
 	 *
 	 * It tries to set the text as markup. If the markup is invalid it will try


### PR DESCRIPTION
The main change here is avoid a crash, but there's also a fix for a possible UI issue with text looking bad. I've made the two changes in a single commit, because if we backport either we might as well backport both (in my opinion).

The effect of text looking bad might only occur with certain combinations of OS, debug/release builds, and potentially graphics card and driver; I don't know whether it ever occurs. The effect is similar to  #1568, #1744 and #1925, to the extent that I'd expect any reports of it to be treated as duplicates of those bugs, however it doesn't quite match the screenshots in those bugs; when this bug is the root cause.

Simulated screenshot, showing what happens if Cairo pads the stride to twice the width - the first half of the text (vertically) looks OK. For this bug to cause the screenshots in #1568, #1744 and #1925 would need an excessive amount of padding, which is why I doubt it's the cause of those bugs.
![half_stride_malin](https://user-images.githubusercontent.com/101462/89774326-f7fb9180-db05-11ea-872e-279a13c7c2e5.png)


Refactor text.cpp's buffer alloc, throw instead of crashing if it needs more than 2GB

The limit is arbitrary, and 2 gigabytes is very large. The new TODO comment
in the .cpp file gives a possible future refactor which would reduce the limit.

The old early-return for surface_buffer_.empty() moves upwards and changes to
testing for zeros before the allocation; it now also acts as a guard for
division by zero in the (height > int::max() / stride) test.

The loop around from_cairo_format() relied on stride being exactly
sizeof(uint32_t) * width, an assumption which would break if
cairo_format_stride_for_width added padding.