### PR TITLE
Add 'Delay Advancements [modification]

### DIFF
--- a/data/_main.cfg
+++ b/data/_main.cfg
@@ -37,6 +37,7 @@
 
 {campaigns/}
 
+{modifications.cfg}
 [ais]
     default_ai_algorithm=ai_default_rca
     [default_config]

--- a/data/modifications.cfg
+++ b/data/modifications.cfg
@@ -1,0 +1,5 @@
+[modification]
+    id = "delay_advancements"
+    name = _ "Delay Advancements"
+    type = "hybrid"
+[/modification]

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -534,7 +534,7 @@ void play_controller::do_init_side()
 		bool delay_advancements = std::find(active_mods.begin(), active_mods.end(), "delay_advancements") != active_mods.end();
 
 		for(unit &u : resources::gameboard->units()) {
-			if(u.side() == current_side()) {
+			if(delay_advancements && u.side() == current_side()) {
 				advance_unit_at(u.get_location());
 			}
 		}

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -20,6 +20,7 @@
 
 #include "play_controller.hpp"
 
+#include "actions/advancement.hpp"
 #include "actions/create.hpp"
 #include "actions/heal.hpp"
 #include "actions/undo.hpp"
@@ -528,6 +529,16 @@ void play_controller::do_init_side()
 
 	// Make sure vision is accurate.
 	actions::clear_shroud(current_side(), true);
+	{
+		const auto& active_mods = get_saved_game().classification().active_mods;
+		bool delay_advancements = std::find(active_mods.begin(), active_mods.end(), "delay_advancements") != active_mods.end();
+
+		for(unit &u : resources::gameboard->units()) {
+			if(u.side() == current_side()) {
+				advance_unit_at(u.get_location());
+			}
+		}
+	}
 	init_side_end();
 	check_victory();
 	sync.do_final_checkup();

--- a/src/units/helper.cpp
+++ b/src/units/helper.cpp
@@ -20,6 +20,9 @@
 #include "units/unit.hpp"
 #include "units/helper.hpp"
 #include "units/types.hpp"
+#include "resources.hpp"
+#include "play_controller.hpp"
+#include "saved_game.hpp"
 
 namespace unit_helper {
 
@@ -30,7 +33,17 @@ int number_of_possible_advances(const unit &u)
 
 bool will_certainly_advance(const unit_map::iterator &u)
 {
-	return u.valid() && u->advances() && number_of_possible_advances(*u) > 0;
+	if(!u.valid()) {
+		return false;
+	}
+	if(resources::controller) {
+		const auto& active_mods = resources::controller->get_saved_game().classification().active_mods;
+		bool delay_advancements = std::find(active_mods.begin(), active_mods.end(), "delay_advancements") != active_mods.end();
+		if(delay_advancements && resources::controller->current_side() != u->side()) {
+			return false;
+		}
+	}
+	return u->advances() && number_of_possible_advances(*u) > 0;
 }
 
 std::string resistance_color(const int resistance)


### PR DESCRIPTION
Depsite being a [modification] this is actuall implemented
in the C++ code the [modification] just sets a flag.

With this modification active all advancements are delayed
until its the players (that controls the unit in question) turn
again.

This is meant as an alterntive to the preset advancement
type of mod.  want to play around with this alternative mod a a bit in 1.15
maybe we will remove it later if we find ot that it wasn't a good idea.

The problbme this is supposed to fix is that advancemnts
are done randomly during the enemeies turn. It has a few
advantages over the preset advancemnt approach:
1) It can easily handle Amlas and normal advancement
2) It doesn't need special code to handle the case that
   A unit advances multiple times. During an enemies turn.
3) It doesn't break in case that other wml code changed
   The advancements of a unit after the pre-selected advancement was chosen
4) It might be difficult for the user to know in advance which units
have a chance to advance during the next turn, if for example multiple of enemy units
unexpectedly attack one of the players units.
 

It also has a disadvantage: it changes the rules of the
game quite a bit, in particular if the units heals form
an advancement (which us usually the case), since now
with this 'healing the unit on advancement by retaliation'
during the enemies turn can no longer happen. I still
think its worth to think about this and test it though.