### PR TITLE
Only show notifications for visible mp games (fixes #4723)

### DIFF
--- a/src/game_initialization/lobby_info.cpp
+++ b/src/game_initialization/lobby_info.cpp
@@ -343,6 +343,24 @@ void lobby_info::make_games_vector()
 	games_visibility_.flip();
 }
 
+bool lobby_info::is_game_visible(const game_info& game) {
+	bool show = true;
+
+	for(const auto& filter_func : game_filters_) {
+		show = filter_func(game);
+
+		if(!show) {
+			break;
+		}
+	}
+
+	if(game_filter_invert_) {
+		show = !show;
+	}
+
+	return show;
+}
+
 void lobby_info::apply_game_filter()
 {
 	// Since games_visibility_ is a visibility mask over games_,
@@ -350,21 +368,7 @@ void lobby_info::apply_game_filter()
 	assert(games_visibility_.size() == games_.size());
 
 	for(unsigned i = 0; i < games_.size(); ++i) {
-		bool show = true;
-
-		for(const auto& filter_func : game_filters_) {
-			show = filter_func(*games_[i]);
-
-			if(!show) {
-				break;
-			}
-		}
-
-		if(game_filter_invert_) {
-			show = !show;
-		}
-
-		games_visibility_[i] = show;
+		games_visibility_[i] = is_game_visible(*games_[i]);
 	}
 }
 

--- a/src/game_initialization/lobby_info.hpp
+++ b/src/game_initialization/lobby_info.hpp
@@ -83,6 +83,9 @@ public:
 		game_filter_invert_ = value;
 	}
 
+	/** Returns whether the game would be visible after the game filters are applied */
+	bool is_game_visible(const game_info&);
+
 	/** Generates a new list of games that match the current filter functions and inversion setting. */
 	void apply_game_filter();
 

--- a/src/gui/dialogs/multiplayer/lobby.cpp
+++ b/src/gui/dialogs/multiplayer/lobby.cpp
@@ -310,7 +310,9 @@ void mp_lobby::update_gamelist_diff()
 		if(game.display_status == mp::game_info::NEW) {
 			// call void do_notify(notify_mode mode, const std::string& sender, const std::string& message)
 			// sender will be the game_info.scenario (std::string) and message will be game_info.name (std::string)
-			do_notify(mp::NOTIFY_GAME_CREATED, game.scenario, game.name);
+			if (lobby_info_.is_game_visible(game)) {
+				do_notify(mp::NOTIFY_GAME_CREATED, game.scenario, game.name);
+			}
 
 			LOG_LB << "Adding game to listbox " << game.id << "\n";
 


### PR DESCRIPTION
https://github.com/wesnoth/wesnoth/issues/4723

Don't know if this approach is best, but I broke out a `is_game_visible` method from `apply_game_filter` to test if an individual game is visible.
I had originally considered adding some sort of check in
https://github.com/wesnoth/wesnoth/blob/1cdc4ef530835876621f74b681646271fc4646b0/src/gui/dialogs/multiplayer/lobby.cpp#L310-L313
 but it proved tricky because the game filter isn't actually applied until https://github.com/wesnoth/wesnoth/blob/1cdc4ef530835876621f74b681646271fc4646b0/src/gui/dialogs/multiplayer/lobby.cpp#L397 Making an additional call to `apply_game_filter` beforehand worked but didn't seem like a good idea to call it so many times. (the logic in `lobby.cpp` is messy enough already)
