### PR TITLE
campaignd: Fix broken Windows support

### DIFF
--- a/src/server/campaignd/fs_commit.hpp
+++ b/src/server/campaignd/fs_commit.hpp
@@ -87,6 +87,8 @@ private:
 	scoped_ostream out_;
 #ifndef _WIN32
 	int outfd_;
+#else
+	void* handle_; // Actually a HANDLE
 #endif
 };
 


### PR DESCRIPTION
This creates temporary files with the `FILE_SHARE_DELETE` sharing mode on Windows when using `filesystem::atomic_commit`,  thus allowing us to rename them to their final location without having to close them beforehand. Without these changes, campaignd gets really upset when trying to rename files created with `atomic_commit` since Windows by default will deny deletion/renaming of open files.

**UPDATE 2020-11-20:** Now it also makes it so the temporary files overwrite the destination in a POSIX-like fashion by using `SetFileInformationByHandle()`.

~~... Or at least so the theory goes.~~

~~`Wine (5.0) is being temperamental and campaignd doesn't work properly on it, with client requests not going completely through for some mysterious reason, and even occasionally crashing with a segmentation fault somewhere in Wine land. Maybe our network code does something that Wine *really* doesn't like. So for the time being, this code is almost completely untested. I may try using MSVC++ instead at some point when I feel like it, or someone else can do it for me.`~~

**Testing procedure:**

* Run `campaignd.exe` so it will generate its initial configuration (`server.cfg`) and data dir in the current working path (or somewhere else if using the `-s <PATH>` command line switch). Make sure it doesn't log any errors involving `server.cfg`.
* Restart `campaignd.exe`. Again make sure it doesn't print any errors involving `server.cfg`.
* Upload an add-on with the Wesnoth client.
* Reupload the same add-on, modified.
* Verify that no errors involving the add-on were printed and that the modified version is what clients get when installing it fresh.

**Caveats:**

~~This is not in a mergeable state right now due to lack of testing. Additionally, the `rename()` call in `atomic_commit::commit()` needs to be replaced with `_wrename()` for Unicode path safety.~~

~~A simpler alternative to calling `CreateFile()` ourselves would be to reset the underlying `ostream` pointer in `filesystem::atomic_commit::commit()` before renaming the temporary file to force it to be closed first. However, this would mean that callers would have to take care not to use any existing references to the `ostream` following a call to `commit()`.~~