### PR TITLE
Make saved_game::expand_scenario() look correct, and add a const

### DIFF
--- a/src/saved_game.cpp
+++ b/src/saved_game.cpp
@@ -269,7 +269,7 @@ void saved_game::set_defaults()
 void saved_game::expand_scenario()
 {
 	if(this->starting_point_type_ == STARTING_POINT_NONE && !has_carryover_expanded_) {
-		game_config_manager::get()->load_game_config_for_game(this->classification(), this->get_scenario_id());
+		game_config_manager::get()->load_game_config_for_game(this->classification(), carryover_["next_scenario"]);
 
 		const game_config_view& game_config = game_config_manager::get()->game_config();
 		const config& scenario =
@@ -646,7 +646,7 @@ config saved_game::to_config() const
 	return r;
 }
 
-std::string saved_game::get_scenario_id()
+std::string saved_game::get_scenario_id() const
 {
 	std::string scenario_id;
 

--- a/src/saved_game.hpp
+++ b/src/saved_game.hpp
@@ -104,7 +104,7 @@ public:
 	/// @return the starting pos for replays. Usually this is [replay_start] but it can also be a [scenario] if no [replay_start] is present
 	const config& get_replay_starting_point();
 	/// @return the id of the currently played scenario or the id of the next scenario if this is a between-scenaios-save (also called start-of-scenario-save).
-	std::string get_scenario_id();
+	std::string get_scenario_id() const;
 	/// @return the config from which the game will be started. (this is [scenario] or [snapshot] in the savefile)
 	config& get_starting_point();
 	const config& get_starting_point() const { return starting_point_; }


### PR DESCRIPTION
This doesn't change the behavior - the changed line is in a conditional block
which tells us exactly which of scenario_id()'s code paths will happen, and it
will still end up using carryover_["next_scenario"]. The change is just making
it consistent with the way that other lines in expand_scenario() find out which
scenario id to use; it's preparing to load the next scenario, so it should use
that scenario's id to load any metadata, not the current scenario's id.

Also, scenario_id() should be const. This helps with refactoring out the
existence of a de-facto singleton instance of saved_game.