### PR TITLE
add-ons manager translated titles and description also for System default language

### DIFF
--- a/src/addon/info.cpp
+++ b/src/addon/info.cpp
@@ -18,10 +18,11 @@
 #include "config.hpp"
 #include "font/pango/escape.hpp"
 #include "gettext.hpp"
-#include "language.hpp"
 #include "picture.hpp"
 #include "log.hpp"
 #include "serialization/string_utils.hpp"
+
+#include <boost/locale.hpp>
 
 static lg::log_domain log_addons_client("addons-client");
 #define ERR_AC LOG_STREAM(err ,  log_addons_client)
@@ -155,18 +156,29 @@ addon_info_translation addon_info_translation::invalid = {false, "", ""};
 
 addon_info_translation addon_info::translated_info() const
 {
-	std::string locale = get_language().localename;
+	const boost::locale::info& locale_info = translation::get_effective_locale_info();
 
-	if(locale != "en_US") {
-		auto info = info_translations.find(locale);
-		if(info != info_translations.end()) {
-			return info->second;
-		}
+	std::string lang_name_short = locale_info.language();
+	std::string lang_name_long = lang_name_short;
+	if(!locale_info.country().empty()) {
+		lang_name_long += '_';
+		lang_name_long += locale_info.country();
+	}
+	if(!locale_info.variant().empty()) {
+		lang_name_long += '@';
+		lang_name_long += locale_info.variant();
+		lang_name_short += '@';
+		lang_name_short += locale_info.variant();
+	}
 
-		info = info_translations.find(locale.substr(0, 2));
-		if(info != info_translations.end()) {
-			return info->second;
-		}
+	auto info = info_translations.find(lang_name_long);
+	if(info != info_translations.end()) {
+		return info->second;
+	}
+
+	info = info_translations.find(lang_name_short);
+	if(info != info_translations.end()) {
+		return info->second;
 	}
 
 	return addon_info_translation::invalid;

--- a/src/gettext.cpp
+++ b/src/gettext.cpp
@@ -527,4 +527,9 @@ bool ci_search(const std::string& s1, const std::string& s2)
 	                   ls2.begin(), ls2.end()) != ls1.end();
 }
 
+const boost::locale::info& get_effective_locale_info()
+{
+	std::lock_guard<std::mutex> lock(get_mutex());
+	return std::use_facet<boost::locale::info>(get_manager().get_locale());
+}
 }

--- a/src/gettext.hpp
+++ b/src/gettext.hpp
@@ -37,6 +37,7 @@
 #include <string>
 #include <vector>
 #include <ctime>
+#include <boost/locale.hpp>
 
 #ifndef GETTEXT_DOMAIN
 # define GETTEXT_DOMAIN PACKAGE
@@ -85,6 +86,14 @@ namespace translation
 	std::string strftime(const std::string& format, const std::tm* time);
 
 	bool ci_search(const std::string& s1, const std::string& s2);
+
+	/**
+	 * A facet that holds general information about the effective locale.
+	 * This describes the actual translation target language,
+	 * unlike language_def.localename in language.hpp, where the "System
+	 * default language" is represented by an empty string.
+	 */
+	const boost::locale::info& get_effective_locale_info();
 }
 
 //#define _(String) translation::dsgettext(GETTEXT_DOMAIN,String)


### PR DESCRIPTION
The nice new feature that allows translated add-on titles and descriptions in the add-ons manager works well when the language preference is explicitly set to some supported language, but not when "System default language" is selected, because this is represented by an empty string in language.hpp. This pull request fixes this by getting the effective locale (the actual translation target language) from gettext.