### PR TITLE
Deprecate [event]remove=yes, recommend [remove_event]

### DIFF
--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -766,6 +766,7 @@ end
 
 function wml_actions.event(cfg)
 	if cfg.remove then
+		wesnoth.deprecated_message("[event]remove=yes", 2, "1.17.0", "Use [remove_event] instead of [event]remove=yes")
 		wml_actions.remove_event(cfg)
 	else
 		wesnoth.add_event_handler(cfg)


### PR DESCRIPTION
The remove attribute for [event] was never added to the validation schema,
and using [remove_event] seems easier to search WML for. Let's just recommend
the new key and deprecate the old one.

Tested with the current implementation of #5215