### PR TITLE
Orb refactor and ally orb colors during allies' turns (#1424)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
  ### Language and i18n
  ### Lua API
  ### Multiplayer
+   * During allies' turns, use orb colors to show which ones can still move (issue #1424). Also enabled for allied AI sides in singleplayer.
  ### Terrain
  ### Units
  ### User interface

--- a/data/core/help.cfg
+++ b/data/core/help.cfg
@@ -277,7 +277,11 @@ To see where the enemy can move to during their next turn, press Ctrl-v or Cmd-v
         title= _ "Shroud and Fog of War"
         text= _ "In some scenarios, parts of the map will be hidden from you. There are two mechanisms that can be used separately or together. The <italic>text='shroud'</italic> hides both the terrain and any units at a location. However, once it is cleared, you can always see that location. The <italic>text='fog of war'</italic> only hides units and ownership of villages (other than by you or your allies). The fog of war is cleared temporarily when you have units nearby, but returns when they leave. Both the shroud and the fog of war are cleared by units. Each unit clears locations adjacent to those within one turn’s move (ignoring zones of control and enemy units).
 
-Normally you can undo a unit’s movement, as long as an event with a randomized result has not occurred, such as combat or recruitment (as most units receive random traits when recruited). Exploring hidden terrain by clearing shroud or fog will also prevent undos to a previous state. You may wish to activate <bold>text='Delay Shroud Updates'</bold> in the actions menu. This will prevent units from clearing shroud or fog until the next randomized event or a manual update via <bold>text='Update Shroud Now'</bold> (or the end of your turn) and thereby preserve your ability to undo movement."
+Normally you can undo a unit’s movement, as long as an event with a randomized result has not occurred, such as combat or recruitment (as most units receive random traits when recruited). Exploring hidden terrain by clearing shroud or fog will also prevent undos to a previous state. You may wish to activate <bold>text='Delay Shroud Updates'</bold> in the actions menu. This will prevent units from clearing shroud or fog until the next randomized event or a manual update via <bold>text='Update Shroud Now'</bold> (or the end of your turn) and thereby preserve your ability to undo movement." + "
+
+" + _ "<header>text='Multiplayer and undo'</header>" + "
+
+" + _ "In multiplayer games, moves that have been sent to the network can’t be undone; the game delays sending data to try to preserve your undo ability. When discussing with teammates, remember that the other players are usually looking at a snapshot from the time of the last combat or fog-revealing move. Chat messages and map labels are sent immediately, however they don’t cause the undoable moves to be sent."
     [/topic]
     # wmllint: markcheck on
 
@@ -376,13 +380,17 @@ If a strike is determined to hit, it will always do at least 1 point of damage. 
     [topic]
         id=orbs
         title= _ "Orbs"
-        text= _ "On top of the energy bar shown next to each unit of yours is an orb. For units you control, this orb is:" + "
+        text= _ "There are colored indicators above the energy bars of some units, consisting of a colored orb and (for leaders) a crown." + "
 
-<img>src=help/orb-green.png align=here</img>" + _ " green if it hasn’t moved this turn," + "
-<img>src=help/orb-yellow.png align=here</img>" + _ " yellow if it has moved, but could still move further or attack, or" + "
-<img>src=help/orb-red.png align=here</img>" + _ " red if it can no longer move or attack, or the user ended the unit’s turn." + "
-<img>src=help/orb-blue.png align=here</img>" + _ " blue if the unit is an ally you do not control." + "
-<img>src=help/orb-none.png align=here</img>" + _ " Enemy units have no orb on top of their energy bar."
+<img>src=help/orb-green.png align=here</img> <img>src=help/orb-yellow.png align=here</img> <img>src=help/orb-red.png align=here</img> <img>src=help/orb-blue.png align=here</img> <img>src=help/orb-none.png align=here</img>
+
+" + _ "The orbs show whether the unit can move, and the standard colors are:" + "
+" + _ "• <bold>text='Green'</bold> if it hasn’t moved this turn." + "
+" + _ "• <bold>text='Yellow'</bold> if it has moved, but could still move further or attack." + "
+" + _ "• <bold>text='Red'</bold> if it can no longer move or attack.
+    • Red is also used after the ‘end unit turn’ command, and when a unit is in the middle of a multi-turn move (has been told to move further than it can in the current turn)." + "
+" + _ "• <bold>text='Blue'</bold> for allied units. During the ally’s own turn, their units will be shown with the green/yellow/red colors; however their moves, and the corresponding orb changes, are delayed as explained in <ref>dst='shroud_and_fog' text='Shroud and Fog of War'</ref>." + "
+" + _ "• Enemy units normally don’t have orbs, however these can be enabled in the advanced preference “Customize orb colors”."
     [/topic]
     # wmllint: markcheck on
 

--- a/projectfiles/CodeBlocks/wesnoth.cbp
+++ b/projectfiles/CodeBlocks/wesnoth.cbp
@@ -1169,6 +1169,8 @@
 		<Unit filename="../../src/units/make.hpp" />
 		<Unit filename="../../src/units/map.cpp" />
 		<Unit filename="../../src/units/map.hpp" />
+		<Unit filename="../../src/units/orb_status.cpp" />
+		<Unit filename="../../src/units/orb_status.hpp" />
 		<Unit filename="../../src/units/ptr.hpp" />
 		<Unit filename="../../src/units/race.cpp" />
 		<Unit filename="../../src/units/race.hpp" />

--- a/projectfiles/VC16/wesnoth.vcxproj
+++ b/projectfiles/VC16/wesnoth.vcxproj
@@ -3348,6 +3348,13 @@
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Debug|x64'">$(IntDir)Units\</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Release|x64'">$(IntDir)Units\</ObjectFileName>
     </ClCompile>
+    <ClCompile Include="..\..\src\units\orb_status.cpp">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)Units\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='ReleaseDEBUG|x64'">$(IntDir)Units\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)Units\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Debug|x64'">$(IntDir)Units\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Release|x64'">$(IntDir)Units\</ObjectFileName>
+    </ClCompile>
     <ClCompile Include="..\..\src\units\race.cpp">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)Units\</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='ReleaseDEBUG|x64'">$(IntDir)Units\</ObjectFileName>
@@ -4117,6 +4124,7 @@
     <ClInclude Include="..\..\src\units\id.hpp" />
     <ClInclude Include="..\..\src\units\make.hpp" />
     <ClInclude Include="..\..\src\units\map.hpp" />
+    <ClInclude Include="..\..\src\units\orb_status.hpp" />
     <ClInclude Include="..\..\src\units\ptr.hpp" />
     <ClInclude Include="..\..\src\units\race.hpp" />
     <ClInclude Include="..\..\src\units\types.hpp" />

--- a/source_lists/wesnoth
+++ b/source_lists/wesnoth
@@ -364,6 +364,7 @@ units/helper.cpp
 units/id.cpp
 units/make.cpp
 units/map.cpp
+units/orb_status.cpp
 units/race.cpp
 units/types.cpp
 units/udisplay.cpp

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -47,6 +47,7 @@
 #include "units/unit.hpp"
 #include "units/animation_component.hpp"
 #include "units/drawer.hpp"
+#include "units/orb_status.hpp"
 #include "whiteboard/manager.hpp"
 #include "show_dialog.hpp"
 #include "gui/dialogs/loading_screen.hpp"
@@ -1880,24 +1881,16 @@ void display::draw_minimap_units()
 		int side = u.side();
 		color_t col = team::get_minimap_color(side);
 
-		if (!preferences::minimap_movement_coding()) {
-
-			if (dc_->teams()[currentTeam_].is_enemy(side)) {
-				col = game_config::color_info(preferences::enemy_color()).rep();
+		if(!preferences::minimap_movement_coding()) {
+			auto status = orb_status::allied;
+			if(dc_->teams()[currentTeam_].is_enemy(side)) {
+				status = orb_status::enemy;
+			} else if(currentTeam_ + 1 == static_cast<unsigned>(side)) {
+				status = dc_->unit_orb_status(u);
 			} else {
-
-				if (currentTeam_ +1 == static_cast<unsigned>(side)) {
-
-					if (u.movement_left() == u.total_movement())
-						col = game_config::color_info(preferences::unmoved_color()).rep();
-					else if (u.movement_left() == 0)
-						col = game_config::color_info(preferences::moved_color()).rep();
-					else
-						col = game_config::color_info(preferences::partial_color()).rep();
-
-				} else
-					col = game_config::color_info(preferences::allied_color()).rep();
+				// no-op, status is already set to orb_status::allied;
 			}
+			col = game_config::color_info(orb_status_helper::get_orb_color(status)).rep();
 		}
 
 		double u_x = u.get_location().x * xscaling;

--- a/src/display_context.cpp
+++ b/src/display_context.cpp
@@ -71,11 +71,6 @@ unit_const_ptr display_context::get_visible_unit_shared_ptr(const map_location &
 	return u.get_shared_ptr();
 }
 
-/**
- * Will return true iff the unit @a u has any possible moves
- * it can do (including attacking etc).
- */
-
 bool display_context::unit_can_move(const unit &u) const
 {
 	if(!u.attacks_left() && u.movement_left()==0)
@@ -105,7 +100,20 @@ bool display_context::unit_can_move(const unit &u) const
 		}
 	}
 
+	// This should probably check if the unit can teleport too
+
 	return false;
+}
+
+orb_status display_context::unit_orb_status(const unit& u) const
+{
+	if(u.user_end_turn())
+		return orb_status::moved;
+	if(u.movement_left() == u.total_movement() && u.attacks_left() == u.max_attacks())
+		return orb_status::unmoved;
+	if(unit_can_move(u))
+		return orb_status::partial;
+	return orb_status::moved;
 }
 
 int display_context::village_owner(const map_location& loc) const

--- a/src/display_context.hpp
+++ b/src/display_context.hpp
@@ -21,9 +21,10 @@
 
 #pragma once
 
+#include "units/orb_status.hpp"
+#include "units/ptr.hpp"
 #include <string>
 #include <vector>
-#include "units/ptr.hpp"
 
 class team;
 class gamemap;
@@ -63,11 +64,28 @@ public:
 	const unit * get_visible_unit(const map_location &loc, const team &current_team, bool see_all = false) const;
 	unit_const_ptr get_visible_unit_shared_ptr(const map_location &loc, const team &current_team, bool see_all = false) const;
 
-	// From actions:: namespace
+	/**
+	 * True if, and only if, at least one of the following is true:
+	 *
+	 * (a) the unit can move to another hex, taking account of ZoC and
+	 * terrain costs vs current movement points.
+	 *
+	 * (b) the unit can make an attack from the hex that it's currently on,
+	 * requires attack points and a non-petrified enemy in an adjacent hex.
+	 *
+	 * This does not check which player's turn is currently active, the result is calculated
+	 * assuming that the unit's owner is currently active.
+	 */
+	bool unit_can_move(const unit& u) const;
 
-	bool unit_can_move(const unit & u) const;
-
-	// From class team
+	/**
+	 * Returns an enumurated summary of whether this unit can move and/or attack.
+	 *
+	 * This does not check which player's turn is currently active, the result is calculated
+	 * assuming that the unit's owner is currently active. For this reason this never returns
+	 * orb_status::enemy nor orb_status::allied.
+	 */
+	orb_status unit_orb_status(const unit& u) const;
 
 	/**
 	 * Given the location of a village, will return the 1-based number

--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -252,13 +252,21 @@ void unit_drawer::redraw_unit (const unit & u) const
 
 		using namespace orb_status_helper;
 		std::unique_ptr<image::locator> orb_img = nullptr;
-		if(std::size_t(side) != viewing_team + 1) {
-			if(viewing_team_ref.is_enemy(side)) {
-				if(preferences::show_enemy_orb() && !u.incapacitated())
-					orb_img = get_orb_image(orb_status::enemy);
-			} else if(preferences::show_allied_orb())
-				orb_img = get_orb_image(orb_status::allied);
-		} else if(playing_team == viewing_team && !u.user_end_turn()) {
+		if(viewing_team_ref.is_enemy(side)) {
+			if(preferences::show_enemy_orb() && !u.incapacitated())
+				orb_img = get_orb_image(orb_status::enemy);
+		} else if(static_cast<std::size_t>(side) != playing_team + 1) {
+			// We're looking at either the player's own unit or an ally's unit, but either way it
+			// doesn't belong to the playing_team and isn't expected to move until after its next
+			// turn refresh.
+			auto os = orb_status::moved;
+			if(static_cast<std::size_t>(side) != viewing_team + 1)
+				os = orb_status::allied;
+			if(prefs_show_orb(os))
+				orb_img = get_orb_image(os);
+		} else {
+			// We're looking at either the player's own unit, or an ally's unit, during the unit's
+			// owner's turn.
 			auto os = dc.unit_orb_status(u);
 			if(prefs_show_orb(os))
 				orb_img = get_orb_image(os);

--- a/src/units/orb_status.cpp
+++ b/src/units/orb_status.cpp
@@ -1,0 +1,60 @@
+/*
+   Copyright (C) 2020 by Steve Cotton <steve@octalot.co.uk>
+   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#include "units/orb_status.hpp"
+#include "preferences/game.hpp"
+
+bool orb_status_helper::prefs_show_orb(orb_status os)
+{
+	switch(os) {
+	case orb_status::unmoved:
+		return preferences::show_unmoved_orb();
+	case orb_status::moved:
+		return preferences::show_moved_orb();
+	case orb_status::partial:
+		return preferences::show_partial_orb();
+	case orb_status::allied:
+		return preferences::show_allied_orb();
+	case orb_status::enemy:
+		return preferences::show_enemy_orb();
+	default:
+		assert(!"expected to handle all the enum values");
+	}
+}
+
+std::string orb_status_helper::get_orb_color(orb_status os)
+{
+	switch(os) {
+	case orb_status::unmoved:
+		return preferences::unmoved_color();
+	case orb_status::moved:
+		return preferences::moved_color();
+	case orb_status::partial:
+		return preferences::partial_color();
+	case orb_status::allied:
+		return preferences::allied_color();
+	case orb_status::enemy:
+		return preferences::enemy_color();
+	default:
+		assert(!"expected to handle all the enum values");
+	}
+}
+
+std::unique_ptr<image::locator> orb_status_helper::get_orb_image(orb_status os)
+{
+	if(!prefs_show_orb(os))
+		return nullptr;
+	auto color = get_orb_color(os);
+	return std::make_unique<image::locator>(game_config::images::orb + "~RC(magenta>" + color + ")");
+}

--- a/src/units/orb_status.hpp
+++ b/src/units/orb_status.hpp
@@ -1,0 +1,58 @@
+/*
+   Copyright (C) 2020 by Steve Cotton <steve@octalot.co.uk>
+   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#pragma once
+
+#include "picture.hpp"
+
+#include <memory>
+#include <string>
+
+/**
+ * Corresponds to the colored orbs displayed above units' hp-bar and xp-bar.
+ */
+enum class orb_status {
+	/** The unit still has full movement and all attacks available. */
+	unmoved,
+	/** All moves and possible attacks have been done. */
+	moved,
+	/** There are still moves and/or attacks possible, but the unit doesn't fit in the "unmoved" status. */
+	partial,
+	/** Belongs to a friendly side */
+	allied,
+	/** Belongs to a non-friendly side; normally visualised by not displaying an orb. */
+	enemy
+};
+
+namespace orb_status_helper
+{
+/**
+ * Wrapper for the various preferences::show_..._orb() methods, using the
+ * enum instead of exposing a separate function for each preference.
+ */
+bool prefs_show_orb(orb_status os);
+
+/**
+ * Wrapper for the various preferences::unmoved_color(), moved_color(), etc
+ * methods, using the enum instead of exposing a separate function for each
+ * preference.
+ */
+std::string get_orb_color(orb_status os);
+
+/**
+ * Wrapper which will assemble the image path (including IPF for the color from get_orb_color) for a given orb.
+ * Returns nullptr if prefs_show_orb returns false.
+ */
+std::unique_ptr<image::locator> get_orb_image(orb_status os);
+} // namespace orb_status_helper


### PR DESCRIPTION
Note: the build will fail on MacOS, as the new orb_status files still need
adding to the MacOS build.

Instead of using the allied orb during their turn, the unmoved, moved and
partial orbs are shown. The player's own units will be shown with the moved orb
during the ally's turn, which matches the previous behavior. This is intended for
co-operative MP campaigns, where it will make it easier for players to discuss
possible moves. The UX is also visible in SP scenarios with allied sides, HttT's
first scenario is an easy place to see what it does.

Updated the documentation about orb colors. In these docs I've moved all of
the images to a single line above the bullet-pointed list, as otherwise the
layout looked bad once a line wrapped - the first line appeared
horizontally-aligned with the center of the image, the second started under the
image.

Added documentation about the delay in multiplayer games, as the purpose of this
orb-coloring feature is to assist discussion in multiplayer games.

Refactoring the orb-coloring code, adding new units/orb_status.hpp

Instead of creating lots of image::locators and calling a family of
similarly-named preferences functions, this refactor encapsulates that logic
and uses an enum.

An assert has been added to `unit_drawer`'s constructor. There are two callers
- the `display` class guards it with an explicit check before constructing
unit_drawer. The `game_display` class doesn't have an explicit check, but it's
clear that other code in that class assumes the teams are already valid (and
would crash if they weren't).

Other issues connected with this PR
---

Issue #5155's proposed orb_status::disengaged has been tested with this, and
builds on the refactor in the first of this PR's two commits.

The orbs' help page suggests that there should be documentation about the crowns
too, however I want to separate any work on that from this PR. Issue #4455 tracks
the info about crowns.