### PR TITLE
Tweak Dead Water difficulty

### DIFF
--- a/data/campaigns/Dead_Water/scenarios/04_Slavers.cfg
+++ b/data/campaigns/Dead_Water/scenarios/04_Slavers.cfg
@@ -47,11 +47,11 @@
 
     {DEFAULT_SCHEDULE_DUSK}
     turns=10
-    {TURNS4 30 28 26 24}
+    {TURNS4 32 28 26 24}
 
     [side]
         {SIDE_1}
-        {GOLD4 180 180 160 150}
+        {GOLD4 200 180 160 150}
     [/side]
     {STARTING_VILLAGES 1 6}
 
@@ -142,8 +142,8 @@
             [/avoid]
         [/ai]
 
-        {GOLD4 200 250 300 350}
-        {INCOME4 8 10 12 12}
+        {GOLD4 150 250 300 350}
+        {INCOME4 6 8 10 12}
         [unit]
             type=Saurian Skirmisher
             ai_special=guardian
@@ -197,8 +197,8 @@
             [/avoid]
         [/ai]
 
-        {GOLD4 120 170 220 280}
-        {INCOME4 4 6 8 10}
+        {GOLD4 100 170 220 280}
+        {INCOME4 2 6 8 10}
         [unit]
             type=Saurian Skirmisher
             ai_special=guardian
@@ -246,8 +246,8 @@
             [/avoid]
         [/ai]
 
-        {GOLD4 250 300 350 400}
-        {INCOME4 8 10 12 14}
+        {GOLD4 200 300 350 400}
+        {INCOME4 6 10 12 14}
 
         [unit]
             type=Saurian Skirmisher

--- a/data/campaigns/Dead_Water/scenarios/06_Uncharted_Islands.cfg
+++ b/data/campaigns/Dead_Water/scenarios/06_Uncharted_Islands.cfg
@@ -39,11 +39,11 @@
     {DW_TRACK {JOURNEY_06_NEW} }
 
     {DEFAULT_SCHEDULE_DAWN}
-    {TURNS4 25 24 23 22}
+    {TURNS4 28 27 26 25}
 
     [side]
         {SIDE_1}
-        {GOLD4 240 200 180 160}
+        {GOLD4 250 200 180 160}
     [/side]
     {STARTING_VILLAGES 1 6}
 
@@ -67,8 +67,8 @@
             x=1
             y=2
         [/village]
-        {GOLD4 280 340 380 460}
-        {INCOME4 22 24 28 30}
+        {GOLD4 250 340 380 460}
+        {INCOME4 20 22 24 26}
     [/side]
 
     # I want mostly cuttle fish and water serpents, so I'll limit

--- a/data/campaigns/Dead_Water/scenarios/10_The_Flaming_Sword.cfg
+++ b/data/campaigns/Dead_Water/scenarios/10_The_Flaming_Sword.cfg
@@ -27,14 +27,15 @@
     {DW_TRACK {JOURNEY_10_NEW} }
 
     {DEFAULT_SCHEDULE}
-    {TURNS4 30 28 28 28}
+    {TURNS4 34 32 30 28}
     victory_when_enemies_defeated=no
 
     # wmllint: validate-off
     [side]
         {SIDE_1}
         fog=yes
-        {GOLD4 120 120 120 120}
+        {INCOME4 4 3 2 1}
+        {GOLD4 150 140 130 120}
     [/side]
     # wmllint: validate-on
 
@@ -66,8 +67,8 @@
         [/ai]
 
         {FLAG_VARIANT undead}
-        {INCOME4 30 35 40 45}
-        {GOLD4 500 600 700 800}
+        {INCOME4 25 30 35 40}
+        {GOLD4 400 500 600 700}
     [/side]
 
     {STARTING_VILLAGES 2 5}
@@ -140,8 +141,12 @@
 
 #ifdef EASY
         {LIMIT_CONTEMPORANEOUS_RECRUITS 2 (Wraith) 4}
-        {LIMIT_CONTEMPORANEOUS_RECRUITS 2 (Shadow) 4}
+        {LIMIT_CONTEMPORANEOUS_RECRUITS 2 (Shadow) 1}
         {LIMIT_CONTEMPORANEOUS_RECRUITS 2 (Spectre) 1}
+        {LIMIT_CONTEMPORANEOUS_RECRUITS 2 (Deathblade) 1}
+        {LIMIT_CONTEMPORANEOUS_RECRUITS 2 (Bone Shooter) 1}
+        {LIMIT_CONTEMPORANEOUS_RECRUITS 2 (Revenant) 1}
+        {LIMIT_CONTEMPORANEOUS_RECRUITS 2 (Necrophage) 1}
 #endif
 #ifdef NORMAL
         {LIMIT_CONTEMPORANEOUS_RECRUITS 2 (Dread Bat) 2}


### PR DESCRIPTION
I found Dead Water to be too hard for me when I first played it on EASY, so I tweaked the difficulty a bit. I realize that Dead Water is supposed to be one of the harder campaigns, but since my changes are mostly confined to the EASY difficulty, they shouldn't affect the harder ones too much. I'm marking this as a draft since I messed up the pattern that held between certain values that varied by difficulty, so I might want to re-edit to make that consistent (or not, if people don't want that). I might also want to do an entire second playthru where I edit all the scenarios and not just the ones that gave me trouble, so that's another reason for marking this as a draft. 