### PR TITLE
Refactor translatable strings for the SotA zombie recruit dialog

### DIFF
--- a/data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg
@@ -13,81 +13,97 @@
 #define ZOMBIE_INIT
     [event]
         name=prestart
+        #wmllint: markcheck off
+        # TODO: Most of the sota_variation strings could probably reuse race names from core and just add the parentheses in the Lua code
+        # sota_variation will be used in the zombie recruit dialog
         [set_variables]
             name=zombies
-            [split]
-                list="SotA Flying Corpse_Bat,
-                SotA Walking Corpse_Rat,
-                SotA Walking Corpse_Wolf,
-                SotA Walking Corpse_Human,
-                SotA Walking Corpse_Mounted,
-                SotA Walking Corpse_Wolf Rider,
-                SotA Swimming Corpse,
-                SotA Walking Corpse_Saurian,
-                SotA Walking Corpse_Wose,
-                SotA Walking Corpse_Goblin,
-                SotA Flying Corpse_Gryphon,
-                SotA Walking Corpse_Spider,
-                SotA Walking Corpse_Troll,
-                SotA Walking Corpse_Dwarf"
-                key=type
-                separator=","
-            [/split]
+            [value]
+                type=SotA Flying Corpse_Bat
+                sota_variation= _ "(Bat)"
+                allow_recruit_message= _ "You can now raise bat corpses!"
+                allow_recruit=no
+            [/value]
+            [value]
+                type=SotA Walking Corpse_Rat
+                sota_variation= _ "(Rat)"
+                allow_recruit_message= _ "You can now raise rat corpses!"
+                allow_recruit=no
+            [/value]
+            [value]
+                type=SotA Walking Corpse_Wolf
+                sota_variation= _ "(Wolf)"
+                allow_recruit_message= _ "You can now raise wolf corpses!"
+                allow_recruit=no
+            [/value]
+            [value]
+                type=SotA Walking Corpse_Human
+                sota_variation= _ "(Human)"
+                allow_recruit_message= _ "You can now raise human corpses!"
+                allow_recruit=no
+            [/value]
+            [value]
+                type=SotA Walking Corpse_Mounted
+                sota_variation= _ "(Mounted)"
+                allow_recruit_message= _ "You can now raise mounted corpses!"
+                allow_recruit=no
+            [/value]
+            [value]
+                type=SotA Walking Corpse_Wolf Rider
+                sota_variation= _ "(Wolf Rider)"
+                allow_recruit_message= _ "You can now raise wolf rider corpses!"
+                allow_recruit=no
+            [/value]
+            [value]
+                type=SotA Swimming Corpse
+                sota_variation= _ "(Merfolk)"
+                allow_recruit_message= _ "You can now raise merfolk corpses!"
+                allow_recruit=no
+            [/value]
+            [value]
+                type=SotA Walking Corpse_Saurian
+                sota_variation= _ "(Saurian)"
+                allow_recruit_message= _ "You can now raise saurian corpses!"
+                allow_recruit=no
+            [/value]
+            [value]
+                type=SotA Walking Corpse_Wose
+                sota_variation= _ "(Wose)"
+                allow_recruit_message= _ "You can now raise wose corpses!"
+                allow_recruit=no
+            [/value]
+            [value]
+                type=SotA Walking Corpse_Goblin
+                sota_variation= _ "(Goblin)"
+                allow_recruit_message= _ "You can now raise goblin corpses!"
+                allow_recruit=no
+            [/value]
+            [value]
+                type=SotA Flying Corpse_Gryphon
+                sota_variation= _ "(Gryphon)"
+                allow_recruit_message= _ "You can now raise gryphon corpses!"
+                allow_recruit=no
+            [/value]
+            [value]
+                type=SotA Walking Corpse_Spider
+                sota_variation= _ "(Spider)"
+                allow_recruit_message= _ "You can now raise spider corpses!"
+                allow_recruit=no
+            [/value]
+            [value]
+                type=SotA Walking Corpse_Troll
+                sota_variation= _ "(Troll)"
+                allow_recruit_message= _ "You can now raise troll corpses!"
+                allow_recruit=no
+            [/value]
+            [value]
+                type=SotA Walking Corpse_Dwarf
+                sota_variation= _ "(Dwarf)"
+                allow_recruit_message= _ "You can now raise dwarf corpses!"
+                allow_recruit=no
+            [/value]
         [/set_variables]
-        # This string will be used in the zombie recruit dialog box.
-        [set_variables]
-            name=zombies
-            mode=merge
-            [split]
-                list= _ "(Bat),
-                (Rat),
-                (Wolf),
-                (Human),
-                (Mounted),
-                (Wolf Rider),,
-                (Saurian),
-                (Wose),
-                (Goblin),
-                (Gryphon),
-                (Spider),
-                (Troll),
-                (Dwarf)" # po: The extra comma after (Wolf Rider) is for the swimming corpse. Since there is only one of those, it would be redundant to label it in English. You can add (Swimmer) before the second comma if it makes more sense in your language to do so. Be careful not to delete any commas!
-                key=sota_variation
-                separator=","
-            [/split]
-        [/set_variables]
-        [set_variables]
-            name=zombies
-            mode=merge
-            [split]
-                list= _ "You can now raise bat corpses!,
-                You can now raise rat corpses!,
-                You can now raise wolf corpses!,
-                You can now raise human corpses!,
-                You can now raise mounted corpses!,
-                You can now raise wolf rider corpses!,
-                You can now raise swimming corpses!,
-                You can now raise saurian corpses!,
-                You can now raise wose corpses!,
-                You can now raise goblin corpses!,
-                You can now raise gryphon corpses!,
-                You can now raise spider corpses!,
-                You can now raise troll corpses!,
-                You can now raise dwarf corpses!" # po: Be careful not to delete any commas!
-                key=allow_recruit_message
-                separator=","
-            [/split]
-        [/set_variables]
-        [set_variables]
-            name=zombies
-            mode=merge
-            [split]
-                # The player starts out with no zombies available.
-                list="no,no,no,no,no,no,no,no,no,no,no,no,no,no"
-                key=allow_recruit
-                separator=","
-            [/split]
-        [/set_variables]
+        #wmllint: markcheck on
     [/event]
 #enddef
 

--- a/data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg
@@ -120,47 +120,14 @@
 # This macro saves the currently recruitable zombies into a string that can be used in a
 # [set_variables] statement later to restore the list. (LOAD_ZOMBIE_LIST does that.)
 #define SAVE_ZOMBIE_LIST VARIABLE
-    [foreach]
-        array=zombies
-        [do]
-            [if]
-                [variable]
-                    name=this_item.allow_recruit
-                    boolean_equals=yes
-                [/variable]
-                [then]
-                    [set_variable]
-                        name={VARIABLE}
-                        value=${VARIABLE}| + "yes,"
-                    [/set_variable]
-                [/then]
-                [else]
-                    [set_variable]
-                        name={VARIABLE}
-                        value=${VARIABLE}| + "no,"
-                    [/set_variable]
-                [/else]
-            [/if]
-        [/do]
-    [/foreach]
-    # Remove the trailing comma from the string.
     [set_variable]
-        name={VARIABLE}
-        value="$(substring( '${VARIABLE}', 0, (length('${VARIABLE}')-1) ))"
+        name=ardonna_zombies
+        [join]
+            variable=zombies
+            key=allow_recruit
+            separator=","
+        [/join]
     [/set_variable]
-
-    # This *should* work, but doesn't as of 1.14.5. It causes a lua error because of
-    # concatenation of a boolean, presumably because the strings are all either
-    # "yes" or "no". If that changes, this code can be uncommented, and the code
-    # above removed.
-    #     [set_variable]
-    #         name=ardonna_zombies
-    #         [join]
-    #             variable=zombies
-    #             key=allow_recruit
-    #             separator=","
-    #         [/join]
-    #     [/set_variable]
 #enddef
 
 #define LOAD_ZOMBIE_LIST VARIABLE

--- a/data/lua/wml/set_variable.lua
+++ b/data/lua/wml/set_variable.lua
@@ -148,7 +148,16 @@ function wesnoth.wml_actions.set_variable(cfg, variables)
 				if #string_to_join > 0 then
 					string_to_join = string_to_join .. separator
 				end
-				string_to_join = string_to_join .. element[key_name]
+				local elem = element[key_name]
+				if type(elem) == 'boolean' then
+					-- Use yes/no instead of true/false for booleans
+					elem = elem and 'yes' or 'no'
+				elseif getmetatable(elem) ~= 'translatable string' then
+					-- Not entirely sure if this branch is necessary, since it probably only triggers for numbers
+					-- It certainly can't hurt, though.
+					elem = tostring(elem)
+				end
+				string_to_join = string_to_join .. elem
 			end
 		end
 


### PR DESCRIPTION
I think it's easier for translators if each string is actually just one string. Using "split" on a translatable string just unnecessarily complicates things.

I also fixed a bug in `[set_variable]` which was referenced by a comment in the SotA zombie-utils file.