### PR TITLE
1.14 add-ons manager translated titles and description also for System default language

### DIFF
--- a/src/gettext.hpp
+++ b/src/gettext.hpp
@@ -37,6 +37,7 @@
 #include <string>
 #include <vector>
 #include <ctime>
+#include <boost/locale.hpp>
 
 #ifndef GETTEXT_DOMAIN
 # define GETTEXT_DOMAIN PACKAGE
@@ -85,6 +86,14 @@ namespace translation
 	std::string strftime(const std::string& format, const std::tm* time);
 
 	bool ci_search(const std::string& s1, const std::string& s2);
+
+	/**
+	 * A facet that holds general information about the effective locale.
+	 * This describes the actual translation target language,
+	 * unlike language_def.localename in language.hpp, where the "System
+	 * default language" is represented by an empty string.
+	 */
+	const boost::locale::info& get_effective_locale_info();
 }
 
 //#define _(String) translation::dsgettext(GETTEXT_DOMAIN,String)

--- a/src/gettext_boost.cpp
+++ b/src/gettext_boost.cpp
@@ -538,4 +538,9 @@ bool ci_search(const std::string& s1, const std::string& s2)
 	                   ls2.begin(), ls2.end()) != ls1.end();
 }
 
+const boost::locale::info& get_effective_locale_info()
+{
+	std::lock_guard<std::mutex> lock(get_mutex());
+	return std::use_facet<boost::locale::info>(get_manager().get_locale());
+}
 }


### PR DESCRIPTION
Backport of pull-request #5109 from master to 1.14.
The nice new feature that allows translated add-on titles and descriptions in the add-ons manager works well when the language preference is explicitly set to some supported language, but not when "System default language" is selected, because this is represented by an empty string in language.hpp. This pull request fixes this by getting the effective locale (the actual translation target language) from gettext.