### PR TITLE
Allow users to set chat lines to 0.

### DIFF
--- a/data/gui/window/preferences/05_multiplayer.cfg
+++ b/data/gui/window/preferences/05_multiplayer.cfg
@@ -30,7 +30,7 @@
 						[slider]
 							id = "chat_lines"
 							definition = "default"
-							minimum_value = 1
+							minimum_value = 0
 							maximum_value = 20
 							step_size = 1
 							tooltip = _ "Set the number of chat lines shown"


### PR DESCRIPTION
Allow users to set chat lines to 0. #1082 fix.

This is really simple fix making me wonder if its correct, I tested it and it seems to work as intended without any bugs. If this wasn't done because of some internal reason or good of players this can be closed.