### PR TITLE
revert Redesign force cth macro

### DIFF
--- a/data/core/macros/utils.cfg
+++ b/data/core/macros/utils.cfg
@@ -513,8 +513,6 @@
     #!         greater_than=10
     #!     [/variable]
     #! )}
-    # WARNING : if an unit must disappear in mid-battle before attack end was fired, don't use [unstore_unit] but recreate unit or cth modifications
-    # persist. Or don't use this macro.
     [event]
         name=attack
         first_time_only=no
@@ -533,34 +531,81 @@
             [/and]
         [/filter_condition]
 
-        [object]
-            id=forced_cth
-            [filter]
-                id=$unit.id
-            [/filter]
-            silent=yes
-            duration=turn end
-            take_only_once=no
-            [effect]
-                apply_to=new_ability
-                [abilities]
-                    [chance_to_hit]
+        [foreach]
+            array=unit.attack
+            [do]
+                [if]
+                    #This is to mute a warning message about retrieving a member of non-existant wml container.
+                    [variable]
+                        name=this_item.specials.length
+                        greater_than=0
+                    [/variable]
+
+                    [variable]
+                        name=this_item.specials.chance_to_hit.length
+                        greater_than=0
+                    [/variable]
+
+                    [then]
+                        [set_variables]
+                            name=this_item.specials.original_chance_to_hit
+                            to_variable=this_item.specials.chance_to_hit
+                        [/set_variables]
+
+                        {CLEAR_VARIABLE this_item.specials.chance_to_hit}
+                    [/then]
+                [/if]
+
+                [set_variables]
+                    name=this_item.specials.chance_to_hit
+
+                    [value]
                         id=forced_cth
                         value={CTH_NUMBER}
                         cumulative=no
-                        affect_self=yes
-                        [filter_opponent]
-                            {SECOND_FILTER}
-                        [/filter_opponent]
-                    [/chance_to_hit]
-                [/abilities]
-            [/effect]
-        [/object]
+                    [/value]
+                [/set_variables]
+            [/do]
+        [/foreach]
+
+        [unstore_unit]
+            variable=unit
+            find_vacant=no
+        [/unstore_unit]
+
         [event]
             name=attack end
-            [remove_object]
-                object_id=forced_cth
-            [/remove_object]
+            delayed_variable_substitution=yes
+
+            [if]
+                [variable]
+                    name=unit.length
+                    numerical_equals=0
+                [/variable]
+                [then]
+                    # Unit vanished mid-fight
+                    [return][/return]
+                [/then]
+            [/if]
+
+            [foreach]
+                array=unit.attack
+                [do]
+                    {CLEAR_VARIABLE this_item.specials.chance_to_hit}
+
+                    [set_variables]
+                        name=this_item.specials.chance_to_hit
+                        to_variable=this_item.specials.original_chance_to_hit
+                    [/set_variables]
+
+                    {CLEAR_VARIABLE this_item.specials.original_chance_to_hit}
+                [/do]
+            [/foreach]
+
+            [unstore_unit]
+                variable=unit
+                find_vacant=no
+            [/unstore_unit]
         [/event]
     [/event]
 
@@ -585,59 +630,81 @@
             [/and]
         [/filter_condition]
 
-        [object]
-            id=forced_cth
-            [filter]
-                id=$second_unit.id
-            [/filter]
-            silent=yes
-            duration=turn end
-            take_only_once=no
-            [effect]
-                apply_to=new_ability
-                [abilities]
-                    [chance_to_hit]
+        [foreach]
+            array=second_unit.attack
+            [do]
+                [if]
+                    [variable]
+                        name=this_item.specials.length
+                        greater_than=0
+                    [/variable]
+
+                    [variable]
+                        name=this_item.specials.chance_to_hit.length
+                        greater_than=0
+                    [/variable]
+
+                    [then]
+                        [set_variables]
+                            name=this_item.specials.original_chance_to_hit
+                            to_variable=this_item.specials.chance_to_hit
+                        [/set_variables]
+
+                        {CLEAR_VARIABLE this_item.specials.chance_to_hit}
+                    [/then]
+                [/if]
+
+                [set_variables]
+                    name=this_item.specials.chance_to_hit
+
+                    [value]
                         id=forced_cth
                         value={CTH_NUMBER}
                         cumulative=no
-                        affect_self=yes
-                        [filter_opponent]
-                            {SECOND_FILTER}
-                        [/filter_opponent]
-                    [/chance_to_hit]
-                [/abilities]
-            [/effect]
-        [/object]
+                    [/value]
+                [/set_variables]
+            [/do]
+        [/foreach]
+
+        [unstore_unit]
+            variable=second_unit
+            find_vacant=no
+        [/unstore_unit]
+
         [event]
             name=attack end
-            [remove_object]
-                object_id=forced_cth
-            [/remove_object]
+            delayed_variable_substitution=yes
+
+            [if]
+                [variable]
+                    name=second_unit.length
+                    numerical_equals=0
+                [/variable]
+                [then]
+                    # Unit vanished mid-fight
+                    [return][/return]
+                [/then]
+            [/if]
+
+            [foreach]
+                array=second_unit.attack
+                [do]
+                    {CLEAR_VARIABLE this_item.specials.chance_to_hit}
+
+                    [set_variables]
+                        name=this_item.specials.chance_to_hit
+                        to_variable=this_item.specials.original_chance_to_hit
+                    [/set_variables]
+
+                    {CLEAR_VARIABLE this_item.specials.original_chance_to_hit}
+                [/do]
+            [/foreach]
+
+            [unstore_unit]
+                variable=second_unit
+                find_vacant=no
+            [/unstore_unit]
         [/event]
-    [/event]
-    [event]
-        name=unit placed
-        first_time_only=no
-
-        [filter]
-            ability=forced_cth
-        [/filter]
-
-        [remove_object]
-            object_id=forced_cth
-        [/remove_object]
-    [/event]
-    [event]
-        name=prestart,start,victory
-        [filter_condition]
-            [have_unit]
-                ability=forced_cth
-            [/have_unit]
-        [/filter_condition]
-
-        [remove_object]
-            object_id=forced_cth
-        [/remove_object]
     [/event]
 #enddef
 


### PR DESCRIPTION
revert https://github.com/wesnoth/wesnoth/commit/866420adf85ec1da02f565f2efd1933bf27419c4#diff-ca2b2f3f52116e047fc943b701f7798e0008c99644d9edf7ade1daf66ae61b7d

when i replaced 1.12/1.14 version of FORCE CTH, the weapon abilities overwrited the regular cth specials but now the cth mike marksman or magical don't affected, i must place the 1.14 version of macro for fixing that.