### PR TITLE
Don't lose text focus on mp player join (fixes #3715)

### DIFF
--- a/src/gui/dialogs/multiplayer/mp_join_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_join_game.cpp
@@ -345,8 +345,6 @@ void mp_join_game::generate_side_list(window& window)
 
 	tree_view& tree = find_widget<tree_view>(&window, "side_list", false);
 
-	window.keyboard_capture(&tree);
-
 	tree.clear();
 	team_tree_map_.clear();
 	const std::map<std::string, string_map> empty_map;


### PR DESCRIPTION
https://github.com/wesnoth/wesnoth/issues/3715

To reproduce:
1. Player 1 hosts a multiplayer game
2. Player 2 joins the game. Player 2 focuses the chat input
3. Player 3 joins the game. Player 2 is no longer focused on the chat input

Does anyone know why we set keyboard focus here?
https://github.com/wesnoth/wesnoth/blob/6aa6c010e77eeded27dccbb200af06214363937f/src/gui/dialogs/multiplayer/mp_join_game.cpp#L348
I've looked through the commit history and it was there since the original version of the file. This takes away focus from the chat input when a player joins, and doesn't look like it does anything useful. But I could be wrong - I'm pretty new to the codebase.

