### PR TITLE
Show an error message when --preprocess-defines is ignored

### DIFF
--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -557,6 +557,14 @@ static int process_command_args(const commandline_options& cmdline_opts)
 		return handle_validate_command(*cmdline_opts.validate_wml, validator, boost::get_optional_value_or(cmdline_opts.preprocess_defines, {}));
 	}
 
+	if(cmdline_opts.preprocess_defines || cmdline_opts.preprocess_input_macros || cmdline_opts.preprocess_path) {
+		// It would be good if this was supported for running tests too, possibly for other uses.
+		// For the moment show an error message instead of leaving the user wondering why it doesn't work.
+		std::cerr << "That --preprocess-* option is only supported when using --preprocess or --validate-wml.\n";
+		// Return an error status other than -1, because in our caller -1 means no error
+		return -2;
+	}
+
 	// Not the most intuitive solution, but I wanted to leave current semantics for now
 	return -1;
 }


### PR DESCRIPTION
While making it work would be better, this is a minimial change to at least
get the developer back on track instead of wasting time trying to work out
why putting this in a campaign's _main.cfg file doesn't work:

    #ifdef ENABLE_CAMPAIGN_TESTS
        {./test/}
    #endif

Context for this is in #5273. @Pentarctagon thanks for the suggestion, but don't worry I was already trying this and wasting the time before you posted it.