### PR TITLE
Typo fix in shortcut of polish version.

### DIFF
--- a/packaging/windows/translations.nsh
+++ b/packaging/windows/translations.nsh
@@ -121,7 +121,7 @@
   LangString		LCode			${LANG_POLISH}			"pl"
   LangString		LEditor			${LANG_POLISH}			"Edytor map"
   LangString		LManual			${LANG_POLISH}			"Podręcznik użytkownika"
-  LangString		LWesnoth		${LANG_POLISH}			"Bitwy o Wesnoth"
+  LangString		LWesnoth		${LANG_POLISH}			"Bitwa o Wesnoth"
   LangString		LUserdata		${LANG_POLISH}			"Dane użytkownika"
 
   !insertmacro		MUI_LANGUAGE	"Portuguese"


### PR DESCRIPTION
"Bitwy" means "Battles", in name there is clearly only single "Battle" thus it shouldn't be "Bitwy" but "Bitwa".