### PR TITLE
Update World Conquest II Strings

### DIFF
--- a/data/campaigns/World_Conquest/era/factions/strings.cfg
+++ b/data/campaigns/World_Conquest/era/factions/strings.cfg
@@ -7,8 +7,8 @@ world_conquest_era#enddef
 _"World Conquest" #enddef
 
 #define STR_ERA_DESCRIPTION_WC_II
-	_"Units are defined as pairs in recruit list: Every time a unit is recruited, it is remplaced by its pair. This era is designed to be balanced playing World Conquest II.
-Includes an in-game help to know pairs status, with a right-click on an emty hex." #enddef
+	_"Units are defined as pairs in recruit list: Every time a unit is recruited, it is replaced by its pair. This era is designed to be balanced playing World Conquest II.
+Includes an in-game help to know pairs status, with a right-click on an empty hex." #enddef
 
 #define STR_HORDE
 _"The Horde" #enddef

--- a/data/campaigns/World_Conquest/lua/campaign/objectives.lua
+++ b/data/campaigns/World_Conquest/lua/campaign/objectives.lua
@@ -7,7 +7,7 @@ local strings = {
 	wct_defeat_condition = _ "Lose your leader and all your commanders",
 	difficulty = "Difficulty: ",
 	version = "Version",
-	help_available = _ "An in-game help is available: rightclick on any empty hex.",
+	help_available = _ "An in-game help is available: right-click on any empty hex.",
 }
 
 function wesnoth.wml_actions.wc2_objectives(cfg)

--- a/data/campaigns/World_Conquest/lua/game_mechanics/bonus_point_definitions.lua
+++ b/data/campaigns/World_Conquest/lua/game_mechanics/bonus_point_definitions.lua
@@ -6,15 +6,15 @@ local STR_BONUS_BONES_NAMES = { _"Point", _"Rest", _"Lair", _"Exile", _"Bane", _
 
 local STR_BONUS_BONES_SWAMP_NAMES = { _"Point", _"Rest", _"Lair", _"Exile", _"Bane", _"Death", _"Passage", _"Curse", _"Quagmire" }
 
-local STR_BONUS_DEAD_OAK_NAMES = { _"Rest", _"Point", _"Lair", _"Exile", _"Bane", _"Death", _"Curse", _"Wasteland", _"Desolation", _"Despair", _"Desert", _"Route", _"Passage", _"Cementery" }
+local STR_BONUS_DEAD_OAK_NAMES = { _"Rest", _"Point", _"Lair", _"Exile", _"Bane", _"Death", _"Curse", _"Wasteland", _"Desolation", _"Despair", _"Desert", _"Route", _"Passage", _"Cemetery" }
 
 local STR_BONUS_VILLAGE_RUINED_NAMES = { _"Rest", _"Ruin", _"Lair", _"Exile", _"Bane", _"Curse", _"Destruction", _"Desolation", _"Vestige", _"Disaster" }
 
-local STR_BONUS_BURIAL_NAMES = { _"Point", _"Rest", _"Lair", _"Passage", _"Bane", _"Massacre", _"Curse", _"Disaster", _"Cementery" }
+local STR_BONUS_BURIAL_NAMES = { _"Point", _"Rest", _"Lair", _"Passage", _"Bane", _"Massacre", _"Curse", _"Disaster", _"Cemetery" }
 
 local STR_BONUS_BURIAL_SAND_NAMES = { _"Point", _"Rest", _"Lair", _"Exile", _"Passage", _"Bane", _"Massacre", _"Curse", _"Disaster" }
 
-local STR_BONUS_BURIAL_CAVE_NAMES = { _"Rest", _"Lair", _"Passage", _"Bane", _"Grotto", _"Curse", _"Cave", _"Cementery", _"Graveyard" }
+local STR_BONUS_BURIAL_CAVE_NAMES = { _"Rest", _"Lair", _"Passage", _"Bane", _"Grotto", _"Curse", _"Cave", _"Cemetery", _"Graveyard" }
 
 local STR_BONUS_DETRITUS_NAMES = { _"Point", _"Rest", _"Ruin", _"Lair", _"Exile", _"Passage", _"Bane", _"Massacre", _"Curse", _"Quagmire", _"Bog", _"Hideout", _"Desolation" }
 
@@ -60,7 +60,7 @@ local STR_BONUS_LILIES_NAMES = { _"Point", _"Passage", _"Lair", _"Rest", _"Water
 
 local STR_BONUS_LILIES_SWAMP_NAMES = { _"Point", _"Passage", _"Rest", _"Lair", _"Exile", _"Domain", _"Curse", _"Secret", _"Hideout", _"Bane", _"Marsh" }
 
-local STR_BONUS_ROCK_SAND_NAMES = { _"Rest", _"Point", _"Passage", _"Ruin", _"Lair", _"Exile", _"Delirium", _"Graveyard", _"Cementery", _"Ossuary", _"Domain", _"Route", _"Vestige" }
+local STR_BONUS_ROCK_SAND_NAMES = { _"Rest", _"Point", _"Passage", _"Ruin", _"Lair", _"Exile", _"Delirium", _"Graveyard", _"Cemetery", _"Ossuary", _"Domain", _"Route", _"Vestige" }
 
 local STR_BONUS_ROCK_NAMES = { _"Rest", _"Point", _"Passage", _"Ruin", _"Lair", _"Exile", _"Domain", _"Route", _"Vestige" }
 

--- a/data/campaigns/World_Conquest/lua/game_mechanics/invest/invest_show_dialog.lua
+++ b/data/campaigns/World_Conquest/lua/game_mechanics/invest/invest_show_dialog.lua
@@ -60,7 +60,7 @@ function wc2_show_invest_dialog_impl(args)
 			wesnoth.set_dialog_value(_ "Heroes", "left_tree", cati_current, "category_name")
 			local i = 1
 			if available_commanders then
-				local desc = _ "Commanders will take your leaders place when the leader dies, possible commanders:"
+				local desc = _ "Commanders will take your leader’s place when the leader dies, possible commanders:"
 				for j,v in ipairs(available_commanders) do
 					desc = desc .. "\n" .. wesnoth.unit_types[v].name
 				end

--- a/data/campaigns/World_Conquest/lua/game_mechanics/invest/invest_tellunit.lua
+++ b/data/campaigns/World_Conquest/lua/game_mechanics/invest/invest_tellunit.lua
@@ -45,7 +45,7 @@ invest_tellunit.dialog_wml = {
 		T.row {
 			T.column {
 				T.button {
-					label = _"Ok",
+					label = _"OK",
 					id = "ok",
 				},
 			},

--- a/data/campaigns/World_Conquest/lua/game_mechanics/promote_commander.lua
+++ b/data/campaigns/World_Conquest/lua/game_mechanics/promote_commander.lua
@@ -3,7 +3,7 @@ local on_event = wesnoth.require("on_event")
 
 local strings = {
 	defeat = _ "No! This is the end!",
-	promotion = _ "Don't lose heart comrades, we can still win this battle."
+	promotion = _ "Don’t lose heart comrades, we can still win this battle."
 }
 
 -- when a leader dies, take a commonder and make him the leader.

--- a/data/campaigns/World_Conquest/lua/game_mechanics/unittypedata.lua
+++ b/data/campaigns/World_Conquest/lua/game_mechanics/unittypedata.lua
@@ -2,11 +2,11 @@ local _ = wesnoth.textdomain 'wesnoth-wc'
 
 type_infos = {
 	["default"] = {
-		founddialogue = _"You guys look like you could use some help. Mind if I join in? It's been a while since I had a good fight!",
+		founddialogue = _"You look like you could use some help. Mind if I join in? It’s been a while since I had a good fight!",
 		reply = _ "Excellent. We could always use more help.",
 	},
 	["Orcish Grunt"] = { 
-		founddialogue=_"'bout time. Been forever since I had a good fight, eh?",
+		founddialogue=_"’bout time. Been forever since I had a good fight, eh?",
 		image="units/orcs/grunt.png",
 		name="Orcish Grunt",
 	},
@@ -21,7 +21,7 @@ type_infos = {
 		name="Orcish Archer",
 	},
 	["Orcish Assassin"] = { 
-		founddialogue=_"Heya, boss. Looks like you've got some guys need killing.",
+		founddialogue=_"Hey boss. Looks like you’ve got some prey that need killing.",
 		image="units/orcs/assassin.png",
 		name="Orcish Assassin",
 	},
@@ -31,11 +31,11 @@ type_infos = {
 		name="Wolf Rider",
 		alt_reply = { { 
 			race="wose",
-			reply=_"Ok. But take care where your dog does its stuff.",
+			reply=_"Very well. But take care where your dog does its stuff.",
 		} }
 	},
 	["Orcish Leader"] = { 
-		founddialogue=_"Heh, looks like you whelps might be getting in over your heads. Good thing I'm here now to win this fight for ya, huh?",
+		founddialogue=_"Heh, looks like you whelps might be getting in over your heads. Good thing I’m here now to win this fight for ya, huh?",
 		image="units/orcs/leader.png",
 		name="Orcish Leader",
 	},
@@ -58,7 +58,7 @@ type_infos = {
 		name="Elvish Fighter",
 	},
 	["Elvish Archer"] = { 
-		founddialogue=_"You guys look like you could use some help. Mind if I join in? It's been a while since I had a good fight!",
+		founddialogue=_"You look like you could use some help. Mind if I join in? It’s been a while since I had a good fight!",
 		image="units/elves-wood/archer.png",
 		name="Elvish Archer",
 	},
@@ -68,7 +68,7 @@ type_infos = {
 		name="Elvish Shaman",
 		alt_reply = { { 
 			race="elf,wose",
-			reply=_"Yea, flower power!",
+			reply=_"Yeah, flower power!",
 		} }
 	},
 	["Elvish Scout"] = { 
@@ -100,7 +100,7 @@ type_infos = {
 		} }
 	},
 	["Cavalryman"] = { 
-		founddialogue=_"You're not from around here, but I seem to find myself between employers at the moment and I'm not picky. I'll fight for you, if you'll have me.",
+		founddialogue=_"You’re not from around here, but I seem to find myself between employers at the moment and I’m not picky. I’ll fight for you, if you’ll have me.",
 		image="units/human-loyalists/cavalryman/cavalryman.png~CROP(14,14,72,72)",
 		name="Cavalryman",
 		alt_reply = { { 
@@ -123,12 +123,12 @@ type_infos = {
 		name="Spearman",
 	},
 	["Fencer"] = { 
-		founddialogue=_"Looks like you're a bit down on your luck, my friends. But now that I am here, there's nothing to worry about!",
+		founddialogue=_"Looks like you’re a bit down on your luck, my friends. But now that I am here, there’s nothing to worry about!",
 		image="units/human-loyalists/fencer.png",
 		name="Fencer",
 	},
 	["Heavy Infantryman"] = { 
-		founddialogue=_"Finally reinforcements are here! I've been pinned down for days. Help me fight my way out of here and I'll gladly follow you!",
+		founddialogue=_"Finally reinforcements are here! I’ve been pinned down for days. Help me fight my way out of here and I’ll gladly follow you!",
 		image="units/human-loyalists/heavyinfantry.png",
 		name="Heavy Infantryman",
 	},
@@ -138,7 +138,7 @@ type_infos = {
 		name="Bowman",
 	},
 	["Sergeant"] = { 
-		founddialogue=_"You're not from around here, but I seem to find myself between employers at the moment and I'm not picky. I'll fight for you, if you'll have me.",
+		founddialogue=_"You’re not from around here, but I seem to find myself between employers at the moment and I’m not picky. I’ll fight for you, if you’ll have me.",
 		image="units/human-loyalists/sergeant.png",
 		name="Sergeant",
 	},
@@ -157,12 +157,12 @@ type_infos = {
 		} }
 	},
 	["Dwarvish Fighter"] = { 
-		founddialogue=_"Having trouble, eh? Never worry, lads, we'll sort 'em out soon enough!",
+		founddialogue=_"Having trouble, eh? Never worry, lads, we’ll sort ’em out soon enough!",
 		image="units/dwarves/fighter.png",
 		name="Dwarvish Fighter",
 	},
 	["Thief"] = { 
-		founddialogue=_"You've got me, guv, it's a fair cop! Just lemme work for you instead. You won't regret it, guv, I promise!",
+		founddialogue=_"You’ve got me, guv, it’s a fair cop! Just lemme work for you instead. You won’t regret it, guv, I promise!",
 		image="units/human-outlaws/thief.png",
 		name="Thief",
 	},
@@ -172,7 +172,7 @@ type_infos = {
 		name="Dwarvish Thunderer",
 	},
 	["Poacher"] = { 
-		founddialogue=_"What, you want my help? A guy like me? Huh, that's rich. Oh well... let's give it a shot, eh?",
+		founddialogue=_"What, you want my help? A guy like me? Huh, that’s rich. Oh well... let’s give it a shot, eh?",
 		image="units/human-outlaws/poacher.png",
 		name="Poacher",
 	},
@@ -182,7 +182,7 @@ type_infos = {
 		name="Dwarvish Guardsman",
 	},
 	["Footpad"] = { 
-		founddialogue=_"Hey, hey, easy there! I done nothin' to hurt you. We're all friends here, right? Looks like you might be in a tight spot, but don't worry. No one's better at getting out of tight spots than me, boss!",
+		founddialogue=_"Hey, hey, easy there! I done nothin’ to hurt you. We’re all friends here, right? Looks like you might be in a tight spot, but don’t worry. No one’s better at getting out of tight spots than me, boss!",
 		image="units/human-outlaws/footpad.png",
 		name="Footpad",
 	},
@@ -199,7 +199,7 @@ type_infos = {
 		} }
 	},
 	["Gryphon Rider"] = { 
-		founddialogue=_"Need a hand? Me an' me bird can get just about anywheres you need.",
+		founddialogue=_"Need a hand? Me an’ me bird can get just about anywheres you need.",
 		image="units/dwarves/gryphon-rider.png",
 		name="Gryphon Rider",
 		alt_reply = { { 
@@ -211,7 +211,7 @@ type_infos = {
 		} }
 	},
 	["Dwarvish Scout"] = { 
-		founddialogue=_"Having trouble, eh? Never worry, lads, we'll sort 'em out soon enough!",
+		founddialogue=_"Having trouble, eh? Never worry, lads, we’ll sort ’em out soon enough!",
 		image="units/dwarves/scout.png",
 		name="Dwarvish Scout",
 	},
@@ -231,7 +231,7 @@ type_infos = {
 		name="Drake Burner",
 		alt_reply = { { 
 			race="drake",
-			reply=_"Perfect. We can always use more fire power.",
+			reply=_"Perfect. We can always use more firepower.",
 		} }
 	},
 	["Saurian Augur"] = { 
@@ -244,7 +244,7 @@ type_infos = {
 		} }
 	},
 	["Drake Glider"] = { 
-		founddialogue=_"You may be out to take over the land and the seas, but you'll never get anywhere without control of the skies. Fortunately I'm here to help you!",
+		founddialogue=_"You may be out to take over the land and the seas, but you’ll never get anywhere without control of the skies. Fortunately I’m here to help you!",
 		image="units/drakes/glider.png",
 		name="Drake Glider",
 		alt_reply = { { 
@@ -258,7 +258,7 @@ type_infos = {
 		name="Saurian Skirmisher",
 	},
 	["Skeleton"] = { 
-		founddialogue=_"Don't hit me! I'm just your average regular friendly talking skeleton, see? Looks like you fellows could use some help!",
+		founddialogue=_"Don’t hit me! I’m just your average regular friendly talking skeleton, see? Looks like you fellows could use some help!",
 		image="units/undead-skeletal/skeleton/skeleton.png",
 		name="Skeleton",
 	},
@@ -268,7 +268,7 @@ type_infos = {
 		name="Skeleton Archer",
 	},
 	["Ghoul"] = { 
-		founddialogue=_"I say, old sport! It looks like you've got a spot of bother. Well, chin up, I say! I'm sure we'll make a simply smashing team-up. We can sort this lot out and be done by tea, what?",
+		founddialogue=_"I say, old sport! It looks like you’ve got a spot of bother. Well, chin up, I say! I’m sure we’ll make a simply smashing team-up. We can sort this lot out and be done by tea, what?",
 		image="units/undead/ghoul.png",
 		name="Ghoul",
 		reply=_"Have at thee, unholy abomin... wait, huh?",
@@ -307,7 +307,7 @@ type_infos = {
 		} }
 	},
 	["Thug"] = { 
-		founddialogue=_"What, you want my help? A guy like me? Huh, that's rich. Oh well... let's give it a shot, eh?",
+		founddialogue=_"What, you want my help? A guy like me? Huh, that’s rich. Oh well... let’s give it a shot, eh?",
 		image="units/human-outlaws/thug.png",
 		name="Thug",
 	},
@@ -328,7 +328,7 @@ type_infos = {
 		founddialogue=_"...",
 		image="units/undead/zombie.png",
 		name="Walking Corpse",
-		reply=_"Odd, it doesn't seem to attack. I wonder if we can use it?",
+		reply=_"Odd, it doesn’t seem to attack. I wonder if we can use it?",
 		alt_reply = { { 
 			race="undead,bats",
 			reply=_"Excellent. We could always use more help.",
@@ -373,7 +373,7 @@ type_infos = {
 		name="Dune Rover",
 	},
 	["Dune Piercer"] = { 
-		founddialogue=_"Heh, looks like you whelps might be getting in over your heads. Good thing I'm here now to win this fight for ya, huh?",
+		founddialogue=_"Heh, looks like you whelps might be getting in over your heads. Good thing I’m here now to win this fight for ya, huh?",
 		image="units/dunefolk/piercer.png",
 		name="Dune Piercer",
 	},

--- a/data/campaigns/World_Conquest/lua/game_mechanics/wocopedia/help.lua
+++ b/data/campaigns/World_Conquest/lua/game_mechanics/wocopedia/help.lua
@@ -36,36 +36,36 @@ function wesnoth.wml_actions.wc2_show_wocopedia(cfg)
 		local str_cat_mechnics = _ "Game Mechanics"
 		local str_des_mechnics = cfg.mechanics_text or
 			_ "<b>Gold</b>:\n" ..
-			_ "Carryover is 15%, comunitary and avoid negative amounts. Early finish bonus is superior to village control, but it is not directly related to their amount.\n\n" ..
+			_ "Carryover rate is 15% and split evenly among players. Negative amounts will not carry over. Early finish bonus is superior to village control, but it is not directly related to the carryover amount.\n\n" ..
 			_ "<b>Autorecall</b>:\n" ..
-			_ "Units with trait HEROIC are recalled at start of each scenario with no cost (up to castle size).\n\n" ..
+			_ "Units with trait HEROIC are recalled at the start of each scenario with no cost (up to castle size).\n\n" ..
 			_ "<b>Recall Cost</b>:\n" ..
 			_ "Units costing less than 17 gold are cheaper to recall.\n\n" ..
-			_ "<b>Trainings</b>:\n" ..
-			_ "Every time you recruit a new unit, your trainings levels will be applied. Every chance will do different dice rolls, if a unit gains training beneficts, you can see them in a trait \"trained\".\n\n" ..
+			_ "<b>Training</b>:\n" ..
+			_ "Every time you recruit a new unit, your training levels will be applied. If a unit gains training benefits, you can see them with the trait \"trained\". Each unit’s chance of gaining training benefits is independent of another’s.\n\n" ..
 			_ "<b>Upkeep</b>:\n" ..
 			_ "Units with trait HEROIC or holding any magic ITEM have FREE upkeep.\n\n" ..
 			_ "<b>Bonus Points</b>:\n" ..
-			_ "In every scenario the game generates as many bonus points on the map as there are players in the game, the bonus points can be picked up by player units and either contain artifacts, loyal units or training.\n\n" ..
+			_ "In every scenario the game generates as many bonus points on the map as there are players in the game, the bonus points can be picked up by player units and either contain artifacts, loyal units, or training.\n\n" ..
 			_ "<b>Army discipline</b>:\n" ..
-			_ "At scenarios 1 to 3, for each training level player already own, trainers found have 2% to 4% chance to become advanced trainers (provide 2 levels). Becomes irrelevant from scenario 4 because all trainers always will be advanced.\n\n" ..
+			_ "At scenarios 1 to 3, for each training level players already own, trainers found have 2% to 4% chance to become advanced trainers (provide 2 levels). Becomes irrelevant from scenario 4 onwards because all trainers will always be advanced.\n\n" ..
 			""
 		local str_cat_feedback = _ "Feedback"
 		local str_des_feedback =
 			_ "<b>Feedback</b>:\n" ..
-			_ "For feedback plase either post in the Word conquest II thread in the official wesnoth forum https://r.wesnoth.org/t39651 or file an issue at github https://github.com/gfgtdf/World_Conquest_II/issues .\n\n" ..
+			_ "For feedback please either post in the World Conquest II thread in the official Wesnoth forum https://r.wesnoth.org/t39651 or file an issue at GitHub https://github.com/gfgtdf/World_Conquest_II/issues .\n\n" ..
 			""
 		local str_cat_abilities = _ "Abilities"
 		local str_des_abilities =
 			_ "Ability <b>Autorecall</b>:\n" ..
-			_ "Units with trait HEROIC are recalled at start of each scenario with no cost (up to castle size).\n\n" ..
+			_ "Units with trait HEROIC are recalled at the start of each scenario with no cost (up to castle size).\n\n" ..
 			""
 		local str_cat_training = _ "Training"
-		local str_des_training = _ "<b>Training</b>\nTraining improves newly recruited units, it has no effect on already recruited units. The follwing list shows all available trainings, the training you currently have is marked in green."
+		local str_des_training = _ "<b>Training</b>\nTraining improves newly recruited units, it has no effect on already recruited units. The following list shows all available training, the training you currently have is marked in green."
 		local str_cat_items = _ "Artifacts"
-		local str_des_items = _ "<b>Items</b>\nItems can be given to units to make them stronger. You can get artifcats in three ways: 1) By choosing an item as your starting bonus, 2) By finding it on a map in a bonus point, 3) By dropping from enemies in later scenarios. Note however that not all units can pickup all items."
+		local str_des_items = _ "<b>Items</b>\nItems can be given to units to make them stronger. You can get artifacts in three ways: 1) By choosing an item as your starting bonus; 2) By finding it on a map in a bonus point; 3) By dropping from enemies in later scenarios. Note, however, that not all units can pick up all items."
 		local str_cat_era = _ "Factions"
-		local str_des_era = _ "<b>Factions</b>\n The Word Conquest 2 era consists of faction that are build of pairs of mainline faction of which at one has a healer available (Drakes, Rebels and Loyalists), and one does not (Orcs, Dwarves and Undead) the recruilist is also organized in pairs so that you sometimes have to recruit a different units before you can recruit the units that you want. The available heroes, desertes and random leaders also depend on your factions, the items you can get do not depend on the faction you choose."
+		local str_des_era = _ "<b>Factions</b>\n The World Conquest II era consists of factions that are built from pairs of mainline factions. One faction will have a healer available (Drakes, Rebels and Loyalists) and one will not (Orcs, Dwarves and Undead). The recruit list is also organized in pairs so that sometimes you will have to recruit a different unit before you can recruit the units that you want. The available heroes, deserters, and random leaders also depend on your factions; the items you can get do not depend on the faction you choose."
 		local str_cat_settings = _ "Settings"
 
 		---- add general topic ----

--- a/data/campaigns/World_Conquest/lua/game_mechanics/wocopedia/help_dialog.lua
+++ b/data/campaigns/World_Conquest/lua/game_mechanics/wocopedia/help_dialog.lua
@@ -699,7 +699,7 @@ return {
 						T.column {
 							horizontal_alignment = "right",
 							T.button {
-								label = "Ok",
+								label = "OK",
 								id = "ok",
 							}
 						}

--- a/data/campaigns/World_Conquest/lua/map/scenario_utils/plot.lua
+++ b/data/campaigns/World_Conquest/lua/map/scenario_utils/plot.lua
@@ -41,33 +41,33 @@ function add_plot(scenario, scenario_num, nplayers)
 		start_message("4", false, _ "Yes! We will drive them into the sea!")
 		start_message("1,2,3", false, _ "Never fear! Your trusted friends stand beside you!")
 
-		end_message("1,2,3", true, _ "Victory is ours! Let us take sail in search of new lands to conquer!")
+		end_message("1,2,3", true, _ "Victory is ours! Let us set sail in search of new lands to conquer!")
 	elseif scenario_num == 2 then
 		local r = wesnoth.random(nplayers)
 		start_message(r, true, _ "Ahhh. Just look at these fertile lands, ripe for conquest!")
-		start_message("4", true, _ "What's this?! Foreign invaders have set foot upon our shores!")
-		start_message("5", true, _ "We'll send them back to where they came from quick enough. All troops, to me!")
+		start_message("4", true, _ "What’s this?! Foreign invaders have set foot upon our shores!")
+		start_message("5", true, _ "We’ll send them back to where they came from quick enough. All troops, to me!")
 
 		end_message("1,2,3", false, _ "We win! Truly ours will be a glorious empire!")
 		end_message("1,2,3", true, _ "Do not get hasty! To reach the great continents of the east we must subdue the savage coast of Moragdu, notorious for its corsairs, before we can advance further.")
 	elseif scenario_num == 3 then
-		start_message("4", true, _ "What's this? It is a long time since strangers have set foot upon Moragdu--and in such great numbers too!")
+		start_message("4", true, _ "What’s this? It is a long time since strangers have set foot upon Moragdu — and in such great numbers too!")
 		start_message("5", true, _ "The time of prophecies is upon us! The destroyers have arrived from beyond the sea!")
-		start_message("6", true, _ "I don't know what the lizard is babbling about, but we'll sort these 'destroyers' out quickly enough.")
+		start_message("6", true, _ "I don’t know what the lizard is babbling about, but we’ll sort these ‘destroyers’ out quickly enough.")
 
-		end_message("1,2,3", true, _ "Victory is ours! Let us take sail in search of new lands to conquer!")
+		end_message("1,2,3", true, _ "Victory is ours! Let us set sail in search of new lands to conquer!")
 	elseif scenario_num == 4 then
 		local r = wesnoth.random(nplayers)
 		start_message("5", true, _ "Ready yourselves, men! The conquering hordes are upon us!")
 		start_message("4", true, _ "Word has come to our island of your victories. Your army is impressive, but it will avail you not.")
 		start_message("6", true, _ "Indeed. You come this far, and no farther!")
-		start_message(r, true, _ "Hah! We didn't come all this way just to give up and go home. We will destroy you as we have destroyed all that have stood before us!")
+		start_message(r, true, _ "Hah! We didn’t come all this way just to give up and go home. We will destroy you as we have destroyed all that have stood before us!")
 		start_message("7", true, _ "So be it. We stand squarely behind our allies.")
-		start_message("2,3", true, _ "You are not the only ones with allies! We'll push on till the end!")
+		start_message("2,3", true, _ "You are not the only ones with allies! We’ll push on till the end!")
 
 		end_message("1,2,3", true, _ "Onwards to the ships!")
-		end_message("1,2,3", false, _ "We have travelled great oceans and brought low mighty empires. Should we not wait until regain our forces?")
-		end_message("1,2,3", true, _ "One last effort! We better finish our campaign when we hold initiative, before Winter's arrive.")
+		end_message("1,2,3", false, _ "We have travelled great oceans and brought low mighty empires. Should we not wait until our forces regain their strength?")
+		end_message("1,2,3", true, _ "One last effort! We better finish our campaign when we hold initiative, before Winter arrives.")
 	else
 		local r = wesnoth.random(nplayers)
 
@@ -76,9 +76,9 @@ function add_plot(scenario, scenario_num, nplayers)
 		start_message("5", false, _ "All the peoples of the world stand against you. Though we would be enemies otherwise, we are united in our cause. We must stop you!")
 		start_message("1,2,3", false, _ "No, not all of them. Today our full strength stands behind our allies!")
 
-		end_message("1", true, _ "That's it, our work is done here!")
+		end_message("1", true, _ "That’s it, our work is done here!")
 		end_message("2", true, _ "The whole world is now ours to command!")
-		end_message("3", true, _ "It was hard, but I almost regreat the fun is over.")
+		end_message("3", true, _ "It was hard, but I almost regret the fun is over.")
 		table.insert(vicroy_event, wml.tag.endlevel {
 			result = "victory",
 			music = "sad.ogg",

--- a/data/campaigns/World_Conquest/lua/map/settings/settings_dialog.lua
+++ b/data/campaigns/World_Conquest/lua/map/settings/settings_dialog.lua
@@ -228,7 +228,7 @@ local dialog_wml = {
 							T.column {
 								horizontal_alignment = "right",
 								T.button {
-									label = "Ok",
+									label = "OK",
 									id = "ok",
 								}
 							}

--- a/data/campaigns/World_Conquest/lua/optional_mechanics/pick_advance.lua
+++ b/data/campaigns/World_Conquest/lua/optional_mechanics/pick_advance.lua
@@ -38,7 +38,7 @@ function wesnoth.wml_actions.wc2_pya_pick(cfg)
 	end
 	local picked = u.variables.wc2_pya_pick
 	local options = u.advances_to
-	local str_advancer_option = _ "Currently I'm set to advance towards: $name \n\nWhat are your new orders?"
+	local str_advancer_option = _ "Currently I’m set to advance towards: $name \n\nWhat are your new orders?"
 	local current_name = picked and wesnoth.unit_types[picked].name or _"Random"
 	local message_wml = {
 		x=cfg.x,

--- a/data/campaigns/World_Conquest/resources/strings/artifacts.cfg
+++ b/data/campaigns/World_Conquest/resources/strings/artifacts.cfg
@@ -4,10 +4,10 @@
 _ "Adamant armor" #enddef
 
 #define STR_ITEM_STEADFAST_INFO
-_ "The sturdy plates of this lightweight armor increase the user's physical resistances (to a maximum of 10%) and grants the steadfast ability." #enddef
+_ "The sturdy plates of this lightweight armor increase the user’s physical resistances (to a maximum of 10%) and grants the steadfast ability." #enddef
 
 #define STR_ITEM_BACKSTAB_NAME
-_ "Assassin's ring" #enddef
+_ "Assassin’s ring" #enddef
 
 #define STR_ITEM_BACKSTAB_INFO
 _ "This plain ring with a pleasantly smooth and slippery surface gives its owner unmatched sneak attacking skills." #enddef
@@ -28,7 +28,7 @@ _ "This shamanic totem protects from poison, drain, and plague. Bearers of the t
 _ "Blood ring" #enddef
 
 #define STR_ITEM_DRAIN_M_INFO
-_ "This pulsing ring empowers the bearer's melee attacks with the ability to drain lifeforce from their victim." #enddef
+_ "This pulsing ring empowers the bearer’s melee attacks with the ability to drain lifeforce from their victim." #enddef
 
 #define STR_ITEM_DRAIN_R_NAME
 _ "Cursed symbol of life" #enddef
@@ -40,10 +40,10 @@ _ "This vampiric amulet allows a unit to drain enemy life from a safe distance."
 _ "Eagle eye longbow" #enddef
 
 #define STR_ITEM_MARKSMAN_R_INFO
-_ "This enchanted longbow enhances the wielder's ranged attacks with uncanny precision and increased damage." #enddef
+_ "This enchanted longbow enhances the wielder’s ranged attacks with uncanny precision and increased damage." #enddef
 
 #define STR_ITEM_PLAGUE_NAME
-_ "Forbidden grimorie" #enddef
+_ "Forbidden grimoire" #enddef
 
 #define STR_ITEM_PLAGUE_INFO
 _ "This unholy manual gives the user the arcane knowledge to resurrect enemies slain in melee combat as the walking dead." #enddef
@@ -55,37 +55,37 @@ _ "Forcefield" #enddef
 _ "adjacent enemies do 13% less damage" #enddef
 
 #define STR_ITEM_FORCEFIELD_INFO
-_ "Charged with intense magic, this shield generates a forcefield causing adjacent enemies to inflict less damage around wielder." #enddef
+_ "Charged with intense magic, this shield generates a forcefield causing adjacent enemies to inflict less damage around the wielder." #enddef
 
 #define STR_ITEM_FEEDING_NAME
-_ "Ghast's marrow" #enddef
+_ "Ghast’s marrow" #enddef
 
 #define STR_ITEM_FEEDING_INFO
-_ "This grisly concoction instills the drinker with an insatiable unholy hunger for more blood. Everytime a foe is slain, a part of his lifeforce is eternally claimed by the through arcane ghoulish powers." #enddef
+_ "This grisly concoction instills the drinker with an insatiable unholy hunger for more blood. Every time a foe is slain, a part of his lifeforce is eternally claimed through arcane ghoulish powers." #enddef
 
 #define STR_ITEM_IMPACT_NAME
 _ "Root of the Elder Wose" #enddef
 
 #define STR_ITEM_IMPACT_INFO
-_ " Dwarven Forged, this blunt weapon mimics the crushing power of the Wose." #enddef
+_ " Dwarven forged, this blunt weapon mimics the crushing power of the Wose." #enddef
 
 #define STR_ITEM_CHARGE_NAME
 _ "Cruel spike" #enddef
 
 #define STR_ITEM_CHARGE_INFO
-_ "This enchanted spear drives the owner to commit himself to his rage. A unit's melee strikes are doubled in power when attacking, but the same is true for the retaliation strike of the defender." #enddef
+_ "This enchanted spear drives the owner to commit himself to his rage. A unit’s melee strikes are doubled in power when attacking, but the same is true for the retaliation strike of the defender." #enddef
 
 #define STR_ITEM_FIRE_NAME
 _ "Heart of fire" #enddef
 
 #define STR_ITEM_FIRE_INFO
-_ "This magic orb infuses the wielder's melee attacks with fiery power, changing their damage type. It also improves fire resistance." #enddef
+_ "This magic orb infuses the wielder’s melee attacks with fiery power, changing their damage type. It also improves fire resistance." #enddef
 
 #define STR_ITEM_ILLUMINATES_NAME
 _ "Herald armor" #enddef
 
 #define STR_ITEM_ILLUMINATES_INFO
-_ "This holy armor of thin gold radiates pure light, illuminating the bearer's body and soul. This effect will heal allies, blind evil, and preemptively smite those who seek to do harm." #enddef
+_ "This holy armor of thin gold radiates pure light, illuminating the bearer’s body and soul. This effect will heal allies, blind evil, and preemptively smite those who seek to do harm." #enddef
 
 #define STR_ITEM_ARCANE_NAME
 _ "Holy water" #enddef
@@ -109,13 +109,13 @@ _ "These potent herbs give the bearer the ability to heal adjacent units and cur
 _ "Melange" #enddef
 
 #define STR_ITEM_DRUG_INFO
-_ "This exotic drug of organic origin enhances user's vitality and awareness. It has no effect consumed by undead." #enddef
+_ "This exotic drug of organic origin enhances user’s vitality and awareness. It has no effect when consumed by undead." #enddef
 
 #define STR_ITEM_SLOW_M_NAME
 _ "Ring of frostbite" #enddef
 
 #define STR_ITEM_SLOW_M_INFO
-_ "This frigid ring envelops the user's melee attacks with icy cold, changing their damage to cold and allowing them to inflict deathly chills that slow the enemy." #enddef
+_ "This frigid ring envelops the user’s melee attacks with icy cold, changing their damage to cold and allowing them to inflict deathly chills that slow the enemy." #enddef
 
 #define STR_ITEM_ELEMENTALS_NAME
 _ "Ring of power" #enddef
@@ -127,7 +127,7 @@ _ "Wearing this ring enhances damage with arcane and elemental attacks, allowing
 _ "Runic sword" #enddef
 
 #define STR_ITEM_MAGICAL_INFO
-_ "This magic sword empowers the wielder's melee attacks with the magical property." #enddef
+_ "This magic sword empowers the wielder’s melee attacks with the magical property." #enddef
 
 #define STR_ITEM_ATTACK_ARCANE_NAME
 _ "Staff of radiance" #enddef
@@ -172,16 +172,16 @@ _ "Trident of storms" #enddef
 _ "This legendary trident can summon lightning from the heavens, granting its wielder magical ranged fire attack." #enddef
 
 #define STR_ITEM_REGENERATES_NAME
-_ "Trollsblood potion" #enddef
+_ "Trolls blood potion" #enddef
 
 #define STR_ITEM_REGENERATES_INFO
 _ "This foul-smelling potion allows the imbiber to regenerate health." #enddef
 
 #define STR_ITEM_POISON_NAME
-_ "Oinment of venom" #enddef
+_ "Ointment of venom" #enddef
 
 #define STR_ITEM_POISON_INFO
-_ "This deadly poison envenoms the user's blade and pierce attacks, increasing damage and allowing them to inflict poison." #enddef
+_ "This deadly poison envenoms the user’s blade and pierce attacks, increasing damage and allowing them to inflict poison." #enddef
 
 #define STR_ITEM_LEADERSHIP_NAME
 _ "War banner" #enddef
@@ -190,7 +190,7 @@ _ "War banner" #enddef
 _ "adjacent allies do 20% more damage" #enddef
 
 #define STR_ITEM_LEADERSHIP_INFO
-_ "This inspiring banner rallies the bearer's allies to war, imparting a damage bonus to the allied units around." #enddef
+_ "This inspiring banner rallies the bearer’s allies to war, imparting a damage bonus to the allied units around it." #enddef
 
 #define STR_ITEM_FLYING_NAME
 _ "Winged scepter" #enddef
@@ -199,7 +199,7 @@ _ "Winged scepter" #enddef
 _ "This wondrous rod imparts the user the ability to soar through the skies, making it a breeze to move through most terrain. Units that can already fly get improved defenses." #enddef
 
 #define STR_ITEM_SNOW_NAME
-_ "Winter's bloom" #enddef
+_ "Winter’s bloom" #enddef
 
 #define STR_ITEM_SNOW_INFO
 _ "This delicate blossom rarely found in snowy peaks, is strongly appreciated for its beneficial effects on health." #enddef

--- a/data/campaigns/World_Conquest/resources/strings/effects.cfg
+++ b/data/campaigns/World_Conquest/resources/strings/effects.cfg
@@ -19,13 +19,13 @@ _ "This unit can lead ~allied~ units that are next to it, making them fight bett
 _ "corruption" #enddef
 
 #define STR_CORRUPTION_DESCRIPTION
-_ "This unit corrupts adjacent enemies at the beginning of our turn. Currupted units lose 6 HP or are reduced to 1 HP. Corruption can not, of itself, kill a unit." #enddef
+_ "This unit corrupts adjacent enemies at the beginning of our turn. Corrupted units lose 6 HP or are reduced to 1 HP. Corruption cannot, of itself, kill a unit." #enddef
 
 #define STR_DARKNESS
 _ "darkness" #enddef
 
 #define STR_DARKNESS_DESCRIPTION
-_ "This unit darks the surrounding area, making chaotic units fight better, and lawful units fight worse. Any units adjacent to this unit will fight as if it were dusk when it is day, and as if it were night when it is dusk." #enddef
+_ "This unit darkens the surrounding area, making chaotic units fight better, and lawful units fight worse. Any units adjacent to this unit will fight as if it were dusk when it is day, and as if it were night when it is dusk." #enddef
 
 #define STR_DISTRACT
 _ "distract" #enddef
@@ -37,13 +37,13 @@ _ "Allied units ignore enemy zones of control adjacent to this unit." #enddef
 _ "flight" #enddef
 
 #define STR_FLIGHT_DESCRIPTION
-_ "Full movement and up to 50 defenses in all terrains but cave or mushroom grove." #enddef
+_ "Full movement and up to 50% defense in all terrains but cave or mushroom grove." #enddef
 
 #define STR_SWIM
 _ "swim" #enddef
 
 #define STR_SWIM_DESCRIPTION
-_ "Full movement and up to 60 defenses in water or swamp and up to 70 defense in reef." #enddef
+_ "Full movement and up to 60% defense in water or swamp and up to 70% defense in reef." #enddef
 
 #define STR_FORCEFIELD
 _ "forcefield" #enddef
@@ -82,7 +82,7 @@ _ "terrain^water" #enddef
 _ "improved defenses" #enddef
 
 #define STR_LIVING
-_ "no undead^consumed by a living beign:" #enddef
+_ "no undead^consumed by a living being:" #enddef
 
 #define STR_UP_TO VALUE
 _ "up to"+" {VALUE}% " #enddef

--- a/data/campaigns/World_Conquest/resources/strings/training.cfg
+++ b/data/campaigns/World_Conquest/resources/strings/training.cfg
@@ -4,7 +4,7 @@
 _ "Melee Combat" #enddef
 
 #define STR_MELEE_FOUND
-_ "Looks like you could use some help. A grizzled old veteran like me won't be much use on the field, but I bet I can teach your men a thing or two about swordplay." #enddef
+_ "Looks like you could use some help. A grizzled old veteran like me won’t be much use on the field, but I bet I can teach your men a thing or two about swordplay." #enddef
 
 #define STR_RANGER_NAME
 _ "Ranger Tactics" #enddef
@@ -16,25 +16,25 @@ _ "I sympathize with your cause, but this is not my battle. I will not fight for
 _ "Health" #enddef
 
 #define STR_HEALTH_FOUND
-_ "Looks like a pretty grim fight you've got up ahead. I've got too many troubles of my own to join in, but stick about a whiles and I'll put some steel in your backbone. When I'm through with you you'll be able to keep on going no matter the odds!" #enddef
+_ "Looks like a pretty grim fight you’ve got up ahead. I’ve got too many troubles of my own to join in, but stick about a while and I’ll put some steel in your backbone. When I’m through with you you’ll be able to keep on going no matter the odds!" #enddef
 
 #define STR_MOVEMENT_NAME
 _ "Movement" #enddef
 
 #define STR_MOVEMENT_FOUND
-_ "What, you want me to join the fight? Quite out of the question, old boy! I'm afraid battlefields just aren't my scene - no drama, no style, no romance! No finesse at all! You probably wouldn't understand, so let me show you. I'll teach you how to break out of those dreary marching formations and step light as a feather!" #enddef
+_ "What, you want me to join the fight? Quite out of the question, old boy! I’m afraid battlefields just aren’t my scene - no drama, no style, no romance! No finesse at all! You probably wouldn’t understand, so let me show you. I’ll teach you how to break out of those dreary marching formations and step light as a feather!" #enddef
 
 #define STR_EXPERIENCE_NAME
 _ "Combat Experience" #enddef
 
 #define STR_EXPERIENCE_FOUND
-_ " Join the battle? Nay, lads, my talents would be wasted on the frontlines. Give me some raw recruits to work with, though, and I'll whip 'em into shape for you. I know what real battle is like; by the time I'm through with 'em, your newbies might have some idea of it too." #enddef
+_ " Join the battle? Nay, lads, my talents would be wasted on the frontlines. Give me some raw recruits to work with, though, and I’ll whip ’em into shape for you. I know what real battle is like; by the time I’m through with ’em, your newbies might have some idea of it too." #enddef
 
 #define STR_DARK_NAME
 _ "Dark" #enddef
 
 #define STR_DARK_FOUND
-_ "I haven't lived centuries fighting other's battles, but I could combat boredown teaching your men a couple of things about dark techniques." #enddef
+_ "I haven’t lived centuries fighting others’ battles, but I could combat boredom teaching your men a couple of things about dark techniques." #enddef
 
 #define STR_ID_AMBUSH
 ambush #enddef


### PR DESCRIPTION
**Before** merging this I have some questions about some phrases in `data/campaigns/World_Conquest/lua/game_mechanics/wocopedia/help.lua` that I didn't know how to decipher (from a native English speaker's point of view):

Line 39:
> Carryover is 15%, comunitary and avoid negative amounts.

I don't know what 'comunitary' is supposed to mean. Communal? Also what does 'carry-over avoid negative amounts' supposed to mean? Gold will always be non-negative at the start of a scenario?

Line 45:
> Every chance will do different dice rolls

This is in the context of units' training. Every chance of what? Every time a new unit is recruited there will be a different chance of being trained?

Line 68 (partially edited):
> The World Conquest II era consists of factions that are build of pairs of mainline factions of which one has a healer available (Drakes, Rebels and Loyalists), and one does not (Orcs, Dwarves and Undead) the recruit list is also organized in pairs so that you sometimes have to recruit a different unit before you can recruit the units that you want. The available heroes, desertes, and random leaders also depend on your factions, the items you can get do not depend on the faction you choose.

I didn't understand what was meant by 'factions that are build of pairs of mainline factions'. Also... 'desertes'?

I'm guessing @gfgtdf as author (?) can help with the review. I found these while reviewing #5100 for @shikadiqueen.