### PR TITLE
AToTB S02: Rewrite the script with the elves thinking the baddies are grey mages

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 ## Version 1.15.6+dev
  ### Campaigns
+   * A Tale of Two Brothers:
+     * S02: Changed the antagonists' motive and dialogue to sound more believable
    * Secrets of the Ancients:
      * Revisions to Bone Captain
      * Scenario 2 uses new Iron Fence terrain, in preparation for potential map revisions.

--- a/data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg
@@ -317,6 +317,11 @@ Will he heed the call? I do not know if he has kept the amulet; we have not spok
             message= _ "That they should dare this! We will give chase at once."
         [/message]
 
+        [set_variable]
+            name=who_slew_mordak
+            value=$second_unit.id
+        [/set_variable]
+
         [endlevel]
             result=victory
             bonus=yes

--- a/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
@@ -34,7 +34,7 @@
             story=_ "16 V, 363 YW
 Excerpt from the journal of Arvith of Maghre
 
-We’ve been searching three days for Baran, and turned up nothing. My best hunch was to head north into the borderlands, where the necromancer’s minions could safely hide; everywhere else is more farmland. At first I thought the search might be useless, but late in the first day we found a set of tracks. Some of them had been made by skeletal feet.
+We’ve been searching three days for Baran, and turned up nothing. My best hunch was to head north into the borderlands, where the necromancer’s minions could safely hide; everywhere else is more farmland. At first I thought the search might be useless, but late in the first day we found a set of tracks. Some of them had been made by skeletal feet, although after their first campsite the tracks were merely those of men carrying heavy loads.
 
 We’re close enough to be certain now: those tracks are heading into the Grey Woods. No one from Maghre or any of the other villages has gone into that forest in living memory. Stories have been passed down for generations warning against it. Supposedly the place is haunted by lost souls who hunger for the living, and anyone who dies there is doomed to join them."
         [/part]
@@ -173,7 +173,7 @@ Besides... I want my brother back."
         id=Muff Toras
         name= _ "Muff Toras"
         unrenamable=yes
-        x,y=9,4
+        x,y=9,5
 
         [ai]
             passive_leader=yes
@@ -184,28 +184,6 @@ Besides... I want my brother back."
                 path=stage[main_loop].candidate_action[villages]
             [/modify_ai]
         [/ai]
-
-#ifdef EASY
-        [unit]
-            type=Skeleton
-            x,y=9,5
-        [/unit]
-
-        [unit]
-            type=Skeleton
-            x,y=9,3
-        [/unit]
-#else
-        [unit]
-            type=Revenant
-            x,y=9,5
-        [/unit]
-
-        [unit]
-            type=Revenant
-            x,y=9,3
-        [/unit]
-#endif
     [/side]
 
     [event]
@@ -387,12 +365,38 @@ Besides... I want my brother back."
 
         [message]
             speaker=Nil-Galion
-            message= _ "Those men told me their prisoner had attempted to murder their master, and warned that evil men would follow him. Advance no further, or you will die."
+            message= _ "Those men caught their prisoner practicing necromancy; for your sake, I hope he was not your brother. Assume that the man they caught was your brother’s murderer, and rest assured that the grey mages will release all of the souls that their prisoner’s evil magic has bound to this world."
+        [/message]
+
+        [if]
+            [variable]
+                name="who_slew_mordak"
+                equals=Arvith
+            [/variable]
+            [then]
+                [message]
+                    speaker=Arvith
+                    message= _ "We killed the necromancer on the battlefield! I struck the killing blow myself."
+                [/message]
+            [/then]
+            [else]
+                [message]
+                    speaker=Arvith
+                    message= _ "We killed the necromancer on the battlefield! I saw the killing blow with my own eyes."
+                [/message]
+            [/else]
+        [/if]
+
+        [message]
+            speaker=Nil-Galion
+            message= _ "We heard the sounds of battle three days ago, but the foul reek of death was unmistakable as the prisoner passed us; if your brother really is the prisoner then he is also a necromancer. Remember your brother as we all hope he was, and know that the prisoner’s fate will be revenge as dire as you could wish.
+
+Either way, nothing will be gained by your intrusion into our woods. Now advance no further, or you will die."
         [/message]
 
         [message]
             speaker=Arvith
-            message= _ "So much for those ghost stories. Mere elves will not stop me from freeing Baran!"
+            message= _ "So much for those ghost stories, but even ghosts might have been more observant than these elves. Still, they will not stop me from freeing Baran!"
         [/message]
 
         [message]
@@ -422,6 +426,7 @@ Besides... I want my brother back."
         [modify_side]
             side=3
             hidden=no
+            team_name=evil
         [/modify_side]
 
         {MODIFY_AI_ADD_CANDIDATE_ACTION 3 main_loop (
@@ -445,10 +450,86 @@ Besides... I want my brother back."
             message= _ "I see them! There they are!"
         [/message]
 
+        [move_unit]
+            id=Muff Toras
+            to_x,to_y=9,4
+            force_scroll=yes
+        [/move_unit]
+
         [message]
             speaker=Muff Toras
             message= _ "Curses! If they had been an hour slower, our master’s reinforcements would already be here to meet us."
         [/message]
+
+#ifdef EASY
+        [unit]
+            type=Skeleton
+            x,y=9,5
+            side=3
+            animate=yes
+        [/unit]
+
+        [unit]
+            type=Skeleton
+            x,y=9,3
+            side=3
+            animate=yes
+        [/unit]
+#else
+        [unit]
+            type=Revenant
+            x,y=9,5
+            side=3
+            animate=yes
+        [/unit]
+
+        [unit]
+            type=Revenant
+            x,y=9,3
+            side=3
+            animate=yes
+        [/unit]
+#endif
+
+        [message]
+            speaker=Arvith
+            # po: it's likely that all the elves are already dead, and Arvith is just shouting to the forest
+            message= _ "Well, elves? Now do you see who the necromancers are?"
+        [/message]
+
+        # It seems odd if there's no reply to that, but the elves are probably all already dead
+        [move_unit_fake]
+            type=Elvish Scout
+            side=2
+            x=19,16
+            y=4,5
+        [/move_unit_fake]
+        [unit]
+            id=messenger_elf
+            side=2
+            type=Elvish Scout
+            x,y=16,5
+        [/unit]
+        [message]
+            speaker=messenger_elf
+            # po: a elven scout rides in from off-map, takes their first look at the situation, and realises that they have no idea what's going on
+            message= _ "I heard sounds of battle, but did not expect to see this. I will inform the Council, they can work out who the necromancers are."
+            scroll=no
+        [/message]
+        [kill]
+            id=messenger_elf
+        [/kill]
+        [move_unit_fake]
+            type=Elvish Scout
+            side=2
+            x=16,19
+            y=5,4
+        [/move_unit_fake]
+
+        [modify_side]
+            side=2
+            team_name=elves,good
+        [/modify_side]
 
         {VARIABLE found_kidnappers yes}
         [show_objectives][/show_objectives]
@@ -637,7 +718,7 @@ Besides... I want my brother back."
 
         [message]
             speaker=Nil-Galion
-            message= _ "Foolish human, you have killed me but you will not catch the undead in time. I have fulfilled my contract, and will be reanimated soon to become a lord of their armies."
+            message= _ "Deluded fool, you are rescuing a necromancer. I can only hope that you are too late, and that our souls will rest in peace."
         [/message]
 
         [kill]


### PR DESCRIPTION
@Earth-Cake and @Konrad22 
This is about 10 lines of translatable text, not sure if it's okay to backport to 1.14.
The storyline itself is going to have large changes by 1.18 (maybe 1.16), so I'm not sure if
this will ever be in a stable release. But having had the idea, I thought I'd make a PR for it.

If a player loads a start-of-S02 save without the `who_slew_mordak variable` then it will still
work, showing the "I saw the killing blow with my own eyes" version.

Explanation for what's going on (put in the commit message because this bit is non-canon):

There are some "grey mages" in the Grey Woods, who appear in the Liberty
campaign. Most of the details of these were removed from 1.15, but in 1.14's
Liberty S06 they don't tolerate necromancers. SotA mentions an ancient elvish
civil war in these woods, with the ghosts still haunting the battlefield. I'm
assuming a general truce between elves and grey mages, on the understanding
that the grey mages are doing exorcisms of ghosts from the ancient war.