### PR TITLE
UtBS S02: Recognise Beach Sands and embellishments when spawning ghosts

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg
@@ -1730,11 +1730,11 @@
             [filter]
                 side=1
             [/filter]
-            terrain=Hd, Dd, Rr
+            terrain=Hd^*, Dd^*, Ds^*, Rr^*
             [filter_adjacent_location]
                 count="5,6"
                 adjacent="n,ne,se,s,sw,nw"
-                terrain=Hd, Dd, Rr
+                terrain=Hd^*, Dd^*, Ds^*, Rr^*
             [/filter_adjacent_location]
         [/store_locations]
 
@@ -1763,7 +1763,7 @@
 
                 [store_locations]
                     variable=spawn
-                    terrain=Hd, Dd, Rr
+                    terrain=Hd^*, Dd^*, Ds^*, Rr^*
                     [filter_adjacent_location]
                         [filter]
                             side=1


### PR DESCRIPTION
Fixes #5149.

@nemaara in terms of balance, without this fix I saw only 1 ghost during the first night; with this fix I had 3 ghosts spawn at end-of-turn-4, and another 2 at end-of-turn-5. They do attack the scorpions too, but it definitely needs a balance check.