### PR TITLE
Add support for async queries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-﻿
-# set minimum version
+﻿# set minimum version
 cmake_minimum_required(VERSION 3.1)
 
 project(wesnoth)
@@ -58,6 +57,13 @@ option(ENABLE_TESTS "Build unit tests")
 option(ENABLE_NLS "Enable building of translations" ${ENABLE_GAME})
 option(ENABLE_HISTORY "Enable using GNU history for history in lua console" ON)
 
+# boost::asio::post is new with 1.66
+if(ENABLE_MYSQL)
+	set(BOOST_VERSION "1.66")
+else()
+	set(BOOST_VERSION "1.56")
+endif(ENABLE_MYSQL)
+
 # set what std version to use
 if(NOT CXX_STD)
 	set(CXX_STD "14")
@@ -80,7 +86,7 @@ else()
 	set(CRYPTO_LIBRARY "-framework Security")
 endif()
 
-find_package(Boost 1.56 REQUIRED COMPONENTS iostreams program_options regex system thread random)
+find_package(Boost ${BOOST_VERSION} REQUIRED COMPONENTS iostreams program_options regex system thread random)
 
 # no, gettext executables are not required when NLS is deactivated
 find_package(Gettext)
@@ -535,7 +541,7 @@ if(ENABLE_GAME OR ENABLE_TESTS)
 endif(ENABLE_GAME OR ENABLE_TESTS)
 
 if(ENABLE_TESTS)
-	find_package( Boost 1.56 REQUIRED COMPONENTS unit_test_framework )
+	find_package( Boost ${BOOST_VERSION} REQUIRED COMPONENTS unit_test_framework )
 endif(ENABLE_TESTS)
 
 if(ENABLE_GAME)
@@ -567,8 +573,8 @@ if(ENABLE_GAME)
 	endif(ENABLE_HISTORY AND HISTORY_FOUND)
 endif(ENABLE_GAME)
 
-find_package(Boost 1.56 REQUIRED COMPONENTS filesystem)
-find_package(Boost 1.56 REQUIRED COMPONENTS locale)
+find_package(Boost ${BOOST_VERSION} REQUIRED COMPONENTS filesystem)
+find_package(Boost ${BOOST_VERSION} REQUIRED COMPONENTS locale)
 
 if(ENABLE_POT_UPDATE_TARGET)
 	find_package(TranslationTools REQUIRED)

--- a/SConstruct
+++ b/SConstruct
@@ -184,7 +184,11 @@ if env['distcc']:
 
 if env['ccache']: env.Tool('ccache')
 
-boost_version = '1.56.0'
+# boost::asio::post is new with 1.66
+if env["forum_user_handler"]:
+    boost_version = "1.66"
+else:
+    boost_version = "1.56"
 
 
 def SortHelpText(a, b):

--- a/src/server/common/dbconn.hpp
+++ b/src/server/common/dbconn.hpp
@@ -31,6 +31,9 @@ class dbconn
 {
 	public:
 		dbconn(const config& c);
+
+		int async_test_query(int limit);
+
 		std::string get_uuid();
 		std::string get_tournaments();
 		bool user_exists(const std::string& name);
@@ -60,27 +63,28 @@ class dbconn
 		std::string db_tournament_query_;
 
 		void log_sql_exception(const std::string& text, const mariadb::exception::base& e);
+		mariadb::connection_ref create_connection();
 
 		template<typename... Args>
-		void get_complex_results(rs_base& base, const std::string& sql, Args&&... args);
+		void get_complex_results(mariadb::connection_ref connection, rs_base& base, const std::string& sql, Args&&... args);
 
 		template<typename... Args>
-		std::string get_single_string(const std::string& sql, Args&&... args);
+		std::string get_single_string(mariadb::connection_ref connection, const std::string& sql, Args&&... args);
 
 		template<typename... Args>
-		int get_single_int(const std::string& sql, Args&&... args);
+		long get_single_long(mariadb::connection_ref connection, const std::string& sql, Args&&... args);
 
 		template<typename... Args>
-		bool exists(const std::string& sql, Args&&... args);
+		bool exists(mariadb::connection_ref connection, const std::string& sql, Args&&... args);
 
 		template<typename... Args>
-		mariadb::result_set_ref select(const std::string& sql, Args&&... args);
+		mariadb::result_set_ref select(mariadb::connection_ref connection, const std::string& sql, Args&&... args);
 
 		template<typename... Args>
-		int modify(const std::string& sql, Args&&... args);
+		int modify(mariadb::connection_ref connection, const std::string& sql, Args&&... args);
 
 		template<typename... Args>
-		mariadb::statement_ref query(const std::string& sql, Args&&... args);
+		mariadb::statement_ref query(mariadb::connection_ref connection, const std::string& sql, Args&&... args);
 
 		template<typename Arg, typename... Args>
 		void prepare(mariadb::statement_ref stmt, int i, Arg arg, Args&&... args);

--- a/src/server/common/forum_user_handler.hpp
+++ b/src/server/common/forum_user_handler.hpp
@@ -74,8 +74,10 @@ class fuh : public user_handler {
 		void db_insert_modification_info(const std::string& uuid, int game_id, const std::string& modification_name, const std::string& modification_source, const std::string& modification_version);
 		void db_set_oos_flag(const std::string& uuid, int game_id);
 
+		void async_test_query(boost::asio::io_service& io_service, int limit);
+
 	private:
-		dbconn conn;
+		dbconn conn_;
 		std::string db_users_table_;
 		std::string db_extra_table_;
 		int mp_mod_group_;

--- a/src/server/common/user_handler.hpp
+++ b/src/server/common/user_handler.hpp
@@ -21,6 +21,8 @@ class config;
 #include <ctime>
 #include <string>
 
+#include <boost/asio.hpp>
+
 /**
  * An interface class to handle nick registration
  * To activate it put a [user_handler] section into the
@@ -141,4 +143,5 @@ class user_handler {
 		virtual void db_insert_game_player_info(const std::string& uuid, int game_id, const std::string& username, int side_number, int is_host, const std::string& faction, const std::string& version, const std::string& source, const std::string& current_user) =0;
 		virtual void db_insert_modification_info(const std::string& uuid, int game_id, const std::string& modification_name, const std::string& modification_source, const std::string& modification_version) =0;
 		virtual void db_set_oos_flag(const std::string& uuid, int game_id) =0;
+		virtual void async_test_query(boost::asio::io_service& io_service, int limit) =0;
 };

--- a/utils/travis/docker_run.sh
+++ b/utils/travis/docker_run.sh
@@ -122,24 +122,31 @@ else
 
         ccache -s
         ccache -z
+# remove once 1804 isn't used anymore
+    elif [ "$IMAGE" == "1804" ]; then
+        scons wesnoth wesnothd campaignd boost_unit_tests build="$CFG" \
+              ctool=$CC cxxtool=$CXX cxx_std=$CXXSTD \
+              extra_flags_config="-pipe" strict="$STRICT" forum_user_handler=false \
+              nls="$NLS" enable_lto="$LTO" sanitize="$SAN" jobs=2 --debug=time
+        BUILD_RET=$?
     else
         scons wesnoth wesnothd campaignd boost_unit_tests build="$CFG" \
               ctool=$CC cxxtool=$CXX cxx_std=$CXXSTD \
               extra_flags_config="-pipe" strict="$STRICT" forum_user_handler=true \
               nls="$NLS" enable_lto="$LTO" sanitize="$SAN" jobs=2 --debug=time
         BUILD_RET=$?
-
-# rename debug executables to what the tests expect
-        if [ "$CFG" == "debug" ]; then
-            mv wesnoth-debug wesnoth
-            mv wesnothd-debug wesnothd
-            mv campaignd-debug campaignd
-            mv boost_unit_tests-debug boost_unit_tests
-        fi
     fi
 
     if [ $BUILD_RET != 0 ]; then
         exit $BUILD_RET
+    fi
+
+# rename debug executables to what the tests expect
+    if [ "$CFG" == "debug" ]; then
+        mv wesnoth-debug wesnoth
+        mv wesnothd-debug wesnothd
+        mv campaignd-debug campaignd
+        mv boost_unit_tests-debug boost_unit_tests
     fi
 
     if [ "$UPLOAD_ID" != "" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then


### PR DESCRIPTION
@soliton- @loonycyborg - while obviously this isn't remotely ready for review/merging yet, I would appreciate if you could take a quick look at what I have so far and make sure it makes sense.  Particular points of note:
* The `async_test_query()` is there as a query that will take a noticeable amount of time to complete, for testing purposes.
* In an actual async query implementation, the call to boost::asio::post that passes `io_service_` as the first argument would be where `async_send_doc_queued()` would be used (rather than just the cout that's there for the test query now).
* For the connection pool (`conn_pool_`), the idea is that [0] is what's used for all the existing, non-async queries.  [1] and above are used for async queries.
* `get_single_int()` was changed to `get_single_long()` since count(*) is returned as a long.