### PR TITLE
campaignd: Implement basic command line interface

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -372,6 +372,7 @@ if env["prereqs"]:
         conf.CheckBoost("iostreams", require_version = boost_version) & \
         conf.CheckBoostIostreamsGZip() & \
         conf.CheckBoostIostreamsBZip2() & \
+        conf.CheckBoost("program_options", require_version = boost_version) & \
         conf.CheckBoost("random", require_version = boost_version) & \
         conf.CheckBoost("smart_ptr", header_only = True) & \
 	CheckAsio(conf) & \
@@ -404,7 +405,6 @@ if env["prereqs"]:
     have_client_prereqs = have_client_prereqs & conf.CheckCairo(min_version = "1.10")
     have_client_prereqs = have_client_prereqs & conf.CheckPango("cairo", require_version = "1.22.0")
     have_client_prereqs = have_client_prereqs & conf.CheckPKG("fontconfig")
-    have_client_prereqs = have_client_prereqs & conf.CheckBoost("program_options", require_version = boost_version)
     have_client_prereqs = have_client_prereqs & conf.CheckBoost("regex")
     if not have_client_prereqs:
         Warning("Client prerequisites are not met. wesnoth cannot be built.")

--- a/source_lists/campaignd
+++ b/source_lists/campaignd
@@ -4,4 +4,5 @@ server/common/simple_wml.cpp
 server/campaignd/addon_utils.cpp
 server/campaignd/blacklist.cpp
 server/campaignd/fs_commit.cpp
+server/campaignd/options.cpp
 server/campaignd/server.cpp

--- a/source_lists/libwesnoth_core
+++ b/source_lists/libwesnoth_core
@@ -1,5 +1,6 @@
 color.cpp
 color_range.cpp
+commandline_argv.cpp
 config.cpp
 crypt_blowfish/crypt_blowfish.c
 config_attribute_value.cpp

--- a/src/commandline_argv.cpp
+++ b/src/commandline_argv.cpp
@@ -15,6 +15,7 @@
 
 #ifdef _WIN32
 
+#include "global.hpp"
 #include "serialization/unicode_cast.hpp"
 
 #include <windows.h>

--- a/src/commandline_argv.cpp
+++ b/src/commandline_argv.cpp
@@ -1,0 +1,95 @@
+/*
+   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#include "commandline_argv.hpp"
+
+#ifdef _WIN32
+
+#include "serialization/unicode_cast.hpp"
+
+#include <windows.h>
+
+namespace {
+
+bool win32_parse_single_arg(const char*& next, const char* end, std::string& res)
+{
+	// strip leading whitespace
+	while(next != end && *next == ' ') {
+		++next;
+	}
+
+	if(next == end) {
+		return false;
+	}
+
+	bool is_escaped = false;
+
+	for(; next != end; ++next) {
+		if(*next == ' ' && !is_escaped) {
+			break;
+		} else if(*next == '"' && !is_escaped) {
+			is_escaped = true;
+			continue;
+		} else if(*next == '"' && is_escaped && next + 1 != end && *(next + 1) == '"') {
+			res.push_back('"');
+			++next;
+			continue;
+		} else if(*next == '"' && is_escaped) {
+			is_escaped = false;
+			continue;
+		} else {
+			res.push_back(*next);
+		}
+	}
+
+	return true;
+}
+
+std::vector<std::string> win32_read_argv(const std::string& input)
+{
+	const char* start = &input[0];
+	const char* end = start + input.size();
+
+	std::string buffer;
+	std::vector<std::string> res;
+
+	while(win32_parse_single_arg(start, end, buffer)) {
+		res.emplace_back();
+		res.back().swap(buffer);
+	}
+
+	return res;
+}
+
+}
+
+#endif
+
+std::vector<std::string> read_argv(int argc, char** argv)
+{
+#ifdef _WIN32
+	UNUSED(argc);
+	UNUSED(argv);
+	// On Windows, argv is ANSI-encoded by default. Wesnoth absolutely needs to
+	// work with UTF-8 values in order to avoid losing or corrupting
+	// information from the command line.
+	auto flat_cmdline = unicode_cast<std::string>(std::wstring{GetCommandLineW()});
+	return win32_read_argv(flat_cmdline);
+#else
+	std::vector<std::string> args;
+	for(int i = 0; i < argc; ++i) {
+		args.push_back(std::string(argv[i]));
+	}
+	return args;
+#endif
+}

--- a/src/commandline_argv.hpp
+++ b/src/commandline_argv.hpp
@@ -1,0 +1,26 @@
+/*
+   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+/**
+ * Reads argv into a vector of STL strings.
+ *
+ * @note Both parameters are ignored on Windows in order to obtain guaranteed
+ *       Unicode-safe versions through the Win32 API. Do NOT try to pass values
+ *       other than the ones you got from main() here.
+ */
+std::vector<std::string> read_argv(int argc, char** argv);

--- a/src/commandline_options.hpp
+++ b/src/commandline_options.hpp
@@ -38,8 +38,8 @@ class config;
 
 class commandline_options
 {
-/// To be used for printing help to the commandline.
-friend std::ostream& operator<<(std::ostream &os, const commandline_options& cmdline_opts);
+	/// To be used for printing help to the commandline.
+	friend std::ostream& operator<<(std::ostream &os, const commandline_options& cmdline_opts);
 
 public:
 	commandline_options(const std::vector<std::string>& args);

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -891,6 +891,22 @@ std::string get_cwd()
 
 	return cwd.generic_string();
 }
+
+bool set_cwd(const std::string& dir)
+{
+	error_code ec;
+	bfs::current_path(bfs::path{dir}, ec);
+
+	if(ec) {
+		ERR_FS << "Failed to set current directory: " << ec.message() << '\n';
+		return false;
+	} else {
+		LOG_FS << "Process working directory set to " << dir << '\n';
+	}
+
+	return true;
+}
+
 std::string get_exe_dir()
 {
 #ifdef _WIN32

--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -200,6 +200,8 @@ struct other_version_dir
 std::vector<other_version_dir> find_other_version_saves_dirs();
 
 std::string get_cwd();
+bool set_cwd(const std::string& dir);
+
 std::string get_exe_dir();
 
 bool make_directory(const std::string& dirname);

--- a/src/server/campaignd/options.cpp
+++ b/src/server/campaignd/options.cpp
@@ -1,0 +1,133 @@
+/*
+   Copyright (C) 2020 by Iris Morelle <shadowm@wesnoth.org>
+   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#include "server/campaignd/options.hpp"
+
+#include "commandline_argv.hpp"
+#include "formatter.hpp"
+#include "log.hpp"
+#include "serialization/string_utils.hpp"
+
+#include <boost/program_options/cmdline.hpp>
+#include <boost/program_options/parsers.hpp>
+#include <boost/program_options/variables_map.hpp>
+
+namespace po = boost::program_options;
+
+namespace campaignd {
+
+command_line::command_line(int argc, char** argv)
+	: command_line(read_argv(argc, argv))
+{
+}
+
+command_line::command_line(const std::vector<std::string>& args)
+	: help(false)
+	, version(false)
+#if 0
+	, config_file()
+	, server_dir()
+	, port(0)
+#endif
+	, show_log_domains(false)
+	, log_domain_levels()
+	, log_precise_timestamps(false)
+	, argv0_(args.at(0))
+	, args_(args.begin() + 1, args.end())
+	, help_text_()
+{
+	po::options_description opts_general{"General options"};
+	opts_general.add_options()
+		("help,h", "prints this message and exits.")
+		("version,v", "displays the server version and exits.")
+		;
+
+#if 0
+	po::options_description opts_server{"Server configuration"};
+	opts_server.add_options()
+		("config,c", po::value<std::string>(), "specifies the path to the server configuration file.")
+		("server-dir,s",  po::value<std::string>(), "specifies the path to the server storage dir.")
+		("port,p", po::value<unsigned short>(), "specifies the port number on which the server will listen for client connections.")
+		;
+#endif
+
+	po::options_description opts_log{"Logging options"};
+	opts_log.add_options()
+		("logdomains", "lists defined log domains and exits")
+		("log-error", po::value<std::string>(), "sets the severity level of the specified log domain(s) to 'error'. <arg> should be given as a comma-separated list of domains.")
+		("log-warning", po::value<std::string>(), "sets the severity level of the specified log domain(s) to 'warning'. This is the default for all log domains other than 'campaignd' and 'server'.")
+		("log-info", po::value<std::string>(), "sets the severity level of the specified log domain(s) to 'info'. This is the default for the 'campaignd' and 'server' log domains.")
+		("log-debug", po::value<std::string>(), "sets the severity level of the specified log domain(s) to 'debug'.")
+		("log-none", po::value<std::string>(), "disables logging for the specified log domain(s).")
+		("log-precise", "shows the timestamps in log output with more precision.")
+		;
+
+	po::options_description opts;
+	opts.add(opts_general).add(opts_log);
+
+	static const int style = po::command_line_style::default_style ^ po::command_line_style::allow_guessing;
+
+	po::variables_map vm;
+	po::store(po::command_line_parser(args_).options(opts).style(style).run(), vm);
+
+	static const std::map<std::string, int> log_levels = {
+		{ "error",   lg::err().get_severity() },
+		{ "warning", lg::warn().get_severity() },
+		{ "info",    lg::info().get_severity() },
+		{ "debug",   lg::debug().get_severity() },
+		{ "none",    -1 }
+	};
+
+	if(vm.count("help")) {
+		if(!help) {
+			help_text_ = formatter() << "Usage: " << argv0_ << " [<options>]\n" << opts;
+		}
+
+		help = true;
+	}
+	if(vm.count("version")) {
+		version = true;
+	}
+
+#if 0
+	if(vm.count("config")) {
+		config_file = vm["config"].as<std::string>();
+	}
+	if(vm.count("server-dir")) {
+		server_dir = vm["server-dir"].as<std::string>();
+	}
+	if(vm.count("port")) {
+		port = vm["port"].as<unsigned short>();
+	}
+#endif
+
+	if(vm.count("logdomains")) {
+		show_log_domains = true;
+	}
+	for(const auto& lvl : log_levels) {
+		const auto& swtch = std::string{"log-"} + lvl.first;
+		const auto severity = lvl.second;
+		if(vm.count(swtch)) {
+			const auto& domains = utils::split(vm[swtch].as<std::string>());
+			for(const auto& d : domains) {
+				log_domain_levels[d] = severity;
+			}
+		}
+	}
+	if(vm.count("log-precise")) {
+		log_precise_timestamps = true;
+	}
+}
+
+} // end namespace campaignd

--- a/src/server/campaignd/options.cpp
+++ b/src/server/campaignd/options.cpp
@@ -35,11 +35,9 @@ command_line::command_line(int argc, char** argv)
 command_line::command_line(const std::vector<std::string>& args)
 	: help(false)
 	, version(false)
-#if 0
 	, config_file()
 	, server_dir()
-	, port(0)
-#endif
+	, port()
 	, show_log_domains(false)
 	, log_domain_levels()
 	, log_precise_timestamps(false)
@@ -53,14 +51,12 @@ command_line::command_line(const std::vector<std::string>& args)
 		("version,v", "displays the server version and exits.")
 		;
 
-#if 0
 	po::options_description opts_server{"Server configuration"};
 	opts_server.add_options()
-		("config,c", po::value<std::string>(), "specifies the path to the server configuration file.")
-		("server-dir,s",  po::value<std::string>(), "specifies the path to the server storage dir.")
+		("config,c", po::value<std::string>(), "specifies the path to the server configuration file. By default this is server.cfg in the server directory.")
+		("server-dir,s",  po::value<std::string>(), "specifies the path to the server directory. By default this is the process working directory.")
 		("port,p", po::value<unsigned short>(), "specifies the port number on which the server will listen for client connections.")
 		;
-#endif
 
 	po::options_description opts_log{"Logging options"};
 	opts_log.add_options()
@@ -74,7 +70,7 @@ command_line::command_line(const std::vector<std::string>& args)
 		;
 
 	po::options_description opts;
-	opts.add(opts_general).add(opts_log);
+	opts.add(opts_general).add(opts_server).add(opts_log);
 
 	static const int style = po::command_line_style::default_style ^ po::command_line_style::allow_guessing;
 
@@ -100,7 +96,6 @@ command_line::command_line(const std::vector<std::string>& args)
 		version = true;
 	}
 
-#if 0
 	if(vm.count("config")) {
 		config_file = vm["config"].as<std::string>();
 	}
@@ -110,7 +105,6 @@ command_line::command_line(const std::vector<std::string>& args)
 	if(vm.count("port")) {
 		port = vm["port"].as<unsigned short>();
 	}
-#endif
 
 	if(vm.count("logdomains")) {
 		show_log_domains = true;

--- a/src/server/campaignd/options.hpp
+++ b/src/server/campaignd/options.hpp
@@ -49,14 +49,12 @@ public:
 	/** True if --version was passed. */
 	bool version;
 
-#if 0
 	/** Path to the add-ons server configuration file. */
 	boost::optional<std::string> config_file;
 	/** Path to the add-ons server storage dir. */
 	boost::optional<std::string> server_dir;
 	/** Port number on which the server will listen for incoming connections. */
 	boost::optional<unsigned short> port;
-#endif
 
 	/** True if --logdomains was passed. */
 	bool show_log_domains;

--- a/src/server/campaignd/options.hpp
+++ b/src/server/campaignd/options.hpp
@@ -1,0 +1,78 @@
+/*
+   Copyright (C) 2020 by Iris Morelle <shadowm@wesnoth.org>
+   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+/**
+ * @file
+ * campaignd command line options parsing.
+ */
+
+#pragma once
+
+#include <boost/optional.hpp>
+#include <boost/program_options/options_description.hpp>
+#include <map>
+
+namespace campaignd {
+
+class command_line
+{
+public:
+	/**
+	 * Reads the command line.
+	 */
+	command_line(int argc, char** argv);
+
+	/**
+	 * Retrieves the --help text.
+	 *
+	 * @note This text is only available when --help is used. Otherwise,
+	 *       an empty string is returned instead.
+	 */
+	const std::string& help_text() const
+	{
+		return help_text_;
+	}
+
+	/** True if --help was passed. */
+	bool help;
+	/** True if --version was passed. */
+	bool version;
+
+#if 0
+	/** Path to the add-ons server configuration file. */
+	boost::optional<std::string> config_file;
+	/** Path to the add-ons server storage dir. */
+	boost::optional<std::string> server_dir;
+	/** Port number on which the server will listen for incoming connections. */
+	boost::optional<unsigned short> port;
+#endif
+
+	/** True if --logdomains was passed. */
+	bool show_log_domains;
+	/** Log domain/severity configuration. */
+	std::map<std::string, int> log_domain_levels;
+	/** Whether to use higher precision for log timestamps. */
+	bool log_precise_timestamps;
+
+private:
+	std::string argv0_;
+	std::vector<std::string> args_;
+	std::string help_text_;
+
+	command_line(const std::vector<std::string>& args);
+
+	void parse_log_domains(const std::string& domains_string, int severity);
+};
+
+} // end namespace campaignd

--- a/src/server/campaignd/server.hpp
+++ b/src/server/campaignd/server.hpp
@@ -33,7 +33,8 @@ namespace campaignd {
 class server : public server_base
 {
 public:
-	explicit server(const std::string& cfg_file);
+	explicit server(const std::string& cfg_file,
+					unsigned short port = 0);
 	server(const config& server) = delete;
 	~server();
 


### PR DESCRIPTION
Adds a basic command line interface to campaignd implementing options to change logging configuration and set the server dir and config file path. This uses Boost.program_options, so some changes to the SCons build recipe were required (CMake links wesnothd and campaignd against Boost.program_options regardless already).

This changes campaignd's startup behaviour slightly so that campaignd ensures that the directory containing the config file exists before doing anything else. Normally this wouldn't be noticeable since the default behaviour continues to be to use `./server.cfg` (pwd should exist, right?), but it's important in the event that the user passes `-c` with a nonexistent path.

Additionally, it moves the argv repackaging logic out of wesnoth.cpp, in particular all the Windows-specific code. I would like to make wesnothd use it as well later since it presumably also incorrectly assumes `argv` contains UTF-8 data on Windows like the game proper used to do.