### PR TITLE
UtBS: add female variants to dehydration text

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/utils/dehydration-utils.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/utils/dehydration-utils.cfg
@@ -100,12 +100,31 @@ Hd, Dd*, Dd^E*, Rd #enddef
                             dehydrated=yes
                         [/status]
                     [/modify_unit]
-                    [floating_text]
-                        x=$dehydrating_units[$i].x
-                        y=$dehydrating_units[$i].y
-                        text= _ "thirst"
-                        {COLOR_HARM}
-                    [/floating_text]
+
+                    [if]
+                        [variable]
+                            name=dehydrating_units[$i].gender
+                            equals=female
+                        [/variable]
+
+                        [then]
+                            [floating_text]
+                                x=$dehydrating_units[$i].x
+                                y=$dehydrating_units[$i].y
+                                text= _ "female^thirst"
+                                {COLOR_HARM}
+                            [/floating_text]
+                        [/then]
+
+                        [else]
+                            [floating_text]
+                                x=$dehydrating_units[$i].x
+                                y=$dehydrating_units[$i].y
+                                text= _ "thirst"
+                                {COLOR_HARM}
+                            [/floating_text]
+                        [/else]
+                    [/if]
                 [/else]
             [/if]
         [/do]
@@ -150,12 +169,31 @@ Hd, Dd*, Dd^E*, Rd #enddef
                     dehydrated=no
                 [/status]
             [/modify_unit]
-            [floating_text]
-                x=$hydrating_units[$i].x
-                y=$hydrating_units[$i].y
-                text= _ "refreshed"
-                {COLOR_HEAL}
-            [/floating_text]
+
+            [if]
+                [variable]
+                    name=hydrating_units[$i].gender
+                    equals=female
+                [/variable]
+
+                [then]
+                    [floating_text]
+                        x=$hydrating_units[$i].x
+                        y=$hydrating_units[$i].y
+                        text= _ "female^refreshed"
+                        {COLOR_HEAL}
+                    [/floating_text]
+                [/then]
+
+                [else]
+                    [floating_text]
+                        x=$hydrating_units[$i].x
+                        y=$hydrating_units[$i].y
+                        text= _ "refreshed"
+                        {COLOR_HEAL}
+                    [/floating_text]
+                [/else]
+            [/if]
 
             [remove_object]
                 x,y=$hydrating_units[$i].x,$hydrating_units[$i].y
@@ -254,7 +292,8 @@ Hd, Dd*, Dd^E*, Rd #enddef
         [unstore_unit]
             variable=unit
             find_vacant=no
-            text= _ "refreshed"
+            male_text= _ "refreshed"
+            female_text= _ "female^refreshed"
             {COLOR_HEAL}
             advance=no
         [/unstore_unit]


### PR DESCRIPTION
Added `"female^thirst"` and `"female^refreshed"` to the dehydration macro because otherwise it was creating translational problems in some languages. For example, we had to use `теперь легче` (`now it's easier`) phrase in Russian for the word `refreshed` whereas we could just have written `освежился` / `освежилась` if there were gender specific variants (as it is in the IftU translation).