### PR TITLE
Add addon version selection dropdown list

### DIFF
--- a/data/gui/window/addon_manager.cfg
+++ b/data/gui/window/addon_manager.cfg
@@ -125,16 +125,13 @@
 									[column]
 										border = "left,top,bottom"
 										border_size = 5
-										horizontal_alignment = "left"
-
-										[scroll_label]
-											id = "version"
-											definition = "default_small"
-
-											horizontal_scrollbar_mode = "never"
-											vertical_scrollbar_mode = "never"
-										[/scroll_label]
-
+										horizontal_alignment = "right"
+										
+										[menu_button]
+											id = "version_filter"
+											definition = "default"
+											tooltip = _"Select the add-on version"
+										[/menu_button]
 									[/column]
 
 								[/row]

--- a/src/addon/client.cpp
+++ b/src/addon/client.cpp
@@ -261,7 +261,7 @@ bool addons_client::delete_remote_addon(const std::string& id, std::string& resp
 	return !update_last_error(response_buf);
 }
 
-bool addons_client::download_addon(config& archive_cfg, const std::string& id, const std::string& title, bool increase_downloads)
+bool addons_client::download_addon(config& archive_cfg, const std::string& id, const std::string& title, const version_info& version, bool increase_downloads)
 {
 	archive_cfg.clear();
 
@@ -270,6 +270,7 @@ bool addons_client::download_addon(config& archive_cfg, const std::string& id, c
 
 	request_body["name"] = id;
 	request_body["increase_downloads"] = increase_downloads;
+	request_body["version"] = version.str();
 	request_body["from_version"] = get_addon_version_info(id);
 
 	utils::string_map i18n_symbols;
@@ -399,7 +400,7 @@ bool addons_client::try_fetch_addon(const addon_info & addon)
 	config archive;
 
 	if(!(
-		download_addon(archive, addon.id, addon.display_title_full(), !is_addon_installed(addon.id)) &&
+		download_addon(archive, addon.id, addon.display_title_full(), addon.current_version, !is_addon_installed(addon.id)) &&
 		install_addon(archive, addon)
 		)) {
 		const std::string& server_error = get_last_server_error();

--- a/src/addon/client.hpp
+++ b/src/addon/client.hpp
@@ -148,7 +148,7 @@ private:
 	* @param increase_downloads Whether to request the server to increase the add-on's
 	*                           download count or not (e.g. when upgrading).
 	*/
-	bool download_addon(config& archive_cfg, const std::string& id, const std::string& title, bool increase_downloads = true);
+	bool download_addon(config& archive_cfg, const std::string& id, const std::string& title, const version_info& version, bool increase_downloads = true);
 
 	/**
 	* Installs the specified add-on using an archive received from the server.

--- a/src/addon/info.cpp
+++ b/src/addon/info.cpp
@@ -79,12 +79,17 @@ void addon_info::read(const config& cfg)
 	title = cfg["title"].str();
 	description = cfg["description"].str();
 	icon = cfg["icon"].str();
-	version = cfg["version"].str();
+	current_version = cfg["version"].str();
+	versions.emplace(cfg["version"].str());
 	author = cfg["author"].str();
 	size = cfg["size"];
 	downloads = cfg["downloads"];
 	uploads = cfg["uploads"];
 	type = get_addon_type(cfg["type"].str());
+
+	for(const config& version : cfg.child_range("version")) {
+		versions.emplace(version["version"].str());
+	}
 
 	const config::const_child_itors& locales_as_configs = cfg.child_range("translation");
 
@@ -111,12 +116,17 @@ void addon_info::write(config& cfg) const
 	cfg["title"] = title;
 	cfg["description"] = description;
 	cfg["icon"] = icon;
-	cfg["version"] = version.str();
+	cfg["version"] = current_version.str();
 	cfg["author"] = author;
 	cfg["size"] = size;
 	cfg["downloads"] = downloads;
 	cfg["uploads"] = uploads;
 	cfg["type"] = get_addon_type_string(type);
+
+	for(const version_info& version : versions) {
+		config& version_cfg = cfg.add_child("version");
+		version_cfg["version"] = version.str();
+	}
 
 	for(const auto& element : info_translations) {
 		config& locale = cfg.add_child("translation");
@@ -135,7 +145,7 @@ void addon_info::write(config& cfg) const
 
 void addon_info::write_minimal(config& cfg) const
 {
-	cfg["version"] = version.str();
+	cfg["version"] = current_version.str();
 	cfg["uploads"] = uploads;
 	cfg["type"] = get_addon_type_string(type);
 	cfg["title"] = title;

--- a/src/addon/info.hpp
+++ b/src/addon/info.hpp
@@ -86,7 +86,8 @@ struct addon_info
 
 	std::string icon;
 
-	version_info version;
+	version_info current_version;
+	std::set<version_info, std::greater<version_info>> versions;
 
 	std::string author;
 
@@ -117,8 +118,8 @@ struct addon_info
 
 	addon_info()
 		: id(), title(), description(), icon()
-		, version(), author(), size(), downloads()
-		, uploads(), type(), tags(), locales()
+		, current_version(), versions(), author(), size()
+		, downloads(), uploads(), type(), tags(), locales()
 		, core()
 		, depends()
 		, feedback_url()
@@ -130,8 +131,8 @@ struct addon_info
 
 	explicit addon_info(const config& cfg)
 		: id(), title(), description(), icon()
-		, version(), author(), size(), downloads()
-		, uploads(), type(), tags(), locales()
+		, current_version(), versions(), author(), size()
+		, downloads(), uploads(), type(), tags(), locales()
 		, core()
 		, depends()
 		, feedback_url()
@@ -151,7 +152,8 @@ struct addon_info
 			this->title = o.title;
 			this->description = o.description;
 			this->icon = o.icon;
-			this->version = o.version;
+			this->current_version = o.current_version;
+			this->versions = o.versions;
 			this->author = o.author;
 			this->size = o.size;
 			this->downloads = o.downloads;

--- a/src/addon/state.cpp
+++ b/src/addon/state.cpp
@@ -33,10 +33,10 @@ addon_tracking_info get_addon_tracking_info(const addon_info& addon)
 	if(is_addon_installed(id)) {
 		if(t.can_publish) {
 			if(addon.local_only) {
-				t.installed_version = addon.version;
+				t.installed_version = addon.current_version;
 				//t.remote_version = version_info();
 			} else {
-				t.remote_version = addon.version;
+				t.remote_version = *addon.versions.begin();
 
 				// Try to obtain the version number from the .pbl first.
 				config pbl = get_addon_pbl_info(id);
@@ -50,7 +50,7 @@ addon_tracking_info get_addon_tracking_info(const addon_info& addon)
 		} else {
 			// We normally use the _info.cfg version instead.
 			t.installed_version = get_addon_version_info(id);
-			t.remote_version = addon.version;
+			t.remote_version = *addon.versions.begin();
 		}
 
 		if(t.remote_version == t.installed_version) {

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -666,7 +666,16 @@ void addon_manager::execute_action_on_selected_addon(window& window)
 
 void addon_manager::install_addon(const addon_info& addon, window& window)
 {
-	addons_client::install_result result = client_.install_addon_with_checks(addons_, addon);
+	addon_info versioned_addon = addon;
+	widget* parent = &window;
+	if(stacked_widget* stk = find_widget<stacked_widget>(&window, "main_stack", false, false)) {
+		parent = stk->get_layer_grid(1);
+	}
+	if(addon.id == find_widget<addon_list>(&window, "addons", false).get_selected_addon()->id) {
+		versioned_addon.current_version = find_widget<menu_button>(parent, "version_filter", false).get_value_string();
+	}
+
+	addons_client::install_result result = client_.install_addon_with_checks(addons_, versioned_addon);
 
 	// Take note if any wml_changes occurred
 	need_wml_cache_refresh_ |= result.wml_changed;

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -885,7 +885,7 @@ void addon_manager::on_addon_select(window& window)
 
 	find_widget<styled_widget>(parent, "title", false).set_label(info->display_title_translated_or_original());
 	find_widget<styled_widget>(parent, "description", false).set_label(info->description_translated());
-	find_widget<styled_widget>(parent, "version", false).set_label(info->version.str());
+	menu_button& version_filter = find_widget<menu_button>(parent, "version_filter", false);
 	find_widget<styled_widget>(parent, "author", false).set_label(info->author);
 	find_widget<styled_widget>(parent, "type", false).set_label(info->display_type());
 
@@ -929,6 +929,8 @@ void addon_manager::on_addon_select(window& window)
 	bool updatable = tracking_info_[info->id].state == ADDON_INSTALLED_UPGRADABLE;
 
 	stacked_widget& action_stack = find_widget<stacked_widget>(parent, "action_stack", false);
+	// #TODO: Add tooltips with upload time and pack size
+	std::vector<config> version_filter_entries;
 
 	if(!tracking_info_[info->id].can_publish) {
 		action_stack.select_layer(0);
@@ -943,13 +945,23 @@ void addon_manager::on_addon_select(window& window)
 		}
 
 		find_widget<button>(parent, "uninstall", false).set_active(installed);
+
+		for(const auto& f : info->versions) {
+			version_filter_entries.emplace_back("label", f.str());
+		}
+		version_filter.set_active(true);
 	} else {
 		action_stack.select_layer(1);
 
 		// Always enable the publish button, but disable the delete button if not yet published.
 		find_widget<button>(parent, "publish", false).set_active(true);
 		find_widget<button>(parent, "delete", false).set_active(!info->local_only);
+
+		// Show only the version to be published
+		version_filter_entries.emplace_back("label", info->current_version.str());
+		version_filter.set_active(false);
 	}
+	version_filter.set_values(version_filter_entries);
 }
 
 bool addon_manager::exit_hook(window& window)

--- a/src/gui/widgets/addon_list.cpp
+++ b/src/gui/widgets/addon_list.cpp
@@ -203,7 +203,7 @@ void addon_list::set_addons(const addons_list& addons)
 			ss << tracking_info.installed_version.str() << "\n";
 		}
 
-		ss << addon.version.str();
+		ss << (*addon.versions.begin()).str();
 
 		if(special_version_display) {
 			ss.str(colorize_addon_state_string(ss.str(), tracking_info.state, false));


### PR DESCRIPTION
Replaced the version display label in the addons manager with a dropdown list displaying all the downloadable versions in descending order with the latest version chosen by default. The selector is frozen for the pubishable addons on their .pbl set version.

The tooltips with useful data like the upload time and the pack size will be added later (not in this pr) as they require some work on the server side.

Tested on my Wesnoth instance.