### PR TITLE
Move the game content info (scenario/era/modifications) into their own table.

### DIFF
--- a/src/server/common/dbconn.cpp
+++ b/src/server/common/dbconn.cpp
@@ -30,7 +30,7 @@ dbconn::dbconn(const config& c)
 	, db_extra_table_(c["db_extra_table"].str())
 	, db_game_info_table_(c["db_game_info_table"].str())
 	, db_game_player_info_table_(c["db_game_player_info_table"].str())
-	, db_game_modification_info_table_(c["db_game_modification_info_table"].str())
+	, db_game_content_info_table_(c["db_game_content_info_table"].str())
 	, db_user_group_table_(c["db_user_group_table"].str())
 	, db_tournament_query_(c["db_tournament_query"].str())
 {
@@ -208,12 +208,12 @@ void dbconn::write_user_int(const std::string& column, const std::string& name, 
 	}
 }
 
-void dbconn::insert_game_info(const std::string& uuid, int game_id, const std::string& version, const std::string& name, const std::string& map_name, const std::string& era_name, int reload, int observers, int is_public, int has_password, const std::string& map_source, const std::string& map_version, const std::string& era_source, const std::string& era_version)
+void dbconn::insert_game_info(const std::string& uuid, int game_id, const std::string& version, const std::string& name, int reload, int observers, int is_public, int has_password)
 {
 	try
 	{
-		modify(connection_, "INSERT INTO `"+db_game_info_table_+"`(INSTANCE_UUID, GAME_ID, INSTANCE_VERSION, GAME_NAME, MAP_NAME, ERA_NAME, RELOAD, OBSERVERS, PUBLIC, PASSWORD, MAP_SOURCE_ADDON, MAP_VERSION, ERA_SOURCE_ADDON, ERA_VERSION) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-			uuid, game_id, version, name, map_name, era_name, reload, observers, is_public, has_password, map_source, map_version, era_source, era_version);
+		modify(connection_, "INSERT INTO `"+db_game_info_table_+"`(INSTANCE_UUID, GAME_ID, INSTANCE_VERSION, GAME_NAME, RELOAD, OBSERVERS, PUBLIC, PASSWORD) VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
+			uuid, game_id, version, name, reload, observers, is_public, has_password);
 	}
 	catch(const mariadb::exception::base& e)
 	{
@@ -244,16 +244,16 @@ void dbconn::insert_game_player_info(const std::string& uuid, int game_id, const
 		log_sql_exception("Failed to insert game player info row for UUID `"+uuid+"` and game ID `"+std::to_string(game_id)+"`", e);
 	}
 }
-void dbconn::insert_modification_info(const std::string& uuid, int game_id, const std::string& modification_name, const std::string& modification_source, const std::string& modification_version)
+void dbconn::db_insert_game_content_info(const std::string& uuid, int game_id, const std::string& type, const std::string& id, const std::string& source, const std::string& version)
 {
 	try
 	{
-		modify(connection_, "INSERT INTO `"+db_game_modification_info_table_+"`(INSTANCE_UUID, GAME_ID, MODIFICATION_NAME, SOURCE_ADDON, VERSION) VALUES(?, ?, ?, ?, ?)",
-			uuid, game_id, modification_name, modification_source, modification_version);
+		modify(connection_, "INSERT INTO `"+db_game_content_info_table_+"`(INSTANCE_UUID, GAME_ID, TYPE, ID, SOURCE, VERSION) VALUES(?, ?, ?, ?, ?, ?)",
+			uuid, game_id, type, id, source, version);
 	}
 	catch(const mariadb::exception::base& e)
 	{
-		log_sql_exception("Failed to insert game modification info row for UUID `"+uuid+"` and game ID `"+std::to_string(game_id)+"`", e);
+		log_sql_exception("Failed to insert game content info row for UUID `"+uuid+"` and game ID `"+std::to_string(game_id)+"`", e);
 	}
 }
 void dbconn::set_oos_flag(const std::string& uuid, int game_id)
@@ -261,7 +261,7 @@ void dbconn::set_oos_flag(const std::string& uuid, int game_id)
 	try
 	{
 		modify(connection_, "UPDATE `"+db_game_info_table_+"` SET OOS = 1 WHERE INSTANCE_UUID = ? AND GAME_ID = ?",
-		uuid, game_id);
+			uuid, game_id);
 	}
 	catch(const mariadb::exception::base& e)
 	{

--- a/src/server/common/dbconn.hpp
+++ b/src/server/common/dbconn.hpp
@@ -43,10 +43,10 @@ class dbconn
 		int get_user_int(const std::string& table, const std::string& column, const std::string& name);
 		void write_user_int(const std::string& column, const std::string& name, int value);
 		ban_check get_ban_info(const std::string& name, const std::string& ip);
-		void insert_game_info(const std::string& uuid, int game_id, const std::string& version, const std::string& name, const std::string& map_name, const std::string& era_name, int reload, int observers, int is_public, int has_password, const std::string& map_source, const std::string& map_version, const std::string& era_source, const std::string& era_version);
+		void insert_game_info(const std::string& uuid, int game_id, const std::string& version, const std::string& name, int reload, int observers, int is_public, int has_password);
 		void update_game_end(const std::string& uuid, int game_id, const std::string& replay_location);
 		void insert_game_player_info(const std::string& uuid, int game_id, const std::string& username, int side_number, int is_host, const std::string& faction, const std::string& version, const std::string& source, const std::string& current_user);
-		void insert_modification_info(const std::string& uuid, int game_id, const std::string& modification_name, const std::string& modification_source, const std::string& modification_version);
+		void db_insert_game_content_info(const std::string& uuid, int game_id, const std::string& type, const std::string& id, const std::string& source, const std::string& version);
 		void set_oos_flag(const std::string& uuid, int game_id);
 
 	private:
@@ -58,7 +58,7 @@ class dbconn
 		std::string db_extra_table_;
 		std::string db_game_info_table_;
 		std::string db_game_player_info_table_;
-		std::string db_game_modification_info_table_;
+		std::string db_game_content_info_table_;
 		std::string db_user_group_table_;
 		std::string db_tournament_query_;
 

--- a/src/server/common/forum_user_handler.cpp
+++ b/src/server/common/forum_user_handler.cpp
@@ -211,8 +211,8 @@ std::string fuh::get_tournaments(){
 	return conn_.get_tournaments();
 }
 
-void fuh::db_insert_game_info(const std::string& uuid, int game_id, const std::string& version, const std::string& name, const std::string& map_name, const std::string& era_name, int reload, int observers, int is_public, int has_password, const std::string& map_source, const std::string& map_version, const std::string& era_source, const std::string& era_version){
-	conn_.insert_game_info(uuid, game_id, version, name, map_name, era_name, reload, observers, is_public, has_password, map_source, map_version, era_source, era_version);
+void fuh::db_insert_game_info(const std::string& uuid, int game_id, const std::string& version, const std::string& name, int reload, int observers, int is_public, int has_password){
+	conn_.insert_game_info(uuid, game_id, version, name, reload, observers, is_public, has_password);
 }
 
 void fuh::db_update_game_end(const std::string& uuid, int game_id, const std::string& replay_location){
@@ -223,8 +223,8 @@ void fuh::db_insert_game_player_info(const std::string& uuid, int game_id, const
 	conn_.insert_game_player_info(uuid, game_id, username, side_number, is_host, faction, version, source, current_user);
 }
 
-void fuh::db_insert_modification_info(const std::string& uuid, int game_id, const std::string& modification_name, const std::string& modification_source, const std::string& modification_version){
-	conn_.insert_modification_info(uuid, game_id, modification_name, modification_source, modification_version);
+void fuh::db_insert_game_content_info(const std::string& uuid, int game_id, const std::string& type, const std::string& id, const std::string& source, const std::string& version){
+	conn_.db_insert_game_content_info(uuid, game_id, type, id, source, version);
 }
 
 void fuh::db_set_oos_flag(const std::string& uuid, int game_id){

--- a/src/server/common/forum_user_handler.hpp
+++ b/src/server/common/forum_user_handler.hpp
@@ -68,10 +68,10 @@ class fuh : public user_handler {
 
 		std::string get_uuid();
 		std::string get_tournaments();
-		void db_insert_game_info(const std::string& uuid, int game_id, const std::string& version, const std::string& name, const std::string& map_name, const std::string& era_name, int reload, int observers, int is_public, int has_password, const std::string& map_source, const std::string& map_version, const std::string& era_source, const std::string& era_version);
+		void db_insert_game_info(const std::string& uuid, int game_id, const std::string& version, const std::string& name, int reload, int observers, int is_public, int has_password);
 		void db_update_game_end(const std::string& uuid, int game_id, const std::string& replay_location);
 		void db_insert_game_player_info(const std::string& uuid, int game_id, const std::string& username, int side_number, int is_host, const std::string& faction, const std::string& version, const std::string& source, const std::string& current_user);
-		void db_insert_modification_info(const std::string& uuid, int game_id, const std::string& modification_name, const std::string& modification_source, const std::string& modification_version);
+		void db_insert_game_content_info(const std::string& uuid, int game_id, const std::string& type, const std::string& id, const std::string& source, const std::string& version);
 		void db_set_oos_flag(const std::string& uuid, int game_id);
 
 		void async_test_query(boost::asio::io_service& io_service, int limit);

--- a/src/server/common/user_handler.hpp
+++ b/src/server/common/user_handler.hpp
@@ -138,10 +138,10 @@ class user_handler {
 
 		virtual std::string get_uuid() =0;
 		virtual std::string get_tournaments() =0;
-		virtual void db_insert_game_info(const std::string& uuid, int game_id, const std::string& version, const std::string& name, const std::string& map_name, const std::string& era_name, int reload, int observers, int is_public, int has_password, const std::string& map_source, const std::string& map_version, const std::string& era_source, const std::string& era_version) =0;
+		virtual void db_insert_game_info(const std::string& uuid, int game_id, const std::string& version, const std::string& name, int reload, int observers, int is_public, int has_password) =0;
 		virtual void db_update_game_end(const std::string& uuid, int game_id, const std::string& replay_location) =0;
 		virtual void db_insert_game_player_info(const std::string& uuid, int game_id, const std::string& username, int side_number, int is_host, const std::string& faction, const std::string& version, const std::string& source, const std::string& current_user) =0;
-		virtual void db_insert_modification_info(const std::string& uuid, int game_id, const std::string& modification_name, const std::string& modification_source, const std::string& modification_version) =0;
+		virtual void db_insert_game_content_info(const std::string& uuid, int game_id, const std::string& type, const std::string& id, const std::string& source, const std::string& version) =0;
 		virtual void db_set_oos_flag(const std::string& uuid, int game_id) =0;
 		virtual void async_test_query(boost::asio::io_service& io_service, int limit) =0;
 };

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -1649,32 +1649,13 @@ void server::handle_player_in_game(socket_ptr socket, std::shared_ptr<simple_wml
 			const simple_wml::node& m = *g.level().root().child("multiplayer");
 			DBG_SERVER << simple_wml::node_to_string(m) << '\n';
 			// [addon] info handling
-			std::string scenario_addon_id = "";
-			std::string scenario_addon_version = "";
-			std::string scenario_id = "";
-			std::string era_addon_id = "";
-			std::string era_addon_version = "";
-			std::string era_id = "";
 			for(const auto& addon : m.children("addon")) {
 				for(const auto& content : addon->children("content")) {
-					const simple_wml::string_span& type = content->attr("type");
-					if(type == "scenario") {
-						scenario_addon_id = addon->attr("id").to_string();
-						scenario_addon_version = addon->attr("version").to_string();
-						scenario_id = content->attr("id").to_string();
-					} else if(type == "era") {
-						era_addon_id = addon->attr("id").to_string();
-						era_addon_version = addon->attr("version").to_string();
-						era_id = content->attr("id").to_string();
-					} else if(type == "modification") {
-						user_handler_->db_insert_modification_info(uuid_, g.db_id(), content->attr("id").to_string(), addon->attr("id").to_string(), addon->attr("version").to_string());
-					} else {
-						WRN_SERVER << "[multiplayer][addon][content] sent with unknown type.\n" << simple_wml::node_to_string(*addon) << '\n';
-					}
+					user_handler_->db_insert_game_content_info(uuid_, g.db_id(), content->attr("type").to_string(), content->attr("id").to_string(), addon->attr("id").to_string(), addon->attr("version").to_string());
 				}
 			}
 
-			user_handler_->db_insert_game_info(uuid_, g.db_id(), game_config::wesnoth_version.str(), g.name(), scenario_id, era_id, g.is_reload(), m["observer"].to_bool(), !m["private_replay"].to_bool(), g.has_password(), scenario_addon_id, scenario_addon_version, era_addon_id, era_addon_version);
+			user_handler_->db_insert_game_info(uuid_, g.db_id(), game_config::wesnoth_version.str(), g.name(), g.is_reload(), m["observer"].to_bool(), !m["private_replay"].to_bool(), g.has_password());
 
 			const simple_wml::node::child_list& sides = g.get_sides_list();
 			for(unsigned side_index = 0; side_index < sides.size(); ++side_index) {

--- a/utils/mp-server/table_definitions.sql
+++ b/utils/mp-server/table_definitions.sql
@@ -66,12 +66,6 @@ create table game_info
     GAME_NAME        VARCHAR(255) NOT NULL,
     START_TIME       TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     END_TIME         TIMESTAMP NULL DEFAULT NULL,
-    MAP_NAME         VARCHAR(255) NOT NULL,
-    MAP_SOURCE_ADDON VARCHAR(255) NOT NULL DEFAULT '',
-    MAP_VERSION      VARCHAR(255) NOT NULL DEFAULT '',
-    ERA_NAME         VARCHAR(255) NOT NULL,
-    ERA_SOURCE_ADDON VARCHAR(255) NOT NULL DEFAULT '',
-    ERA_VERSION      VARCHAR(255) NOT NULL DEFAULT '',
     REPLAY_NAME      VARCHAR(255),
     OOS              BIT(1) NOT NULL DEFAULT 0,
     RELOAD           BIT(1) NOT NULL,
@@ -104,13 +98,18 @@ create table game_player_info
     PRIMARY KEY (INSTANCE_UUID, GAME_ID, SIDE_NUMBER)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- information about any modifications that the game present in game_info has enabled
-create table game_modification_info
+-- information about the scenario/era/modifications for the game
+-- TYPE: one of era/scenario/modification
+-- ID: the id of the content
+-- SOURCE: the id of the add-on that the particular content came from
+-- VERSION: the version of the source add-on
+create table game_content_info
 (
     INSTANCE_UUID     CHAR(36) NOT NULL,
     GAME_ID           INT UNSIGNED NOT NULL,
-    MODIFICATION_NAME VARCHAR(255) NOT NULL,
-    SOURCE_ADDON      VARCHAR(255) NOT NULL DEFAULT '',
-    VERSION           VARCHAR(255) NOT NULL DEFAULT '',
-    PRIMARY KEY (INSTANCE_UUID, GAME_ID, MODIFICATION_NAME)
+    TYPE              VARCHAR(255) NOT NULL,
+    ID                VARCHAR(255) NOT NULL,
+    SOURCE            VARCHAR(255) NOT NULL,
+    VERSION           VARCHAR(255) NOT NULL,
+    PRIMARY KEY (INSTANCE_UUID, GAME_ID, TYPE, ID)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
Fixes #5066

---

As a reminder to myself as well, the existing MAP_NAME and ERA_NAME columns will need to be given defaults prior to the updated wesnothd being rebuilt.  Then once the existing data is migrated to the new table, I intend to drop the era/map columns on GAME_INFO as well as the modification-specific table.