### PR TITLE
UtBS: Make "quenoth" a separate race to "elf" (fixes #4876)

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/_main.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/_main.cfg
@@ -182,7 +182,7 @@
         first_time_only=no
 
         [filter]
-            race=elf
+            race=quenoth,elf
         [/filter]
 
         [filter_condition]
@@ -213,7 +213,7 @@
 [/campaign]
 # wmllint: validate-on
 
-#Append Units
+#Append Units, including the movetypes and race definition
 [units]
     {UTBS_INCLUDE units/units.cfg}
     {UTBS_INCLUDE units/quenoth}
@@ -222,13 +222,6 @@
     {UTBS_INCLUDE units/nagas}
     {UTBS_INCLUDE units/other}
     {UTBS_INCLUDE units/undead}
-
-    [hide_help]
-        # wmllint: markcheck off
-        type_adv_tree=Elvish Fighter,Elvish Shaman,Elvish Archer,Elvish Scout,Elvish Lord,Wose
-        # wmllint: markcheck on
-        type=Elvish Lady
-    [/hide_help]
 [/units]
 
 {UTBS_INCLUDE scenarios}

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
@@ -1205,11 +1205,11 @@
     # tentacles appear at start of player’s turn
 
     [event]
-        name=moveto
+        name=enter_hex
 
         [filter]
-            x=27
-            y=17
+            x=27-29,28-29
+            y=17,18
             side=1
         [/filter]
 

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
@@ -657,8 +657,14 @@
         [if]
             [variable]
                 name=unit.race
-                equals=elf
+                equals=quenoth
             [/variable]
+            [or]
+                [variable]
+                    name=unit.race
+                    equals=elf
+                [/variable]
+            [/or]
             [then]
                 [message]
                     x,y=9,36

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
@@ -3081,7 +3081,7 @@
         [if]
             [have_unit]
                 x,y=$x1,$y1
-                race=elf
+                race=quenoth,elf
             [/have_unit]
 
             [then]
@@ -3131,7 +3131,7 @@
         [message]
             x,y=12-23,15-20
             side=1
-            race=elf
+            race=quenoth,elf
             message= _ "Can you see very far? Do you have any idea where we are?"
         [/message]
 

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg
@@ -868,7 +868,7 @@
                 [/message]
                 [message]
                     speaker=$unit.id
-                    race=elf
+                    race=quenoth,elf
                     message= _ "As I envy your kind’s prowess when fighting in the water."
                 [/message]
             [/else]
@@ -1120,7 +1120,7 @@
 
         [filter]
             side=1
-            race=elf
+            race=quenoth,elf
             [filter_location]
                 terrain=W*
             [/filter_location]
@@ -1145,7 +1145,7 @@
         [filter]
             x,y=6, 38
             side=1
-            race=elf
+            race=quenoth,elf
         [/filter]
 
         [if]

--- a/data/campaigns/Under_the_Burning_Suns/units/other/Dark_Assassin1.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/other/Dark_Assassin1.cfg
@@ -2,7 +2,7 @@
 [unit_type]
     id=Dark Assassin1
     name= _ "Dark Assassin"
-    race=elf
+    race=quenoth
     image=units/other/dark-assassin.png
     [defend]
         start_time=-126

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Archer.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Archer.cfg
@@ -5,7 +5,7 @@
     name= _ "Quenoth Archer"
     image=units/quenoth/archer.png
     profile="portraits/quenoth/archer.png"
-    race=elf
+    race=quenoth
     hitpoints=36
     movement_type=quenoth_horse
     [resistance]

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Champion.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Champion.cfg
@@ -3,7 +3,7 @@
 [unit_type]
     id=Quenoth Champion
     name= _ "Quenoth Champion"
-    race=elf
+    race=quenoth
     ignore_race_traits=yes
     {TRAIT_STRONG}
     {TRAIT_QUICK}

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Corrupted_Elf.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Corrupted_Elf.cfg
@@ -3,7 +3,7 @@
 [unit_type]
     id=Corrupted Quenoth Elf
     name= _ "Corrupted Elf"
-    race=elf
+    race=quenoth
     image=units/quenoth/corrupted-elf.png
     hitpoints=60
     movement_type=quenoth_foot

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Divine_Avatar.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Divine_Avatar.cfg
@@ -3,7 +3,7 @@
     id=Divine Avatar
     name= _ "female^Divine Avatar"
     gender=female
-    race=elf
+    race=quenoth
     image=units/quenoth/eloh.png
     # The baseframe is larger than usual to make compositing with the back haloin animations trivial.
     bar_offset_x,bar_offset_y=0,0

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Druid.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Druid.cfg
@@ -3,7 +3,7 @@
 [unit_type]
     id=Quenoth Druid
     name= _ "female^Quenoth Druid"
-    race=elf
+    race=quenoth
     gender=female
     image=units/quenoth/druid.png
     profile="portraits/quenoth/druid.png"

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Fighter.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Fighter.cfg
@@ -3,7 +3,7 @@
 [unit_type]
     id=Quenoth Fighter
     name= _ "Quenoth Fighter"
-    race=elf
+    race=quenoth
     ignore_race_traits=yes
     {TRAIT_STRONG}
     {TRAIT_QUICK}

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Flanker.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Flanker.cfg
@@ -3,7 +3,7 @@
 [unit_type]
     id=Quenoth Flanker
     name= _ "Quenoth Flanker"
-    race=elf
+    race=quenoth
     ignore_race_traits=yes
     {TRAIT_STRONG}
     {TRAIT_QUICK}

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Marksman.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Marksman.cfg
@@ -5,7 +5,7 @@
     name= _ "Quenoth Marksman"
     image=units/quenoth/marksman.png
     profile="portraits/quenoth/marksman.png"
-    race=elf
+    race=quenoth
     hitpoints=46
     movement_type=quenoth_horse
     [resistance]

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Mystic.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Mystic.cfg
@@ -3,7 +3,7 @@
 [unit_type]
     id=Quenoth Mystic
     name= _ "female^Quenoth Mystic"
-    race=elf
+    race=quenoth
     gender=female
     image=units/quenoth/mystic/mystic.png
     profile="portraits/quenoth/mystic.png"

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Outrider.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Outrider.cfg
@@ -5,7 +5,7 @@
     name= _ "Quenoth Outrider"
     image=units/quenoth/outrider.png
     profile="portraits/quenoth/outrider.png"
-    race=elf
+    race=quenoth
     hitpoints=54
     movement_type=quenoth_horse
     [resistance]

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Pathfinder.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Pathfinder.cfg
@@ -5,7 +5,7 @@
     name= _ "Quenoth Pathfinder"
     image=units/quenoth/pathfinder.png
     profile="portraits/quenoth/pathfinder.png"
-    race=elf
+    race=quenoth
     hitpoints=40
     movement_type=quenoth_horse
     [resistance]

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Ranger.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Ranger.cfg
@@ -3,7 +3,7 @@
 [unit_type]
     id=Quenoth Ranger
     name= _ "Quenoth Ranger"
-    race=elf
+    race=quenoth
     ignore_race_traits=yes
     {TRAIT_STRONG}
     {TRAIT_QUICK}

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Scout.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Scout.cfg
@@ -5,7 +5,7 @@
     name= _ "Quenoth Scout"
     image=units/quenoth/scout.png
     profile="portraits/quenoth/scout.png"
-    race=elf
+    race=quenoth
     hitpoints=26
     movement_type=quenoth_horse
     movement=8

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Shaman.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Shaman.cfg
@@ -3,7 +3,7 @@
 [unit_type]
     id=Quenoth Shaman
     name= _ "female^Quenoth Shaman"
-    race=elf
+    race=quenoth
     gender=female
     image=units/quenoth/shaman.png
     profile="portraits/quenoth/shaman.png"

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Shyde.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Shyde.cfg
@@ -3,7 +3,7 @@
 [unit_type]
     id=Quenoth Shyde
     name= _ "female^Quenoth Shyde"
-    race=elf
+    race=quenoth
     gender=female
     image=units/quenoth/shyde.png
     profile="portraits/quenoth/shyde.png"

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Sun_Singer.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Sun_Singer.cfg
@@ -3,7 +3,7 @@
 [unit_type]
     id=Quenoth Sun Singer
     name= _ "female^Quenoth Sun Singer"
-    race=elf
+    race=quenoth
     gender=female
     image=units/quenoth/sun_singer/sun-singer.png
     profile="portraits/quenoth/sun_singer.png"

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Sun_Sylph.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Sun_Sylph.cfg
@@ -3,7 +3,7 @@
 [unit_type]
     id=Quenoth Sun Sylph
     name= _ "female^Quenoth Sun Sylph"
-    race=elf
+    race=quenoth
     gender=female
     image=units/quenoth/sun_sylph/sun-sylph.png
     profile="portraits/quenoth/sun_sylph.png"

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Tauroch_Flagbearer.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Tauroch_Flagbearer.cfg
@@ -6,7 +6,7 @@
     image=units/quenoth/tauroch/flagbearer.png
     image_icon="units/quenoth/tauroch/flagbearer.png~CROP(0,0,72,72)"
     profile="portraits/quenoth/tauroch_flagbearer.png"
-    race=elf
+    race=quenoth
     # Base movement of 4 is too little, but we don't want them to get 6 either
     # if they're quick, so instead they just have 5 movement but can't get quick
     ignore_race_traits=yes

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Tauroch_Protector.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Tauroch_Protector.cfg
@@ -6,7 +6,7 @@
     image=units/quenoth/tauroch/protector.png
     image_icon="units/quenoth/tauroch/protector.png~CROP(0,0,72,72)"
     profile="portraits/quenoth/tauroch_protector.png"
-    race=elf
+    race=quenoth
     # Base movement of 4 is too little, but we don't want them to get 6 either
     # if they're quick, so instead they just have 5 movement but can't get quick
     ignore_race_traits=yes

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Tauroch_Rider.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Tauroch_Rider.cfg
@@ -6,7 +6,7 @@
     image=units/quenoth/tauroch/rider.png
     image_icon="units/quenoth/tauroch/rider.png~CROP(0,0,72,72)"
     profile="portraits/quenoth/tauroch_rider.png"
-    race=elf
+    race=quenoth
     # Base movement of 4 is too little, but we don't want them to get 6 either
     # if they're quick, so instead they just have 5 movement but can't get quick
     ignore_race_traits=yes

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Tauroch_Stalwart.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Tauroch_Stalwart.cfg
@@ -6,7 +6,7 @@
     image=units/quenoth/tauroch/stalwart.png
     image_icon="units/quenoth/tauroch/stalwart.png~CROP(0,0,72,72)"
     profile="portraits/quenoth/tauroch_stalwart.png"
-    race=elf
+    race=quenoth
     # Base movement of 4 is too little, but we don't want them to get 6 either
     # if they're quick, so instead they just have 5 movement but can't get quick
     ignore_race_traits=yes

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Tauroch_Vanguard.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Tauroch_Vanguard.cfg
@@ -6,7 +6,7 @@
     image=units/quenoth/tauroch/vanguard.png
     image_icon="units/quenoth/tauroch/vanguard.png~CROP(0,0,72,72)"
     profile="portraits/quenoth/tauroch_vanguard.png"
-    race=elf
+    race=quenoth
     # Base movement of 4 is too little, but we don't want them to get 6 either
     # if they're quick, so instead they just have 5 movement but can't get quick
     ignore_race_traits=yes

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Warrior.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Warrior.cfg
@@ -3,7 +3,7 @@
 [unit_type]
     id=Quenoth Warrior
     name= _ "Quenoth Warrior"
-    race=elf
+    race=quenoth
     ignore_race_traits=yes
     {TRAIT_STRONG}
     {TRAIT_QUICK}

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
@@ -436,7 +436,7 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
 
 [unit_type]
     id=Quenoth Youth
-    race=elf
+    race=quenoth
     ignore_race_traits=yes
     gender=male,female
     name= _ "Quenoth Youth"
@@ -491,7 +491,7 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
 
 [unit_type]
     id=Quenoth Youth 2
-    race=elf
+    race=quenoth
     ignore_race_traits=yes
     gender=male,female
     name= _ "Quenoth Youth"
@@ -548,7 +548,7 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
 
 [unit_type]
     id=Quenoth Youth 3
-    race=elf
+    race=quenoth
     ignore_race_traits=yes
     gender=male,female
     name= _ "Quenoth Youth"

--- a/data/campaigns/Under_the_Burning_Suns/units/units.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/units.cfg
@@ -1,3 +1,17 @@
+#textdomain wesnoth-utbs
+[race]
+    id=quenoth
+    help_taxonomy=elf
+    male_name= _ "race^Quenoth Elf"
+    female_name= _ "race+female^Quenoth Elf"
+    plural_name= _ "race^Quenoth Elves"
+    description= _"Compared to the elves of the Great Continent around the time of Wesnoth, the Quenoth Elves are far more suited to life in the desert."
+    num_traits=2
+    markov_chain_size=2
+    {ELVISH_NAMES}
+    {TRAIT_DEXTROUS}
+[/race]
+
 #desert elves move fast across the sands, but are not used to forests
 #they are also a bit faster in caves
 [movetype]


### PR DESCRIPTION
# Main commit

UtBS: Make "quenoth" a separate race to "elf" (fixes #4876)

This is motivated by reorganising the help pages to split the Quenoth from the
"pointy ears, pale skin" help text in data/core/units.cfg. It also means that
there's no reason to [hide_help] for the default era elvish units. The new help
text is just a short placeholder for now.

The new race has [race]help_taxonomy=elf.

If the player loads a mid-campaign save then their recalls and heroes will have
race=elf while new recruits have race=quenoth.  For that reason, I've changed
the scenarios' event triggers to recognise both races.

When levelling up, units with race=elf may change to race=quenoth.

Opening the help for a unit will show the help as if the unit has race=quenoth,
even when right-clicking on a race=elf unit. This is good.

For a few of these, I think another race might be better - they're converted to
Quenoth here, as they were Elves before. The Corrupted Elf is should probably be
considered undead, and the Divine Avatar should possibly be something else, more
like an elemental than a living creature. That those two are currently included
in the elves does have the side-effect of hiding a plot spoiler about the Dark
Assassin who is also included in the elves (the spoiler being that this one is
correct, he really is an elf).

# Second commit

UtBS S02: Make the warning about the tentacles an enter_hex instead of a moveto

If you try to move straight into the water, the explorer should stop at the
lake edge and comment about where they're going. Trivial change, mainly because
I was using a fast unit for debugging and wondered why I hadn't triggered the
lake monsters.