### PR TITLE
Fix inverted logic in working out which resources are active

### DIFF
--- a/src/game_classification.cpp
+++ b/src/game_classification.cpp
@@ -142,7 +142,7 @@ std::set<std::string> game_classification::active_addons(const std::string& scen
 
 		const modevents_entry& current = mods.front();
 		if(current.type == "resource") {
-			if(loaded_resources.insert(current.id).second) {
+			if(!loaded_resources.insert(current.id).second) {
 				mods.pop_front();
 				continue;
 			}


### PR DESCRIPTION
This line is meant to skip the rest of the loop for things that have previously
been inserted in to loaded_resources; but instead it skipped the rest of the
loop unless the id was already in loaded_resources. Fixes #5126.