### PR TITLE
SoF: fix #5278 in scenario 4 and a small fix for scenario 2p5

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
      * Revisions to Bone Captain
      * Scenario 2 uses new Iron Fence terrain, in preparation for potential map revisions.
    * Sceptre of Fire:
+     * Scenario 2p5: increased the turn limit by 1 and enhanced victory filter conditions
+     * Scenario 4: fixed a bug that prevented resources from spawning and added some small flavor adjustments
      * Some revisions/bugfixes to Scenario 9 "Caverns of Flame"
  ### Lua API
  ### Multiplayer

--- a/data/campaigns/Sceptre_of_Fire/scenarios/2p5_Reaching_the_Runecrafter.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/2p5_Reaching_the_Runecrafter.cfg
@@ -2,7 +2,7 @@
 [scenario]
     name= _ "Reaching the Runecrafter"
     id=2p5_Reaching_the_Runecrafter
-    turns=15
+    turns=16
     map_file=2p5_Reaching_the_Runecrafter.map
     next_scenario=3_Searching_for_the_Runecrafter
     victory_when_enemies_defeated=no
@@ -333,10 +333,16 @@
                     y=1-3
                 [/have_unit]
             [/and]
+            [and]
+                [have_unit]
+                    id=Rugnur
+                    y=1-3
+                [/have_unit]
+            [/and]
         [/filter_condition]
         [filter]
-            id=Rugnur
-            y=1-3 # might need revision
+            side=1
+            y=1-3
         [/filter]
         [message]
             speaker=Rugnur

--- a/data/campaigns/Sceptre_of_Fire/scenarios/4_Gathering_Materials.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/4_Gathering_Materials.cfg
@@ -391,117 +391,6 @@
             variable=resource_return_locations
         [/store_locations]
 
-        # Here we need to randomize the coal and gold locations by
-        # hand, because the map generator can otherwise sometimes place
-        # them inside cavewall.
-
-        # The first coal pile is somewhere near where side 2 starts
-
-        [store_locations]
-            [filter]
-                side=2
-                canrecruit=yes
-            [/filter]
-
-            radius=5
-
-            [filter_radius]
-                terrain=!,Xu,Qxu,*^V*
-            [/filter_radius]
-
-            variable=possible_coal_1_locations
-        [/store_locations]
-
-        {RANDOM 1..$possible_coal_1_locations.length}
-        {VARIABLE_OP random sub 1}
-
-        {VARIABLE coal_1.x $possible_coal_1_locations[$random].x}
-        {VARIABLE coal_1.y $possible_coal_1_locations[$random].y}
-
-        # The second coal pile is somewhere near where side 4 starts
-
-        [store_locations]
-            [filter]
-                side=4
-                canrecruit=yes
-            [/filter]
-
-            radius=5
-
-            [filter_radius]
-                terrain=!,Xu,Qxu,*^V*
-            [/filter_radius]
-
-            variable=possible_coal_2_locations
-        [/store_locations]
-
-        {RANDOM 1..$possible_coal_2_locations.length}
-        {VARIABLE_OP random sub 1}
-
-        {VARIABLE coal_2.x $possible_coal_2_locations[$random].x}
-        {VARIABLE coal_2.y $possible_coal_2_locations[$random].y}
-
-        # And the gold pile is 8-12 hexes away from where side 3 starts
-
-        [store_locations]
-            [and]
-                [filter]
-                    side=3
-                    canrecruit=yes
-                [/filter]
-
-                radius=12
-
-                [filter_radius]
-                    terrain=!,Xu,Qxu,*^V*
-                [/filter_radius]
-            [/and]
-
-            [not]
-                [filter]
-                    side=3
-                    canrecruit=yes
-                [/filter]
-
-                radius=8
-
-                # Not sure if this is really needed
-                [filter_radius]
-                    terrain=!,Xu,Qxu,*^V*
-                [/filter_radius]
-            [/not]
-
-            variable=possible_gold_locations
-        [/store_locations]
-
-        {RANDOM 1..$possible_gold_locations.length}
-        {VARIABLE_OP random sub 1}
-
-        {VARIABLE gold_1.x $possible_gold_locations[$random].x}
-        {VARIABLE gold_1.y $possible_gold_locations[$random].y}
-
-        [item]
-            image=items/gold.png
-            x,y=$gold_1.x,$gold_1.y
-        [/item]
-
-        [item]
-            image=items/coal.png
-            x,y=$coal_1.x,$coal_1.y
-        [/item]
-
-        [item]
-            image=items/coal.png
-            x,y=$coal_2.x,$coal_2.y
-        [/item]
-
-        {VARIABLE coalin 0}
-        {VARIABLE goldin 0}
-
-        {CLEAR_VARIABLE possible_coal_1_locations}
-        {CLEAR_VARIABLE possible_coal_2_locations}
-        {CLEAR_VARIABLE possible_gold_locations}
-
         # Here we overlay a mask containing a rather random pattern of
         # suitable terrains on the map, because the map generator itself
         # only places the very basic terrains (floor, walls, etc)
@@ -563,6 +452,141 @@
                 terrain=Uu^Br/
             [/rule]
         [/terrain_mask]
+
+        # Here we need to randomize the coal and gold locations by
+        # hand, because the map generator can otherwise sometimes place
+        # them inside cavewall.
+
+        # The first coal pile is somewhere near where side 2 starts
+
+        [store_locations]
+            [filter]
+                side=2
+                canrecruit=yes
+            [/filter]
+
+            radius=5
+
+            [filter_radius]
+                terrain=!,Xu,Qxu,*^V*
+            [/filter_radius]
+
+            variable=possible_coal_1_locations
+        [/store_locations]
+
+        [store_locations]
+            find_in=possible_coal_1_locations
+            [not]
+                terrain=Kud,Cud,Re,*^Br*
+            [/not]
+            variable=possible_coal_1_locations
+        [/store_locations]
+
+        {RANDOM 1..$possible_coal_1_locations.length}
+        {VARIABLE_OP random sub 1}
+
+        {VARIABLE coal_1.x $possible_coal_1_locations[$random].x}
+        {VARIABLE coal_1.y $possible_coal_1_locations[$random].y}
+
+        # The second coal pile is somewhere near where side 4 starts
+
+        [store_locations]
+            [filter]
+                side=4
+                canrecruit=yes
+            [/filter]
+
+            radius=5
+
+            [filter_radius]
+                terrain=!,Xu,Qxu,*^V*
+            [/filter_radius]
+
+            variable=possible_coal_2_locations
+        [/store_locations]
+
+        [store_locations]
+            find_in=possible_coal_2_locations
+            [not]
+                terrain=Kud,Cud,Re,*^Br*
+            [/not]
+            variable=possible_coal_2_locations
+        [/store_locations]
+
+        {RANDOM 1..$possible_coal_2_locations.length}
+        {VARIABLE_OP random sub 1}
+
+        {VARIABLE coal_2.x $possible_coal_2_locations[$random].x}
+        {VARIABLE coal_2.y $possible_coal_2_locations[$random].y}
+
+        # And the gold pile is 8-12 hexes away from where side 3 starts
+
+        [store_locations]
+            [and]
+                [filter]
+                    side=3
+                    canrecruit=yes
+                [/filter]
+
+                radius=12
+
+                [filter_radius]
+                    terrain=!,Xu,Qxu,*^V*
+                [/filter_radius]
+            [/and]
+
+            [not]
+                [filter]
+                    side=3
+                    canrecruit=yes
+                [/filter]
+
+                radius=8
+
+                # Not sure if this is really needed
+                [filter_radius]
+                    terrain=!,Xu,Qxu,*^V*
+                [/filter_radius]
+            [/not]
+
+            variable=possible_gold_locations
+        [/store_locations]
+
+        [store_locations]
+            find_in=possible_gold_locations
+            [not]
+                terrain=Kud,Cud,Re,*^Br*
+            [/not]
+            variable=possible_gold_locations
+        [/store_locations]
+
+        {RANDOM 1..$possible_gold_locations.length}
+        {VARIABLE_OP random sub 1}
+
+        {VARIABLE gold_1.x $possible_gold_locations[$random].x}
+        {VARIABLE gold_1.y $possible_gold_locations[$random].y}
+
+        [item]
+            image=items/gold.png
+            x,y=$gold_1.x,$gold_1.y
+        [/item]
+
+        [item]
+            image=items/coal.png
+            x,y=$coal_1.x,$coal_1.y
+        [/item]
+
+        [item]
+            image=items/coal.png
+            x,y=$coal_2.x,$coal_2.y
+        [/item]
+
+        {VARIABLE coalin 0}
+        {VARIABLE goldin 0}
+
+        {CLEAR_VARIABLE possible_coal_1_locations}
+        {CLEAR_VARIABLE possible_coal_2_locations}
+        {CLEAR_VARIABLE possible_gold_locations}
 
         # one cart near the player, another cart randomly further out
         # can probably be better optimized

--- a/data/campaigns/Sceptre_of_Fire/scenarios/4_Gathering_Materials.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/4_Gathering_Materials.cfg
@@ -406,7 +406,7 @@
             radius=5
 
             [filter_radius]
-                terrain=!,Xu,Qxu,Cud,Kud,*^V*
+                terrain=!,Xu,Qxu,*^V*
             [/filter_radius]
 
             variable=possible_coal_1_locations
@@ -429,7 +429,7 @@
             radius=5
 
             [filter_radius]
-                terrain=!,Xu,Qxu,Cud,Kud,*^V*
+                terrain=!,Xu,Qxu,*^V*
             [/filter_radius]
 
             variable=possible_coal_2_locations
@@ -453,7 +453,7 @@
                 radius=12
 
                 [filter_radius]
-                    terrain=!,Xu,Qxu,Cud,Kud,*^V*
+                    terrain=!,Xu,Qxu,*^V*
                 [/filter_radius]
             [/and]
 
@@ -467,7 +467,7 @@
 
                 # Not sure if this is really needed
                 [filter_radius]
-                    terrain=!,Xu,Qxu,Cud,Kud,*^V*
+                    terrain=!,Xu,Qxu,*^V*
                 [/filter_radius]
             [/not]
 


### PR DESCRIPTION
SoF S2p5:
-  increased the turn limit by 1 because the scenario felt _very_ tight on time even on easy difficulty (and my changes in 1.15.4 slightly increased minimum travel distance).
- the victory event filters were only triggered by Rugnur's moveto events; this is inconsistent with the scenario objectives and could also lead to costing the player a full turn if Rugnur wasn't the last hero moved to the tunnels end. I changed the event to trigger on any player movement while the heroes reached their destination. Tested to work for all three heroes.

SoF S4:
- reverted my commit from 1.15.4 to fix #5278 
- re-added the functionality of that commit and extended it to also encompass rails
- tested this extensively...