### PR TITLE
DM and LoW: Remove '[story][part]delay=' attributes

### DIFF
--- a/data/campaigns/Delfadors_Memoirs/scenarios/14_Shadows.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/14_Shadows.cfg
@@ -15,7 +15,6 @@
     [story]
         [part]
             story= _ "Kalenz and his troops fared swiftly south and then westward along the north bank of the Great River. They successfully evaded the orcs, but would soon find there were grimmer foes awaiting them."
-            delay=4000
         [/part]
     [/story]
     {DM_TRACK {KALENZ_STAGE2}}

--- a/data/campaigns/Delfadors_Memoirs/scenarios/15_Save_the_King.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/15_Save_the_King.cfg
@@ -16,13 +16,11 @@
         [part]
             show_title=yes
             story= _ "Following Delfador, the elves moved to unite with the Wesnothian forces and meet Zorlan head-on..."
-            delay=4000
             {DM_BIGMAP}
             {KALENZ_STAGE3}
         [/part]
         [part]
             story= _ "but the King was in an unenviable position..."
-            delay=4000
         [/part]
     [/story]
 

--- a/data/campaigns/Delfadors_Memoirs/scenarios/16_Dark_Sky_Over_Weldyn.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/16_Dark_Sky_Over_Weldyn.cfg
@@ -16,7 +16,6 @@
         [part]
             music=loyalists.ogg
             story=_"Kalenz and Chantal and their troops departed to ride against the remnants of the orcish Great Horde. Delfador returned to Weldyn with the King and his gift from the elves, the Book of Crelanu. However, despite the victory, Delfador was deeply worried by the undead menace. On the way back they met with Lionel who was arriving with reinforcements, and were deeply saddened to learn that Leollyn had died under very suspicious circumstances."
-            delay=8000
         [/part]
         [part]
             background=story/portraits/garard-large.png

--- a/data/campaigns/Delfadors_Memoirs/scenarios/18_The_Portal_of_Doom.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/18_The_Portal_of_Doom.cfg
@@ -24,7 +24,6 @@
     [story]
         [part]
             story= _ "The dwarves led Delfador through a veritable maze of tunnels. Delfador was amazed at the speed with which the dwarves could move through their tunnels. Far sooner than he would have believed possible they reached their destination, undetected by Iliah-Malal."
-            delay=4000
             show_title=yes
         [/part]
     [/story]

--- a/data/campaigns/Delfadors_Memoirs/scenarios/19_Showdown_in_the_Northern_Swamp.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/19_Showdown_in_the_Northern_Swamp.cfg
@@ -16,11 +16,9 @@
     [story]
         [part]
             story= _ "With the portal closed, Iliah-Malal was weakened. He retreated into the Swamp of Dread to recover his strength and attempt another conjuration. Delfador’s troop, hurrying west by secret Dwarvish ways and stealthily crossing the Listra by night, found the necromancer there, on the brink of raising another army amidst the fetid reek."
-            delay=4000
         [/part]
         [part]
             story= _ "Using dwarvish and elvish messengers, Delfador was able to communicate the news to the King and ask for help. Mustering all the troops he could find, Lionel marched north to join Delfador for the battle that would decide the fate of Wesnoth."
-            delay=4000
         [/part]
     [/story]
     {DM_TRACK {TRIUMPH_STAGE3}}

--- a/data/campaigns/Delfadors_Memoirs/scenarios/20_Prince_of_Wesnoth.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/20_Prince_of_Wesnoth.cfg
@@ -20,16 +20,13 @@
             # The "generation" is the 26 years between 470YW and 496YW.
             # Delfador is 54 at this time.
             story= _ "Following the alliance’s victory and the peace treaty came a period of calm that lasted a generation. The new King had learned to trust Delfador at the battle of Abez Ford, and it was no surprise that Delfador became Garard II’s most valued advisor."
-            delay=4000
         [/part]
         [part]
             story= _ "The elves knew that with Delfador close to the King, Wesnoth would be a reliable ally. And it was for a while."
-            delay=4000
         [/part]
         [part]
             # Asheviere marries Garard II in 478.
             story= _ "But Delfador was not alone in having the King’s ear; there was one yet closer to him. The Queen’s power was rising..."
-            delay=8000
             background="story/httt_story3.jpg"
         [/part]
         [part]

--- a/data/campaigns/Delfadors_Memoirs/scenarios/21_Clash_at_the_Manor.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/21_Clash_at_the_Manor.cfg
@@ -30,15 +30,12 @@
         [/part]
         [part]
             story= _ "Although the King did reprimand Eldred for his actions, Delfador could sense that the military commanders were solidly behind Eldred and his mother. Asheviere had flattered them and beguiled them with promises of glory and plunder in a coming war."
-            delay=4000
         [/part]
         [part]
             story= _ "Delfador was granted an audience with the King and expressed his concerns about the Book, but the King put off a decision until Asheviere returned to Weldyn, and ordered Delfador to take no further action. And for once, Delfador knew he could not obey the King’s order."
-            delay=4000
         [/part]
         [part]
             story= _ "Since he could not ask even his personal guard to go against the King’s wishes, he turned to Kalenz and the elves. Traveling by night to remain unseen they reached Asheviere’s family demesne."
-            delay=4000
         [/part]
     [/story]
     {DM_TRACK {BOOK_STAGE3}}

--- a/data/campaigns/Delfadors_Memoirs/scenarios/22_Face_of_the_Enemy.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/22_Face_of_the_Enemy.cfg
@@ -22,7 +22,6 @@
         [/part]
         [part]
             story= _ "Delfador and the elves went through the secret door and ended in the dungeon, a veritable maze of narrow corridors."
-            delay=4000
         [/part]
     [/story]
 

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg
@@ -26,7 +26,6 @@
 
     [story]
         [part]
-            delay=4000
             title= _ "<i>The Legend of Wesmere</i>
 Chapter One"
         [/part]
@@ -41,29 +40,24 @@ Chapter One"
         [/part]
         [part]
             story=_ "Though not of noble birth, Kalenz showed early promise in the arts of his people. His quick intelligence gained him more than usual respect among elders normally inclined to pay little heed to anyone younger than a century old."
-            delay=4000
             background="story/characters/kalenz.png"
             scale_background=no
         [/part]
         [part]
             story=_ "Landar and Kalenz were friends from childhood. He too attracted the attention of elders, at first because of a knack for mischief and pranks. But there was no real harm in the boy, and his jokes made him popular among the younger elves."
-            delay=4000
             background="story/characters/landar.png"
             scale_background=no
         [/part]
         [part]
             story=_ "Perhaps the elders sensed that changing times would require more flexible minds; these were the years when humans from the Green Isle were establishing themselves south of the Great River, and the known world was changing more rapidly than it had for a thousand years before."
-            delay=4000
         [/part]
         [part]
             story=_ "Some changes were good. The Elves, awakened as from a long dream, began to increase in population. But some were very bad, and the worst of those was the coming of the orcs, the wreckers, the tree-killers. The years of their long childhoods were a golden age, and the last time of untroubled peace."
-            delay=4000
         [/part]
         [part]
             story=_ "The elves had never been a martial people, and they were not prepared for the inevitable war with the orcs. The friends came of age in the very year that Erlornas of Wesmere fought the first orcish raiders. Within the next decade orcish raids greatly increased, and their shadow loomed ever greater over the elves.
 
 This is the story of Kalenz, Landar, and of the Elves in the first days of the humans in Wesnoth."
-            delay=8000
             background="story/landscape-battlefield.jpg"
         [/part]
     [/story]

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg
@@ -26,7 +26,6 @@
     [story]
         [part]
             story= _ "Kalenz and his band broke out of the orcish encirclement, only to discover that the country on the direct route to the Ka’lian was already swarming with orcs. The raid on Kalenz’s home, it seemed, had been but one small part of a great migration south. There was no choice but to make a detour through territory the elves would rather have avoided..."
-            delay=8000
         [/part]
     [/story]
     {LOW_TRACK {FLIGHT_STAGE2} }

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg
@@ -55,7 +55,6 @@
     [story]
         [part]
             story= _ "Events at the Ka’lian took an ominous turn before Kalenz and his band could arrive there..."
-            delay=4000
         [/part]
     [/story]
     {LOW_TRACK {FLIGHT_STAGE3} }

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg
@@ -38,7 +38,6 @@
     [story]
 #ifdef MULTIPLAYER
         [part]
-            delay=4000
             title= _ "<i>The Legend of Wesmere</i>
 Chapter Two"
         [/part]
@@ -50,7 +49,6 @@ Chapter Two"
         [/part]
         [part]
             story= _ "Kalenz and his forces raced to relieve the siege of the Elvish Treasury..."
-            delay=4000
             {LOW_BIGMAP}
             {FLIGHT_COMPLETE}
             {TREASURY_STAGE1}

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter2/05_The_Saurian_Treasury.cfg
@@ -39,7 +39,6 @@
     [story]
         [part]
             story= _ "Elvish scouts found the trail of the Saurian war party without difficulty. The way back to the saurians’ treasury was clear..."
-            delay=4000
             {LOW_BIGMAP}
             {FLIGHT_COMPLETE}
             {TREASURY_STAGE2}

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter2/06_Acquaintance_in_Need.cfg
@@ -22,7 +22,6 @@
     [story]
         [part]
             story= _ "To evade the saurians blocking the eastern approaches to Wesmere, Kalenz and his war-band moved to enter Wesmere Forest from a different direction..."
-            delay=4000
             {LOW_BIGMAP}
             {FLIGHT_COMPLETE}
             {TREASURY_STAGE3}

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg
@@ -20,7 +20,6 @@
     [story]
         [part]
             story= _ "The journey back to Wesmere was surprisingly uneventful, the orcs having apparently withdrawn to regroup after their defeats. Kalenz and his band returned just in time..."
-            delay=4000
         [/part]
     [/story]
     {LOW_TRACK ( {FLIGHT_COMPLETE} {TREASURY_STAGE4} ) }

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg
@@ -24,20 +24,17 @@
     [story]
 #ifdef MULTIPLAYER
         [part]
-            delay=4000
             title= _ "<i>The Legend of Wesmere</i>
 Chapter Three"
             #  show_title=yes
         [/part]
 #endif
         [part]
-            delay=4000
             title= _ "Chapter Three
 <i>The Book of Crelanu</i>"
             show_title=yes
         [/part]
         [part]
-            delay=4000
             story= _ "Believing that Wesmere’s seeming safety might prove a costly illusion, Kalenz, Landar and Olurf left enough troops and resources to guard it strongly before starting off on the long and dangerous trip to the great mage of Thoria. They would soon find that peril was closer than they had reckoned."
         [/part]
     [/story]

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/10_Cliffs_of_Thoria.cfg
@@ -25,7 +25,6 @@
     [story]
         [part]
             story= _ "Leaving Arkan-Thoria behind, Kalenz and his band ventured into the dangerous mountains of Thoria..."
-            delay=4000
         [/part]
     [/story]
     {LOW_TRACK ( {FLIGHT_COMPLETE} {TREASURY_COMPLETE} {BOOK_STAGE3} ) }

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg
@@ -22,7 +22,6 @@
     [story]
         [part]
             story= _ "Quickening their pace, the elves and dwarves raced towards the smoke..."
-            delay=4000
             {LOW_BIGMAP}
             {FLIGHT_COMPLETE}
             {TREASURY_COMPLETE}

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg
@@ -38,7 +38,6 @@
     [story]
 #ifdef MULTIPLAYER
         [part]
-            delay=4000
             title= _ "<i>The Legend of Wesmere</i>
 Chapter Four"
         [/part]
@@ -46,12 +45,9 @@ Chapter Four"
         [part]
             title= _ "Chapter Four
 <i>The Alliance</i>"
-            #delay=4000
-            #show_title=yes
         [/part]
         [part]
             story= _ "With the human-elf alliance revived, our heroes hurried to the battlefield..."
-            delay=4000
             {LOW_BIGMAP}
             {TREASURY_COMPLETE}
             {BOOK_COMPLETE}

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg
@@ -31,7 +31,6 @@
     [story]
         [part]
             story= _ "With the orcs embroiled in a civil war, Kalenz seized the chance to take back his beloved home. Reports had been arriving of an enclave of Northern Elves yet holding out against the orcish invaders. It was quickly decided to send a force to their aid. But harsh winter weather descended while it was en route..."
-            delay=4000
         [/part]
     [/story]
     {LOW_TRACK ( {TREASURY_COMPLETE} {BOOK_COMPLETE} {ALLIANCE_STAGE4} ) }

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter5/19_Costly_Revenge.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter5/19_Costly_Revenge.cfg
@@ -31,7 +31,6 @@
     [story]
 #ifdef MULTIPLAYER
         [part]
-            delay=4000
             title= _ "<i>The Legend of Wesmere</i>
 Chapter Five"
         [/part]
@@ -43,7 +42,6 @@ Chapter Five"
         [part]
             show_title=yes
             story= _ "But Kalenz failed to persuade the dwarves. The dwarves left, and Landar insisted the elves must march on the empire of the Saurians..."
-            delay=4000
             {LOW_BIGMAP}
             {SAURIANS_STAGE1}
         [/part]

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter5/20_Council_Ruling.cfg
@@ -14,7 +14,6 @@
     [story]
         [part]
             story= _ "With the once mighty Saurian empire destroyed, saurians had been reduced to scattered bands lurking in waste places. But the Elves still had problems of their own..."
-            delay=4000
             {LOW_BIGMAP}
             {SAURIANS_STAGE2}
         [/part]

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg
@@ -35,17 +35,14 @@
     [story]
         [part]
             story= _ "After the council’s decision, Kalenz and Cleodil retired in the North."
-            delay=4000
             {LOW_BIGMAP}
             {CIVILWAR_STAGE1}
         [/part]
         [part]
             story= _ "Free of the pressure of war, they took delight in each other. The heart-bond they had formed amidst peril and death grew closer, and all but vanquished the remnant evil Crelanu’s philter had left in Kalenz. The two began to think of having children."
-            delay=8000
         [/part]
         [part]
             story= _ "But their peace was not to last. In the outer world, the blood tides were rising. And in the heart of Landar, who had once been their friend, evil was not vanquished, but festered and grew..."
-            delay=8000
         [/part]
     [/story]
 

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg
@@ -31,7 +31,6 @@
         [/part]
         [part]
             story= _ "Kalenz’s veterans joined the host of the Northern Elves under Uradredia. Very soon, Landar’s army appeared..."
-            delay=4000
             {LOW_BIGMAP}
             {CIVILWAR_STAGE2}
         [/part]

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg
@@ -31,7 +31,6 @@
         [part]
             # wmllint: local spelling Gitamoth
             story= _ "It is said that the battle with the North Elves was the beginning of the end for Landar’s revolt. But civil war smoldered on for many more years, neither side mustering enough strength to achieve a decisive victory. Until, eventually, Landar’s increasingly harsh and arrogant ways drove away many of his followers. After assembling all the troops he could, Kalenz marched against his old friend and now mortal enemy, Landar, in the forest of Gitamoth..."
-            delay=4000
             {LOW_BIGMAP}
             {CIVILWAR_STAGE3}
         [/part]

--- a/data/campaigns/Legend_of_Wesmere/utils/bigmap.cfg
+++ b/data/campaigns/Legend_of_Wesmere/utils/bigmap.cfg
@@ -20,7 +20,6 @@
     [story]
         [part]
             show_title=yes
-            delay=4000
             {LOW_BIGMAP}
             {STAGE}
         [/part]


### PR DESCRIPTION
None of these had any effect, either on 1.15 or 1.14. I doubt that they ever
had an effect, because if these story screens had 4 second or even 8 second
delays then it would surely have been treated as a bug.

A schema update for this will follow in PR #5242.