### PR TITLE
SotA: Don't concatenate strings in the recruit dialog

### DIFF
--- a/data/campaigns/Secrets_of_the_Ancients/units/SotA_Corpses.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/units/SotA_Corpses.cfg
@@ -84,10 +84,13 @@
 
 #textdomain wesnoth-sota
 [unit_type]
-    # This unit appears in the recruit list as soon as the player has access to more than
-    # one type of walking corpse. Trying to recruit it launches the zombie recruit dialog.
     id=SotA Walking Corpse_Dummy
-    name= _ "All Corpses" #po: "Walking Corpse" is not used here because some swim, and some fly.
+    # po: A fake unit type that appears in the recruit list as soon as the
+    # po: player has access to more than one type of walking corpse. Trying to
+    # po: recruit it launches the zombie recruit dialog as a child of the normal
+    # po: recruitment dialog. "Walking Corpse" is not used here because some swim,
+    # po: and some fly.
+    name= _ "All Corpses"
     hide_help=yes
     image="units/undead/corpses-unit.png"
     experience=1

--- a/data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg
@@ -20,85 +20,89 @@
             name=zombies
             [value]
                 type=SotA Flying Corpse_Bat
-                sota_variation= _ "(Bat)"
+                # po: shown instead of the unit_type name in the recruitment dialog
+                sota_name_in_recruit_dialog= _ "recruit^Flying Corpse (Bat)"
                 allow_recruit_message= _ "You can now raise bat corpses!"
                 allow_recruit=no
             [/value]
             [value]
                 type=SotA Walking Corpse_Rat
-                sota_variation= _ "(Rat)"
+                sota_name_in_recruit_dialog= _ "recruit^Walking Corpse (Rat)"
                 allow_recruit_message= _ "You can now raise rat corpses!"
                 allow_recruit=no
             [/value]
             [value]
                 type=SotA Walking Corpse_Wolf
-                sota_variation= _ "(Wolf)"
+                sota_name_in_recruit_dialog= _ "recruit^Walking Corpse (Wolf)"
                 allow_recruit_message= _ "You can now raise wolf corpses!"
                 allow_recruit=no
             [/value]
             [value]
                 type=SotA Walking Corpse_Human
-                sota_variation= _ "(Human)"
+                sota_name_in_recruit_dialog= _ "recruit^Walking Corpse (Human)"
                 allow_recruit_message= _ "You can now raise human corpses!"
                 allow_recruit=no
             [/value]
             [value]
                 type=SotA Walking Corpse_Mounted
-                sota_variation= _ "(Mounted)"
+                # po: the mount is an undead horse (not a wolf), this is shown instead of the unit_type name in the recruitment dialog
+                sota_name_in_recruit_dialog= _ "recruit^Walking Corpse (Mounted)"
                 allow_recruit_message= _ "You can now raise mounted corpses!"
                 allow_recruit=no
             [/value]
             [value]
                 type=SotA Walking Corpse_Wolf Rider
-                sota_variation= _ "(Wolf Rider)"
+                sota_name_in_recruit_dialog= _ "recruit^Walking Corpse (Wolf Rider)"
                 allow_recruit_message= _ "You can now raise wolf rider corpses!"
                 allow_recruit=no
             [/value]
             [value]
                 type=SotA Swimming Corpse
-                sota_variation= _ "(Merfolk)"
-                allow_recruit_message= _ "You can now raise merfolk corpses!"
+                # po: this is used for both naga and merfolk zombies
+                sota_name_in_recruit_dialog= _ "recruit^Swimming Corpse"
+                # po: this is used for both naga and merfolk zombies
+                allow_recruit_message= _ "You can now raise swimming corpses!"
                 allow_recruit=no
             [/value]
             [value]
                 type=SotA Walking Corpse_Saurian
-                sota_variation= _ "(Saurian)"
+                sota_name_in_recruit_dialog= _ "recruit^Walking Corpse (Saurian)"
                 allow_recruit_message= _ "You can now raise saurian corpses!"
                 allow_recruit=no
             [/value]
             [value]
                 type=SotA Walking Corpse_Wose
-                sota_variation= _ "(Wose)"
+                sota_name_in_recruit_dialog= _ "recruit^Walking Corpse (Wose)"
                 allow_recruit_message= _ "You can now raise wose corpses!"
                 allow_recruit=no
             [/value]
             [value]
                 type=SotA Walking Corpse_Goblin
-                sota_variation= _ "(Goblin)"
+                sota_name_in_recruit_dialog= _ "recruit^Walking Corpse (Goblin)"
                 allow_recruit_message= _ "You can now raise goblin corpses!"
                 allow_recruit=no
             [/value]
             [value]
                 type=SotA Flying Corpse_Gryphon
-                sota_variation= _ "(Gryphon)"
+                sota_name_in_recruit_dialog= _ "recruit^Flying Corpse (Gryphon)"
                 allow_recruit_message= _ "You can now raise gryphon corpses!"
                 allow_recruit=no
             [/value]
             [value]
                 type=SotA Walking Corpse_Spider
-                sota_variation= _ "(Spider)"
+                sota_name_in_recruit_dialog= _ "recruit^Walking Corpse (Spider)"
                 allow_recruit_message= _ "You can now raise spider corpses!"
                 allow_recruit=no
             [/value]
             [value]
                 type=SotA Walking Corpse_Troll
-                sota_variation= _ "(Troll)"
+                sota_name_in_recruit_dialog= _ "recruit^Walking Corpse (Troll)"
                 allow_recruit_message= _ "You can now raise troll corpses!"
                 allow_recruit=no
             [/value]
             [value]
                 type=SotA Walking Corpse_Dwarf
-                sota_variation= _ "(Dwarf)"
+                sota_name_in_recruit_dialog= _ "recruit^Walking Corpse (Dwarf)"
                 allow_recruit_message= _ "You can now raise dwarf corpses!"
                 allow_recruit=no
             [/value]

--- a/data/campaigns/Secrets_of_the_Ancients/utils/zombie_recruit_dialog.lua
+++ b/data/campaigns/Secrets_of_the_Ancients/utils/zombie_recruit_dialog.lua
@@ -108,7 +108,12 @@ local function preshow(dialog)
             end
 
             local list_item = dialog.unit_list:add_item()
-            list_item.unit_type.label   = afford_color_span_start .. unit_type.name .. " " .. z.sota_variation .. afford_color_span_end
+            if z.sota_name_in_recruit_dialog then
+                list_item.unit_type.label   = afford_color_span_start .. z.sota_name_in_recruit_dialog .. afford_color_span_end
+            else
+                -- the player started the campaign with 1.15.6 or earlier
+                list_item.unit_type.label   = afford_color_span_start .. unit_type.name .. " " .. z.sota_variation .. afford_color_span_end
+            end
             list_item.unit_sprite.label = unit_type.image .. "~RC(magenta>red)"
             list_item.unit_cost.label   = afford_color_span_start .. unit_type.cost .. afford_color_span_end
 


### PR DESCRIPTION
Instead of trying to concatenate translatable strings, just make a single full
string to be shown in the recruitment dialog. This came from trying to update
the i18n hints, and realising my suggest of making the swimmers "Merfolk" in
f6dc83375 was causing problems when they could also be nagas.

These strings are stored in a variable at the start of the campaign (in
ZOMBIE_INIT), so won't appear when loading an existing save game. This is why
the Lua script keeps some support for the old names (although they're not going
to be translated in that case).

@ivanovic and @shikadiqueen I believe this is better for translators, but is it?
I'd also like to ask and apologise to our Polish translator, who has already translated
the 1.15.6 changes from f6dc83375.