### PR TITLE
Fix load game search filter for long filenames (fixes #5156)

### DIFF
--- a/src/gui/dialogs/game_load.cpp
+++ b/src/gui/dialogs/game_load.cpp
@@ -346,21 +346,18 @@ void game_load::filter_text_changed(text_box_base* textbox, const std::string& t
 	show_items.resize(list.get_item_count(), true);
 
 	if(!text.empty()) {
-		for(unsigned int i = 0; i < list.get_item_count(); i++) {
+		for(unsigned int i = 0; i < list.get_item_count() && i < games_.size(); i++) {
 			grid* row = list.get_row_grid(i);
-
-			grid::iterator it = row->begin();
-			label& filename_label = find_widget<label>(*it, "filename", false);
 
 			bool found = false;
 			for(const auto & word : words)
 			{
-				found = std::search(filename_label.get_label().str().begin(),
-									filename_label.get_label().str().end(),
+				found = std::search(games_[i].name().begin(),
+									games_[i].name().end(),
 									word.begin(),
 									word.end(),
 									chars_equal_insensitive)
-						!= filename_label.get_label().str().end();
+						!= games_[i].name().end();
 
 				if(!found) {
 					// one word doesn't match, we don't reach words.end()


### PR DESCRIPTION
I recently came across https://github.com/wesnoth/wesnoth/issues/5156 and decided to look into it.

Instead of comparing to the filename from the label widget, I've changed it to compare to the `games_` save_info list, which seems to have the full filenames (the `delete_button_callback` method in this file already uses `games_` to get the exact filename to delete, so this seems like a similar use case). I've tested my changes locally and searching for words in long filenames work now.

Let me know if this is the right approach, thanks