### PR TITLE
gitignore some additional patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,6 +202,8 @@ fonts/.uuid
 *~
 .deps
 .dirstamp
+*.cfg-bak
+*.orig
 
 # might be good to have, but not in data
 data/**/*.xcf

--- a/data/tools/emacs_mode/.gitignore
+++ b/data/tools/emacs_mode/.gitignore
@@ -1,0 +1,3 @@
+*.elc
+wesnoth-mode.info
+wesnoth-mode.pdf


### PR DESCRIPTION
This is just the gitignore part of #5164; the ignored files are generated and/or binary files that don't belong in the repository.
