### PR TITLE
Convert the editor_action framework to use std::unique_ptr instead of raw pointers

### DIFF
--- a/src/editor/action/action.hpp
+++ b/src/editor/action/action.hpp
@@ -42,13 +42,9 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_whole_map* clone() const;
-
-	void perform_without_undo(map_context& m) const;
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	void perform_without_undo(map_context& m) const override;
+	const std::string& get_name() const override;
 
 protected:
 	editor_map m_;
@@ -75,7 +71,7 @@ public:
 	 */
 	virtual void extend(const editor_map& map, const std::set<map_location>& locs) = 0;
 
-	const std::string& get_name() const
+	const std::string& get_name() const override
 	{
 		static const std::string name("extendable");
 		return name;
@@ -103,45 +99,36 @@ public:
 	editor_action_chain& operator=(const editor_action_chain& other);
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_chain* clone() const;
+	std::unique_ptr<editor_action> clone() const override;
 
 	/**
 	 * Create an action chain from a deque of action pointers.
 	 * Note: the action chain assumes ownership of the pointers.
 	 */
-	explicit editor_action_chain(std::deque<editor_action*> actions)
-		: actions_(actions)
-	{
-	}
-
-	/**
-	 * Create an action chain by wrapping around a single action pointer.
-	 * Note: the action chain assumes ownership of the pointer.
-	 */
-	explicit editor_action_chain(editor_action* action)
-		: actions_(1, action)
+	explicit editor_action_chain(std::deque<std::unique_ptr<editor_action>> actions)
+		: actions_(std::move(actions))
 	{
 	}
 
 	/**
 	 * The destructor deletes all the owned action pointers
 	 */
-	~editor_action_chain();
+	~editor_action_chain() override = default;
 
 	/**
 	 * Go through the chain and add up all the action counts
 	 */
-	int action_count() const;
+	int action_count() const override;
 
 	/**
 	 * Add an action at the end of the chain
 	 */
-	void append_action(editor_action* a);
+	void append_action(std::unique_ptr<editor_action> a);
 
 	/**
 	 * Add an action at the beginning of the chain
 	 */
-	void prepend_action(editor_action* a);
+	void prepend_action(std::unique_ptr<editor_action> a);
 
 	/**
 	 * @return true when there are no actions in the chain. Empty
@@ -154,32 +141,31 @@ public:
 	 * Remove the last added action and return it, transferring
 	 * ownership to the caller
 	 */
-	editor_action* pop_last_action();
+	std::unique_ptr<editor_action> pop_last_action();
 
 	/**
 	 * Remove the first added action and return it, transferring
 	 * ownership to the caller
 	 */
-	editor_action* pop_first_action();
+	std::unique_ptr<editor_action> pop_first_action();
 
 	/**
 	 * Perform all the actions in order and create a undo action chain
 	 */
-	editor_action_chain* perform(map_context& m) const;
+	std::unique_ptr<editor_action> perform(map_context& m) const override;
 
 	/**
 	 * Perform all the actions in order
 	 */
-	void perform_without_undo(map_context& m) const;
+	void perform_without_undo(map_context& m) const override;
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	const std::string& get_name() const override;
 
 protected:
 	/**
 	 * The action pointers owned by this action chain
 	 */
-	std::deque<editor_action*> actions_;
+	std::deque<std::unique_ptr<editor_action>> actions_;
 };
 
 /**
@@ -194,7 +180,7 @@ public:
 	{
 	}
 
-	const std::string& get_name() const
+	const std::string& get_name() const override
 	{
 		static const std::string name("location");
 		return name;
@@ -216,7 +202,7 @@ public:
 	{
 	}
 
-	const std::string& get_name() const
+	const std::string& get_name() const override
 	{
 		static const std::string name("location_terrain");
 		return name;
@@ -237,9 +223,9 @@ public:
 	{
 	}
 
-	void extend(const editor_map& map, const std::set<map_location>& locs);
+	void extend(const editor_map& map, const std::set<map_location>& locs) override;
 
-	const std::string& get_name() const
+	const std::string& get_name() const override
 	{
 		static const std::string name("area");
 		return name;
@@ -261,17 +247,11 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_paste* clone() const;
-
-	editor_action_paste* perform(map_context& mc) const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	void extend(const editor_map& map, const std::set<map_location>& locs);
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	std::unique_ptr<editor_action> perform(map_context& mc) const override;
+	void perform_without_undo(map_context& mc) const override;
+	void extend(const editor_map& map, const std::set<map_location>& locs) override;
+	const std::string& get_name() const override;
 
 protected:
 	map_location offset_;
@@ -292,15 +272,10 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_paint_area* clone() const;
-
-	editor_action_paste* perform(map_context& mc) const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	std::unique_ptr<editor_action> perform(map_context& mc) const override;
+	void perform_without_undo(map_context& mc) const override;
+	const std::string& get_name() const override;
 
 protected:
 	t_translation::terrain_code t_;
@@ -320,22 +295,18 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_fill* clone() const;
-
-	editor_action_paint_area* perform(map_context& mc) const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	std::unique_ptr<editor_action> perform(map_context& mc) const override;
+	void perform_without_undo(map_context& mc) const override;
+	const std::string& get_name() const override;
 
 protected:
 	bool one_layer_;
 };
 
 /**
- * Set starting position action
+ * Set starting position action, sets location ids (both for starting locations
+ * and for non-starting locations).
  */
 class editor_action_starting_position : public editor_action_location
 {
@@ -346,15 +317,10 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_starting_position* clone() const;
-
-	editor_action* perform(map_context& mc) const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	std::unique_ptr<editor_action> perform(map_context& mc) const override;
+	void perform_without_undo(map_context& mc) const override;
+	const std::string& get_name() const override;
 
 protected:
 	std::string loc_id_;
@@ -380,13 +346,9 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_resize_map* clone() const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	void perform_without_undo(map_context& mc) const override;
+	const std::string& get_name() const override;
 
 protected:
 	int x_size_;
@@ -405,13 +367,9 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_apply_mask* clone() const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	void perform_without_undo(map_context& mc) const override;
+	const std::string& get_name() const override;
 
 private:
 	gamemap mask_;
@@ -425,11 +383,9 @@ public:
 	{
 	}
 
-	editor_action_create_mask* clone() const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	void perform_without_undo(map_context& mc) const override;
+	const std::string& get_name() const override;
 
 private:
 	editor_map target_;
@@ -446,15 +402,10 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_shuffle_area* clone() const;
-
-	editor_action_paste* perform(map_context& mc) const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	std::unique_ptr<editor_action> perform(map_context& mc) const override;
+	void perform_without_undo(map_context& mc) const override;
+	const std::string& get_name() const override;
 };
 
 } // end namespace editor

--- a/src/editor/action/action_base.hpp
+++ b/src/editor/action/action_base.hpp
@@ -46,7 +46,7 @@ public:
 	/**
 	 * Action cloning
 	 */
-	virtual editor_action* clone() const = 0;
+	virtual std::unique_ptr<editor_action> clone() const = 0;
 
 	/**
 	 * Perform the action, returning an undo action that,
@@ -56,7 +56,7 @@ public:
 	 * undo, call the perform_without_undo function and
 	 * return the undo object.
 	 */
-	virtual editor_action* perform(map_context&) const;
+	virtual std::unique_ptr<editor_action> perform(map_context&) const;
 
 	/**
 	 * Perform the action without creating an undo action.
@@ -129,9 +129,9 @@ struct editor_action_exception : public editor_exception
 		return name;                                                                                                   \
 	}                                                                                                                  \
                                                                                                                        \
-	editor_action_##id* editor_action_##id::clone() const                                                              \
+	std::unique_ptr<editor_action> editor_action_##id::clone() const                                                              \
 	{                                                                                                                  \
-		return new editor_action_##id(*this);                                                                          \
+		return std::make_unique<editor_action_##id>(*this);                                                                          \
 	}                                                                                                                  \
 
 } // end namespace editor

--- a/src/editor/action/action_item.cpp
+++ b/src/editor/action/action_item.cpp
@@ -28,11 +28,11 @@ namespace editor
 {
 IMPLEMENT_ACTION(item)
 
-editor_action* editor_action_item::perform(map_context& mc) const
+std::unique_ptr<editor_action> editor_action_item::perform(map_context& mc) const
 {
-	editor_action_ptr undo(new editor_action_item_delete(loc_));
+	auto undo = std::make_unique<editor_action_item_delete>(loc_);
 	perform_without_undo(mc);
-	return undo.release();
+	return undo;
 }
 
 void editor_action_item::perform_without_undo(map_context& /*mc*/) const
@@ -45,7 +45,7 @@ void editor_action_item::perform_without_undo(map_context& /*mc*/) const
 
 IMPLEMENT_ACTION(item_delete)
 
-editor_action* editor_action_item_delete::perform(map_context& /*mc*/) const
+std::unique_ptr<editor_action> editor_action_item_delete::perform(map_context& /*mc*/) const
 {
 	//	item_map& items = mc.get_items();
 	//	item_map::const_item_iterator item_it = items.find(loc_);
@@ -71,12 +71,12 @@ void editor_action_item_delete::perform_without_undo(map_context& /*mc*/) const
 
 IMPLEMENT_ACTION(item_replace)
 
-editor_action* editor_action_item_replace::perform(map_context& mc) const
+std::unique_ptr<editor_action> editor_action_item_replace::perform(map_context& mc) const
 {
-	editor_action_ptr undo(new editor_action_item_replace(new_loc_, loc_));
+	auto undo = std::make_unique<editor_action_item_replace>(new_loc_, loc_);
 
 	perform_without_undo(mc);
-	return undo.release();
+	return undo;
 }
 
 void editor_action_item_replace::perform_without_undo(map_context& /*mc*/) const
@@ -105,11 +105,11 @@ void editor_action_item_replace::perform_without_undo(map_context& /*mc*/) const
 
 IMPLEMENT_ACTION(item_facing)
 
-editor_action* editor_action_item_facing::perform(map_context& mc) const
+std::unique_ptr<editor_action> editor_action_item_facing::perform(map_context& mc) const
 {
-	editor_action_ptr undo(new editor_action_item_facing(loc_, old_direction_, new_direction_));
+	auto undo = std::make_unique<editor_action_item_facing>(loc_, old_direction_, new_direction_);
 	perform_without_undo(mc);
-	return undo.release();
+	return undo;
 }
 
 void editor_action_item_facing::perform_without_undo(map_context& /*mc*/) const

--- a/src/editor/action/action_item.hpp
+++ b/src/editor/action/action_item.hpp
@@ -35,6 +35,10 @@ namespace editor
 {
 /**
  * place a new item on the map
+ *
+ * \todo remove commented-out code (no separate ticket, but editor cleanup is on the roadmap for 1.15.11)
+ * action_item.cpp is full of commented-out code, it seems to be deadweight
+ * with the real implementation to be found in mouse_action_item.cpp.
  */
 class editor_action_item : public editor_action_location
 {
@@ -45,15 +49,10 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_item* clone() const;
-
-	editor_action* perform(map_context& mc) const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	std::unique_ptr<editor_action> perform(map_context& mc) const override;
+	void perform_without_undo(map_context& mc) const override;
+	const std::string& get_name() const override;
 
 protected:
 	overlay item_;
@@ -70,15 +69,10 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_item_delete* clone() const;
-
-	editor_action* perform(map_context& mc) const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	std::unique_ptr<editor_action> perform(map_context& mc) const override;
+	void perform_without_undo(map_context& mc) const override;
+	const std::string& get_name() const override;
 };
 
 class editor_action_item_replace : public editor_action_location
@@ -90,15 +84,10 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_item_replace* clone() const;
-
-	editor_action* perform(map_context& mc) const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	std::unique_ptr<editor_action> perform(map_context& mc) const override;
+	void perform_without_undo(map_context& mc) const override;
+	const std::string& get_name() const override;
 
 protected:
 	map_location new_loc_;
@@ -115,15 +104,10 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_item_facing* clone() const;
-
-	editor_action* perform(map_context& mc) const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	std::unique_ptr<editor_action> perform(map_context& mc) const override;
+	void perform_without_undo(map_context& mc) const override;
+	const std::string& get_name() const override;
 
 protected:
 	map_location::DIRECTION new_direction_;

--- a/src/editor/action/action_label.cpp
+++ b/src/editor/action/action_label.cpp
@@ -26,13 +26,13 @@ namespace editor
 {
 IMPLEMENT_ACTION(label)
 
-editor_action* editor_action_label::perform(map_context& mc) const
+std::unique_ptr<editor_action> editor_action_label::perform(map_context& mc) const
 {
-	editor_action_ptr undo;
+	std::unique_ptr<editor_action> undo;
 
 	const terrain_label* old_label = mc.get_labels().get_label(loc_);
 	if(old_label) {
-		undo.reset(new editor_action_label(
+		undo = std::make_unique<editor_action_label>(
 			loc_,
 			old_label->text(),
 			old_label->team_name(),
@@ -40,14 +40,14 @@ editor_action* editor_action_label::perform(map_context& mc) const
 			old_label->visible_in_fog(),
 			old_label->visible_in_shroud(),
 			old_label->immutable(),
-			old_label->category())
+			old_label->category()
 		);
 	} else {
-		undo.reset(new editor_action_label_delete(loc_));
+		undo = std::make_unique<editor_action_label_delete>(loc_);
 	}
 
 	perform_without_undo(mc);
-	return undo.release();
+	return undo;
 }
 
 void editor_action_label::perform_without_undo(map_context& mc) const
@@ -58,17 +58,15 @@ void editor_action_label::perform_without_undo(map_context& mc) const
 
 IMPLEMENT_ACTION(label_delete)
 
-editor_action* editor_action_label_delete::perform(map_context& mc) const
+std::unique_ptr<editor_action> editor_action_label_delete::perform(map_context& mc) const
 {
-	editor_action_ptr undo;
-
 	const terrain_label* deleted = mc.get_labels().get_label(loc_);
 
 	if(!deleted) {
 		return nullptr;
 	}
 
-	undo.reset(new editor_action_label(
+	auto undo = std::make_unique<editor_action_label>(
 		loc_,
 		deleted->text(),
 		deleted->team_name(),
@@ -76,11 +74,11 @@ editor_action* editor_action_label_delete::perform(map_context& mc) const
 		deleted->visible_in_fog(),
 		deleted->visible_in_shroud(),
 		deleted->immutable(),
-		deleted->category())
+		deleted->category()
 	);
 
 	perform_without_undo(mc);
-	return undo.release();
+	return undo;
 }
 
 void editor_action_label_delete::perform_without_undo(map_context& mc) const

--- a/src/editor/action/action_label.hpp
+++ b/src/editor/action/action_label.hpp
@@ -56,15 +56,10 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_label* clone() const;
-
-	editor_action* perform(map_context& mc) const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	std::unique_ptr<editor_action> perform(map_context& mc) const override;
+	void perform_without_undo(map_context& mc) const override;
+	const std::string& get_name() const override;
 
 protected:
 	const std::string text_;
@@ -86,15 +81,10 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_label_delete* clone() const;
-
-	editor_action* perform(map_context& mc) const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	std::unique_ptr<editor_action> perform(map_context& mc) const override;
+	void perform_without_undo(map_context& mc) const override;
+	const std::string& get_name() const override;
 };
 
 } // end namespace editor

--- a/src/editor/action/action_select.cpp
+++ b/src/editor/action/action_select.cpp
@@ -33,7 +33,7 @@ void editor_action_select::extend(const editor_map& /*map*/, const std::set<map_
 	}
 }
 
-editor_action* editor_action_select::perform(map_context& mc) const
+std::unique_ptr<editor_action> editor_action_select::perform(map_context& mc) const
 {
 	std::set<map_location> undo_locs;
 	for(const map_location& loc : area_) {
@@ -42,7 +42,7 @@ editor_action* editor_action_select::perform(map_context& mc) const
 	}
 
 	perform_without_undo(mc);
-	return new editor_action_select(undo_locs);
+	return std::make_unique<editor_action_select>(undo_locs);
 }
 
 void editor_action_select::perform_without_undo(map_context& mc) const
@@ -66,7 +66,7 @@ void editor_action_deselect::extend(const editor_map& map, const std::set<map_lo
 	}
 }
 
-editor_action* editor_action_deselect::perform(map_context& mc) const
+std::unique_ptr<editor_action> editor_action_deselect::perform(map_context& mc) const
 {
 	std::set<map_location> undo_locs;
 	for(const map_location& loc : area_) {
@@ -77,7 +77,7 @@ editor_action* editor_action_deselect::perform(map_context& mc) const
 	}
 
 	perform_without_undo(mc);
-	return new editor_action_select(undo_locs);
+	return std::make_unique<editor_action_select>(undo_locs);
 }
 
 void editor_action_deselect::perform_without_undo(map_context& mc) const
@@ -90,7 +90,7 @@ void editor_action_deselect::perform_without_undo(map_context& mc) const
 
 IMPLEMENT_ACTION(select_all)
 
-editor_action_select* editor_action_select_all::perform(map_context& mc) const
+std::unique_ptr<editor_action> editor_action_select_all::perform(map_context& mc) const
 {
 	std::set<map_location> current = mc.map().selection();
 	mc.map().select_all();
@@ -102,7 +102,7 @@ editor_action_select* editor_action_select_all::perform(map_context& mc) const
 		all.begin(), all.end(), current.begin(), current.end(), std::inserter(undo_locs, undo_locs.begin()));
 
 	mc.set_everything_changed();
-	return new editor_action_select(undo_locs);
+	return std::make_unique<editor_action_select>(undo_locs);
 }
 
 void editor_action_select_all::perform_without_undo(map_context& mc) const
@@ -113,12 +113,12 @@ void editor_action_select_all::perform_without_undo(map_context& mc) const
 
 IMPLEMENT_ACTION(select_none)
 
-editor_action_select* editor_action_select_none::perform(map_context& mc) const
+std::unique_ptr<editor_action> editor_action_select_none::perform(map_context& mc) const
 {
 	std::set<map_location> current = mc.map().selection();
 	mc.map().clear_selection();
 	mc.set_everything_changed();
-	return new editor_action_select(current);
+	return std::make_unique<editor_action_select>(current);
 }
 
 void editor_action_select_none::perform_without_undo(map_context& mc) const
@@ -129,10 +129,10 @@ void editor_action_select_none::perform_without_undo(map_context& mc) const
 
 IMPLEMENT_ACTION(select_inverse)
 
-editor_action_select_inverse* editor_action_select_inverse::perform(map_context& mc) const
+std::unique_ptr<editor_action> editor_action_select_inverse::perform(map_context& mc) const
 {
 	perform_without_undo(mc);
-	return new editor_action_select_inverse();
+	return std::make_unique<editor_action_select_inverse>();
 }
 
 void editor_action_select_inverse::perform_without_undo(map_context& mc) const

--- a/src/editor/action/action_select.hpp
+++ b/src/editor/action/action_select.hpp
@@ -40,17 +40,11 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_select* clone() const;
-
-	void extend(const editor_map& map, const std::set<map_location>& locs);
-
-	editor_action* perform(map_context& mc) const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	void extend(const editor_map& map, const std::set<map_location>& locs) override;
+	std::unique_ptr<editor_action> perform(map_context& mc) const override;
+	void perform_without_undo(map_context& mc) const override;
+	const std::string& get_name() const override;
 };
 
 /**
@@ -64,17 +58,11 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_deselect* clone() const;
-
-	void extend(const editor_map& map, const std::set<map_location>& locs);
-
-	editor_action* perform(map_context& mc) const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	void extend(const editor_map& map, const std::set<map_location>& locs) override;
+	std::unique_ptr<editor_action> perform(map_context& mc) const override;
+	void perform_without_undo(map_context& mc) const override;
+	const std::string& get_name() const override;
 };
 
 /**
@@ -87,15 +75,10 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_select_all* clone() const;
-
-	editor_action_select* perform(map_context& mc) const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	std::unique_ptr<editor_action> perform(map_context& mc) const override;
+	void perform_without_undo(map_context& mc) const override;
+	const std::string& get_name() const override;
 };
 
 /**
@@ -108,15 +91,10 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_select_none* clone() const;
-
-	editor_action_select* perform(map_context& mc) const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	std::unique_ptr<editor_action> perform(map_context& mc) const override;
+	void perform_without_undo(map_context& mc) const override;
+	const std::string& get_name() const override;
 };
 
 /**
@@ -129,15 +107,10 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_select_inverse* clone() const;
-
-	editor_action_select_inverse* perform(map_context& mc) const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	std::unique_ptr<editor_action> perform(map_context& mc) const override;
+	void perform_without_undo(map_context& mc) const override;
+	const std::string& get_name() const override;
 };
 
 } // end namespace editor

--- a/src/editor/action/action_unit.cpp
+++ b/src/editor/action/action_unit.cpp
@@ -31,11 +31,11 @@ namespace editor
 {
 IMPLEMENT_ACTION(unit)
 
-editor_action* editor_action_unit::perform(map_context& mc) const
+std::unique_ptr<editor_action> editor_action_unit::perform(map_context& mc) const
 {
-	editor_action_ptr undo(new editor_action_unit_delete(loc_));
+	auto undo = std::make_unique<editor_action_unit_delete>(loc_);
 	perform_without_undo(mc);
-	return undo.release();
+	return undo;
 }
 
 void editor_action_unit::perform_without_undo(map_context& mc) const
@@ -47,16 +47,15 @@ void editor_action_unit::perform_without_undo(map_context& mc) const
 
 IMPLEMENT_ACTION(unit_delete)
 
-editor_action* editor_action_unit_delete::perform(map_context& mc) const
+std::unique_ptr<editor_action> editor_action_unit_delete::perform(map_context& mc) const
 {
 	unit_map& units = mc.units();
 	unit_map::const_unit_iterator unit_it = units.find(loc_);
 
-	editor_action_ptr undo;
 	if(unit_it != units.end()) {
-		undo.reset(new editor_action_unit(loc_, *unit_it));
+		auto undo = std::make_unique<editor_action_unit>(loc_, *unit_it);
 		perform_without_undo(mc);
-		return undo.release();
+		return undo;
 	}
 
 	return nullptr;
@@ -74,12 +73,11 @@ void editor_action_unit_delete::perform_without_undo(map_context& mc) const
 
 IMPLEMENT_ACTION(unit_replace)
 
-editor_action* editor_action_unit_replace::perform(map_context& mc) const
+std::unique_ptr<editor_action> editor_action_unit_replace::perform(map_context& mc) const
 {
-	editor_action_ptr undo(new editor_action_unit_replace(new_loc_, loc_));
-
+	auto undo = std::make_unique<editor_action_unit_replace>(new_loc_, loc_);
 	perform_without_undo(mc);
-	return undo.release();
+	return undo;
 }
 
 void editor_action_unit_replace::perform_without_undo(map_context& mc) const
@@ -109,11 +107,11 @@ void editor_action_unit_replace::perform_without_undo(map_context& mc) const
 
 IMPLEMENT_ACTION(unit_facing)
 
-editor_action* editor_action_unit_facing::perform(map_context& mc) const
+std::unique_ptr<editor_action> editor_action_unit_facing::perform(map_context& mc) const
 {
-	editor_action_ptr undo(new editor_action_unit_facing(loc_, old_direction_, new_direction_));
+	auto undo = std::make_unique<editor_action_unit_facing>(loc_, old_direction_, new_direction_);
 	perform_without_undo(mc);
-	return undo.release();
+	return undo;
 }
 
 void editor_action_unit_facing::perform_without_undo(map_context& mc) const

--- a/src/editor/action/action_unit.hpp
+++ b/src/editor/action/action_unit.hpp
@@ -43,15 +43,10 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_unit* clone() const;
-
-	editor_action* perform(map_context& mc) const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	std::unique_ptr<editor_action> perform(map_context& mc) const override;
+	void perform_without_undo(map_context& mc) const override;
+	const std::string& get_name() const override;
 
 protected:
 	unit_ptr u_;
@@ -68,15 +63,10 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_unit_delete* clone() const;
-
-	editor_action* perform(map_context& mc) const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	std::unique_ptr<editor_action> perform(map_context& mc) const override;
+	void perform_without_undo(map_context& mc) const override;
+	const std::string& get_name() const override;
 };
 
 class editor_action_unit_replace : public editor_action_location
@@ -88,15 +78,10 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_unit_replace* clone() const;
-
-	editor_action* perform(map_context& mc) const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	std::unique_ptr<editor_action> perform(map_context& mc) const override;
+	void perform_without_undo(map_context& mc) const override;
+	const std::string& get_name() const override;
 
 protected:
 	map_location new_loc_;
@@ -113,15 +98,10 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_unit_facing* clone() const;
-
-	editor_action* perform(map_context& mc) const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	std::unique_ptr<editor_action> perform(map_context& mc) const override;
+	void perform_without_undo(map_context& mc) const override;
+	const std::string& get_name() const override;
 
 protected:
 	map_location::DIRECTION new_direction_;

--- a/src/editor/action/action_village.hpp
+++ b/src/editor/action/action_village.hpp
@@ -41,15 +41,10 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_village* clone() const;
-
-	editor_action* perform(map_context& mc) const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	std::unique_ptr<editor_action> perform(map_context& mc) const override;
+	void perform_without_undo(map_context& mc) const override;
+	const std::string& get_name() const override;
 
 private:
 	int side_number_;
@@ -66,15 +61,10 @@ public:
 	{
 	}
 
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_village_delete* clone() const;
-
-	editor_action* perform(map_context& mc) const;
-
-	void perform_without_undo(map_context& mc) const;
-
-	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	const std::string& get_name() const;
+	std::unique_ptr<editor_action> clone() const override;
+	std::unique_ptr<editor_action> perform(map_context& mc) const override;
+	void perform_without_undo(map_context& mc) const override;
+	const std::string& get_name() const override;
 };
 
 } // end namespace editor

--- a/src/editor/action/mouse/mouse_action.cpp
+++ b/src/editor/action/mouse/mouse_action.cpp
@@ -50,43 +50,43 @@ std::set<map_location> mouse_action::affected_hexes(
 	return res;
 }
 
-editor_action* mouse_action::drag_left(editor_display& /*disp*/,
+std::unique_ptr<editor_action> mouse_action::drag_left(editor_display& /*disp*/,
 		int /*x*/, int /*y*/, bool& /*partial*/, editor_action* /*last_undo*/)
 {
 	return nullptr;
 }
 
-editor_action* mouse_action::drag_right(editor_display& /*disp*/,
+std::unique_ptr<editor_action> mouse_action::drag_right(editor_display& /*disp*/,
 		int /*x*/, int /*y*/, bool& /*partial*/, editor_action* /*last_undo*/)
 {
 	return nullptr;
 }
 
-editor_action* mouse_action::drag_end_left(
+std::unique_ptr<editor_action> mouse_action::drag_end_left(
 		editor_display& /*disp*/, int /*x*/, int /*y*/)
 {
 	return nullptr;
 }
 
-editor_action* mouse_action::drag_end_right(
+std::unique_ptr<editor_action> mouse_action::drag_end_right(
 		editor_display& /*disp*/, int /*x*/, int /*y*/)
 {
 	return nullptr;
 }
 
-editor_action* mouse_action::up_right(
+std::unique_ptr<editor_action> mouse_action::up_right(
 		editor_display& /*disp*/, int /*x*/, int /*y*/)
 {
 	return nullptr;
 }
 
-editor_action* mouse_action::up_left(
+std::unique_ptr<editor_action> mouse_action::up_left(
 		editor_display& /*disp*/, int /*x*/, int /*y*/)
 {
 	return nullptr;
 }
 
-editor_action* mouse_action::key_event(
+std::unique_ptr<editor_action> mouse_action::key_event(
 	editor_display& disp, const SDL_Event& event)
 {
 	if (!has_alt_modifier() && (event.key.keysym.sym >= '1' && event.key.keysym.sym <= '9')) {
@@ -102,16 +102,16 @@ editor_action* mouse_action::key_event(
 	if (!disp.map().on_board(previous_move_hex_) || event.type != SDL_KEYUP) {
 		return nullptr;
 	}
-	editor_action* a = nullptr;
+	std::unique_ptr<editor_action> a;
 	if ((has_alt_modifier() && (event.key.keysym.sym >= '1' && event.key.keysym.sym <= '9'))
 	|| event.key.keysym.sym == SDLK_DELETE) {
 		int res = event.key.keysym.sym - '0';
 		if (res > gamemap::MAX_PLAYERS || event.key.keysym.sym == SDLK_DELETE) res = 0;
 		const std::string* old_id = disp.map().is_starting_position(previous_move_hex_);
 		if (res == 0 && old_id != nullptr) {
-			a = new editor_action_starting_position(map_location(), *old_id);
+			a = std::make_unique<editor_action_starting_position>(map_location(), *old_id);
 		} else if (res > 0 && (old_id == nullptr || *old_id == std::to_string(res))) {
-			a = new editor_action_starting_position(previous_move_hex_, std::to_string(res));
+			a = std::make_unique<editor_action_starting_position>(previous_move_hex_, std::to_string(res));
 		}
 	}
 	return a;
@@ -201,40 +201,40 @@ std::set<map_location> brush_drag_mouse_action::affected_hexes(
 	return get_brush().project(hex);
 }
 
-editor_action* brush_drag_mouse_action::click_left(editor_display& disp, int x, int y)
+std::unique_ptr<editor_action> brush_drag_mouse_action::click_left(editor_display& disp, int x, int y)
 {
 	map_location hex = disp.hex_clicked_on(x, y);
 	previous_drag_hex_ = hex;
 	return click_perform_left(disp, affected_hexes(disp, hex));
 }
 
-editor_action* brush_drag_mouse_action::click_right(editor_display& disp, int x, int y)
+std::unique_ptr<editor_action> brush_drag_mouse_action::click_right(editor_display& disp, int x, int y)
 {
 	map_location hex = disp.hex_clicked_on(x, y);
 	previous_drag_hex_ = hex;
 	return click_perform_right(disp, affected_hexes(disp, hex));
 }
 
-editor_action* brush_drag_mouse_action::drag_left(editor_display& disp,
+std::unique_ptr<editor_action> brush_drag_mouse_action::drag_left(editor_display& disp,
 		int x, int y, bool& partial, editor_action* last_undo)
 {
 	return drag_generic<&brush_drag_mouse_action::click_perform_left>(disp, x, y, partial, last_undo);
 }
 
-editor_action* brush_drag_mouse_action::drag_right(editor_display& disp,
+std::unique_ptr<editor_action> brush_drag_mouse_action::drag_right(editor_display& disp,
 		int x, int y, bool& partial, editor_action* last_undo)
 {
 	return drag_generic<&brush_drag_mouse_action::click_perform_right>(disp, x, y, partial, last_undo);
 }
 
-editor_action* brush_drag_mouse_action::drag_end(
+std::unique_ptr<editor_action> brush_drag_mouse_action::drag_end(
 		editor_display& /*disp*/, int /*x*/, int /*y*/)
 {
 	return nullptr;
 }
 
-template <editor_action* (brush_drag_mouse_action::*perform_func)(editor_display&, const std::set<map_location>&)>
-editor_action* brush_drag_mouse_action::drag_generic(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo)
+template <std::unique_ptr<editor_action> (brush_drag_mouse_action::*perform_func)(editor_display&, const std::set<map_location>&)>
+std::unique_ptr<editor_action> brush_drag_mouse_action::drag_generic(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo)
 {
 	map_location hex = disp.hex_clicked_on(x, y);
 	move(disp, hex);
@@ -242,7 +242,7 @@ editor_action* brush_drag_mouse_action::drag_generic(editor_display& disp, int x
 		editor_action_extendable* last_undo_x = dynamic_cast<editor_action_extendable*>(last_undo);
 		LOG_ED << "Last undo is " << last_undo << " and as x " << last_undo_x << "\n";
 		partial = true;
-		editor_action* a = (this->*perform_func)(disp, affected_hexes(disp, hex));
+		auto a = (this->*perform_func)(disp, affected_hexes(disp, hex));
 		previous_drag_hex_ = hex;
 		return a;
 	} else {
@@ -258,7 +258,7 @@ const brush& brush_drag_mouse_action::get_brush()
 }
 
 
-editor_action* mouse_action_paint::click_left(editor_display& disp, int x, int y)
+std::unique_ptr<editor_action> mouse_action_paint::click_left(editor_display& disp, int x, int y)
 {
 	if (has_ctrl_modifier()) {
 		map_location hex = disp.hex_clicked_on(x, y);
@@ -269,7 +269,7 @@ editor_action* mouse_action_paint::click_left(editor_display& disp, int x, int y
 	}
 }
 
-editor_action* mouse_action_paint::click_right(editor_display& disp, int x, int y)
+std::unique_ptr<editor_action> mouse_action_paint::click_right(editor_display& disp, int x, int y)
 {
 	if (has_ctrl_modifier()) {
 		map_location hex = disp.hex_clicked_on(x, y);
@@ -280,20 +280,27 @@ editor_action* mouse_action_paint::click_right(editor_display& disp, int x, int 
 	}
 }
 
-editor_action* mouse_action_paint::click_perform_left(
+std::unique_ptr<editor_action> mouse_action_paint::click_perform_left(
 		editor_display& /*disp*/, const std::set<map_location>& hexes)
 {
 	if (has_ctrl_modifier()) return nullptr;
-	return new editor_action_chain(new editor_action_paint_area(
+	// \todo why is this a chain and not an individual action? I guess that mouse drags were meant
+	// to be optimised with one undo for multiple hexes, but it seems that was never added.
+	auto chain = std::make_unique<editor_action_chain>();
+	chain->append_action(std::make_unique<editor_action_paint_area>(
 			hexes, terrain_palette_.selected_fg_item(), has_shift_modifier()));
+	return chain;
 }
 
-editor_action* mouse_action_paint::click_perform_right(
+std::unique_ptr<editor_action> mouse_action_paint::click_perform_right(
 		editor_display& /*disp*/, const std::set<map_location>& hexes)
 {
 	if (has_ctrl_modifier()) return nullptr;
-	return new editor_action_chain(new editor_action_paint_area(
+	// \todo why is this a chain and not an individual action?
+	auto chain = std::make_unique<editor_action_chain>();
+	chain->append_action(std::make_unique<editor_action_paint_area>(
 			hexes, terrain_palette_.selected_bg_item(), has_shift_modifier()));
+	return chain;
 }
 
 void mouse_action_paint::set_mouse_overlay(editor_display& disp)
@@ -317,14 +324,13 @@ std::set<map_location> mouse_action_paste::affected_hexes(
 	return paste_.get_offset_area(hex);
 }
 
-editor_action* mouse_action_paste::click_left(editor_display& disp, int x, int y)
+std::unique_ptr<editor_action> mouse_action_paste::click_left(editor_display& disp, int x, int y)
 {
 	map_location hex = disp.hex_clicked_on(x, y);
-	editor_action_paste* a = new editor_action_paste(paste_, hex);
-	return a;
+	return std::make_unique<editor_action_paste>(paste_, hex);
 }
 
-editor_action* mouse_action_paste::click_right(editor_display& /*disp*/, int /*x*/, int /*y*/)
+std::unique_ptr<editor_action> mouse_action_paste::click_right(editor_display& /*disp*/, int /*x*/, int /*y*/)
 {
 	return nullptr;
 }
@@ -355,7 +361,7 @@ std::set<map_location> mouse_action_fill::affected_hexes(
 	return disp.map().get_contiguous_terrain_tiles(hex);
 }
 
-editor_action* mouse_action_fill::click_left(editor_display& disp, int x, int y)
+std::unique_ptr<editor_action> mouse_action_fill::click_left(editor_display& disp, int x, int y)
 {
 	map_location hex = disp.hex_clicked_on(x, y);
 	if (has_ctrl_modifier()) {
@@ -364,13 +370,12 @@ editor_action* mouse_action_fill::click_left(editor_display& disp, int x, int y)
 	} else {
 		/** @todo only take the base terrain into account when searching for contiguous terrain when painting base only */
 		//or use a different key modifier for that
-		editor_action_fill* a = new editor_action_fill(hex, terrain_palette_.selected_fg_item(),
+		return std::make_unique<editor_action_fill>(hex, terrain_palette_.selected_fg_item(),
 				has_shift_modifier());
-		return a;
 	}
 }
 
-editor_action* mouse_action_fill::click_right(editor_display& disp, int x, int y)
+std::unique_ptr<editor_action> mouse_action_fill::click_right(editor_display& disp, int x, int y)
 {
 	map_location hex = disp.hex_clicked_on(x, y);
 	if (has_ctrl_modifier()) {
@@ -379,9 +384,8 @@ editor_action* mouse_action_fill::click_right(editor_display& disp, int x, int y
 	} else {
 		/** @todo only take the base terrain into account when searching for contiguous terrain when painting base only */
 		//or use a different key modifier for that
-		editor_action_fill* a = new editor_action_fill(hex, terrain_palette_.selected_bg_item(),
+		return std::make_unique<editor_action_fill>(hex, terrain_palette_.selected_bg_item(),
 				has_shift_modifier());
-		return a;
 	}
 }
 
@@ -391,7 +395,7 @@ void mouse_action_fill::set_mouse_overlay(editor_display& disp)
 			terrain_palette_.selected_bg_item());
 }
 
-editor_action* mouse_action_starting_position::up_left(editor_display& disp, int x, int y)
+std::unique_ptr<editor_action> mouse_action_starting_position::up_left(editor_display& disp, int x, int y)
 {
 	if (!click_) return nullptr;
 	click_ = false;
@@ -409,15 +413,15 @@ editor_action* mouse_action_starting_position::up_left(editor_display& disp, int
 	}
 
 	std::string new_player_at_hex = location_palette_.selected_item();
-	editor_action* a = nullptr;
+	std::unique_ptr<editor_action> a;
 
 	if(!player_starting_at_hex || new_player_at_hex != *player_starting_at_hex) {
 		// Set a starting position
-		a = new editor_action_starting_position(hex, new_player_at_hex);
+		a = std::make_unique<editor_action_starting_position>(hex, new_player_at_hex);
 	}
 	else {
 		// Erase current starting position
-		a = new editor_action_starting_position(map_location(), *player_starting_at_hex);
+		a = std::make_unique<editor_action_starting_position>(map_location(), *player_starting_at_hex);
 	}
 
 	update_brush_highlights(disp, hex);
@@ -425,24 +429,24 @@ editor_action* mouse_action_starting_position::up_left(editor_display& disp, int
 	return a;
 }
 
-editor_action* mouse_action_starting_position::click_left(editor_display& /*disp*/, int /*x*/, int /*y*/)
+std::unique_ptr<editor_action> mouse_action_starting_position::click_left(editor_display& /*disp*/, int /*x*/, int /*y*/)
 {
 	click_ = true;
 	return nullptr;
 }
 
-editor_action* mouse_action_starting_position::up_right(editor_display& disp, int x, int y)
+std::unique_ptr<editor_action> mouse_action_starting_position::up_right(editor_display& disp, int x, int y)
 {
 	map_location hex = disp.hex_clicked_on(x, y);
 	auto player_starting_at_hex = disp.map().is_starting_position(hex);
 	if (player_starting_at_hex != nullptr) {
-		return new editor_action_starting_position(map_location(), *player_starting_at_hex);
+		return std::make_unique<editor_action_starting_position>(map_location(), *player_starting_at_hex);
 	} else {
 		return nullptr;
 	}
 }
 
-editor_action* mouse_action_starting_position::click_right(editor_display& /*disp*/, int /*x*/, int /*y*/)
+std::unique_ptr<editor_action> mouse_action_starting_position::click_right(editor_display& /*disp*/, int /*x*/, int /*y*/)
 {
 	return nullptr;
 }

--- a/src/editor/action/mouse/mouse_action.hpp
+++ b/src/editor/action/mouse/mouse_action.hpp
@@ -67,39 +67,39 @@ public:
 	/**
 	 * A click, possibly the beginning of a drag. Must be overridden.
 	 */
-	virtual editor_action* click_left(editor_display& disp, int x, int y) = 0;
+	virtual std::unique_ptr<editor_action> click_left(editor_display& disp, int x, int y) = 0;
 
 	/**
 	 * A click, possibly the beginning of a drag. Must be overridden.
 	 */
-	virtual editor_action* click_right(editor_display& disp, int x, int y) = 0;
+	virtual std::unique_ptr<editor_action> click_right(editor_display& disp, int x, int y) = 0;
 
 	/**
 	 * Drag operation. A click should have occurred earlier. Defaults to no action.
 	 */
-	virtual editor_action* drag_left(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
+	virtual std::unique_ptr<editor_action> drag_left(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
 
 	/**
 	 * Drag operation. A click should have occurred earlier. Defaults to no action.
 	 */
-	virtual editor_action* drag_right(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
+	virtual std::unique_ptr<editor_action> drag_right(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
 
 	/**
 	 * The end of dragging. Defaults to no action.
 	 */
-	virtual editor_action* drag_end_left(editor_display& disp, int x, int y);
+	virtual std::unique_ptr<editor_action> drag_end_left(editor_display& disp, int x, int y);
 
-	virtual editor_action* drag_end_right(editor_display& disp, int x, int y);
+	virtual std::unique_ptr<editor_action> drag_end_right(editor_display& disp, int x, int y);
 
-	virtual editor_action* up_left(editor_display& disp, int x, int y);
+	virtual std::unique_ptr<editor_action> up_left(editor_display& disp, int x, int y);
 
-	virtual editor_action* up_right(editor_display& disp, int x, int y);
+	virtual std::unique_ptr<editor_action> up_right(editor_display& disp, int x, int y);
 
 	/**
 	 * Function called by the controller on a key event for the current mouse action.
 	 * Defaults to starting position processing.
 	 */
-	virtual editor_action* key_event(editor_display& disp, const SDL_Event& e);
+	virtual std::unique_ptr<editor_action> key_event(editor_display& disp, const SDL_Event& e);
 
 	/**
 	 * Helper variable setter - pointer to a toolbar menu/button used for highlighting
@@ -180,40 +180,40 @@ public:
 	/**
 	 * The actual action function which is called by click() and drag(). Derived classes override this instead of click() and drag().
 	 */
-	virtual editor_action* click_perform_left(editor_display& disp, const std::set<map_location>& hexes) = 0;
+	virtual std::unique_ptr<editor_action> click_perform_left(editor_display& disp, const std::set<map_location>& hexes) = 0;
 
 	/**
 	 * The actual action function which is called by click() and drag(). Derived classes override this instead of click() and drag().
 	 */
-	virtual editor_action* click_perform_right(editor_display& disp, const std::set<map_location>& hexes) = 0;
+	virtual std::unique_ptr<editor_action> click_perform_right(editor_display& disp, const std::set<map_location>& hexes) = 0;
 
 	/**
 	 * Calls click_perform_left()
 	 */
-	editor_action* click_left(editor_display& disp, int x, int y);
+	std::unique_ptr<editor_action> click_left(editor_display& disp, int x, int y);
 
 	/**
 	 * Calls click_perform_right()
 	 */
-	editor_action* click_right(editor_display& disp, int x, int y);
+	std::unique_ptr<editor_action> click_right(editor_display& disp, int x, int y);
 
 	/**
 	 * Calls click_perform() for every new hex the mouse is dragged into.
 	 * @todo partial actions support and merging of many drag actions into one
 	 */
-	editor_action* drag_left(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
+	std::unique_ptr<editor_action> drag_left(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
 
 	/**
 	 * Calls click_perform for every new hex the mouse is dragged into.
 	 * @todo partial actions support and merging of many drag actions into one
 	 */
-	editor_action* drag_right(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
+	std::unique_ptr<editor_action> drag_right(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
 
 	/**
 	 * End of dragging.
 	 * @todo partial actions (the entire drag should end up as one action)
 	 */
-	editor_action* drag_end(editor_display& disp, int x, int y);
+	std::unique_ptr<editor_action> drag_end(editor_display& disp, int x, int y);
 
 protected:
 	/** Brush accessor */
@@ -231,8 +231,8 @@ private:
 	 * The drags differ only in the worker function called, which should be
 	 * passed as the template parameter. This exists only to avoid copy-pasting code.
 	 */
-	template <editor_action* (brush_drag_mouse_action::*perform_func)(editor_display&, const std::set<map_location>&)>
-	editor_action* drag_generic(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
+	template <std::unique_ptr<editor_action> (brush_drag_mouse_action::*perform_func)(editor_display&, const std::set<map_location>&)>
+	std::unique_ptr<editor_action> drag_generic(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
 
 	/**
 	 * Current brush handle. Currently a pointer-to-pointer with full constness.
@@ -259,22 +259,22 @@ public:
 	/**
 	 * Handle terrain sampling before calling generic handler
 	 */
-	editor_action* click_left(editor_display& disp, int x, int y) override;
+	std::unique_ptr<editor_action> click_left(editor_display& disp, int x, int y) override;
 
 	/**
 	 * Handle terrain sampling before calling generic handler
 	 */
-	editor_action* click_right(editor_display& disp, int x, int y) override;
+	std::unique_ptr<editor_action> click_right(editor_display& disp, int x, int y) override;
 
 	/**
 	 * Create an appropriate editor_action and return it
 	 */
-	editor_action* click_perform_left(editor_display& disp, const std::set<map_location>& hexes) override;
+	std::unique_ptr<editor_action> click_perform_left(editor_display& disp, const std::set<map_location>& hexes) override;
 
 	/**
 	 * Create an appropriate editor_action and return it
 	 */
-	editor_action* click_perform_right(editor_display& disp, const std::set<map_location>& hexes) override;
+	std::unique_ptr<editor_action> click_perform_right(editor_display& disp, const std::set<map_location>& hexes) override;
 
 	void set_mouse_overlay(editor_display& disp) override;
 
@@ -309,12 +309,12 @@ public:
 	/**
 	 * Return a paste with offset action
 	 */
-	editor_action* click_left(editor_display& disp, int x, int y) override;
+	std::unique_ptr<editor_action> click_left(editor_display& disp, int x, int y) override;
 
 	/**
 	 * Right click does nothing for now
 	 */
-	editor_action* click_right(editor_display& disp, int x, int y) override;
+	std::unique_ptr<editor_action> click_right(editor_display& disp, int x, int y) override;
 
 	virtual void set_mouse_overlay(editor_display& disp) override;
 
@@ -341,19 +341,19 @@ public:
 	/**
 	 * Tiles that will be painted to, possibly use modifier keys here
 	 */
-	std::set<map_location> affected_hexes(editor_display& disp, const map_location& hex);
+	std::set<map_location> affected_hexes(editor_display& disp, const map_location& hex) override;
 
 	/**
 	 * Left / right click fills with the respective terrain
 	 */
-	editor_action* click_left(editor_display& disp, int x, int y);
+	std::unique_ptr<editor_action> click_left(editor_display& disp, int x, int y) override;
 
 	/**
 	 * Left / right click fills with the respective terrain
 	 */
-	editor_action* click_right(editor_display& disp, int x, int y);
+	std::unique_ptr<editor_action> click_right(editor_display& disp, int x, int y) override;
 
-	virtual void set_mouse_overlay(editor_display& disp);
+	virtual void set_mouse_overlay(editor_display& disp) override;
 
 protected:
 	terrain_palette& terrain_palette_;
@@ -375,18 +375,18 @@ public:
 	 * or returns nullptr if cancel was pressed or there would be no change.
 	 * Do this on mouse up to avoid drag issue.
 	 */
-	editor_action* up_left(editor_display& disp, int x, int y);
+	std::unique_ptr<editor_action> up_left(editor_display& disp, int x, int y) override;
 
-	editor_action* click_left(editor_display& disp, int x, int y);
+	std::unique_ptr<editor_action> click_left(editor_display& disp, int x, int y) override;
 	/**
 	 * Right click only erases the starting position if there is one.
 	 * Do this on mouse up to avoid drag issue,
 	 */
-	editor_action* up_right(editor_display& disp, int x, int y);
+	std::unique_ptr<editor_action> up_right(editor_display& disp, int x, int y) override;
 
-	editor_action* click_right(editor_display& disp, int x, int y);
+	std::unique_ptr<editor_action> click_right(editor_display& disp, int x, int y) override;
 
-	virtual void set_mouse_overlay(editor_display& disp);
+	virtual void set_mouse_overlay(editor_display& disp) override;
 
 private:
 	bool click_;

--- a/src/editor/action/mouse/mouse_action_item.cpp
+++ b/src/editor/action/mouse/mouse_action_item.cpp
@@ -18,7 +18,6 @@
 #include "editor/action/action_item.hpp"
 
 #include "editor/editor_display.hpp"
-//#include "gui/dialogs/item_create.hpp"
 #include "tooltips.hpp"
 #include "gettext.hpp"
 
@@ -42,32 +41,10 @@ void mouse_action_item::move(editor_display& disp, const map_location& hex)
 
 		disp.invalidate(adjacent_set);
 		previous_move_hex_ = hex;
-
-	//	const item_map& items = disp.get_items();
-	//	const item_map::const_item_iterator item_it = items.find(hex);
-//		if (item_it != items.end()) {
-//
-//			disp.set_mouseover_hex_overlay(nullptr);
-//
-//			SDL_Rect rect;
-//			rect.x = disp.get_location_x(hex);
-//			rect.y = disp.get_location_y(hex);
-//			rect.h = disp.hex_size();
-//			rect.w = disp.hex_size();
-//			std::stringstream str;
-//			str << N_("ID: ")   << item_it->id()   << "\n"
-//				<< N_("Name: ") << item_it->name() << "\n"
-//				<< N_("Type: ") << item_it->type_name();
-//			tooltips::clear_tooltips();
-//			tooltips::add_tooltip(rect, str.str());
-//		}
-//		else {
-//			set_mouse_overlay(disp);
-//		}
 	}
 }
 
-editor_action* mouse_action_item::click_left(editor_display& disp, int x, int y)
+std::unique_ptr<editor_action> mouse_action_item::click_left(editor_display& disp, int x, int y)
 {
 	start_hex_ = disp.hex_clicked_on(x, y);
 	if (!disp.get_map().on_board(start_hex_)) {
@@ -77,24 +54,18 @@ editor_action* mouse_action_item::click_left(editor_display& disp, int x, int y)
 	const overlay& item = item_palette_.selected_fg_item();
 	disp.add_overlay(start_hex_, item.image, item.halo, "", "", true);
 
-
-
-//	const item_map::const_item_iterator item_it = items.find(start_hex_);
-//	if (item_it != items.end())
-//		set_item_mouse_overlay(disp, item_it->type());
-
 	click_ = true;
 	return nullptr;
 }
 
-editor_action* mouse_action_item::drag_left(editor_display& disp, int x, int y, bool& /*partial*/, editor_action* /*last_undo*/)
+std::unique_ptr<editor_action> mouse_action_item::drag_left(editor_display& disp, int x, int y, bool& /*partial*/, editor_action* /*last_undo*/)
 {
 	map_location hex = disp.hex_clicked_on(x, y);
 	click_ = (hex == start_hex_);
 	return nullptr;
 }
 
-editor_action* mouse_action_item::up_left(editor_display& disp, int x, int y)
+std::unique_ptr<editor_action> mouse_action_item::up_left(editor_display& disp, int x, int y)
 {
 	if (!click_) return nullptr;
 	click_ = false;
@@ -123,13 +94,18 @@ editor_action* mouse_action_item::up_left(editor_display& disp, int x, int y)
 //	editor_action* action = new editor_action_item(hex, new_item);
 //	return action;
 
+// \todo in #5070: there's a load of commented-out code in this file, it should probably
+// all be deleted. For the function that this comment is in, I've left the commented-out
+// code in because it seems the not-commented code should also be reviewed. AFAICS, the
+// entire function (including the not-commented code) could be deleted, and fall back to
+// the parent class' implementation of just returning nullptr.
+
 	return nullptr;
 }
 
-editor_action* mouse_action_item::drag_end_left(editor_display& disp, int x, int y)
+std::unique_ptr<editor_action> mouse_action_item::drag_end_left(editor_display& disp, int x, int y)
 {
 	if (click_) return nullptr;
-	editor_action* action = nullptr;
 
 	map_location hex = disp.hex_clicked_on(x, y);
 	if (!disp.get_map().on_board(hex))
@@ -140,88 +116,8 @@ editor_action* mouse_action_item::drag_end_left(editor_display& disp, int x, int
 //	if (item_it == items.end())
 //		return nullptr;
 
-	action = new editor_action_item_replace(start_hex_, hex);
-	return action;
+	return std::make_unique<editor_action_item_replace>(start_hex_, hex);
 }
-
-/*
-editor_action* mouse_action_item::click_right(editor_display& disp, int x, int y)
-{
-	map_location hex = disp.hex_clicked_on(x, y);
-	start_hex_ = hex;
-	previous_move_hex_ = hex;
-
-	const item_map& items = disp.get_items();
-	const item_map::const_item_iterator item_it = items.find(start_hex_);
-
-	if (item_it != items.end()) {
-		old_direction_ = item_it->facing();
-	}
-
-	click_ = true;
-	return nullptr;
-}
-*/
-
-//editor_action* mouse_action_item::drag_right(editor_display& disp, int x, int y, bool& /*partial*/, editor_action* /*last_undo*/)
-//{
-//	map_location hex = disp.hex_clicked_on(x, y);
-//	if (previous_move_hex_ == hex)
-//		return nullptr;
-//
-//	click_ = (start_hex_ == hex);
-//	previous_move_hex_ = hex;
-//
-//	const item_map& items = disp.get_items();
-//
-//	const item_map::const_item_iterator item_it = items.find(start_hex_);
-//	if (item_it != items.end()) {
-//		for (map_location::DIRECTION new_direction = map_location::NORTH;
-//				new_direction <= map_location::NORTH_WEST;
-//				new_direction = map_location::DIRECTION(new_direction +1)){
-//			if (item_it->get_location().get_direction(new_direction, 1) == hex) {
-//				return new editor_action_item_facing(start_hex_, new_direction, old_direction_);
-//			}
-//		}
-//	}
-//
-//	return nullptr;
-//}
-
-//editor_action* mouse_action_item::up_right(editor_display& disp, int /*x*/, int /*y*/)
-//{
-//	if (!click_) return nullptr;
-//	click_ = false;
-//
-//	const item_map& items = disp.get_items();
-//	const item_map::const_item_iterator item_it = items.find(start_hex_);
-//	if (item_it != items.end()) {
-//		return new editor_action_item_delete(start_hex_);
-//	}
-//
-//	return nullptr;
-//}
-
-//editor_action* mouse_action_item::drag_end_right(editor_display& disp, int x, int y)
-//{
-//	if (click_) return nullptr;
-//
-//	map_location hex = disp.hex_clicked_on(x, y);
-//	if (!disp.get_map().on_board(hex))
-//		return nullptr;
-//
-//	if(new_direction_ != old_direction_) {
-//
-//	const item_map& items = disp.get_items();
-//	const item_map::const_item_iterator item_it = items.find(start_hex_);
-//		if (item_it != items.end()) {
-//			return new editor_action_item_facing(start_hex_, new_direction_, old_direction_);
-//		}
-//	}
-//
-//	return nullptr;
-//}
-
 
 void mouse_action_item::set_mouse_overlay(editor_display& disp)
 {

--- a/src/editor/action/mouse/mouse_action_item.hpp
+++ b/src/editor/action/mouse/mouse_action_item.hpp
@@ -35,35 +35,35 @@ public:
 	{
 	}
 
-	bool has_context_menu() const {
+	bool has_context_menu() const override {
 		return true;
 	}
 
-	void move(editor_display& disp, const map_location& hex);
+	void move(editor_display& disp, const map_location& hex) override;
 
 	/**
 	 * TODO
 	 */
-	editor_action* click_left(editor_display& disp, int x, int y);
+	std::unique_ptr<editor_action> click_left(editor_display& disp, int x, int y) override;
 
 	/**
 	 * TODO
 	 */
-	editor_action* up_left(editor_display& disp, int x, int y);
+	std::unique_ptr<editor_action> up_left(editor_display& disp, int x, int y) override;
 
-	editor_action* drag_left(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
+	std::unique_ptr<editor_action> drag_left(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo) override;
 
 	/**
 	 * Drag end replaces the item when clicked left, or adjusts
 	 * the facing when clicked right.
 	 */
-	editor_action* drag_end_left(editor_display& disp, int x, int y);
+	std::unique_ptr<editor_action> drag_end_left(editor_display& disp, int x, int y) override;
 
-	editor_action* click_right(editor_display& /*disp*/, int /*x*/, int /*y*/) {
+	std::unique_ptr<editor_action> click_right(editor_display& /*disp*/, int /*x*/, int /*y*/) override {
 		return nullptr;
 	}
 
-	virtual void set_mouse_overlay(editor_display& disp);
+	virtual void set_mouse_overlay(editor_display& disp) override;
 	void set_item_mouse_overlay(editor_display& disp, const overlay& u);
 
 private:

--- a/src/editor/action/mouse/mouse_action_map_label.cpp
+++ b/src/editor/action/mouse/mouse_action_map_label.cpp
@@ -27,7 +27,7 @@
 
 namespace editor {
 
-editor_action* mouse_action_map_label::click_left(editor_display& disp, int x, int y)
+std::unique_ptr<editor_action> mouse_action_map_label::click_left(editor_display& disp, int x, int y)
 {
 	click_ = true;
 	map_location hex = disp.hex_clicked_on(x, y);
@@ -35,7 +35,7 @@ editor_action* mouse_action_map_label::click_left(editor_display& disp, int x, i
 	return nullptr;
 }
 
-editor_action* mouse_action_map_label::drag_left(editor_display& disp, int x, int y
+std::unique_ptr<editor_action> mouse_action_map_label::drag_left(editor_display& disp, int x, int y
 		, bool& /*partial*/, editor_action* /*last_undo*/)
 {
 	map_location hex = disp.hex_clicked_on(x, y);
@@ -43,7 +43,7 @@ editor_action* mouse_action_map_label::drag_left(editor_display& disp, int x, in
 	return nullptr;
 }
 
-editor_action* mouse_action_map_label::up_left(editor_display& disp, int x, int y)
+std::unique_ptr<editor_action> mouse_action_map_label::up_left(editor_display& disp, int x, int y)
 {
 	if (!click_) return nullptr;
 	click_ = false;
@@ -64,21 +64,21 @@ editor_action* mouse_action_map_label::up_left(editor_display& disp, int x, int 
 
 	gui2::dialogs::editor_edit_label d(label, immutable, visible_fog, visible_shroud, color, category);
 
-	editor_action* a = nullptr;
+	std::unique_ptr<editor_action> a;
 	if(d.show()) {
-		a = new editor_action_label(hex, label, team_name, color
+		a = std::make_unique<editor_action_label>(hex, label, team_name, color
 				, visible_fog, visible_shroud, immutable, category);
 		update_brush_highlights(disp, hex);
 	}
 	return a;
 }
 
-editor_action* mouse_action_map_label::click_right(editor_display& /*disp*/, int /*x*/, int /*y*/)
+std::unique_ptr<editor_action> mouse_action_map_label::click_right(editor_display& /*disp*/, int /*x*/, int /*y*/)
 {
 	return nullptr;
 }
 
-editor_action* mouse_action_map_label::up_right(editor_display& disp, int x, int y)
+std::unique_ptr<editor_action> mouse_action_map_label::up_right(editor_display& disp, int x, int y)
 {
 	map_location hex = disp.hex_clicked_on(x, y);
 
@@ -87,10 +87,10 @@ editor_action* mouse_action_map_label::up_right(editor_display& disp, int x, int
 	//if (!clicked_label)
 	//	return nullptr;
 
-	return new editor_action_label_delete(hex);
+	return std::make_unique<editor_action_label_delete>(hex);
 }
 
-editor_action* mouse_action_map_label::drag_end_left(editor_display& disp, int x, int y)
+std::unique_ptr<editor_action> mouse_action_map_label::drag_end_left(editor_display& disp, int x, int y)
 {
 	if (click_) return nullptr;
 
@@ -113,10 +113,11 @@ editor_action* mouse_action_map_label::drag_end_left(editor_display& disp, int x
 	// 1. Delete label in initial hex
 	// 2. Delete label in target hex if it exists, otherwise will no-op
 	// 3. Create label in target hex
-	editor_action_chain* chain = new editor_action_chain(new editor_action_label_delete(clicked_on_));
-	chain->append_action(new editor_action_label_delete(hex));
+	auto chain = std::make_unique<editor_action_chain>();
+	chain->append_action(std::make_unique<editor_action_label_delete>(clicked_on_));
+	chain->append_action(std::make_unique<editor_action_label_delete>(hex));
 	chain->append_action(
-		new editor_action_label(
+		std::make_unique<editor_action_label>(
 			hex,
 			dragged_label->text(),
 			dragged_label->team_name(),

--- a/src/editor/action/mouse/mouse_action_map_label.hpp
+++ b/src/editor/action/mouse/mouse_action_map_label.hpp
@@ -32,31 +32,31 @@ public:
 	  {
 	  }
 
-	editor_action* click_left(editor_display& disp, int x, int y);
+	std::unique_ptr<editor_action> click_left(editor_display& disp, int x, int y) override;
 
 	/**
 	 * Drags a label.
 	 */
-	editor_action* drag_left(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
+	std::unique_ptr<editor_action> drag_left(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo) override;
 
 	/**
 	 * Replaces the label under the mouse with the dragged label.
 	 */
-	editor_action* drag_end_left(editor_display& disp, int x, int y);
+	std::unique_ptr<editor_action> drag_end_left(editor_display& disp, int x, int y) override;
 
 	/**
 	 * Left click displays a dialog that is used for entering the label string.
 	 */
-	editor_action* up_left(editor_display& disp, int x, int y);
+	std::unique_ptr<editor_action> up_left(editor_display& disp, int x, int y) override;
 
-	editor_action* click_right(editor_display& disp, int x, int y);
+	std::unique_ptr<editor_action> click_right(editor_display& disp, int x, int y) override;
 
 	/**
 	 * Right click erases the label under the mouse.
 	 */
-	editor_action* up_right(editor_display& disp, int x, int y);
+	std::unique_ptr<editor_action> up_right(editor_display& disp, int x, int y) override;
 
-	virtual void set_mouse_overlay(editor_display& disp);
+	virtual void set_mouse_overlay(editor_display& disp) override;
 
 private:
 	bool click_;

--- a/src/editor/action/mouse/mouse_action_select.cpp
+++ b/src/editor/action/mouse/mouse_action_select.cpp
@@ -29,30 +29,32 @@ std::set<map_location> mouse_action_select::affected_hexes(
 	}
 }
 
-editor_action* mouse_action_select::key_event(
+std::unique_ptr<editor_action> mouse_action_select::key_event(
 		editor_display& disp, const SDL_Event& event)
 {
-	editor_action* ret = mouse_action::key_event(disp, event);
+	auto ret = mouse_action::key_event(disp, event);
 	update_brush_highlights(disp, previous_move_hex_);
 	return ret;
 }
 
-editor_action* mouse_action_select::click_perform_left(
+std::unique_ptr<editor_action> mouse_action_select::click_perform_left(
 		editor_display& /*disp*/, const std::set<map_location>& hexes)
 {
+	auto chain = std::make_unique<editor_action_chain>();
 	if (has_ctrl_modifier())
-		return new editor_action_chain(new editor_action_deselect(hexes));
+		chain->append_action(std::make_unique<editor_action_deselect>(hexes));
 	else
-		return new editor_action_chain(new editor_action_select(hexes));
+		chain->append_action(std::make_unique<editor_action_select>(hexes));
+	return chain;
 }
 
-editor_action* mouse_action_select::click_perform_right(
+std::unique_ptr<editor_action> mouse_action_select::click_perform_right(
 		editor_display& /*disp*/, const std::set<map_location>& /*hexes*/)
 {
 	return nullptr;
 }
 
-editor_action* mouse_action_select::click_right(editor_display& /*disp*/, int /*x*/, int /*y*/)
+std::unique_ptr<editor_action> mouse_action_select::click_right(editor_display& /*disp*/, int /*x*/, int /*y*/)
 {
 	return nullptr;
 }

--- a/src/editor/action/mouse/mouse_action_select.hpp
+++ b/src/editor/action/mouse/mouse_action_select.hpp
@@ -40,23 +40,23 @@ public:
 	/**
 	 * Force a fake "move" event to update brush overlay on key event
 	 */
-	editor_action* key_event(editor_display& disp, const SDL_Event& e) override;
+	std::unique_ptr<editor_action> key_event(editor_display& disp, const SDL_Event& e) override;
 
 	/**
 	 * Left click/drag selects
 	 */
-	editor_action* click_perform_left(editor_display& disp, const std::set<map_location>& hexes) override;
+	std::unique_ptr<editor_action> click_perform_left(editor_display& disp, const std::set<map_location>& hexes) override;
 
 	/**
 	 * Right click does nothing for now
 	 */
-	editor_action* click_right(editor_display& disp, int x, int y) override;
+	std::unique_ptr<editor_action> click_right(editor_display& disp, int x, int y) override;
 
 
 	/**
 	 * Right click/drag
 	 */
-	editor_action* click_perform_right(editor_display& disp, const std::set<map_location>& hexes) override;
+	std::unique_ptr<editor_action> click_perform_right(editor_display& disp, const std::set<map_location>& hexes) override;
 
 	virtual void set_mouse_overlay(editor_display& disp) override;
 

--- a/src/editor/action/mouse/mouse_action_unit.cpp
+++ b/src/editor/action/mouse/mouse_action_unit.cpp
@@ -84,7 +84,7 @@ void mouse_action_unit::move(editor_display& disp, const map_location& hex)
 	}
 }
 
-editor_action* mouse_action_unit::click_left(editor_display& disp, int x, int y)
+std::unique_ptr<editor_action> mouse_action_unit::click_left(editor_display& disp, int x, int y)
 {
 	start_hex_ = disp.hex_clicked_on(x, y);
 	if (!disp.get_map().on_board(start_hex_)) {
@@ -100,14 +100,14 @@ editor_action* mouse_action_unit::click_left(editor_display& disp, int x, int y)
 	return nullptr;
 }
 
-editor_action* mouse_action_unit::drag_left(editor_display& disp, int x, int y, bool& /*partial*/, editor_action* /*last_undo*/)
+std::unique_ptr<editor_action> mouse_action_unit::drag_left(editor_display& disp, int x, int y, bool& /*partial*/, editor_action* /*last_undo*/)
 {
 	map_location hex = disp.hex_clicked_on(x, y);
 	click_ = (hex == start_hex_);
 	return nullptr;
 }
 
-editor_action* mouse_action_unit::up_left(editor_display& disp, int x, int y)
+std::unique_ptr<editor_action> mouse_action_unit::up_left(editor_display& disp, int x, int y)
 {
 	if (!click_) return nullptr;
 	click_ = false;
@@ -133,14 +133,13 @@ editor_action* mouse_action_unit::up_left(editor_display& disp, int x, int y)
 	unit_race::GENDER gender = ut.genders().front();
 
 	unit_ptr new_unit = unit::create(ut, disp.viewing_side(), true, gender);
-	editor_action* action = new editor_action_unit(hex, *new_unit);
+	auto action = std::make_unique<editor_action_unit>(hex, *new_unit);
 	return action;
 }
 
-editor_action* mouse_action_unit::drag_end_left(editor_display& disp, int x, int y)
+std::unique_ptr<editor_action> mouse_action_unit::drag_end_left(editor_display& disp, int x, int y)
 {
 	if (click_) return nullptr;
-	editor_action* action = nullptr;
 
 	map_location hex = disp.hex_clicked_on(x, y);
 	if (!disp.get_map().on_board(hex))
@@ -151,88 +150,8 @@ editor_action* mouse_action_unit::drag_end_left(editor_display& disp, int x, int
 	if (unit_it == units.end())
 		return nullptr;
 
-	action = new editor_action_unit_replace(start_hex_, hex);
-	return action;
+	return std::make_unique<editor_action_unit_replace>(start_hex_, hex);
 }
-
-/*
-editor_action* mouse_action_unit::click_right(editor_display& disp, int x, int y)
-{
-	map_location hex = disp.hex_clicked_on(x, y);
-	start_hex_ = hex;
-	previous_move_hex_ = hex;
-
-	const unit_map& units = disp.units();
-	const unit_map::const_unit_iterator unit_it = units.find(start_hex_);
-
-	if (unit_it != units.end()) {
-		old_direction_ = unit_it->facing();
-	}
-
-	click_ = true;
-	return nullptr;
-}
-*/
-
-//editor_action* mouse_action_unit::drag_right(editor_display& disp, int x, int y, bool& /*partial*/, editor_action* /*last_undo*/)
-//{
-//	map_location hex = disp.hex_clicked_on(x, y);
-//	if (previous_move_hex_ == hex)
-//		return nullptr;
-//
-//	click_ = (start_hex_ == hex);
-//	previous_move_hex_ = hex;
-//
-//	const unit_map& units = disp.units();
-//
-//	const unit_map::const_unit_iterator unit_it = units.find(start_hex_);
-//	if (unit_it != units.end()) {
-//		for (map_location::DIRECTION new_direction = map_location::NORTH;
-//				new_direction <= map_location::NORTH_WEST;
-//				new_direction = map_location::DIRECTION(new_direction +1)){
-//			if (unit_it->get_location().get_direction(new_direction, 1) == hex) {
-//				return new editor_action_unit_facing(start_hex_, new_direction, old_direction_);
-//			}
-//		}
-//	}
-//
-//	return nullptr;
-//}
-
-//editor_action* mouse_action_unit::up_right(editor_display& disp, int /*x*/, int /*y*/)
-//{
-//	if (!click_) return nullptr;
-//	click_ = false;
-//
-//	const unit_map& units = disp.units();
-//	const unit_map::const_unit_iterator unit_it = units.find(start_hex_);
-//	if (unit_it != units.end()) {
-//		return new editor_action_unit_delete(start_hex_);
-//	}
-//
-//	return nullptr;
-//}
-
-//editor_action* mouse_action_unit::drag_end_right(editor_display& disp, int x, int y)
-//{
-//	if (click_) return nullptr;
-//
-//	map_location hex = disp.hex_clicked_on(x, y);
-//	if (!disp.get_map().on_board(hex))
-//		return nullptr;
-//
-//	if(new_direction_ != old_direction_) {
-//
-//	const unit_map& units = disp.units();
-//	const unit_map::const_unit_iterator unit_it = units.find(start_hex_);
-//		if (unit_it != units.end()) {
-//			return new editor_action_unit_facing(start_hex_, new_direction_, old_direction_);
-//		}
-//	}
-//
-//	return nullptr;
-//}
-
 
 void mouse_action_unit::set_mouse_overlay(editor_display& disp)
 {

--- a/src/editor/action/mouse/mouse_action_unit.hpp
+++ b/src/editor/action/mouse/mouse_action_unit.hpp
@@ -35,35 +35,35 @@ public:
 	{
 	}
 
-	bool has_context_menu() const {
+	bool has_context_menu() const override {
 		return true;
 	}
 
-	void move(editor_display& disp, const map_location& hex);
+	void move(editor_display& disp, const map_location& hex) override;
 
 	/**
 	 * TODO
 	 */
-	editor_action* click_left(editor_display& disp, int x, int y);
+	std::unique_ptr<editor_action> click_left(editor_display& disp, int x, int y) override;
 
 	/**
 	 * TODO
 	 */
-	editor_action* up_left(editor_display& disp, int x, int y);
+	std::unique_ptr<editor_action> up_left(editor_display& disp, int x, int y) override;
 
-	editor_action* drag_left(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
+	std::unique_ptr<editor_action> drag_left(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo) override;
 
 	/**
 	 * Drag end replaces the unit when clicked left, or adjusts
 	 * the facing when clicked right.
 	 */
-	editor_action* drag_end_left(editor_display& disp, int x, int y);
+	std::unique_ptr<editor_action> drag_end_left(editor_display& disp, int x, int y) override;
 
-	editor_action* click_right(editor_display& /*disp*/, int /*x*/, int /*y*/) {
+	std::unique_ptr<editor_action> click_right(editor_display& /*disp*/, int /*x*/, int /*y*/) override {
 		return nullptr;
 	}
 
-	virtual void set_mouse_overlay(editor_display& disp);
+	virtual void set_mouse_overlay(editor_display& disp) override;
 	void set_unit_mouse_overlay(editor_display& disp, const unit_type& u);
 
 private:

--- a/src/editor/action/mouse/mouse_action_village.cpp
+++ b/src/editor/action/mouse/mouse_action_village.cpp
@@ -19,22 +19,22 @@
 
 namespace editor {
 
-editor_action* mouse_action_village::up_left(editor_display& disp, int x, int y)
+std::unique_ptr<editor_action> mouse_action_village::up_left(editor_display& disp, int x, int y)
 {
 	map_location hex = disp.hex_clicked_on(x, y);
 	if (!disp.get_map().on_board(hex))   return nullptr;
 	if (!disp.get_map().is_village(hex)) return nullptr;
 
-	return new editor_action_village(hex, disp.playing_team());
+	return std::make_unique<editor_action_village>(hex, disp.playing_team());
 }
 
-editor_action* mouse_action_village::up_right(editor_display& disp, int x, int y)
+std::unique_ptr<editor_action> mouse_action_village::up_right(editor_display& disp, int x, int y)
 {
 	map_location hex = disp.hex_clicked_on(x, y);
 	if (!disp.get_map().on_board(hex))   return nullptr;
 	if (!disp.get_map().is_village(hex)) return nullptr;
 
-	return new editor_action_village_delete(hex);
+	return std::make_unique<editor_action_village_delete>(hex);
 }
 
 void mouse_action_village::set_mouse_overlay(editor_display& disp)

--- a/src/editor/action/mouse/mouse_action_village.hpp
+++ b/src/editor/action/mouse/mouse_action_village.hpp
@@ -36,24 +36,24 @@ public:
 	/**
 	 * No action.
 	 */
-	editor_action* click_left(editor_display& /*disp*/, int /*x*/, int /*y*/) {return nullptr;}
+	std::unique_ptr<editor_action> click_left(editor_display& /*disp*/, int /*x*/, int /*y*/) override {return nullptr;}
 
 	/**
 	 * If clicked on a village hex field, assigns the ownership of it to the current side.
 	 */
-	editor_action* up_left(editor_display& disp, int x, int y);
+	std::unique_ptr<editor_action> up_left(editor_display& disp, int x, int y) override;
 
 	/**
 	 * No action.
 	 */
-	editor_action* click_right(editor_display& /*disp*/, int /*x*/, int /*y*/) {return nullptr;}
+	std::unique_ptr<editor_action> click_right(editor_display& /*disp*/, int /*x*/, int /*y*/) override {return nullptr;}
 
 	/**
 	 * If clicked on a village hex field, unassigns it's ownership.
 	 */
-	editor_action* up_right(editor_display& disp, int x, int y);
+	std::unique_ptr<editor_action> up_right(editor_display& disp, int x, int y) override;
 
-	virtual void set_mouse_overlay(editor_display& disp);
+	virtual void set_mouse_overlay(editor_display& disp) override;
 };
 
 

--- a/src/editor/controller/editor_controller.hpp
+++ b/src/editor/controller/editor_controller.hpp
@@ -188,13 +188,13 @@ class editor_controller : public controller_base,
 		 * Perform an action, then delete the action object.
 		 * The pointer can be nullptr, in which case nothing will happen.
 		 */
-		void perform_delete(editor_action* action);
+		void perform_delete(std::unique_ptr<editor_action> action);
 
 		/**
 		 * Peform an action on the current map_context, then refresh the display
 		 * and delete the pointer. The pointer can be nullptr, in which case nothing will happen.
 		 */
-		void perform_refresh_delete(editor_action* action, bool drag_part = false);
+		void perform_refresh_delete(std::unique_ptr<editor_action> action, bool drag_part = false);
 
 
 		virtual std::vector<std::string> additional_actions_pressed() override;

--- a/src/editor/editor_common.hpp
+++ b/src/editor/editor_common.hpp
@@ -64,10 +64,7 @@ class map_context;
 class map_fragment;
 class mouse_action;
 
-/** Action pointer typedef. */
-using editor_action_ptr = std::unique_ptr<editor_action>;
-
 /** Action stack typedef. */
-using action_stack = std::deque<editor_action_ptr>;
+using action_stack = std::deque<std::unique_ptr<editor_action>>;
 
 } //end namespace editor

--- a/src/editor/map/map_context.cpp
+++ b/src/editor/map/map_context.cpp
@@ -685,7 +685,7 @@ void map_context::perform_action(const editor_action& action)
 {
 	LOG_ED << "Performing action " << action.get_id() << ": " << action.get_name() << ", actions count is "
 		   << action.get_instance_count() << std::endl;
-	editor_action* undo = action.perform(*this);
+	auto undo = action.perform(*this);
 	if(actions_since_save_ < 0) {
 		// set to a value that will make it impossible to get to zero, as at this point
 		// it is no longer possible to get back the original map state using undo/redo
@@ -694,7 +694,7 @@ void map_context::perform_action(const editor_action& action)
 
 	++actions_since_save_;
 
-	undo_stack_.emplace_back(undo);
+	undo_stack_.emplace_back(std::move(undo));
 
 	trim_stack(undo_stack_);
 
@@ -714,10 +714,10 @@ void map_context::perform_partial_action(const editor_action& action)
 		throw editor_logic_exception("Last undo action not a chain in perform_partial_action()");
 	}
 
-	editor_action* undo = action.perform(*this);
+	auto undo = action.perform(*this);
 
 	// actions_since_save_ += action.action_count();
-	undo_chain->prepend_action(undo);
+	undo_chain->prepend_action(std::move(undo));
 
 	redo_stack_.clear();
 }
@@ -809,7 +809,7 @@ void map_context::partial_undo()
 
 	// a partial undo performs the first action form the current action's action_chain that would be normally performed
 	// i.e. the *first* one.
-	const editor_action_ptr first_action_in_chain(undo_chain->pop_first_action());
+	const auto first_action_in_chain = undo_chain->pop_first_action();
 	if(undo_chain->empty()) {
 		actions_since_save_--;
 		undo_stack_.pop_back();
@@ -836,13 +836,13 @@ void map_context::perform_action_between_stacks(action_stack& from, action_stack
 {
 	assert(!from.empty());
 
-	editor_action_ptr action(nullptr);
+	std::unique_ptr<editor_action> action;
 	action.swap(from.back());
 
 	from.pop_back();
 
-	editor_action* reverse_action = action->perform(*this);
-	to.emplace_back(reverse_action);
+	auto reverse_action = action->perform(*this);
+	to.emplace_back(std::move(reverse_action));
 
 	trim_stack(to);
 }


### PR DESCRIPTION
When returning std::unique_ptr instead of raw pointers, the return type can't be a co-variant, which is why the clone() functions are all being changed to return the base class.   

Most of the dozen or so uses of editor_action_ptr where replaced with the `auto` keyword, but the reason that I didn't use in it the new code was that I find `std::unique_ptr<editor_action>` quicker to read than remembering if editor_action_ptr is a unique_ptr, a shared_ptr or a plain raw pointer.