### PR TITLE
Fix #4961 (halo animations sometimes freeze)

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2512,16 +2512,12 @@ void display::draw(bool update,bool force) {
 
 	draw_init();
 	pre_draw();
-	// invalidate all that needs to be invalidated
+	// invalidate animated terrain, units and haloes
 	invalidate_animations();
 
 	if(!get_map().empty()) {
 		//int simulate_delay = 0;
 
-		/*
-		 * draw_invalidated() also invalidates the halos, so also needs to be
-		 * ran if invalidated_.empty() == true.
-		 */
 		if(!invalidated_.empty()) {
 			draw_invalidated();
 			invalidated_.clear();
@@ -3131,6 +3127,8 @@ void display::invalidate_animations()
 			new_inval |=  u->anim_comp().invalidate(*this);
 		}
 	} while (new_inval);
+
+	halo_man_->unrender(invalidated_);
 }
 
 void display::reset_standing_animations()

--- a/src/game_display.cpp
+++ b/src/game_display.cpp
@@ -226,7 +226,6 @@ void game_display::post_draw() {
 
 void game_display::draw_invalidated()
 {
-	halo_man_->unrender(invalidated_);
 	display::draw_invalidated();
 	if (fake_unit_man_->empty()) {
 		return;


### PR DESCRIPTION
As [this](https://github.com/wesnoth/wesnoth/blob/master/src/display.cpp#L2521-L2524) comment says, we are only redrawing haloes if anything else in the map is invalidating at least one hex.

`halo_man_->unrender(invalidated_)` actually invalidates the hexes covered by haloes which need to be updated, so i'm just moving the call outside the if-clause.