### PR TITLE
Add a unit test for the behavior of [unit]id= recalling units

### DIFF
--- a/data/test/scenarios/recall_by_unit_tag.cfg
+++ b/data/test/scenarios/recall_by_unit_tag.cfg
@@ -1,0 +1,79 @@
+# wmllint: no translatables
+
+# The [unit] tag can recall units if a unit with that id already exists
+# on the recall list. Some edge cases were unclear, so this test finds
+# out what they do.
+#
+# This is a test where any failure should probably be fixed by changing the
+# test to match changes in the engine. Having the test will be useful for
+# reference to find out when the engine behavior changed.
+
+{GENERIC_UNIT_TEST "recall_by_unit_tag" (
+    [event]
+        name = start
+
+        # Create a unit on the recall list, as tested in the "units_offmap_goto_recall" test
+        [unit]
+            x = -10
+            y = -10
+            type = Orcish Grunt
+            side = 1
+            id = Charlie
+            canrecruit = no
+        [/unit]
+
+        # Check assumptions used in the later assert of "there's no copies of the unit on the recall list"
+        {ASSERT (
+            [have_unit]
+                x = recall
+                y = recall
+                search_recall_list = yes
+            [/have_unit]
+        )}
+
+        # A no-op - this doesn't change the x or y coordinate, so Charlie stays off-map
+        [unit]
+            id = Charlie
+        [/unit]
+        {ASSERT (
+            [not]
+                [have_unit]
+                    id = Charlie
+                    search_recall_list = no
+                [/have_unit]
+            [/not]
+        )}
+
+        # Move Charlie on-map
+        [unit]
+            x = 1
+            y = 1
+            id = Charlie
+        [/unit]
+
+        {ASSERT (
+            [have_unit]
+                x = 1
+                y = 1
+                type = Orcish Grunt
+                id = Charlie
+                canrecruit = no
+                side = 1
+                search_recall_list = no
+            [/have_unit]
+        )}
+
+        # Check that there's no copies of the unit on the recall list
+        {ASSERT (
+            [not]
+                [have_unit]
+                    x = recall
+                    y = recall
+                    search_recall_list = yes
+                [/have_unit]
+            [/not]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -53,6 +53,7 @@
 0 test_unit_map
 0 unit_spawns_at_nearest_vacant_hex
 0 units_offmap_goto_recall
+0 recall_by_unit_tag
 0 test_move
 5 test_move_fail_1
 5 test_move_fail_2


### PR DESCRIPTION
Answers a question raised in PR #4999; the test also passes on 1.14.