### PR TITLE
Clean-up leftovers of the SCALING_ALGORITHM preference

### DIFF
--- a/src/preferences/general.cpp
+++ b/src/preferences/general.cpp
@@ -72,8 +72,6 @@ const int def_window_height = 720;
 const int min_font_scaling  = 80;
 const int max_font_scaling  = 150;
 
-const SCALING_ALGORITHM default_scaling_algorithm = SCALING_ALGORITHM::XBRZ_NN;
-
 class prefs_event_handler : public events::sdl_handler {
 public:
 	virtual void handle_event(const SDL_Event &) {}

--- a/src/preferences/general.hpp
+++ b/src/preferences/general.hpp
@@ -18,7 +18,6 @@
 
 #include "config.hpp"
 #include "terrain/translation.hpp"
-#include "utils/make_enum.hpp"
 
 #include <utility>
 
@@ -44,15 +43,6 @@ namespace preferences {
 
 	extern const int min_font_scaling;
 	extern const int max_font_scaling;
-
-	MAKE_ENUM(SCALING_ALGORITHM,
-		(LINEAR, "linear")
-		(NEAREST_NEIGHBOR, "nn")
-		(XBRZ_LIN, "xbrzlin")
-		(XBRZ_NN, "xbrznn")
-	)
-
-	extern const SCALING_ALGORITHM default_scaling_algorithm;
 
 	void write_preferences();
 


### PR DESCRIPTION
Opening a PR just to run the CI tests, going to merge once the CI is done. That's a sanity-check in case some platform-specific code is depending on an indirect `#include "utils/make_enum.hpp"`.

The preference was removed in 15bf3bb25691c6ce71ac2a45bb4e5c06ea9239e6.