### PR TITLE
Reload the fonts (both GUI1 and GUI2) when changing language

### DIFF
--- a/src/font/font_config.cpp
+++ b/src/font/font_config.cpp
@@ -127,8 +127,6 @@ t_string family_order_script;
 
 bool load_font_config()
 {
-	//read font config separately, so we do not have to re-read the whole
-	//config when changing languages
 	config cfg;
 	try {
 		const std::string& cfg_path = filesystem::get_wml_location("hardwired/fonts.cfg");

--- a/src/gui/dialogs/title_screen.cpp
+++ b/src/gui/dialogs/title_screen.cpp
@@ -385,6 +385,7 @@ void title_screen::pre_show(window& win)
 				t_string::reset_translations();
 				::image::flush_cache();
 				sound::flush_cache();
+				font::load_font_config();
 				on_resize(win);
 			}
 		} catch(const std::runtime_error& e) {


### PR DESCRIPTION
Fixes #5194. If starting the game in a given language works properly, then
this PR makes changing to that language without restarting also works properly.
This can work with or without #5200 - I hope to get both of them in as #5200
has a lot of code cleanup; but this one has a better ratio of
bugs fixed vs lines of code to review.

Getting fonts in the correct order is important for CJK (Chinese, Japanese,
Korean), as the same codepoint may have different images even between
DroidSansJapanese and DroidSansFallbackFull (see discussion in issue #5194).

This method of calling load_font_config() to reload the fonts is already used
during startup - see the two calls to it in src/wesnoth.cpp.