### PR TITLE
TSG S8b and epilogue: fix minor inconsistencies

### DIFF
--- a/data/campaigns/The_South_Guard/scenarios/08b_The_Tides_of_War.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/08b_The_Tides_of_War.cfg
@@ -400,8 +400,6 @@
                 condition=lose
             [/objective]
 
-            {TURNS_RUN_OUT}
-
             [note]
                 [show_if]
                     [variable]

--- a/data/campaigns/The_South_Guard/utils/sg_story.cfg
+++ b/data/campaigns/The_South_Guard/utils/sg_story.cfg
@@ -185,7 +185,7 @@
         [part]
             background=story/winter.jpg
             # po: Epilogue B
-            {STORY: _"After the battle, Deoran led an expedition to the southern border posts, where the forts had been smashed into crumbled ruins, and blood and broken weapons were scattered all about. He silently cursed the lich for the lack of bodies at the site of the battle, but deep down, he had known that that would be the fate of the men who had valiantly given their lives so that Westin might survive the undead onslaught. Still, he found small consolation in locating Sir Gerrick’s sword and shield and bearing them back with him to Westin. Those he placed atop Gerrick’s mound, where they became a symbol of sacrifice, and loyalty, and valor."}
+            {STORY: _"After the battle, Deoran led an expedition to the southern border posts, where the forts had been smashed into crumbled ruins, and blood and broken weapons were scattered all about. He silently cursed the lich for the lack of bodies at the site of the battle, but deep down, he had known that that would be the fate of the men who had valiantly given their lives so that Westin might survive the undead onslaught. Still, he found small consolation in locating Sir Gerrick’s glaive and shield and bearing them back with him to Westin. Those he placed atop Gerrick’s mound, where they became a symbol of sacrifice, and loyalty, and valor."}
         [/part]
 
         [part]


### PR DESCRIPTION
Fixes two minor inconsistencies reported by Konrad2 on discord.
TSG S8b: removed an impossible loss condition.
Epilogue: now correctly identifies Sir Gerricks weapon as a glaive.