### PR TITLE
Changes in new monster units regarding experience and advancements

### DIFF
--- a/data/core/about.cfg
+++ b/data/core/about.cfg
@@ -1305,6 +1305,9 @@
         name = "holius-fr"
     [/entry]
     [entry]
+        name = "IceTyp"
+    [/entry]
+    [entry]
         name = "ilyapopov"
     [/entry]
     [entry]

--- a/data/core/units/monsters/Ant.cfg
+++ b/data/core/units/monsters/Ant.cfg
@@ -9,7 +9,7 @@
     hitpoints=22
     movement_type=orcishfoot
     movement=4
-    experience=50
+    experience=25
     level=0
     alignment=neutral
     advances_to=null

--- a/data/core/units/monsters/Bear.cfg
+++ b/data/core/units/monsters/Bear.cfg
@@ -10,7 +10,7 @@
     hitpoints=72
     movement_type=mountainfoot
     movement=6
-    experience=80
+    experience=100
     level=2
     alignment=chaotic
     advances_to=null

--- a/data/core/units/monsters/Giant_Stoat.cfg
+++ b/data/core/units/monsters/Giant_Stoat.cfg
@@ -10,7 +10,7 @@
     hitpoints=23
     movement_type=elusivefoot
     movement=6
-    experience=50
+    experience=25
     level=0
     alignment=chaotic
     advances_to=null

--- a/data/core/units/monsters/Icemonax_Greater.cfg
+++ b/data/core/units/monsters/Icemonax_Greater.cfg
@@ -23,7 +23,7 @@
     hitpoints=56
     movement_type=largefoot
     movement=5
-    experience=80
+    experience=100
     level=2
     alignment=neutral
     advances_to=null

--- a/data/core/units/monsters/Tusker_Gorer.cfg
+++ b/data/core/units/monsters/Tusker_Gorer.cfg
@@ -23,7 +23,7 @@
     hitpoints=35
     movement_type=rodentfoot
     movement=7
-    experience=150
+    experience=50
     {AMLA_DEFAULT}
     level=1
     alignment=neutral

--- a/data/core/units/monsters/Tusker_Tusklet.cfg
+++ b/data/core/units/monsters/Tusker_Tusklet.cfg
@@ -24,10 +24,9 @@
     movement_type=rodentfoot
     movement=5
     experience=26
-    {AMLA_DEFAULT}
     level=0
     alignment=neutral
-    advances_to=null
+    advances_to=Gorer
     undead_variation=mounted
     cost=10
     usage=fighter


### PR DESCRIPTION
Giant Stoat (L0), Giant Ant (L0), Gorer (L1), Cave Bear (L2) and Great Icemonax (L2) have no advancements.
I changed their experience to 50 times level (25 for L0) to match with similar units in mainline.

Tusklet and Gorer are of the same unit line. So I gave Tusklet the advancement to Gorer.

There are some things I am not sure about:
Should Giant Ant (L0) advance to Fire Ant (L1)? I don't think so because they appear in different faunas corresponding to the [forum post](https://forums.wesnoth.org/viewtopic.php?f=9&t=52894) of doofus-01.

Icemonax (L0) and Great Icemonax (L2) are obviously of the same unit line. But their levels differ by two. Hence, an advancement of Icemonax to Great Icemonax would not make much sense at this time.
Will there be a L1 unit between those or will one of them be changed to L1?