### PR TITLE
Fix crash from side not being reset in editor (fixes #4789)

### DIFF
--- a/src/editor/map/context_manager.cpp
+++ b/src/editor/map/context_manager.cpp
@@ -102,6 +102,11 @@ void context_manager::refresh_on_context_change()
 	resources::tod_manager = get_map_context().get_time_manager();
 	resources::classification = &get_map_context().get_classification();
 
+	// Reset side when switching to an existing scenario
+	if (gui().get_teams().size() > 0) {
+		gui().set_team(0, true);
+		gui().set_playing_team(0);
+	}
 	gui().init_flags();
 
 	reload_map();
@@ -970,6 +975,8 @@ void context_manager::new_scenario(int width, int height, const t_translation::t
 
 	// Give the new scenario an initial side.
 	get_map_context().new_side();
+	gui().set_team(0, true);
+	gui().set_playing_team(0);
 	gui_.init_flags();
 }
 


### PR DESCRIPTION
I was investigating https://github.com/wesnoth/wesnoth/issues/4789 and I'm pretty sure that the crash has nothing to do with attempting to place a 2nd unit in the same spot as theorized, but rather that the team index (`currentTeam_`) is not reset when creating or switching to a different scenario. The crash occurs when the team index you're currently on doesn't exist in the scenario you're switching to.

There are 2 ways to reproduce:

**new scenario**
1. In the map editor, create a new scenario.
2. Add a 2nd side and switch to it
3. Create another new scenario

**switching scenarios**
1. In the map editor, create a new scenario
2. Create another new scenario
3. Add a 2nd side and switch to it
4. Switch to the first scenario

My current fix is in two places. The fix in `refresh_on_context_change` is for "switching scenarios", and the one in `new_scenario` takes care of the "new scenario" case.

I had difficulty covering both cases with a fix in just one place - I would have liked to cover both cases within https://github.com/wesnoth/wesnoth/blob/b8f03c40e6f25ad0fd2ae3c6c1d7360c76270ef0/src/editor/map/context_manager.cpp#L97 since this method is called for both new scenarios and switching scenarios. Unfortunately, when a new scenario is created, `teams` is still empty, so setting the team here would fail.

I'm still pretty unfamiliar with the codebase so would love input on if this is the right approach, thanks

edit: on a second thought, is this something we can add to `init_flags()` instead? I wasn't exactly sure what that method was used for