### PR TITLE
Update editor cfg file to reflect earlier changes in scaling

### DIFF
--- a/data/themes/editor.cfg
+++ b/data/themes/editor.cfg
@@ -1004,6 +1004,11 @@
         width=800
         height=600
 
+        [change]
+            id=main-map
+            rect="0,+7,+619,600"
+        [/change]
+
         [remove]
             id=top_button_file3
         [/remove]


### PR DESCRIPTION
  Commit 43de778 made all themes scale from their base dimensions rather
  than from an arbitrary hard-coded 1024x768 pixel size. As a result, the
  800x600 layout for the editor needs its main map explicitly sized --
  the 843-pixel width no longer fits in 800x600, and it isn't being scaled
  down from 1024. (But once it is explicitly set for the 800x600 layout,
  it will scale up for pixel widths between 800 and 1024). This commit
  adds such an explicit sizing, analogous to the one found in default.cfg.

  Resolves #5193.