### PR TITLE
SotA S04: Remove some [image]scale=no attributes

### DIFF
--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg
@@ -85,12 +85,10 @@ The bandit howled, thrashed, tore at his clothes and bindings, eventually diggin
             [image]
                 file=portraits/ardonna.png
                 x,y=64,0
-                scale=no
             [/image]
             [image]
                 file=portraits/undead/ghoul.png~FL()
                 x,y=320,0
-                scale=no
             [/image]
             story= _ "No doubt whatever was left of the mind inside gibbered at what it had become, but the bandit was now my puppet and I stitched the wounds as best I could.  In some ways, this experiment was a failure, but the creature it created would be useful..."
         [/part]


### PR DESCRIPTION
While [background_layer] has a scale attribute, [story][part][image] doesn't. A schema update for that will follow in PR #5242.