### PR TITLE
Use the new animals in the "animals" micro-ai demo

### DIFF
--- a/data/ai/micro_ais/scenarios/animals.cfg
+++ b/data/ai/micro_ais/scenarios/animals.cfg
@@ -3,7 +3,7 @@
 #define ANIMAL_AI_DESCRIPTIONS1
     _"<u>General</u>: These AIs are set up to simulate (to some extent) how these animals behave in real life. This includes that they are animals, meaning that they are not super smart. As an example, the wolves generally hunt in a pack, but are easily distracted by prey coming into range. They are also decent, but not great at cornering deer. For the most part, this is intentional.
 
-<u>Bears (replaced by Ghasts), Spiders and Yetis</u> mostly just wander in their respective parts of the map. They stay out of each other's way (and out of the way of the dogs), but do attack each other if cornered. They attack the other, weaker animals (deer etc.) if those are within range.
+<u>Bears, Spiders and Yetis</u> mostly just wander in their respective parts of the map. They stay out of each other's way (and out of the way of the dogs), but do attack each other if cornered. They attack the other, weaker animals (deer etc.) if those are within range.
 
 <u>Wolves</u> hunt in a pack. They actively go after the closest deer (as long as it stays in the forest) and try to corner it (not always super successfully), but are easily distracted by other prey coming into range. The wolves try to avoid getting into the range of bears, spiders, dogs and the yeti, except when they are going in for an attack. If you let them move for long enough, they will also learn that it is not healthy to attack the tusklets. When no deer is left, they wander randomly. Note that, unlike the Wolves Multipack AI (used in a different scenario), this Wolves AI combines all wolves of the side in the same pack."
 #enddef
@@ -11,15 +11,15 @@
 #define ANIMAL_AI_DESCRIPTIONS2
     _"Each <u>Deer (replaced by Vampire Bats)</u> wanders randomly on forest tiles, except when enemies get in its (the deer's) range, in which case it flees to the farthest point it can reach.
 
-<u>Tuskers (replaced by Ogres)</u> exhibit the same behavior as deer, except when an enemy is next to one of the tusklets. This enemy will then experience the full wrath of an irate boar.
+<u>Tuskers</u> exhibit the same behavior as deer, except when an enemy is next to one of the tusklets. This enemy will then experience the full wrath of an irate boar.
 
-<u>Tusklets (replaced by Young Ogres)</u> blindly follow the closest adult tusker, except when there is no tusker left, in which case they behave the same as deer.
+<u>Tusklets</u> blindly follow the closest adult tusker, except when there is no tusker left, in which case they behave the same as deer.
 
 <u>Rabbits (replaced by Rats)</u> also wander randomly, but in addition disappear into their holes (replaced by straw bales; if any are within reach) when enemies are close. They reappear out of their holes at the beginning of the turn, if it is safe.
 
 <u>Sheep dogs (replaced by Footpads)</u> try to keep their sheep safe. This involves keeping them inside the area outlined by the path the dogs have worn into the meadow, positioning themselves in between the sheep and approaching enemies, and attacking the enemies if those get too close. You might have to let the scenario play for quite some time before you get to see an interesting dog/wolf interaction. If no active herding or protecting move is needed, the dogs go to a random location on the path.
 
-<u>Sheep (replaced by Troll Whelps)</u> wander aimlessly except when a sheep dog is next to them, in which case they run away from the dog. The dogs exploit this by positioning themselves on the outside of the sheep, if possible. Sheep also run away from approaching enemies. The sheep, dogs and forest creatures (deer, tuskers, rabbits) have learned that they are no threat to each other and leave each other alone, demonstrating the enormous self control of a well trained sheep dog."
+<u>Sheep (replaced by Icemonax)</u> wander aimlessly except when a sheep dog is next to them, in which case they run away from the dog. The dogs exploit this by positioning themselves on the outside of the sheep, if possible. Sheep also run away from approaching enemies. The sheep, dogs and forest creatures (deer, tuskers, rabbits) have learned that they are no threat to each other and leave each other alone, demonstrating the enormous self control of a well trained sheep dog."
 #enddef
 
 [test]
@@ -73,8 +73,8 @@
         defeat_condition=no_units_left
         persistent=no
 
-        team_name=ghasts
-        user_team_name= _ "Ghasts" # wmllint: no spellcheck
+        team_name=bears
+        user_team_name= _ "Bears"
 
         gold=0
         income=-2
@@ -129,8 +129,8 @@
         defeat_condition=no_units_left
         persistent=no
 
-        team_name=whelps,forest
-        user_team_name= _ "Whelps"
+        team_name=sheep,forest
+        user_team_name= _ "Sheep"
 
         gold=0
         income=-2
@@ -151,14 +151,14 @@
         {VARIABLE scenario_name animals}
 
         {SCATTER_UNITS 3 "Vampire Bat" 1 (x,y,terrain=6-99,12-99,G*^F*) (side,random_traits=2,no)}
-        {NOTRAIT_UNIT 2 "Ogre" 6 20}
-        {NOTRAIT_UNIT 2 "Ogre" 7 21}
-        {NOTRAIT_UNIT 2 "Young Ogre" 7 20}
-        {NOTRAIT_UNIT 2 "Young Ogre" 8 21}
+        {NOTRAIT_UNIT 2 "Gorer" 6 20}
+        {NOTRAIT_UNIT 2 "Gorer" 7 21}
+        {NOTRAIT_UNIT 2 "Tusklet" 7 20}
+        {NOTRAIT_UNIT 2 "Tusklet" 8 21}
 
         # Do this separately, so that there will definitely be two
-        {SCATTER_UNITS 1 "Ghast" 1 (x,y,terrain=1-10,1-11,G*) (side,random_traits=3,no)}
-        {SCATTER_UNITS 1 "Ghast" 1 (x,y,terrain=11-20,1-11,G*) (side,random_traits=3,no)}
+        {SCATTER_UNITS 1 "Cave Bear" 1 (x,y,terrain=1-10,1-11,G*) (side,random_traits=3,no)}
+        {SCATTER_UNITS 1 "Cave Bear" 1 (x,y,terrain=11-20,1-11,G*) (side,random_traits=3,no)}
 
         {SCATTER_UNITS 1 "Giant Spider" 1 (x,y=51-57,1-8) (side,random_traits=4,no)}
         {SCATTER_UNITS 1 "Giant Spider" 1 (x,y=36-50,1-9) (side,random_traits=4,no)}
@@ -172,14 +172,14 @@
         {NOTRAIT_UNIT 7 "Footpad" 34 24}
         {NOTRAIT_UNIT 7 "Footpad" 25 32}
         {NOTRAIT_UNIT 7 "Footpad" 36 31}
-        {NOTRAIT_UNIT 7 "Troll Whelp" 35 27}
-        {NOTRAIT_UNIT 7 "Troll Whelp" 29 28}
-        {NOTRAIT_UNIT 7 "Troll Whelp" 30 29}
-        {NOTRAIT_UNIT 7 "Troll Whelp" 28 30}
+        {NOTRAIT_UNIT 7 "Icemonax" 35 27}
+        {NOTRAIT_UNIT 7 "Icemonax" 29 28}
+        {NOTRAIT_UNIT 7 "Icemonax" 30 29}
+        {NOTRAIT_UNIT 7 "Icemonax" 28 30}
 
         # Need to make sure these won't be on the border !!!!
         # Other dimension are carefully chosen to give good distribution on map
-        # and not inside th Troll Whelp herding area
+        # and not inside th Icemonax herding area
         {SCATTER_IMAGE (
             terrain=Gg,Gs
             x,y=19-39,17-32
@@ -241,24 +241,24 @@
 
             deer_type=Vampire Bat
             rabbit_type=Giant Rat
-            tusker_type=Ogre
-            tusklet_type=Young Ogre
+            tusker_type=Gorer
+            tusklet_type=Tusklet
             [filter_location]
                 terrain=*^F*
             [/filter_location]
         [/micro_ai]
 
-        # Set up the big_animals micro AI for the Ghasts
+        # Set up the big_animals micro AI for the Bears
         [micro_ai]
             side=3
             ai_type=big_animals
             action=add
 
             [filter]
-                type=Ghast
+                type=Cave Bear
             [/filter]
             [avoid_unit]
-                type=Yeti,Giant Spider,Ghast,Footpad
+                type=Yeti,Giant Spider,Cave Bear,Footpad
             [/avoid_unit]
             [filter_location]
                 x,y=1-40,1-18
@@ -275,7 +275,7 @@
                 type=Giant Spider
             [/filter]
             [avoid_unit]
-                type=Yeti,Giant Spider,Ghast,Footpad
+                type=Yeti,Giant Spider,Cave Bear,Footpad
             [/avoid_unit]
             [filter_location]
                 terrain=H*
@@ -292,7 +292,7 @@
                 type=Yeti
             [/filter]
             [avoid_unit]
-                type=Yeti,Giant Spider,Ghast,Footpad
+                type=Yeti,Giant Spider,Cave Bear,Footpad
             [/avoid_unit]
             [filter_location]
                 terrain=M*
@@ -314,10 +314,10 @@
             [filter_second]
                 type=Vampire Bat
             [/filter_second]
-            avoid_type=Yeti,Giant Spider,Ghast,Footpad
+            avoid_type=Yeti,Giant Spider,Cave Bear,Footpad
         [/micro_ai]
 
-        # Set up the Troll Whelp micro AI
+        # Set up the Icemonax micro AI
         [micro_ai]
             side=7
             ai_type=herding
@@ -327,7 +327,7 @@
                 type=Footpad
             [/filter]
             [filter_second]
-                type=Troll Whelp
+                type=Icemonax
             [/filter_second]
             herd_x,herd_y=32,28
             [filter_location]
@@ -343,7 +343,7 @@
             speaker=narrator
             image=wesnoth-icon.png
             caption="Important Note"
-            message= _ "<span color='#A00000'>Important:</span> The animal Micro AIs in this scenario are written for a number of animal unit types that do not exist in Wesnoth mainline, such as bears, sheep and sheep dogs, or deer. In this test scenario, these units have been replaced by mainline units."
+            message= _ "<span color='#A00000'>Important:</span> The animal Micro AIs in this scenario are written for a number of animal unit types that do not exist in Wesnoth mainline, such as sheep, sheep dogs, or deer. In this test scenario, these units have been replaced by mainline units."
         [/message]
 
         # wmlindent: start ignoring
@@ -414,12 +414,12 @@ Also note: The Animal AIs are coded as Micro AIs. A Micro AI can be added and ad
         [/objectives]
     [/event]
 
-    # After first Ogre attack on wolves, wolves do not attack those any more
+    # After first Gorer attack on wolves, wolves do not attack those any more
     [event]
         name=attack end
         [filter]
             side=2
-            type=Ogre
+            type=Gorer
         [/filter]
         [filter_second]
             side=6
@@ -430,7 +430,7 @@ Also note: The Animal AIs are coded as Micro AIs. A Micro AI can be added and ad
         [message]
             speaker=$second_unit.id
             message= _ "Yowl!
-Translation: Those Ogres are mean!  We better stay away from them and their young."
+Translation: Those boars are mean!  We better stay away from them and their young."
         [/message]
         # wmlindent: stop ignoring
 
@@ -445,7 +445,7 @@ Translation: Those Ogres are mean!  We better stay away from them and their youn
             [filter_second]
                 type=Vampire Bat
             [/filter_second]
-            avoid_type=Yeti,Giant Spider,Ghast,Footpad,Ogre,Young Ogre
+            avoid_type=Yeti,Giant Spider,Cave Bear,Footpad,Gorer,Tusklet
         [/micro_ai]
     [/event]
 
@@ -469,12 +469,12 @@ Translation: Those Ogres are mean!  We better stay away from them and their youn
 #enddef
 
     {NEW_UNIT_SIDE_TURN 2 "Vampire Bat" "0-2" 18 33}
-    {NEW_UNIT_SIDE_TURN 2 "Ogre" "0-1" 1 20}
-    {NEW_UNIT_SIDE_TURN 2 "Young Ogre" "0-1" 1 21}
-    {NEW_UNIT_SIDE_TURN 3 Ghast "0-1" 1 1}
+    {NEW_UNIT_SIDE_TURN 2 Gorer "0-1" 1 20}
+    {NEW_UNIT_SIDE_TURN 2 Tusklet "0-1" 1 21}
+    {NEW_UNIT_SIDE_TURN 3 "Cave Bear" "0-1" 1 1}
     {NEW_UNIT_SIDE_TURN 4 "Giant Spider" "0-1" 57 1}
     {NEW_UNIT_SIDE_TURN 5 Yeti 0 15 1}
     {NEW_UNIT_SIDE_TURN 6 Wolf "0-2" 1 33}
     {NEW_UNIT_SIDE_TURN 7 Footpad "0-2" 30 33}
-    {NEW_UNIT_SIDE_TURN 7 "Troll Whelp" "0-3" 34 33}
+    {NEW_UNIT_SIDE_TURN 7 Icemonax "0-3" 34 33}
 [/test]


### PR DESCRIPTION
Several new animals were added in PR #5039's cbad6f42492be5fcbf8c29a3d10cbc43598ba32c.

The micro-ai demo can be accessed by starting Wesnoth with the command-line
arguments `--test animals`. The scenario uses some stand-ins for animals that
weren't in mainline; the new bears and tuskers fit straight in. For the sheep,
the icemonax's graphics are a bit more sheep-shaped than the troll whelp's.

This demo doesn't need to be balanced, the changed unit stats are no problem.

UtBS's dustboks aren't in core, otherwise I'd use them as the deer stand-in.

@doofus-01 thanks for these new resources. Are the unit ids final (as in, should
I postpone this change in case they get renamed)?