### PR TITLE
avoiding unit placed events

### DIFF
--- a/data/lua/diversion.lua
+++ b/data/lua/diversion.lua
@@ -58,7 +58,7 @@ local status_anim_update = function(is_undo)
 		    changed_something = true
                     ec_unit.status.diversion = true
                     ec_unit:extract()
-                    ec_unit:to_map()
+                    ec_unit:to_map(false)
                     wesnoth.wml_actions.animate_unit {
                             flag = "launching",
                             with_bars = true,
@@ -79,7 +79,7 @@ local status_anim_update = function(is_undo)
 		    changed_something = true
                     ec_unit.status.diversion = false
                     ec_unit:extract()
-                    ec_unit:to_map()
+                    ec_unit:to_map(false)
                     wesnoth.wml_actions.animate_unit {
                             flag = "landing",
                             with_bars = true,

--- a/data/lua/feeding.lua
+++ b/data/lua/feeding.lua
@@ -26,7 +26,7 @@ wesnoth.game_events.add_repeating("die", function()
 			effect.increase_total = effect.increase_total + 1
 			u_killer_cfg.max_hitpoints = u_killer_cfg.max_hitpoints + 1
 			u_killer_cfg.hitpoints = u_killer_cfg.hitpoints + 1
-			wesnoth.units.to_map(u_killer_cfg)
+			wesnoth.units.to_map(u_killer_cfg, false)
 			wesnoth.interface.float_label(ec.x2, ec.y2, _ "+1 max HP", "0,255,0")
 			return
 		end

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -498,7 +498,7 @@ function wml_actions.petrify(cfg)
 		unit.status.petrified = true
 		-- Extract unit and put it back to update animation (not needed for recall units)
 		unit:extract()
-		unit:to_map()
+		unit:to_map(false)
 	end
 
 	for index, unit in ipairs(wesnoth.units.find_on_recall{wml.tag["and"](cfg)}) do
@@ -511,7 +511,7 @@ function wml_actions.unpetrify(cfg)
 		unit.status.petrified = false
 		-- Extract unit and put it back to update animation (not needed for recall units)
 		unit:extract()
-		unit:to_map()
+		unit:to_map(false)
 	end
 
 	for index, unit in ipairs(wesnoth.units.find_on_recall(cfg)) do

--- a/data/lua/wml/harm_unit.lua
+++ b/data/lua/wml/harm_unit.lua
@@ -129,7 +129,7 @@ function wml_actions.harm_unit(cfg)
 
 			-- Extract unit and put it back to update animation if status was changed
 			unit_to_harm:extract()
-			unit_to_harm:to_map()
+			unit_to_harm:to_map(false)
 
 			if add_tab then
 				text = string.format("%s%s", "\t", text)

--- a/data/lua/wml/move_unit.lua
+++ b/data/lua/wml/move_unit.lua
@@ -83,8 +83,8 @@ function wesnoth.wml_actions.move_unit(cfg)
 			local x, y = locs(current_unit)
 			local prevX, prevY = tonumber(current_unit.x), tonumber(current_unit.y)
 			while true do
-				x = tonumber(x) or wml.error(coordinate_error)
-				y = tonumber(y) or wml.error(coordinate_error)
+				x = tonumber(x) or current_unit:to_map(false) or wml.error(coordinate_error)
+				y = tonumber(y) or current_unit:to_map(false) or wml.error(coordinate_error)
 				if not (x == prevX and y == prevY) then x, y = wesnoth.paths.find_vacant_hex(x, y, pass_check) end
 				if not x or not y then wml.error("Could not find a suitable hex near to one of the target hexes in [move_unit].") end
 				table.insert(x_list, x)

--- a/data/lua/wml/move_unit.lua
+++ b/data/lua/wml/move_unit.lua
@@ -112,8 +112,7 @@ function wesnoth.wml_actions.move_unit(cfg)
 			}
 			local x2, y2 = current_unit.x, current_unit.y
 			current_unit.x, current_unit.y = x, y
-			current_unit:to_map()
-
+			current_unit:to_map(false)
 			if unshroud then
 				wesnoth.wml_actions.redraw {clear_shroud=true}
 			end


### PR DESCRIPTION
Guess after all this years I touch the Lua stuff behind the API …

One commit for #5158, other I found while testing for e3e80b4.

This all comes down to this comment:
https://github.com/wesnoth/wesnoth/blob/de9311e2622a9603834113cfd7f3fa2edb4de344/src/scripting/game_lua_kernel.cpp#L2583-L2584

It's the same method `[unstore_unit]fire_events=…` uses internally, just undocumented.

@CelticMinstrel, @gfgtdf can this go in as is?