### PR TITLE
WIP: Orb refactor, disengage orb and allies' orbs

### DIFF
--- a/projectfiles/CodeBlocks/wesnoth.cbp
+++ b/projectfiles/CodeBlocks/wesnoth.cbp
@@ -1169,6 +1169,8 @@
 		<Unit filename="../../src/units/make.hpp" />
 		<Unit filename="../../src/units/map.cpp" />
 		<Unit filename="../../src/units/map.hpp" />
+		<Unit filename="../../src/units/orb_status.cpp" />
+		<Unit filename="../../src/units/orb_status.hpp" />
 		<Unit filename="../../src/units/ptr.hpp" />
 		<Unit filename="../../src/units/race.cpp" />
 		<Unit filename="../../src/units/race.hpp" />

--- a/projectfiles/VC16/wesnoth.vcxproj
+++ b/projectfiles/VC16/wesnoth.vcxproj
@@ -3348,6 +3348,13 @@
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Debug|x64'">$(IntDir)Units\</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Release|x64'">$(IntDir)Units\</ObjectFileName>
     </ClCompile>
+    <ClCompile Include="..\..\src\units\orb_status.cpp">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)Units\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='ReleaseDEBUG|x64'">$(IntDir)Units\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)Units\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Debug|x64'">$(IntDir)Units\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Release|x64'">$(IntDir)Units\</ObjectFileName>
+    </ClCompile>
     <ClCompile Include="..\..\src\units\race.cpp">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)Units\</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='ReleaseDEBUG|x64'">$(IntDir)Units\</ObjectFileName>
@@ -4117,6 +4124,7 @@
     <ClInclude Include="..\..\src\units\id.hpp" />
     <ClInclude Include="..\..\src\units\make.hpp" />
     <ClInclude Include="..\..\src\units\map.hpp" />
+    <ClInclude Include="..\..\src\units\orb_status.hpp" />
     <ClInclude Include="..\..\src\units\ptr.hpp" />
     <ClInclude Include="..\..\src\units\race.hpp" />
     <ClInclude Include="..\..\src\units\types.hpp" />

--- a/source_lists/wesnoth
+++ b/source_lists/wesnoth
@@ -364,6 +364,7 @@ units/helper.cpp
 units/id.cpp
 units/make.cpp
 units/map.cpp
+units/orb_status.cpp
 units/race.cpp
 units/types.cpp
 units/udisplay.cpp

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -47,6 +47,7 @@
 #include "units/unit.hpp"
 #include "units/animation_component.hpp"
 #include "units/drawer.hpp"
+#include "units/orb_status.hpp"
 #include "whiteboard/manager.hpp"
 #include "show_dialog.hpp"
 #include "gui/dialogs/loading_screen.hpp"
@@ -1880,24 +1881,16 @@ void display::draw_minimap_units()
 		int side = u.side();
 		color_t col = team::get_minimap_color(side);
 
-		if (!preferences::minimap_movement_coding()) {
-
-			if (dc_->teams()[currentTeam_].is_enemy(side)) {
-				col = game_config::color_info(preferences::enemy_color()).rep();
+		if(!preferences::minimap_movement_coding()) {
+			auto status = orb_status::allied;
+			if(dc_->teams()[currentTeam_].is_enemy(side)) {
+				status = orb_status::enemy;
+			} else if(currentTeam_ + 1 == static_cast<unsigned>(side)) {
+				status = dc_->unit_orb_status(u);
 			} else {
-
-				if (currentTeam_ +1 == static_cast<unsigned>(side)) {
-
-					if (u.movement_left() == u.total_movement())
-						col = game_config::color_info(preferences::unmoved_color()).rep();
-					else if (u.movement_left() == 0)
-						col = game_config::color_info(preferences::moved_color()).rep();
-					else
-						col = game_config::color_info(preferences::partial_color()).rep();
-
-				} else
-					col = game_config::color_info(preferences::allied_color()).rep();
+				// no-op, status is already set to orb_status::allied;
 			}
+			col = game_config::color_info(orb_status_helper::get_orb_color(status)).rep();
 		}
 
 		double u_x = u.get_location().x * xscaling;

--- a/src/display_context.cpp
+++ b/src/display_context.cpp
@@ -71,11 +71,6 @@ unit_const_ptr display_context::get_visible_unit_shared_ptr(const map_location &
 	return u.get_shared_ptr();
 }
 
-/**
- * Will return true iff the unit @a u has any possible moves
- * it can do (including attacking etc).
- */
-
 bool display_context::unit_can_move(const unit &u) const
 {
 	if(!u.attacks_left() && u.movement_left()==0)
@@ -105,7 +100,20 @@ bool display_context::unit_can_move(const unit &u) const
 		}
 	}
 
+	// This should probably check if the unit can teleport too
+
 	return false;
+}
+
+orb_status display_context::unit_orb_status(const unit& u) const
+{
+	if(u.user_end_turn())
+		return orb_status::moved;
+	if(u.movement_left() == u.total_movement() && u.attacks_left() == u.max_attacks())
+		return orb_status::unmoved;
+	if(unit_can_move(u))
+		return orb_status::partial;
+	return orb_status::moved;
 }
 
 int display_context::village_owner(const map_location& loc) const

--- a/src/display_context.hpp
+++ b/src/display_context.hpp
@@ -21,9 +21,10 @@
 
 #pragma once
 
+#include "units/orb_status.hpp"
+#include "units/ptr.hpp"
 #include <string>
 #include <vector>
-#include "units/ptr.hpp"
 
 class team;
 class gamemap;
@@ -63,11 +64,28 @@ public:
 	const unit * get_visible_unit(const map_location &loc, const team &current_team, bool see_all = false) const;
 	unit_const_ptr get_visible_unit_shared_ptr(const map_location &loc, const team &current_team, bool see_all = false) const;
 
-	// From actions:: namespace
+	/**
+	 * True if, and only if, at least one of the following is true:
+	 *
+	 * (a) the unit can move to another hex, taking account of ZoC and
+	 * terrain costs vs current movement points.
+	 *
+	 * (b) the unit can make an attack from the hex that it's currently on,
+	 * requires attack points and a non-petrified enemy in an adjacent hex.
+	 *
+	 * This does not check which player's turn is currently active, the result is calculated
+	 * assuming that the unit's owner is currently active.
+	 */
+	bool unit_can_move(const unit& u) const;
 
-	bool unit_can_move(const unit & u) const;
-
-	// From class team
+	/**
+	 * Returns an enumurated summary of whether this unit can move and/or attack.
+	 *
+	 * This does not check which player's turn is currently active, the result is calculated
+	 * assuming that the unit's owner is currently active. For this reason this never returns
+	 * orb_status::enemy nor orb_status::allied.
+	 */
+	orb_status unit_orb_status(const unit& u) const;
 
 	/**
 	 * Given the location of a village, will return the 1-based number

--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -252,13 +252,21 @@ void unit_drawer::redraw_unit (const unit & u) const
 
 		using namespace orb_status_helper;
 		std::unique_ptr<image::locator> orb_img = nullptr;
-		if(std::size_t(side) != viewing_team + 1) {
-			if(viewing_team_ref.is_enemy(side)) {
-				if(preferences::show_enemy_orb() && !u.incapacitated())
-					orb_img = get_orb_image(orb_status::enemy);
-			} else if(preferences::show_allied_orb())
-				orb_img = get_orb_image(orb_status::allied);
-		} else if(playing_team == viewing_team && !u.user_end_turn()) {
+		if(viewing_team_ref.is_enemy(side)) {
+			if(preferences::show_enemy_orb() && !u.incapacitated())
+				orb_img = get_orb_image(orb_status::enemy);
+		} else if(static_cast<std::size_t>(side) != playing_team + 1) {
+			// We're looking at either the player's own unit or an ally's unit, but either way it
+			// doesn't belong to the playing_team and isn't expected to move until after its next
+			// turn refresh.
+			auto os = orb_status::moved;
+			if(static_cast<std::size_t>(side) != viewing_team + 1)
+				os = orb_status::allied;
+			if(prefs_show_orb(os))
+				orb_img = get_orb_image(os);
+		} else {
+			// We're looking at either the player's own unit, or an ally's unit, during the unit's
+			// owner's turn.
 			auto os = dc.unit_orb_status(u);
 			if(prefs_show_orb(os))
 				orb_img = get_orb_image(os);

--- a/src/units/orb_status.cpp
+++ b/src/units/orb_status.cpp
@@ -1,0 +1,60 @@
+/*
+   Copyright (C) 2020 by Steve Cotton <steve@octalot.co.uk>
+   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#include "units/orb_status.hpp"
+#include "preferences/game.hpp"
+
+bool orb_status_helper::prefs_show_orb(orb_status os)
+{
+	switch(os) {
+	case orb_status::unmoved:
+		return preferences::show_unmoved_orb();
+	case orb_status::moved:
+		return preferences::show_moved_orb();
+	case orb_status::partial:
+		return preferences::show_partial_orb();
+	case orb_status::allied:
+		return preferences::show_allied_orb();
+	case orb_status::enemy:
+		return preferences::show_enemy_orb();
+	default:
+		assert(!"expected to handle all the enum values");
+	}
+}
+
+std::string orb_status_helper::get_orb_color(orb_status os)
+{
+	switch(os) {
+	case orb_status::unmoved:
+		return preferences::unmoved_color();
+	case orb_status::moved:
+		return preferences::moved_color();
+	case orb_status::partial:
+		return preferences::partial_color();
+	case orb_status::allied:
+		return preferences::allied_color();
+	case orb_status::enemy:
+		return preferences::enemy_color();
+	default:
+		assert(!"expected to handle all the enum values");
+	}
+}
+
+std::unique_ptr<image::locator> orb_status_helper::get_orb_image(orb_status os)
+{
+	if(!prefs_show_orb(os))
+		return nullptr;
+	auto color = get_orb_color(os);
+	return std::make_unique<image::locator>(game_config::images::orb + "~RC(magenta>" + color + ")");
+}

--- a/src/units/orb_status.hpp
+++ b/src/units/orb_status.hpp
@@ -1,0 +1,58 @@
+/*
+   Copyright (C) 2020 by Steve Cotton <steve@octalot.co.uk>
+   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#pragma once
+
+#include "picture.hpp"
+
+#include <memory>
+#include <string>
+
+/**
+ * Corresponds to the colored orbs displayed above units' hp-bar and xp-bar.
+ */
+enum class orb_status {
+	/** The unit still has full movement and all attacks available. */
+	unmoved,
+	/** All moves and possible attacks have been done. */
+	moved,
+	/** There are still moves and/or attacks possible, but the unit doesn't fit in the "unmoved" status. */
+	partial,
+	/** Belongs to a friendly side */
+	allied,
+	/** Belongs to a non-friendly side; normally visualised by not displaying an orb. */
+	enemy
+};
+
+namespace orb_status_helper
+{
+/**
+ * Wrapper for the various preferences::show_..._orb() methods, using the
+ * enum instead of exposing a separate function for each preference.
+ */
+bool prefs_show_orb(orb_status os);
+
+/**
+ * Wrapper for the various preferences::unmoved_color(), moved_color(), etc
+ * methods, using the enum instead of exposing a separate function for each
+ * preference.
+ */
+std::string get_orb_color(orb_status os);
+
+/**
+ * Wrapper which will assemble the image path (including IPF for the color from get_orb_color) for a given orb.
+ * Returns nullptr if prefs_show_orb returns false.
+ */
+std::unique_ptr<image::locator> get_orb_image(orb_status os);
+} // namespace orb_status_helper


### PR DESCRIPTION
This is work-in-progress, particularly for the first of the three
commits. I've done a lot of moving code around, and it doesn't
feel right yet, so I'd welcome all suggestions, even ones that
throw these changes out and implement the two features in different ways.

The first commit is refactoring with no new features, and then the other
two are features using the refactored code's new abilities.

I'm expecting build failures on MacOS, as this adds a new .hpp and .cpp
file without adding them to the XCode project.

Refactoring the orb-coloring code, adding new units/orb_status.hpp
---

Instead of creating lots of image::locators and calling a family of
similarly-named preferences functions, this refactor encapsulates that logic
and uses an enum.

WIP: This needs the new orb_status files adding to the MacOS build.

WIP: Does it make sense to add the orb_status files instead of just
putting these bits in an existing file?

WIP: Should the pref_show_orb and get_orb_color functions move into
src/preferences/general.hpp?

WIP: Some of the changes here are just to reform and reorder lists, ready
to add the disengaged orb to those lists. Should they instead be left to
the disengage commit?

WIP: Add a new orb color for the "disengaged" state (#5155)
---

This will match the mounted Quenoth units' "disengage" skill, when they
can still move but can't attack. It should also trigger for some UMC abilities
that get extra moves after a character attacks.

WIP: The select_orb_colors dialog's layout no longer fits its window size.

WIP: Should addig the extra color (teal) be done here? I've ended up using
the existing white color for the default disengage orb.

WIP: During allies' turns, their units' orbs show the move status (#1424)
---

WIP: the orb-refactor commit that this depends on is WIP.
WIP: check for todos and WIPs, including further down this commit message.

Instead of using the allied orb during their turn, the unmoved, moved and
partial orbs are shown. The player's own units will be shown with the moved orb
during the ally's turn, which matches the previous behavior. This is intended for
co-operative MP campaigns, where it will make it easier for players to discuss
possible moves. The UX is also visible in SP scenarios with allied sides, HttT's
first scenario is an easy place to see what it does.

WIP: test this paragraph. When one player owns multiple sides, or when multiple
players are hot-seating, the usual handling still applies - the orbs are drawn
as if the one that has most recently had its turn is the only side that the
player owns.

The disengaged orb will also be supported, if that feature merges. The code in
this commit needs no further changes to support OrbStatus::disengaged.