### PR TITLE
Update the docs for ":droid full" in the help browser

### DIFF
--- a/data/core/help.cfg
+++ b/data/core/help.cfg
@@ -610,8 +610,8 @@ Clear chat messages.
 Switch debug mode on (does not work in multiplayer). See <ref>dst='debug_commands' text='debug mode commands'</ref>.
 Debug mode is turned off by quitting the game or :nodebug.
 
-" + "<header>text=':droid [<side>] [on|off]'</header>" + _ "
-Set or toggle player on side between human and AI player. The player/client who controls that side needs to issue this command. If no second parameter is supplied, toggle between human and AI. If it is ‘on’, set an AI controller. If it is ‘off’ set a human controller. Defaults to the currently active side if no parameter is supplied.
+" + "<header>text=':droid [<side>] [on|off|full]'</header>" + _ "
+Switch a side between human and AI control. The second parameter can be ‘off’ to bring the side under human control, ‘on’ to watch the AI make its moves, or ‘full’ to make the AI’s turn behave similarily to another player‘s turn. If no second parameter is supplied, it toggles between ‘on’ and ‘off’. Defaults to toggling the currently active side if no parameters are supplied.
 
 " + "<header>text=':controller <side>'</header>" + _ "
 Display the controller status of a side.


### PR DESCRIPTION
This command and the documentation provided by ":help droid" were updated
in efd808ea842ff88174cc2e953c8b871b8c41dae0, but we missed that this command
is also documented in the help browser's (Commands, General Commands) page.

The docs here are more verbose than in ":help", so the text is newly written
instead of being copied from the existing location.