### PR TITLE
SotA: Fix Ardonna's zombie list after Rastabahn's scenarios

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
    * Secrets of the Ancients:
      * Revisions to Bone Captain
      * Scenario 2 uses new Iron Fence terrain, in preparation for potential map revisions.
+     * While the two leaders are separated, only the currently active one learns new zombie types.
    * Sceptre of Fire:
      * Some revisions/bugfixes to Scenario 9 "Caverns of Flame"
  ### Lua API

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/13_Together_Again.cfg
@@ -53,34 +53,10 @@ I never would have been able to escape the trees without ghosts. They had proven
 
         # It's very unlikely that Ras-Tabahn has access to zombie types that Ardonna does
         # not, but we'll check anyway--just for completeness.
-        [set_variables]
-            name=rastabahn_zombie_array
-            [split]
-                list=$rastabahn_zombies
-                key=allow_recruit
-                separator=","
-            [/split]
-        [/set_variables]
-        [foreach]
-            array=zombies
-            [do]
-                [if]
-                    [variable]
-                        name=rastabahn_zombie_array[$i].allow_recruit
-                        boolean_equals=yes
-                    [/variable]
-                    [then]
-                        [set_variable]
-                            name=this_item.allow_recruit
-                            value="yes"
-                        [/set_variable]
-                    [/then]
-                [/if]
-            [/do]
-        [/foreach]
+        {MERGE_ZOMBIE_LIST rastabahn_zombies}
 
         [clear_variable]
-            name=rastabahn_gold, rastabahn_zombies, rastabahn_zombie_array
+            name=rastabahn_gold, rastabahn_zombies
         [/clear_variable]
 
         # Only one Shynal will be recalled.

--- a/data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg
@@ -117,11 +117,15 @@
     [/case]
 #enddef
 
-# This macro saves the currently recruitable zombies into a string that can be used in a
-# [set_variables] statement later to restore the list. (LOAD_ZOMBIE_LIST does that.)
+# This macro saves the currently recruitable zombies into a string that can be
+# used in a [set_variables] statement later to restore the list. Note that the
+# 'zombies' variable is initialized by ZOMBIE_INIT at the start of the campaign
+# and existing save files won't be changed even if the list in ZOMBIE_INIT is
+# reordered or has new types added; so there's no danger of the saved list
+# becoming out-of-sync with the player's zombie list due to any such changes.
 #define SAVE_ZOMBIE_LIST VARIABLE
     [set_variable]
-        name=ardonna_zombies
+        name={VARIABLE}
         [join]
             variable=zombies
             key=allow_recruit
@@ -130,6 +134,10 @@
     [/set_variable]
 #enddef
 
+# Overwrite the current list of recruitable zombies with a saved list. This is
+# used during the split-party section when the narrative switches from Ras to
+# Ardonna, so any unit types that Ras has unlocked should be locked again until
+# Ardonna discovers that type.
 #define LOAD_ZOMBIE_LIST VARIABLE
     [set_variables]
         name=zombies
@@ -140,6 +148,39 @@
             separator=","
         [/split]
     [/set_variables]
+#enddef
+
+# When the two leaders join up again (in S13 Together Again), ensure that all
+# types unlocked by either leader are still unlocked.
+#define MERGE_ZOMBIE_LIST VARIABLE
+    [set_variables]
+        name=temp_merge_zombie_array
+        [split]
+            list=${VARIABLE}
+            key=allow_recruit
+            separator=","
+        [/split]
+    [/set_variables]
+    [foreach]
+        array=zombies
+        [do]
+            [if]
+                [variable]
+                    name=temp_merge_zombie_array[$i].allow_recruit
+                    boolean_equals=yes
+                [/variable]
+                [then]
+                    [set_variable]
+                        name=this_item.allow_recruit
+                        value="yes"
+                    [/set_variable]
+                [/then]
+            [/if]
+        [/do]
+    [/foreach]
+    [clear_variable]
+        name=temp_merge_zombie_array
+    [/clear_variable]
 #enddef
 
 # Each enemy unit type that is killed and *not* immediately raised as a corpse results


### PR DESCRIPTION
Fixes #5256, which was that `{SAVE_ZOMBIE_LIST rastabahn_zombies}` overwrote
the ardonna_zombies variable.

Move the MERGE_ZOMBIE_LIST code to be next to the LOAD and SAVE code, as any
change to one of these functions should probably be done to all of them.

There's a unit test for this in a commit that's auto-attached itself to #5273, but there isn't the framework support to run it - instead it needs #define statements pushed into the toplevel data/_main.cfg file.