### PR TITLE
Addon manager: Save the last sort order in a hidden preference

### DIFF
--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -215,25 +215,25 @@ const std::vector<std::pair<ADDON_TYPE, std::string>> addon_manager::type_filter
 };
 
 const std::vector<addon_manager::addon_order> addon_manager::all_orders_{
-	{N_("addons_order^Name ($order)"), 0,
+	{N_("addons_order^Name ($order)"), "name", 0,
 	[](const addon_info& a, const addon_info& b) { return a.title < b.title; },
 	[](const addon_info& a, const addon_info& b) { return a.title > b.title; }},
-	{N_("addons_order^Author ($order)"), 1,
+	{N_("addons_order^Author ($order)"), "author", 1,
 	[](const addon_info& a, const addon_info& b) { return a.author < b.author; },
 	[](const addon_info& a, const addon_info& b) { return a.author > b.author; }},
-	{N_("addons_order^Size ($order)"), 2,
+	{N_("addons_order^Size ($order)"), "size", 2,
 	[](const addon_info& a, const addon_info& b) { return a.size < b.size; },
 	[](const addon_info& a, const addon_info& b) { return a.size > b.size; }},
-	{N_("addons_order^Downloads ($order)"), 3,
+	{N_("addons_order^Downloads ($order)"), "downloads", 3,
 	[](const addon_info& a, const addon_info& b) { return a.downloads < b.downloads; },
 	[](const addon_info& a, const addon_info& b) { return a.downloads > b.downloads; }},
-	{N_("addons_order^Type ($order)"), 4,
+	{N_("addons_order^Type ($order)"), "type", 4,
 	[](const addon_info& a, const addon_info& b) { return a.display_type() < b.display_type(); },
 	[](const addon_info& a, const addon_info& b) { return a.display_type() > b.display_type(); }},
-	{N_("addons_order^Last updated ($datelike_order)"), -1,
+	{N_("addons_order^Last updated ($datelike_order)"), "last_updated", -1,
 	[](const addon_info& a, const addon_info& b) { return a.updated < b.updated; },
 	[](const addon_info& a, const addon_info& b) { return a.updated > b.updated; }},
-	{N_("addons_order^First uploaded ($datelike_order)"), -1,
+	{N_("addons_order^First uploaded ($datelike_order)"), "first_uploaded", -1,
 	[](const addon_info& a, const addon_info& b) { return a.created < b.created; },
 	[](const addon_info& a, const addon_info& b) { return a.created > b.created; }}
 };
@@ -377,6 +377,30 @@ void addon_manager::pre_show(window& window)
 	}
 
 	order_dropdown.set_values(order_dropdown_entries);
+	{
+		const std::string saved_order_name = preferences::addon_manager_saved_order_name();
+		const preferences::SORT_ORDER saved_order_direction =
+			static_cast<preferences::SORT_ORDER>(preferences::addon_manager_saved_order_direction());
+
+		if(!saved_order_name.empty()) {
+			auto order_it = std::find_if(all_orders_.begin(), all_orders_.end(),
+				[&saved_order_name](const addon_order& order) {return order.as_preference == saved_order_name;});
+			if(order_it != all_orders_.end()) {
+				int index = 2 * (std::distance(all_orders_.begin(), order_it));
+				addon_list::addon_sort_func func;
+				if(saved_order_direction == preferences::SORT_ORDER::ASCENDING) {
+					func = order_it->sort_func_asc;
+				} else {
+					func = order_it->sort_func_desc;
+					++index;
+				}
+				find_widget<menu_button>(&window, "order_dropdown", false).set_value(index, false);
+				auto& addons = find_widget<addon_list>(&window, "addons", false);
+				addons.set_addon_order(func);
+				addons.select_first_addon();
+			}
+		}
+	}
 
 	connect_signal_notify_modified(order_dropdown,
 		std::bind(&addon_manager::order_addons, this, std::ref(window)));
@@ -618,27 +642,31 @@ void addon_manager::order_addons(window& window)
 {
 	const menu_button& order_menu = find_widget<const menu_button>(&window, "order_dropdown", false);
 	const addon_order& order_struct = all_orders_.at(order_menu.get_value() / 2);
-	listbox::SORT_ORDER order = order_menu.get_value() % 2 == 0 ? listbox::SORT_ASCENDING : listbox::SORT_DESCENDING;
+	preferences::SORT_ORDER order = order_menu.get_value() % 2 == 0 ? preferences::SORT_ORDER::ASCENDING : preferences::SORT_ORDER::DESCENDING;
 	addon_list::addon_sort_func func;
-	if(order == listbox::SORT_ASCENDING) {
+	if(order == preferences::SORT_ORDER::ASCENDING) {
 		func = order_struct.sort_func_asc;
 	} else {
 		func = order_struct.sort_func_desc;
 	}
 
 	find_widget<addon_list>(&window, "addons", false).set_addon_order(func);
+	preferences::set_addon_manager_saved_order_name(order_struct.as_preference);
+	preferences::set_addon_manager_saved_order_direction(order);
 }
 
-void addon_manager::on_order_changed(window& window, unsigned int sort_column, listbox::SORT_ORDER order)
+void addon_manager::on_order_changed(window& window, unsigned int sort_column, preferences::SORT_ORDER order)
 {
 	menu_button& order_menu = find_widget<menu_button>(&window, "order_dropdown", false);
 	auto order_it = std::find_if(all_orders_.begin(), all_orders_.end(),
 		[sort_column](const addon_order& order) {return order.column_index == static_cast<int>(sort_column);});
 	int index = 2 * (std::distance(all_orders_.begin(), order_it));
-	if(order == listbox::SORT_DESCENDING) {
+	if(order == preferences::SORT_ORDER::DESCENDING) {
 		++index;
 	}
 	order_menu.set_value(index);
+	preferences::set_addon_manager_saved_order_name(order_it->as_preference);
+	preferences::set_addon_manager_saved_order_direction(order);
 }
 
 template<void(addon_manager::*fptr)(const addon_info& addon, window& window)>

--- a/src/gui/dialogs/addon/manager.hpp
+++ b/src/gui/dialogs/addon/manager.hpp
@@ -50,12 +50,18 @@ private:
 	struct addon_order
 	{
 		std::string label;
+		/// The value used in the preferences file
+		std::string as_preference;
 		int column_index; // -1 if there is no such column
 		addon_list::addon_sort_func sort_func_asc;
 		addon_list::addon_sort_func sort_func_desc;
 
-		addon_order(std::string label_, int column, addon_list::addon_sort_func sort_func_asc_, addon_list::addon_sort_func sort_func_desc_)
-			: label(label_), column_index(column), sort_func_asc(sort_func_asc_), sort_func_desc(sort_func_desc_)
+		addon_order(std::string label_, std::string as_preference_, int column, addon_list::addon_sort_func sort_func_asc_, addon_list::addon_sort_func sort_func_desc_)
+			: label(label_)
+			, as_preference(as_preference_)
+			, column_index(column)
+			, sort_func_asc(sort_func_asc_)
+			, sort_func_desc(sort_func_desc_)
 		{}
 	};
 
@@ -138,7 +144,7 @@ private:
 
 	void apply_filters(window& window);
 	void order_addons(window& window);
-	void on_order_changed(window& window, unsigned int sort_column, listbox::SORT_ORDER order);
+	void on_order_changed(window& window, unsigned int sort_column, preferences::SORT_ORDER order);
 	void show_help();
 
 	boost::dynamic_bitset<> get_name_filter_visibility(const window& window) const;

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -770,7 +770,7 @@ void preferences_dialog::post_build(window& window)
 	hotkey_list.register_sorting_option(3, [this](const int i) { return !visible_hotkeys_[i]->scope[hotkey::SCOPE_EDITOR]; });
 	hotkey_list.register_sorting_option(4, [this](const int i) { return !visible_hotkeys_[i]->scope[hotkey::SCOPE_MAIN_MENU]; });
 
-	hotkey_list.set_active_sorting_option({0, listbox::SORT_ASCENDING}, true);
+	hotkey_list.set_active_sorting_option({0, preferences::SORT_ORDER::ASCENDING}, true);
 
 	connect_signal_mouse_left_click(
 		find_widget<button>(&window, "btn_add_hotkey", false), std::bind(
@@ -911,7 +911,7 @@ void preferences_dialog::default_hotkey_callback(window& window)
 
 	// Set up the list again and reselect the default sorting option.
 	listbox& hotkey_list = setup_hotkey_list(window);
-	hotkey_list.set_active_sorting_option({0, listbox::SORT_ASCENDING}, true);
+	hotkey_list.set_active_sorting_option({0, preferences::SORT_ORDER::ASCENDING}, true);
 
 	find_widget<multimenu_button>(&window, "hotkey_category_menu", false).reset_toggle_states();
 }

--- a/src/gui/dialogs/unit_create.cpp
+++ b/src/gui/dialogs/unit_create.cpp
@@ -155,7 +155,7 @@ void unit_create::pre_show(window& window)
 	list.register_translatable_sorting_option(1, [this](const int i) { return (*units_[i]).type_name().str(); });
 
 	// Select the first entry on sort if no previous selection was provided.
-	list.set_active_sorting_option({0, listbox::SORT_ASCENDING}, choice_.empty());
+	list.set_active_sorting_option({0, preferences::SORT_ORDER::ASCENDING}, choice_.empty());
 
 	list_item_clicked(window);
 }

--- a/src/gui/dialogs/unit_recall.cpp
+++ b/src/gui/dialogs/unit_recall.cpp
@@ -54,8 +54,8 @@ namespace dialogs
 {
 
 // Index 2 is by-level
-static listbox::order_pair sort_last    {-1, listbox::SORT_NONE};
-static listbox::order_pair sort_default { 2, listbox::SORT_DESCENDING};
+static listbox::order_pair sort_last    {-1, preferences::SORT_ORDER::NONE};
+static listbox::order_pair sort_default { 2, preferences::SORT_ORDER::DESCENDING};
 
 REGISTER_DIALOG(unit_recall)
 

--- a/src/gui/widgets/addon_list.cpp
+++ b/src/gui/widgets/addon_list.cpp
@@ -385,7 +385,7 @@ void addon_list::finalize_setup()
 	list.register_sorting_option(3, [this](const int i) { return addon_vector_[i]->downloads; });
 	list.register_translatable_sorting_option(4, [this](const int i) { return addon_vector_[i]->display_type(); });
 
-	auto order = std::make_pair(0, gui2::listbox::SORT_ASCENDING);
+	auto order = std::make_pair(0, preferences::SORT_ORDER::ASCENDING);
 	list.set_active_sorting_option(order);
 }
 
@@ -408,16 +408,7 @@ void addon_list::select_first_addon()
 		// Happens in the dialog unit test.
 		return;
 	}
-
-	const addon_info* first_addon = addon_vector_[0];
-
-	for(const addon_info* a : addon_vector_) {
-		if(translation::icompare(a->display_title_full(), first_addon->display_title_full()) < 0) {
-			first_addon = a;
-		}
-	}
-
-	select_addon(first_addon->id);
+	get_listbox().select_row_at(0);
 }
 
 addon_list_definition::addon_list_definition(const config& cfg)

--- a/src/gui/widgets/addon_list.hpp
+++ b/src/gui/widgets/addon_list.hpp
@@ -134,7 +134,7 @@ public:
 	void add_list_to_keyboard_chain();
 
 	/** Sets up a callback that will be called when the player changes the sorting order. */
-	void set_callback_order_change(std::function<void(unsigned, listbox::SORT_ORDER)> callback) {
+	void set_callback_order_change(std::function<void(unsigned, preferences::SORT_ORDER)> callback) {
 		get_listbox().set_callback_order_change(callback);
 	}
 
@@ -176,10 +176,10 @@ private:
 
 	void finalize_setup();
 
-	/** Needed because otherwise the add-on with the first ID would be initially selected. */
+public:
+	/** Choose the item at the top of the list (taking account of sort order). */
 	void select_first_addon();
 
-public:
 	/** Static type getter that does not rely on the widget being constructed. */
 	static const std::string& type();
 

--- a/src/gui/widgets/listbox.cpp
+++ b/src/gui/widgets/listbox.cpp
@@ -39,6 +39,8 @@
 #define LOG_SCOPE_HEADER get_control_type() + " [" + id() + "] " + __func__
 #define LOG_HEADER LOG_SCOPE_HEADER + ':'
 
+using SORT_ORDER = preferences::SORT_ORDER;
+
 namespace gui2
 {
 // ------------ WIDGET -----------{
@@ -594,20 +596,20 @@ void listbox::order_by_column(unsigned column, widget& widget)
 
 	for(auto& pair : orders_) {
 		if(pair.first != nullptr && pair.first != &selectable) {
-			pair.first->set_value(SORT_NONE);
+			pair.first->set_value(preferences::SORT_ORDER::NONE);
 		}
 	}
 
-	SORT_ORDER order = static_cast<SORT_ORDER>(selectable.get_value());
+	SORT_ORDER order {static_cast<SORT_ORDER::type>(selectable.get_value())};
 
-	if(static_cast<unsigned int>(order) > orders_[column].second.size()) {
+	if(static_cast<unsigned int>(order.v) > orders_[column].second.size()) {
 		return;
 	}
 
-	if(order == SORT_NONE) {
+	if(order == SORT_ORDER::NONE) {
 		order_by(std::less<unsigned>());
 	} else {
-		order_by(orders_[column].second[order - 1]);
+		order_by(orders_[column].second[order.v - 1]);
 	}
 
 	if(callback_order_change_ != nullptr) {
@@ -650,7 +652,7 @@ void listbox::set_active_sorting_option(const order_pair& sort_by, const bool se
 	// Set the sorting toggle widgets' value (in this case, its state) to the given sorting
 	// order. This is necessary since the widget's value is used to determine the order in
 	// @ref order_by_column in lieu of a direction being passed directly.
-	w.set_value(static_cast<int>(sort_by.second));
+	w.set_value(static_cast<int>(sort_by.second.v));
 
 	order_by_column(sort_by.first, dynamic_cast<widget&>(w));
 
@@ -664,19 +666,19 @@ const listbox::order_pair listbox::get_active_sorting_option()
 	for(unsigned int column = 0; column < orders_.size(); ++column) {
 		selectable_item* w = orders_[column].first;
 
-		if(w && w->get_value() != SORT_NONE) {
-			return std::make_pair(column, static_cast<SORT_ORDER>(w->get_value()));
+		if(w && w->get_value() != SORT_ORDER::NONE) {
+			return std::make_pair(column, static_cast<SORT_ORDER::type>(w->get_value()));
 		}
 	}
 
-	return std::make_pair(-1, SORT_NONE);
+	return std::make_pair(-1, SORT_ORDER::NONE);
 }
 
 void listbox::mark_as_unsorted()
 {
 	for(auto& pair : orders_) {
 		if(pair.first != nullptr) {
-			pair.first->set_value(SORT_NONE);
+			pair.first->set_value(SORT_ORDER::NONE);
 		}
 	}
 }

--- a/src/gui/widgets/listbox.hpp
+++ b/src/gui/widgets/listbox.hpp
@@ -20,6 +20,8 @@
 #include "gui/core/widget_definition.hpp"
 #include "gui/core/window_builder.hpp"
 
+#include "preferences/general.hpp"
+
 #include <boost/dynamic_bitset.hpp>
 #include <functional>
 
@@ -279,13 +281,7 @@ public:
 	/** Registers a special sorting function specifically for translatable values. */
 	void register_translatable_sorting_option(const int col, translatable_sorter_func_t f);
 
-	enum SORT_ORDER {
-		SORT_NONE,
-		SORT_ASCENDING,
-		SORT_DESCENDING,
-	};
-
-	using order_pair = std::pair<int, SORT_ORDER>;
+	using order_pair = std::pair<int, preferences::SORT_ORDER>;
 
 	/**
 	 * Sorts the listbox by a pre-set sorting option. The corresponding header widget will also be toggled.
@@ -306,7 +302,7 @@ public:
 	void mark_as_unsorted();
 
 	/** Registers a callback to be called when the active sorting option changes. */
-	void set_callback_order_change(std::function<void(unsigned, SORT_ORDER)> callback)
+	void set_callback_order_change(std::function<void(unsigned, preferences::SORT_ORDER)> callback)
 	{
 		callback_order_change_ = callback;
 	}
@@ -378,7 +374,7 @@ private:
 	typedef std::vector<std::pair<selectable_item*, generator_sort_array>> torder_list;
 	torder_list orders_;
 
-	std::function<void(unsigned, SORT_ORDER)> callback_order_change_;
+	std::function<void(unsigned, preferences::SORT_ORDER)> callback_order_change_;
 
 	/**
 	 * Resizes the content.

--- a/src/preferences/general.cpp
+++ b/src/preferences/general.cpp
@@ -935,4 +935,25 @@ void set_damage_prediction_allow_monte_carlo_simulation(bool value)
 	set("damage_prediction_allow_monte_carlo_simulation", value);
 }
 
+std::string addon_manager_saved_order_name()
+{
+	return get("addon_manager_saved_order_name");
+}
+
+void set_addon_manager_saved_order_name(const std::string& value)
+{
+	set("addon_manager_saved_order_name", value);
+}
+
+SORT_ORDER addon_manager_saved_order_direction()
+{
+	return SORT_ORDER::string_to_enum(get("addon_manager_saved_order_direction"), SORT_ORDER::NONE);
+}
+
+void set_addon_manager_saved_order_direction(SORT_ORDER value)
+{
+	set("addon_manager_saved_order_direction", SORT_ORDER::enum_to_string(value));
+}
+
+
 } // end namespace preferences

--- a/src/preferences/general.hpp
+++ b/src/preferences/general.hpp
@@ -18,6 +18,7 @@
 
 #include "config.hpp"
 #include "terrain/translation.hpp"
+#include "utils/make_enum.hpp"
 
 #include <utility>
 
@@ -244,5 +245,17 @@ namespace preferences {
 
 	bool damage_prediction_allow_monte_carlo_simulation();
 	void set_damage_prediction_allow_monte_carlo_simulation(bool value);
+
+	std::string addon_manager_saved_order_name();
+	void set_addon_manager_saved_order_name(const std::string& value);
+
+	// Sorting for GUI2 listboxes
+	MAKE_ENUM(SORT_ORDER,
+		(NONE, "none")
+		(ASCENDING, "ascending")
+		(DESCENDING, "descending")
+	)
+	SORT_ORDER addon_manager_saved_order_direction();
+	void set_addon_manager_saved_order_direction(SORT_ORDER value);
 
 } // end namespace preferences


### PR DESCRIPTION
This uses MAKE_ENUM for the listbox sort order, so that it can
be serialized to the preferences file.

This is @jostephd 's PR #4409, reopened as a new issue because it has a new author.
Fixes #1090 .