### PR TITLE
campaignd: Add --timings command line option

### DIFF
--- a/src/server/campaignd/options.cpp
+++ b/src/server/campaignd/options.cpp
@@ -41,6 +41,7 @@ command_line::command_line(const std::vector<std::string>& args)
 	, show_log_domains(false)
 	, log_domain_levels()
 	, log_precise_timestamps(false)
+	, report_timings(false)
 	, argv0_(args.at(0))
 	, args_(args.begin() + 1, args.end())
 	, help_text_()
@@ -67,6 +68,7 @@ command_line::command_line(const std::vector<std::string>& args)
 		("log-debug", po::value<std::string>(), "sets the severity level of the specified log domain(s) to 'debug'.")
 		("log-none", po::value<std::string>(), "disables logging for the specified log domain(s).")
 		("log-precise", "shows the timestamps in log output with more precision.")
+		("timings", "outputs timings for serviced requests to stderr.")
 		;
 
 	po::options_description opts;
@@ -121,6 +123,9 @@ command_line::command_line(const std::vector<std::string>& args)
 	}
 	if(vm.count("log-precise")) {
 		log_precise_timestamps = true;
+	}
+	if(vm.count("timings")) {
+		report_timings = true;
 	}
 }
 

--- a/src/server/campaignd/options.hpp
+++ b/src/server/campaignd/options.hpp
@@ -62,6 +62,8 @@ public:
 	std::map<std::string, int> log_domain_levels;
 	/** Whether to use higher precision for log timestamps. */
 	bool log_precise_timestamps;
+	/** Whether to report timing information for server requests. */
+	bool report_timings;
 
 private:
 	std::string argv0_;

--- a/src/server/campaignd/server.hpp
+++ b/src/server/campaignd/server.hpp
@@ -43,7 +43,6 @@ public:
 
 	server& operator=(const config& server) = delete;
 
-private:
 	/**
 	 * Client request information object.
 	 *
@@ -83,6 +82,8 @@ private:
 	};
 
 	friend std::ostream& operator<<(std::ostream& o, const request& r);
+
+private:
 
 	typedef std::function<void (server*, const request& req)> request_handler;
 	typedef std::map<std::string, request_handler> request_handlers_table;

--- a/src/utils/optimer.hpp
+++ b/src/utils/optimer.hpp
@@ -1,0 +1,106 @@
+/*
+   Copyright (C) 2020 by Iris Morelle <shadowm2006@gmail.com>
+   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#pragma once
+
+#include <chrono>
+#include <functional>
+#include <iosfwd>
+
+namespace util {
+
+/**
+ * Reports time elapsed at the end of an object scope.
+ *
+ * The constructor accepts a callable that takes the optimer as its only
+ * argument, which can then be used to write the elapsed time to a stream,
+ * variable, or anything else that's desirable for a particular use case.
+ *
+ * @tparam ResolutionType          Clock resolution -- milliseconds, microseconds, etc.
+ * @tparam ClockType               Clock type -- a monotonic clock by default.
+ */
+template<typename ResolutionType, typename ClockType = std::chrono::steady_clock>
+struct optimer
+{
+	using clock					= ClockType;
+	using resolution			= ResolutionType;
+	using point					= typename clock::time_point;
+	using interval				= typename clock::duration;
+	using report_callback		= std::function<void(const optimer&)>;
+
+	/**
+	 * Constructor, which starts the timer.
+	 *
+	 * The report callback may be an empty object, in which case the destructor
+	 * will not do anything. This may be useful in order to obtain and keep
+	 * track of elapsed time manually for other purposes than console printing.
+	 */
+	explicit optimer(report_callback f = report_callback{})
+		: start_()
+		, repf_(f)
+	{
+		reset();
+	}
+
+	/**
+	 * Destructor, which invokes the report callback.
+	 */
+	~optimer()
+	{
+		if(repf_) {
+			repf_(*this);
+		}
+	}
+
+	/** Resets the timer back to zero. */
+	void reset()
+	{
+		start_ = clock::now();
+	}
+
+	/** Returns the start time point. */
+	point start() const
+	{
+		return start_;
+	}
+
+	/** Returns the elapsed time value. */
+	interval elapsed() const
+	{
+		return clock::now() - start_;
+	}
+
+private:
+	point				start_;
+	report_callback		repf_;
+};
+
+/**
+ * Formats time elapsed for writing to a stream.
+ *
+ * @note The resulting output does <b>not</b> include a time unit suffix.
+ */
+template<typename OpTimerType>
+inline std::ostream& operator<<(std::ostream& o, const OpTimerType& tm)
+{
+	o << std::chrono::duration_cast<typename OpTimerType::resolution>(tm.elapsed()).count();
+	return o;
+}
+
+/**
+ * Time elapsed with millisecond resolution.
+ */
+using ms_optimer = optimer<std::chrono::milliseconds>;
+
+} // end namespace util


### PR DESCRIPTION
Allows reporting the timing for individual requests serviced by campaignd.