### PR TITLE
Help browser: fix behavior of clicking on icons of terrain sections

### DIFF
--- a/src/help/help_impl.cpp
+++ b/src/help/help_impl.cpp
@@ -151,7 +151,6 @@ void parse_config_internal(const config *help_cfg, const config *section_cfg,
 	}
 	else if (section_cfg != nullptr) {
 		const std::vector<std::string> sections = utils::quoted_split((*section_cfg)["sections"]);
-		sec.level = level;
 		std::string id = level == 0 ? "toplevel" : (*section_cfg)["id"].str();
 		if (level != 0) {
 			if (!is_valid_id(id)) {
@@ -885,7 +884,7 @@ void generate_terrain_sections(section& sec, int /*level*/)
 	}
 }
 
-void generate_unit_sections(const config* /*help_cfg*/, section& sec, int level, const bool /*sort_generated*/, const std::string& race)
+void generate_unit_sections(const config* /*help_cfg*/, section& sec, int /*level*/, const bool /*sort_generated*/, const std::string& race)
 {
 	for (const unit_type_data::unit_type_map::value_type &i : unit_types.types()) {
 		const unit_type &type = i.second;
@@ -913,7 +912,6 @@ void generate_unit_sections(const config* /*help_cfg*/, section& sec, int level,
 
 		base_unit.id = ref_id;
 		base_unit.title = type_name;
-		base_unit.level = level +1;
 
 		sec.add_section(base_unit);
 	}

--- a/src/help/help_impl.hpp
+++ b/src/help/help_impl.hpp
@@ -144,8 +144,7 @@ struct section {
 		title(""),
 		id(""),
 		topics(),
-		sections(),
-		level()
+		sections()
 	{
 	}
 
@@ -161,7 +160,6 @@ struct section {
 	std::string title, id;
 	topic_list topics;
 	section_list sections;
-	int level;
 };
 
 

--- a/src/help/help_menu.hpp
+++ b/src/help/help_menu.hpp
@@ -47,13 +47,14 @@ public:
 private:
 	/// Information about an item that is visible in the menu.
 	struct visible_item {
-		visible_item(const section *_sec, const std::string &visible_string);
-		visible_item(const topic *_t, const std::string &visible_string);
+		visible_item(const section *_sec, const std::string &visible_string, int level);
+		visible_item(const topic *_t, const std::string &visible_string, int level);
 		// Invariant, one if these should be nullptr. The constructors
 		// enforce it.
 		const topic *t;
 		const section *sec;
 		std::string visible_string;
+		int level;
 		bool operator==(const visible_item &vis_item) const;
 		bool operator==(const section &sec) const;
 		bool operator==(const topic &t) const;


### PR DESCRIPTION
This commit uses the UI's calculated indent for the UI's event handling, and
removes section::level. The code generating the help sections still has its own
"level", which is used to detect excessive recursion.

This fixes a UI quirk that I only noticed while working out what section::level
was for, while considering the subtopics needed for implementing a taxonomy
system. The help browser calculates indentation for its tree-view based on the
data tree given to it. However, the logic for deciding whether a mouse-click
was on the icon or the text used section::level, rather than any value
calculated in the UI classes. While section::level was often the correct
number, it was wrong for the terrain types' sections.