### PR TITLE
Show [race]help_taxonomy= as "This is a group of units, all of whom are $help_taxonomy"

### DIFF
--- a/data/core/units.cfg
+++ b/data/core/units.cfg
@@ -209,6 +209,7 @@ The eastern provinces of Wesnoth, known as the Clan Homelands, have a geography 
         male_name= _"race^Dunefolk Human"
         female_name= _"race+female^Dunefolk Human"
         plural_name= _"race+plural^Dunefolk"
+        help_taxonomy=human
         description= _"An offshoot of a forgotten nomadic civilization, the Dunefolk lay claim to the river valleys and oases of the Sandy Wastes. How they came to inhabit this far corner of the Great Continent is unknown. Their legends tell of many long and perilous travels through far-flung lands, but the true origin of their people is a topic of endless and heated debate among even the most erudite of their scholars.
 
 Whatever their origin, the Dunefolk have thrived. Bustling cities stand proudly in the largest fertile regions. Skilled artisans, fine smiths, and wealthy merchants form the backbone of the urban economy. Each of these cities also enjoys a degree of independence less common in the more centralized nations to the north, many even maintaining their own standing armies. In times of need, however, each and all rally to a higher authority designated to protect the superior interest of the nation.

--- a/data/schema/units/races.cfg
+++ b/data/schema/units/races.cfg
@@ -10,6 +10,7 @@
 	{SIMPLE_KEY description t_string}
 	{SIMPLE_KEY num_traits int}
 	{SIMPLE_KEY undead_variation string}
+	{SIMPLE_KEY help_taxonomy string}
 	{SIMPLE_KEY ignore_global_traits bool}
 	# Name generation
 	{SIMPLE_KEY male_names t_string}

--- a/src/help/help_impl.hpp
+++ b/src/help/help_impl.hpp
@@ -280,6 +280,7 @@ const topic *find_topic(const section &sec, const std::string &id);
 /// and its subsections. Return the found section or nullptr if none could
 /// be found.
 const section *find_section(const section &sec, const std::string &id);
+section *find_section(section &sec, const std::string &id);
 
 /// Parse a text string. Return a vector with the different parts of the
 /// text. Each markup item is a separate part while the text between

--- a/src/units/race.cpp
+++ b/src/units/race.cpp
@@ -54,7 +54,8 @@ unit_race::unit_race() :
 		traits_(empty_traits().child_range("trait")),
 		topics_(empty_topics().child_range("topic")),
 		global_traits_(true),
-		undead_variation_()
+		undead_variation_(),
+		help_taxonomy_()
 {
 	for(auto& generator : name_generator_) {
 		generator.reset(new name_generator());
@@ -71,7 +72,8 @@ unit_race::unit_race(const config& cfg) :
 		traits_(cfg.child_range("trait")),
 		topics_(cfg.child_range("topic")),
 		global_traits_(!cfg["ignore_global_traits"].to_bool()),
-		undead_variation_(cfg["undead_variation"])
+		undead_variation_(cfg["undead_variation"]),
+		help_taxonomy_(cfg["help_taxonomy"])
 
 {
 	if (id_.empty()) {

--- a/src/units/race.hpp
+++ b/src/units/race.hpp
@@ -62,6 +62,8 @@ public:
 	 */
 	std::string get_icon_path_stem() const;
 
+	const std::string& help_taxonomy() const { return help_taxonomy_; }
+
 	/// Dummy race used when a race is not yet known.
 	static const unit_race null_race;
 
@@ -83,6 +85,7 @@ private:
 	config::const_child_itors topics_;
 	bool global_traits_;
 	std::string undead_variation_;
+	std::string help_taxonomy_;
 };
 
 unit_race::GENDER string_gender(const std::string& str,unit_race::GENDER def=unit_race::MALE);


### PR DESCRIPTION
This allows the help browser to add links between [race]s. I've used the word "group" rather
than "subrace",  it seems less likely to have political overtones.

The code comments talk about both Dunefolk and Quenoth Elves - of these two, only the
Dunefolk's data is changed in this commit, the Quenoth still have race=elf at the moment.

Draft documentation for the Wiki:

```
* '''help_taxonomy''': {{DevFeature1.15|?}} in the help browser, show this
race as a group of units from another race; the value of this attribute should
be the other race's '''id''' attribute. This only affects the help browser, for
all other purposes (such as WML filters) the two races are completely separate.

How this is visualised in the help browser is a GUI design decision, this attribute
merely tells the engine that the relationship exists.
```

The PR provides a visualisation, even though the proposed Wiki-doc is non-specific.
Here's three vertically-sliced screenshots:
![wesnoth_help_taxonomy](https://user-images.githubusercontent.com/101462/92564833-175b1b00-f27a-11ea-90cc-b4b7f8874eb6.png)
