### PR TITLE
Show the "loyal" trait in help

### DIFF
--- a/src/help/help_impl.cpp
+++ b/src/help/help_impl.cpp
@@ -680,7 +680,8 @@ std::vector<topic> generate_trait_topics(const bool sort_generated)
 	for (const unit_type_data::unit_type_map::value_type &i : unit_types.types())
 	{
 		const unit_type &type = i.second;
-		if (description_type(type) == FULL_DESCRIPTION) {
+		const auto desc_type = description_type(type);
+		if (desc_type == FULL_DESCRIPTION || desc_type == HIDDEN_BUT_SHOW_MACROS) {
 			if (config::const_child_itors traits = type.possible_traits()) {
 				for (const config & trait : traits) {
 					const std::string trait_id = trait["id"];
@@ -1015,6 +1016,12 @@ UNIT_DESCRIPTION_TYPE description_type(const unit_type &type)
 	if (encountered_units.find(type.id()) != encountered_units.end()) {
 		return FULL_DESCRIPTION;
 	}
+
+	// See the docs of HIDDEN_BUT_SHOW_MACROS
+	if (type.id() == "Fog Clearer") {
+		return HIDDEN_BUT_SHOW_MACROS;
+	}
+
 	return NO_DESCRIPTION;
 }
 

--- a/src/help/help_impl.hpp
+++ b/src/help/help_impl.hpp
@@ -229,7 +229,20 @@ void generate_races_sections(const config *help_cfg, section &sec, int level);
 void generate_terrain_sections(section &sec, int level);
 std::vector<topic> generate_unit_topics(const bool, const std::string& race);
 void generate_unit_sections(const config *help_cfg, section &sec, int level, const bool, const std::string& race);
-enum UNIT_DESCRIPTION_TYPE {FULL_DESCRIPTION, NO_DESCRIPTION, NON_REVEALING_DESCRIPTION};
+enum UNIT_DESCRIPTION_TYPE {
+	FULL_DESCRIPTION,
+	/** Ignore this unit for documentation purposes. */
+	NO_DESCRIPTION,
+	/**
+	 * Although the unit itself is hidden, traits reachable via this unit are not hidden.
+	 *
+	 * This is a bug workaround - traits are defined by WML macros, and therefore the help
+	 * system has to use a place where that macro is instanciated to provide the documentation.
+	 * None of the normal unit types has the "loyal" trait, but there is a hidden unit which
+	 * does, purely to support the help system.
+	 */
+	HIDDEN_BUT_SHOW_MACROS
+};
 /// Return the type of description that should be shown for a unit of
 /// the given kind. This method is intended to filter out information
 /// about units that should not be shown, for example due to not being


### PR DESCRIPTION
Fixes #1935 for normal users, expanding on aac0941's fix which only showed
these abiities when Wesnoth was in debug mode.

The removed enum member "NON_REVEALING_DESCRIPTION" was unused, and all
existing callers effectively used description_type() as a boolean.

This does mean that the "aged" trait will be shown to all users, even if
they haven't played HttT, however that seems reasonable.