### PR TITLE
Fix hyperlink formatting in texts (fixes #4387, #2934)

### DIFF
--- a/src/font/text.cpp
+++ b/src/font/text.cpp
@@ -767,10 +767,8 @@ bool pango_text::set_markup(utils::string_view text, PangoLayout& layout) {
 
 	if(valid) {
 		if(link_aware_) {
-			std::vector<std::string> links = find_links(raw_text);
-			std::string final_text = text.to_string();
-			format_links(final_text, links);
-			pango_layout_set_markup(&layout, final_text.c_str(), final_text.size());
+			std::string formatted_text = format_links(text.to_string());
+			pango_layout_set_markup(&layout, formatted_text.c_str(), formatted_text.size());
 		} else {
 			pango_layout_set_markup(&layout, text.data(), text.size());
 		}
@@ -784,36 +782,42 @@ bool pango_text::set_markup(utils::string_view text, PangoLayout& layout) {
 	return valid;
 }
 
-std::vector<std::string> pango_text::find_links(utils::string_view text) const {
+/**
+ * Replaces all instances of URLs in a given string with formatted links
+ * and returns the result.
+ */
+std::string pango_text::format_links(const std::string& text) const
+{
 	const std::string delim = " \n\r\t";
-	std::vector<std::string> links;
+	std::string result = "";
 
 	int last_delim = -1;
 	for (std::size_t index = 0; index < text.size(); ++index) {
 		if (delim.find(text[index]) != std::string::npos) {
-			// want to include chars from range since last token, don't want to include any delimiters
-			utils::string_view token = text.substr(last_delim + 1, index - last_delim - 1);
-			if(looks_like_url(token)) {
-				links.push_back(token.to_string());
+			// Token starts from after the last delimiter up to (but not including) this delimiter
+			std::string token = text.substr(last_delim + 1, index - last_delim - 1);
+
+			if (looks_like_url(token)) {
+				result += format_as_link(token, link_color_) + text[index];
+			} else {
+				result += token + text[index];
 			}
+
 			last_delim = index;
 		}
 	}
+
 	if (last_delim < static_cast<int>(text.size()) - 1) {
-		utils::string_view token = text.substr(last_delim + 1, text.size() - last_delim - 1);
+		std::string token = text.substr(last_delim + 1, text.size() - last_delim - 1);
+
 		if(looks_like_url(token)) {
-			links.push_back(token.to_string());
+			result += format_as_link(token, link_color_);
+		} else {
+			result += token;
 		}
 	}
 
-	return links;
-}
-
-void pango_text::format_links(std::string& text, const std::vector<std::string>& links) const
-{
-	for(const std::string& link : links) {
-		boost::algorithm::replace_first(text, link, format_as_link(link, link_color_));
-	}
+	return result;
 }
 
 bool pango_text::validate_markup(utils::string_view text, char** raw_text, std::string& semi_escaped) const

--- a/src/font/text.hpp
+++ b/src/font/text.hpp
@@ -406,8 +406,7 @@ private:
 
 	static void copy_layout_properties(PangoLayout& src, PangoLayout& dst);
 
-	std::vector<std::string> find_links(utils::string_view text) const;
-	void format_links(std::string& text, const std::vector<std::string>& links) const;
+	std::string format_links(const std::string& text) const;
 };
 
 /**


### PR DESCRIPTION
https://github.com/wesnoth/wesnoth/issues/4387 and https://github.com/wesnoth/wesnoth/issues/2934 basically revolve around 2 problems:

**Problem 1: formatting links is done by a naive search and replace**
If there are duplicates of a url, only the first is highlighted, since we are using `replace_first`.
https://github.com/wesnoth/wesnoth/blob/b8f03c40e6f25ad0fd2ae3c6c1d7360c76270ef0/src/font/text.cpp#L812-L817
We can't just do a `replace_all` either, since this won't work correctly when one url is a substring of another url (`http://a.com` and `http://a.com/b`)

To reproduce:
1. Go to multiplayer chat and type `http://a.com` twice. Only the first is highlighted.

**Problem 2: escaping problems with &**
The problems occur when we send unescaped text to
https://github.com/wesnoth/wesnoth/blob/b8f03c40e6f25ad0fd2ae3c6c1d7360c76270ef0/src/font/text.cpp#L773

To reproduce:
1. Go to multiplayer chat and type `http://a.com?a=1&b=2`. You can also type `http://a.com&` to see the chat completely glitch out due to a pango error because it ends with a `&`

**Solution:**
The thing is, in `pango_text::set_markup`, we already receive escaped text that is validated. So we can just use this already escaped text, search for urls, and replace them with the formatted links.

I'm not much of a C++ person so please let me know if I'm doing something weird/unidiomatic, thanks