### PR TITLE
Wrap owning editor_action pointers in unique_ptr

### DIFF
--- a/src/editor/action/action.hpp
+++ b/src/editor/action/action.hpp
@@ -43,7 +43,7 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_whole_map* clone() const;
+	editor_action_ptr clone() const;
 
 	void perform_without_undo(map_context& m) const;
 
@@ -103,14 +103,14 @@ public:
 	editor_action_chain& operator=(const editor_action_chain& other);
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_chain* clone() const;
+	editor_action_ptr clone() const;
 
 	/**
 	 * Create an action chain from a deque of action pointers.
 	 * Note: the action chain assumes ownership of the pointers.
 	 */
-	explicit editor_action_chain(std::deque<editor_action*> actions)
-		: actions_(actions)
+	explicit editor_action_chain(std::deque<editor_action_ptr> actions)
+		: actions_(std::move(actions))
 	{
 	}
 
@@ -118,9 +118,10 @@ public:
 	 * Create an action chain by wrapping around a single action pointer.
 	 * Note: the action chain assumes ownership of the pointer.
 	 */
-	explicit editor_action_chain(editor_action* action)
-		: actions_(1, action)
+	explicit editor_action_chain(editor_action_ptr action)
+		: actions_()
 	{
+		actions_.push_front(std::move(action));
 	}
 
 	/**
@@ -136,12 +137,12 @@ public:
 	/**
 	 * Add an action at the end of the chain
 	 */
-	void append_action(editor_action* a);
+	void append_action(editor_action_ptr a);
 
 	/**
 	 * Add an action at the beginning of the chain
 	 */
-	void prepend_action(editor_action* a);
+	void prepend_action(editor_action_ptr a);
 
 	/**
 	 * @return true when there are no actions in the chain. Empty
@@ -154,18 +155,18 @@ public:
 	 * Remove the last added action and return it, transferring
 	 * ownership to the caller
 	 */
-	editor_action* pop_last_action();
+	editor_action_ptr pop_last_action();
 
 	/**
 	 * Remove the first added action and return it, transferring
 	 * ownership to the caller
 	 */
-	editor_action* pop_first_action();
+	editor_action_ptr pop_first_action();
 
 	/**
 	 * Perform all the actions in order and create a undo action chain
 	 */
-	editor_action_chain* perform(map_context& m) const;
+	editor_action_ptr perform(map_context& m) const;
 
 	/**
 	 * Perform all the actions in order
@@ -179,7 +180,7 @@ protected:
 	/**
 	 * The action pointers owned by this action chain
 	 */
-	std::deque<editor_action*> actions_;
+	std::deque<editor_action_ptr> actions_;
 };
 
 /**
@@ -262,9 +263,9 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_paste* clone() const;
+	editor_action_ptr clone() const;
 
-	editor_action_paste* perform(map_context& mc) const;
+	editor_action_ptr perform(map_context& mc) const;
 
 	void perform_without_undo(map_context& mc) const;
 
@@ -293,9 +294,9 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_paint_area* clone() const;
+	editor_action_ptr clone() const;
 
-	editor_action_paste* perform(map_context& mc) const;
+	editor_action_ptr perform(map_context& mc) const;
 
 	void perform_without_undo(map_context& mc) const;
 
@@ -321,9 +322,9 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_fill* clone() const;
+	editor_action_ptr clone() const;
 
-	editor_action_paint_area* perform(map_context& mc) const;
+	editor_action_ptr perform(map_context& mc) const;
 
 	void perform_without_undo(map_context& mc) const;
 
@@ -347,9 +348,9 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_starting_position* clone() const;
+	editor_action_ptr clone() const;
 
-	editor_action* perform(map_context& mc) const;
+	editor_action_ptr perform(map_context& mc) const;
 
 	void perform_without_undo(map_context& mc) const;
 
@@ -381,7 +382,7 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_resize_map* clone() const;
+	editor_action_ptr clone() const;
 
 	void perform_without_undo(map_context& mc) const;
 
@@ -406,7 +407,7 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_apply_mask* clone() const;
+	editor_action_ptr clone() const;
 
 	void perform_without_undo(map_context& mc) const;
 
@@ -425,7 +426,7 @@ public:
 	{
 	}
 
-	editor_action_create_mask* clone() const;
+	editor_action_ptr clone() const;
 
 	void perform_without_undo(map_context& mc) const;
 
@@ -447,9 +448,9 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_shuffle_area* clone() const;
+	editor_action_ptr clone() const;
 
-	editor_action_paste* perform(map_context& mc) const;
+	editor_action_ptr perform(map_context& mc) const;
 
 	void perform_without_undo(map_context& mc) const;
 

--- a/src/editor/action/action_base.hpp
+++ b/src/editor/action/action_base.hpp
@@ -46,7 +46,7 @@ public:
 	/**
 	 * Action cloning
 	 */
-	virtual editor_action* clone() const = 0;
+	virtual editor_action_ptr clone() const = 0;
 
 	/**
 	 * Perform the action, returning an undo action that,
@@ -56,7 +56,7 @@ public:
 	 * undo, call the perform_without_undo function and
 	 * return the undo object.
 	 */
-	virtual editor_action* perform(map_context&) const;
+	virtual editor_action_ptr perform(map_context&) const;
 
 	/**
 	 * Perform the action without creating an undo action.
@@ -129,9 +129,9 @@ struct editor_action_exception : public editor_exception
 		return name;                                                                                                   \
 	}                                                                                                                  \
                                                                                                                        \
-	editor_action_##id* editor_action_##id::clone() const                                                              \
+	editor_action_ptr editor_action_##id::clone() const								\
 	{                                                                                                                  \
-		return new editor_action_##id(*this);                                                                          \
+		return editor_action_ptr(new editor_action_##id(*this));                                                   \
 	}                                                                                                                  \
 
 } // end namespace editor

--- a/src/editor/action/action_item.cpp
+++ b/src/editor/action/action_item.cpp
@@ -28,11 +28,11 @@ namespace editor
 {
 IMPLEMENT_ACTION(item)
 
-editor_action* editor_action_item::perform(map_context& mc) const
+editor_action_ptr editor_action_item::perform(map_context& mc) const
 {
 	editor_action_ptr undo(new editor_action_item_delete(loc_));
 	perform_without_undo(mc);
-	return undo.release();
+	return undo;
 }
 
 void editor_action_item::perform_without_undo(map_context& /*mc*/) const
@@ -45,7 +45,7 @@ void editor_action_item::perform_without_undo(map_context& /*mc*/) const
 
 IMPLEMENT_ACTION(item_delete)
 
-editor_action* editor_action_item_delete::perform(map_context& /*mc*/) const
+editor_action_ptr editor_action_item_delete::perform(map_context& /*mc*/) const
 {
 	//	item_map& items = mc.get_items();
 	//	item_map::const_item_iterator item_it = items.find(loc_);
@@ -71,12 +71,12 @@ void editor_action_item_delete::perform_without_undo(map_context& /*mc*/) const
 
 IMPLEMENT_ACTION(item_replace)
 
-editor_action* editor_action_item_replace::perform(map_context& mc) const
+editor_action_ptr editor_action_item_replace::perform(map_context& mc) const
 {
 	editor_action_ptr undo(new editor_action_item_replace(new_loc_, loc_));
 
 	perform_without_undo(mc);
-	return undo.release();
+	return undo;
 }
 
 void editor_action_item_replace::perform_without_undo(map_context& /*mc*/) const
@@ -105,11 +105,11 @@ void editor_action_item_replace::perform_without_undo(map_context& /*mc*/) const
 
 IMPLEMENT_ACTION(item_facing)
 
-editor_action* editor_action_item_facing::perform(map_context& mc) const
+editor_action_ptr editor_action_item_facing::perform(map_context& mc) const
 {
 	editor_action_ptr undo(new editor_action_item_facing(loc_, old_direction_, new_direction_));
 	perform_without_undo(mc);
-	return undo.release();
+	return undo;
 }
 
 void editor_action_item_facing::perform_without_undo(map_context& /*mc*/) const

--- a/src/editor/action/action_item.hpp
+++ b/src/editor/action/action_item.hpp
@@ -46,9 +46,9 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_item* clone() const;
+	editor_action_ptr clone() const;
 
-	editor_action* perform(map_context& mc) const;
+	editor_action_ptr perform(map_context& mc) const;
 
 	void perform_without_undo(map_context& mc) const;
 
@@ -71,9 +71,9 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_item_delete* clone() const;
+	editor_action_ptr clone() const;
 
-	editor_action* perform(map_context& mc) const;
+	editor_action_ptr perform(map_context& mc) const;
 
 	void perform_without_undo(map_context& mc) const;
 
@@ -91,9 +91,9 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_item_replace* clone() const;
+	editor_action_ptr clone() const;
 
-	editor_action* perform(map_context& mc) const;
+	editor_action_ptr perform(map_context& mc) const;
 
 	void perform_without_undo(map_context& mc) const;
 
@@ -116,9 +116,9 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_item_facing* clone() const;
+	editor_action_ptr clone() const;
 
-	editor_action* perform(map_context& mc) const;
+	editor_action_ptr perform(map_context& mc) const;
 
 	void perform_without_undo(map_context& mc) const;
 

--- a/src/editor/action/action_label.cpp
+++ b/src/editor/action/action_label.cpp
@@ -26,7 +26,7 @@ namespace editor
 {
 IMPLEMENT_ACTION(label)
 
-editor_action* editor_action_label::perform(map_context& mc) const
+editor_action_ptr editor_action_label::perform(map_context& mc) const
 {
 	editor_action_ptr undo;
 
@@ -47,7 +47,7 @@ editor_action* editor_action_label::perform(map_context& mc) const
 	}
 
 	perform_without_undo(mc);
-	return undo.release();
+	return undo;
 }
 
 void editor_action_label::perform_without_undo(map_context& mc) const
@@ -58,7 +58,7 @@ void editor_action_label::perform_without_undo(map_context& mc) const
 
 IMPLEMENT_ACTION(label_delete)
 
-editor_action* editor_action_label_delete::perform(map_context& mc) const
+editor_action_ptr editor_action_label_delete::perform(map_context& mc) const
 {
 	editor_action_ptr undo;
 
@@ -80,7 +80,7 @@ editor_action* editor_action_label_delete::perform(map_context& mc) const
 	);
 
 	perform_without_undo(mc);
-	return undo.release();
+	return undo;
 }
 
 void editor_action_label_delete::perform_without_undo(map_context& mc) const

--- a/src/editor/action/action_label.hpp
+++ b/src/editor/action/action_label.hpp
@@ -57,9 +57,9 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_label* clone() const;
+	editor_action_ptr clone() const;
 
-	editor_action* perform(map_context& mc) const;
+	editor_action_ptr perform(map_context& mc) const;
 
 	void perform_without_undo(map_context& mc) const;
 
@@ -87,9 +87,9 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_label_delete* clone() const;
+	editor_action_ptr clone() const;
 
-	editor_action* perform(map_context& mc) const;
+	editor_action_ptr perform(map_context& mc) const;
 
 	void perform_without_undo(map_context& mc) const;
 

--- a/src/editor/action/action_select.cpp
+++ b/src/editor/action/action_select.cpp
@@ -33,7 +33,7 @@ void editor_action_select::extend(const editor_map& /*map*/, const std::set<map_
 	}
 }
 
-editor_action* editor_action_select::perform(map_context& mc) const
+editor_action_ptr editor_action_select::perform(map_context& mc) const
 {
 	std::set<map_location> undo_locs;
 	for(const map_location& loc : area_) {
@@ -42,7 +42,7 @@ editor_action* editor_action_select::perform(map_context& mc) const
 	}
 
 	perform_without_undo(mc);
-	return new editor_action_select(undo_locs);
+	return editor_action_ptr(new editor_action_select(undo_locs));
 }
 
 void editor_action_select::perform_without_undo(map_context& mc) const
@@ -66,7 +66,7 @@ void editor_action_deselect::extend(const editor_map& map, const std::set<map_lo
 	}
 }
 
-editor_action* editor_action_deselect::perform(map_context& mc) const
+editor_action_ptr editor_action_deselect::perform(map_context& mc) const
 {
 	std::set<map_location> undo_locs;
 	for(const map_location& loc : area_) {
@@ -77,7 +77,7 @@ editor_action* editor_action_deselect::perform(map_context& mc) const
 	}
 
 	perform_without_undo(mc);
-	return new editor_action_select(undo_locs);
+	return editor_action_ptr(new editor_action_select(undo_locs));
 }
 
 void editor_action_deselect::perform_without_undo(map_context& mc) const
@@ -90,7 +90,7 @@ void editor_action_deselect::perform_without_undo(map_context& mc) const
 
 IMPLEMENT_ACTION(select_all)
 
-editor_action_select* editor_action_select_all::perform(map_context& mc) const
+editor_action_ptr editor_action_select_all::perform(map_context& mc) const
 {
 	std::set<map_location> current = mc.map().selection();
 	mc.map().select_all();
@@ -102,7 +102,7 @@ editor_action_select* editor_action_select_all::perform(map_context& mc) const
 		all.begin(), all.end(), current.begin(), current.end(), std::inserter(undo_locs, undo_locs.begin()));
 
 	mc.set_everything_changed();
-	return new editor_action_select(undo_locs);
+	return editor_action_ptr(new editor_action_select(undo_locs));
 }
 
 void editor_action_select_all::perform_without_undo(map_context& mc) const
@@ -113,12 +113,12 @@ void editor_action_select_all::perform_without_undo(map_context& mc) const
 
 IMPLEMENT_ACTION(select_none)
 
-editor_action_select* editor_action_select_none::perform(map_context& mc) const
+editor_action_ptr editor_action_select_none::perform(map_context& mc) const
 {
 	std::set<map_location> current = mc.map().selection();
 	mc.map().clear_selection();
 	mc.set_everything_changed();
-	return new editor_action_select(current);
+	return editor_action_ptr(new editor_action_select(current));
 }
 
 void editor_action_select_none::perform_without_undo(map_context& mc) const
@@ -129,10 +129,10 @@ void editor_action_select_none::perform_without_undo(map_context& mc) const
 
 IMPLEMENT_ACTION(select_inverse)
 
-editor_action_select_inverse* editor_action_select_inverse::perform(map_context& mc) const
+editor_action_ptr editor_action_select_inverse::perform(map_context& mc) const
 {
 	perform_without_undo(mc);
-	return new editor_action_select_inverse();
+	return editor_action_ptr(new editor_action_select_inverse());
 }
 
 void editor_action_select_inverse::perform_without_undo(map_context& mc) const

--- a/src/editor/action/action_select.hpp
+++ b/src/editor/action/action_select.hpp
@@ -41,11 +41,11 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_select* clone() const;
+	editor_action_ptr clone() const;
 
 	void extend(const editor_map& map, const std::set<map_location>& locs);
 
-	editor_action* perform(map_context& mc) const;
+	editor_action_ptr perform(map_context& mc) const;
 
 	void perform_without_undo(map_context& mc) const;
 
@@ -65,11 +65,11 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_deselect* clone() const;
+	editor_action_ptr clone() const;
 
 	void extend(const editor_map& map, const std::set<map_location>& locs);
 
-	editor_action* perform(map_context& mc) const;
+	editor_action_ptr perform(map_context& mc) const;
 
 	void perform_without_undo(map_context& mc) const;
 
@@ -88,9 +88,9 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_select_all* clone() const;
+	editor_action_ptr clone() const;
 
-	editor_action_select* perform(map_context& mc) const;
+	editor_action_ptr perform(map_context& mc) const;
 
 	void perform_without_undo(map_context& mc) const;
 
@@ -109,9 +109,9 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_select_none* clone() const;
+	editor_action_ptr clone() const;
 
-	editor_action_select* perform(map_context& mc) const;
+	editor_action_ptr perform(map_context& mc) const;
 
 	void perform_without_undo(map_context& mc) const;
 
@@ -130,9 +130,9 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_select_inverse* clone() const;
+	editor_action_ptr clone() const;
 
-	editor_action_select_inverse* perform(map_context& mc) const;
+	editor_action_ptr perform(map_context& mc) const;
 
 	void perform_without_undo(map_context& mc) const;
 

--- a/src/editor/action/action_unit.cpp
+++ b/src/editor/action/action_unit.cpp
@@ -31,11 +31,11 @@ namespace editor
 {
 IMPLEMENT_ACTION(unit)
 
-editor_action* editor_action_unit::perform(map_context& mc) const
+editor_action_ptr editor_action_unit::perform(map_context& mc) const
 {
 	editor_action_ptr undo(new editor_action_unit_delete(loc_));
 	perform_without_undo(mc);
-	return undo.release();
+	return undo;
 }
 
 void editor_action_unit::perform_without_undo(map_context& mc) const
@@ -47,7 +47,7 @@ void editor_action_unit::perform_without_undo(map_context& mc) const
 
 IMPLEMENT_ACTION(unit_delete)
 
-editor_action* editor_action_unit_delete::perform(map_context& mc) const
+editor_action_ptr editor_action_unit_delete::perform(map_context& mc) const
 {
 	unit_map& units = mc.units();
 	unit_map::const_unit_iterator unit_it = units.find(loc_);
@@ -56,10 +56,9 @@ editor_action* editor_action_unit_delete::perform(map_context& mc) const
 	if(unit_it != units.end()) {
 		undo.reset(new editor_action_unit(loc_, *unit_it));
 		perform_without_undo(mc);
-		return undo.release();
 	}
 
-	return nullptr;
+	return undo;
 }
 
 void editor_action_unit_delete::perform_without_undo(map_context& mc) const
@@ -74,12 +73,12 @@ void editor_action_unit_delete::perform_without_undo(map_context& mc) const
 
 IMPLEMENT_ACTION(unit_replace)
 
-editor_action* editor_action_unit_replace::perform(map_context& mc) const
+editor_action_ptr editor_action_unit_replace::perform(map_context& mc) const
 {
 	editor_action_ptr undo(new editor_action_unit_replace(new_loc_, loc_));
 
 	perform_without_undo(mc);
-	return undo.release();
+	return undo;
 }
 
 void editor_action_unit_replace::perform_without_undo(map_context& mc) const
@@ -109,11 +108,11 @@ void editor_action_unit_replace::perform_without_undo(map_context& mc) const
 
 IMPLEMENT_ACTION(unit_facing)
 
-editor_action* editor_action_unit_facing::perform(map_context& mc) const
+editor_action_ptr editor_action_unit_facing::perform(map_context& mc) const
 {
 	editor_action_ptr undo(new editor_action_unit_facing(loc_, old_direction_, new_direction_));
 	perform_without_undo(mc);
-	return undo.release();
+	return undo;
 }
 
 void editor_action_unit_facing::perform_without_undo(map_context& mc) const

--- a/src/editor/action/action_unit.hpp
+++ b/src/editor/action/action_unit.hpp
@@ -44,9 +44,9 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_unit* clone() const;
+	editor_action_ptr clone() const;
 
-	editor_action* perform(map_context& mc) const;
+	editor_action_ptr perform(map_context& mc) const;
 
 	void perform_without_undo(map_context& mc) const;
 
@@ -69,9 +69,9 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_unit_delete* clone() const;
+	editor_action_ptr clone() const;
 
-	editor_action* perform(map_context& mc) const;
+	editor_action_ptr perform(map_context& mc) const;
 
 	void perform_without_undo(map_context& mc) const;
 
@@ -89,9 +89,9 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_unit_replace* clone() const;
+	editor_action_ptr clone() const;
 
-	editor_action* perform(map_context& mc) const;
+	editor_action_ptr perform(map_context& mc) const;
 
 	void perform_without_undo(map_context& mc) const;
 
@@ -114,9 +114,9 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_unit_facing* clone() const;
+	editor_action_ptr clone() const;
 
-	editor_action* perform(map_context& mc) const;
+	editor_action_ptr perform(map_context& mc) const;
 
 	void perform_without_undo(map_context& mc) const;
 

--- a/src/editor/action/action_village.cpp
+++ b/src/editor/action/action_village.cpp
@@ -27,7 +27,7 @@ namespace editor
 {
 IMPLEMENT_ACTION(village)
 
-editor_action* editor_action_village::perform(map_context& mc) const
+editor_action_ptr editor_action_village::perform(map_context& mc) const
 {
 	if(!mc.map().is_village(loc_)) {
 		return nullptr;
@@ -52,7 +52,7 @@ editor_action* editor_action_village::perform(map_context& mc) const
 	}
 
 	perform_without_undo(mc);
-	return undo.release();
+	return undo;
 }
 
 void editor_action_village::perform_without_undo(map_context& mc) const
@@ -71,7 +71,7 @@ void editor_action_village::perform_without_undo(map_context& mc) const
 
 IMPLEMENT_ACTION(village_delete)
 
-editor_action* editor_action_village_delete::perform(map_context& mc) const
+editor_action_ptr editor_action_village_delete::perform(map_context& mc) const
 {
 	editor_action_ptr undo;
 
@@ -82,7 +82,7 @@ editor_action* editor_action_village_delete::perform(map_context& mc) const
 		}
 	}
 
-	return undo.release();
+	return undo;
 }
 
 void editor_action_village_delete::perform_without_undo(map_context& mc) const

--- a/src/editor/action/action_village.hpp
+++ b/src/editor/action/action_village.hpp
@@ -42,9 +42,9 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_village* clone() const;
+	editor_action_ptr clone() const;
 
-	editor_action* perform(map_context& mc) const;
+	editor_action_ptr perform(map_context& mc) const;
 
 	void perform_without_undo(map_context& mc) const;
 
@@ -67,9 +67,9 @@ public:
 	}
 
 	/** Inherited from editor_action, implemented by IMPLEMENT_ACTION. */
-	editor_action_village_delete* clone() const;
+	editor_action_ptr clone() const;
 
-	editor_action* perform(map_context& mc) const;
+	editor_action_ptr perform(map_context& mc) const;
 
 	void perform_without_undo(map_context& mc) const;
 

--- a/src/editor/action/mouse/mouse_action.hpp
+++ b/src/editor/action/mouse/mouse_action.hpp
@@ -67,39 +67,39 @@ public:
 	/**
 	 * A click, possibly the beginning of a drag. Must be overridden.
 	 */
-	virtual editor_action* click_left(editor_display& disp, int x, int y) = 0;
+	virtual editor_action_ptr click_left(editor_display& disp, int x, int y) = 0;
 
 	/**
 	 * A click, possibly the beginning of a drag. Must be overridden.
 	 */
-	virtual editor_action* click_right(editor_display& disp, int x, int y) = 0;
+	virtual editor_action_ptr click_right(editor_display& disp, int x, int y) = 0;
 
 	/**
 	 * Drag operation. A click should have occurred earlier. Defaults to no action.
 	 */
-	virtual editor_action* drag_left(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
+	virtual editor_action_ptr drag_left(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
 
 	/**
 	 * Drag operation. A click should have occurred earlier. Defaults to no action.
 	 */
-	virtual editor_action* drag_right(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
+	virtual editor_action_ptr drag_right(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
 
 	/**
 	 * The end of dragging. Defaults to no action.
 	 */
-	virtual editor_action* drag_end_left(editor_display& disp, int x, int y);
+	virtual editor_action_ptr drag_end_left(editor_display& disp, int x, int y);
 
-	virtual editor_action* drag_end_right(editor_display& disp, int x, int y);
+	virtual editor_action_ptr drag_end_right(editor_display& disp, int x, int y);
 
-	virtual editor_action* up_left(editor_display& disp, int x, int y);
+	virtual editor_action_ptr up_left(editor_display& disp, int x, int y);
 
-	virtual editor_action* up_right(editor_display& disp, int x, int y);
+	virtual editor_action_ptr up_right(editor_display& disp, int x, int y);
 
 	/**
 	 * Function called by the controller on a key event for the current mouse action.
 	 * Defaults to starting position processing.
 	 */
-	virtual editor_action* key_event(editor_display& disp, const SDL_Event& e);
+	virtual editor_action_ptr key_event(editor_display& disp, const SDL_Event& e);
 
 	/**
 	 * Helper variable setter - pointer to a toolbar menu/button used for highlighting
@@ -180,40 +180,40 @@ public:
 	/**
 	 * The actual action function which is called by click() and drag(). Derived classes override this instead of click() and drag().
 	 */
-	virtual editor_action* click_perform_left(editor_display& disp, const std::set<map_location>& hexes) = 0;
+	virtual editor_action_ptr click_perform_left(editor_display& disp, const std::set<map_location>& hexes) = 0;
 
 	/**
 	 * The actual action function which is called by click() and drag(). Derived classes override this instead of click() and drag().
 	 */
-	virtual editor_action* click_perform_right(editor_display& disp, const std::set<map_location>& hexes) = 0;
+	virtual editor_action_ptr click_perform_right(editor_display& disp, const std::set<map_location>& hexes) = 0;
 
 	/**
 	 * Calls click_perform_left()
 	 */
-	editor_action* click_left(editor_display& disp, int x, int y);
+	editor_action_ptr click_left(editor_display& disp, int x, int y);
 
 	/**
 	 * Calls click_perform_right()
 	 */
-	editor_action* click_right(editor_display& disp, int x, int y);
+	editor_action_ptr click_right(editor_display& disp, int x, int y);
 
 	/**
 	 * Calls click_perform() for every new hex the mouse is dragged into.
 	 * @todo partial actions support and merging of many drag actions into one
 	 */
-	editor_action* drag_left(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
+	editor_action_ptr drag_left(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
 
 	/**
 	 * Calls click_perform for every new hex the mouse is dragged into.
 	 * @todo partial actions support and merging of many drag actions into one
 	 */
-	editor_action* drag_right(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
+	editor_action_ptr drag_right(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
 
 	/**
 	 * End of dragging.
 	 * @todo partial actions (the entire drag should end up as one action)
 	 */
-	editor_action* drag_end(editor_display& disp, int x, int y);
+	editor_action_ptr drag_end(editor_display& disp, int x, int y);
 
 protected:
 	/** Brush accessor */
@@ -231,8 +231,8 @@ private:
 	 * The drags differ only in the worker function called, which should be
 	 * passed as the template parameter. This exists only to avoid copy-pasting code.
 	 */
-	template <editor_action* (brush_drag_mouse_action::*perform_func)(editor_display&, const std::set<map_location>&)>
-	editor_action* drag_generic(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
+	template <editor_action_ptr (brush_drag_mouse_action::*perform_func)(editor_display&, const std::set<map_location>&)>
+	editor_action_ptr drag_generic(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
 
 	/**
 	 * Current brush handle. Currently a pointer-to-pointer with full constness.
@@ -259,22 +259,22 @@ public:
 	/**
 	 * Handle terrain sampling before calling generic handler
 	 */
-	editor_action* click_left(editor_display& disp, int x, int y) override;
+	editor_action_ptr click_left(editor_display& disp, int x, int y) override;
 
 	/**
 	 * Handle terrain sampling before calling generic handler
 	 */
-	editor_action* click_right(editor_display& disp, int x, int y) override;
+	editor_action_ptr click_right(editor_display& disp, int x, int y) override;
 
 	/**
 	 * Create an appropriate editor_action and return it
 	 */
-	editor_action* click_perform_left(editor_display& disp, const std::set<map_location>& hexes) override;
+	editor_action_ptr click_perform_left(editor_display& disp, const std::set<map_location>& hexes) override;
 
 	/**
 	 * Create an appropriate editor_action and return it
 	 */
-	editor_action* click_perform_right(editor_display& disp, const std::set<map_location>& hexes) override;
+	editor_action_ptr click_perform_right(editor_display& disp, const std::set<map_location>& hexes) override;
 
 	void set_mouse_overlay(editor_display& disp) override;
 
@@ -309,12 +309,12 @@ public:
 	/**
 	 * Return a paste with offset action
 	 */
-	editor_action* click_left(editor_display& disp, int x, int y) override;
+	editor_action_ptr click_left(editor_display& disp, int x, int y) override;
 
 	/**
 	 * Right click does nothing for now
 	 */
-	editor_action* click_right(editor_display& disp, int x, int y) override;
+	editor_action_ptr click_right(editor_display& disp, int x, int y) override;
 
 	virtual void set_mouse_overlay(editor_display& disp) override;
 
@@ -346,12 +346,12 @@ public:
 	/**
 	 * Left / right click fills with the respective terrain
 	 */
-	editor_action* click_left(editor_display& disp, int x, int y);
+	editor_action_ptr click_left(editor_display& disp, int x, int y);
 
 	/**
 	 * Left / right click fills with the respective terrain
 	 */
-	editor_action* click_right(editor_display& disp, int x, int y);
+	editor_action_ptr click_right(editor_display& disp, int x, int y);
 
 	virtual void set_mouse_overlay(editor_display& disp);
 
@@ -375,16 +375,16 @@ public:
 	 * or returns nullptr if cancel was pressed or there would be no change.
 	 * Do this on mouse up to avoid drag issue.
 	 */
-	editor_action* up_left(editor_display& disp, int x, int y);
+	editor_action_ptr up_left(editor_display& disp, int x, int y);
 
-	editor_action* click_left(editor_display& disp, int x, int y);
+	editor_action_ptr click_left(editor_display& disp, int x, int y);
 	/**
 	 * Right click only erases the starting position if there is one.
 	 * Do this on mouse up to avoid drag issue,
 	 */
-	editor_action* up_right(editor_display& disp, int x, int y);
+	editor_action_ptr up_right(editor_display& disp, int x, int y);
 
-	editor_action* click_right(editor_display& disp, int x, int y);
+	editor_action_ptr click_right(editor_display& disp, int x, int y);
 
 	virtual void set_mouse_overlay(editor_display& disp);
 

--- a/src/editor/action/mouse/mouse_action_item.cpp
+++ b/src/editor/action/mouse/mouse_action_item.cpp
@@ -67,7 +67,7 @@ void mouse_action_item::move(editor_display& disp, const map_location& hex)
 	}
 }
 
-editor_action* mouse_action_item::click_left(editor_display& disp, int x, int y)
+editor_action_ptr mouse_action_item::click_left(editor_display& disp, int x, int y)
 {
 	start_hex_ = disp.hex_clicked_on(x, y);
 	if (!disp.get_map().on_board(start_hex_)) {
@@ -87,14 +87,14 @@ editor_action* mouse_action_item::click_left(editor_display& disp, int x, int y)
 	return nullptr;
 }
 
-editor_action* mouse_action_item::drag_left(editor_display& disp, int x, int y, bool& /*partial*/, editor_action* /*last_undo*/)
+editor_action_ptr mouse_action_item::drag_left(editor_display& disp, int x, int y, bool& /*partial*/, editor_action* /*last_undo*/)
 {
 	map_location hex = disp.hex_clicked_on(x, y);
 	click_ = (hex == start_hex_);
 	return nullptr;
 }
 
-editor_action* mouse_action_item::up_left(editor_display& disp, int x, int y)
+editor_action_ptr mouse_action_item::up_left(editor_display& disp, int x, int y)
 {
 	if (!click_) return nullptr;
 	click_ = false;
@@ -126,10 +126,10 @@ editor_action* mouse_action_item::up_left(editor_display& disp, int x, int y)
 	return nullptr;
 }
 
-editor_action* mouse_action_item::drag_end_left(editor_display& disp, int x, int y)
+editor_action_ptr mouse_action_item::drag_end_left(editor_display& disp, int x, int y)
 {
 	if (click_) return nullptr;
-	editor_action* action = nullptr;
+	editor_action_ptr action;
 
 	map_location hex = disp.hex_clicked_on(x, y);
 	if (!disp.get_map().on_board(hex))
@@ -140,7 +140,7 @@ editor_action* mouse_action_item::drag_end_left(editor_display& disp, int x, int
 //	if (item_it == items.end())
 //		return nullptr;
 
-	action = new editor_action_item_replace(start_hex_, hex);
+	action.reset(new editor_action_item_replace(start_hex_, hex));
 	return action;
 }
 

--- a/src/editor/action/mouse/mouse_action_item.hpp
+++ b/src/editor/action/mouse/mouse_action_item.hpp
@@ -44,22 +44,22 @@ public:
 	/**
 	 * TODO
 	 */
-	editor_action* click_left(editor_display& disp, int x, int y);
+	editor_action_ptr click_left(editor_display& disp, int x, int y);
 
 	/**
 	 * TODO
 	 */
-	editor_action* up_left(editor_display& disp, int x, int y);
+	editor_action_ptr up_left(editor_display& disp, int x, int y);
 
-	editor_action* drag_left(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
+	editor_action_ptr drag_left(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
 
 	/**
 	 * Drag end replaces the item when clicked left, or adjusts
 	 * the facing when clicked right.
 	 */
-	editor_action* drag_end_left(editor_display& disp, int x, int y);
+	editor_action_ptr drag_end_left(editor_display& disp, int x, int y);
 
-	editor_action* click_right(editor_display& /*disp*/, int /*x*/, int /*y*/) {
+	editor_action_ptr click_right(editor_display& /*disp*/, int /*x*/, int /*y*/) {
 		return nullptr;
 	}
 

--- a/src/editor/action/mouse/mouse_action_map_label.cpp
+++ b/src/editor/action/mouse/mouse_action_map_label.cpp
@@ -27,7 +27,7 @@
 
 namespace editor {
 
-editor_action* mouse_action_map_label::click_left(editor_display& disp, int x, int y)
+editor_action_ptr mouse_action_map_label::click_left(editor_display& disp, int x, int y)
 {
 	click_ = true;
 	map_location hex = disp.hex_clicked_on(x, y);
@@ -35,7 +35,7 @@ editor_action* mouse_action_map_label::click_left(editor_display& disp, int x, i
 	return nullptr;
 }
 
-editor_action* mouse_action_map_label::drag_left(editor_display& disp, int x, int y
+editor_action_ptr mouse_action_map_label::drag_left(editor_display& disp, int x, int y
 		, bool& /*partial*/, editor_action* /*last_undo*/)
 {
 	map_location hex = disp.hex_clicked_on(x, y);
@@ -43,7 +43,7 @@ editor_action* mouse_action_map_label::drag_left(editor_display& disp, int x, in
 	return nullptr;
 }
 
-editor_action* mouse_action_map_label::up_left(editor_display& disp, int x, int y)
+editor_action_ptr mouse_action_map_label::up_left(editor_display& disp, int x, int y)
 {
 	if (!click_) return nullptr;
 	click_ = false;
@@ -64,21 +64,21 @@ editor_action* mouse_action_map_label::up_left(editor_display& disp, int x, int 
 
 	gui2::dialogs::editor_edit_label d(label, immutable, visible_fog, visible_shroud, color, category);
 
-	editor_action* a = nullptr;
+	editor_action_ptr a = nullptr;
 	if(d.show()) {
-		a = new editor_action_label(hex, label, team_name, color
-				, visible_fog, visible_shroud, immutable, category);
+		a.reset(new editor_action_label(hex, label, team_name, color
+				, visible_fog, visible_shroud, immutable, category));
 		update_brush_highlights(disp, hex);
 	}
 	return a;
 }
 
-editor_action* mouse_action_map_label::click_right(editor_display& /*disp*/, int /*x*/, int /*y*/)
+editor_action_ptr mouse_action_map_label::click_right(editor_display& /*disp*/, int /*x*/, int /*y*/)
 {
 	return nullptr;
 }
 
-editor_action* mouse_action_map_label::up_right(editor_display& disp, int x, int y)
+editor_action_ptr mouse_action_map_label::up_right(editor_display& disp, int x, int y)
 {
 	map_location hex = disp.hex_clicked_on(x, y);
 
@@ -87,10 +87,10 @@ editor_action* mouse_action_map_label::up_right(editor_display& disp, int x, int
 	//if (!clicked_label)
 	//	return nullptr;
 
-	return new editor_action_label_delete(hex);
+	return editor_action_ptr(new editor_action_label_delete(hex));
 }
 
-editor_action* mouse_action_map_label::drag_end_left(editor_display& disp, int x, int y)
+editor_action_ptr mouse_action_map_label::drag_end_left(editor_display& disp, int x, int y)
 {
 	if (click_) return nullptr;
 
@@ -113,9 +113,9 @@ editor_action* mouse_action_map_label::drag_end_left(editor_display& disp, int x
 	// 1. Delete label in initial hex
 	// 2. Delete label in target hex if it exists, otherwise will no-op
 	// 3. Create label in target hex
-	editor_action_chain* chain = new editor_action_chain(new editor_action_label_delete(clicked_on_));
-	chain->append_action(new editor_action_label_delete(hex));
-	chain->append_action(
+	std::unique_ptr<editor_action_chain> chain(new editor_action_chain(editor_action_ptr(new editor_action_label_delete(clicked_on_))));
+	chain->append_action(editor_action_ptr(new editor_action_label_delete(hex)));
+	chain->append_action(editor_action_ptr(
 		new editor_action_label(
 			hex,
 			dragged_label->text(),
@@ -126,7 +126,7 @@ editor_action* mouse_action_map_label::drag_end_left(editor_display& disp, int x
 			dragged_label->immutable(),
 			dragged_label->category()
 		)
-	);
+	));
 
 	return chain;
 }

--- a/src/editor/action/mouse/mouse_action_map_label.hpp
+++ b/src/editor/action/mouse/mouse_action_map_label.hpp
@@ -32,29 +32,29 @@ public:
 	  {
 	  }
 
-	editor_action* click_left(editor_display& disp, int x, int y);
+	editor_action_ptr click_left(editor_display& disp, int x, int y);
 
 	/**
 	 * Drags a label.
 	 */
-	editor_action* drag_left(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
+	editor_action_ptr drag_left(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
 
 	/**
 	 * Replaces the label under the mouse with the dragged label.
 	 */
-	editor_action* drag_end_left(editor_display& disp, int x, int y);
+	editor_action_ptr drag_end_left(editor_display& disp, int x, int y);
 
 	/**
 	 * Left click displays a dialog that is used for entering the label string.
 	 */
-	editor_action* up_left(editor_display& disp, int x, int y);
+	editor_action_ptr up_left(editor_display& disp, int x, int y);
 
-	editor_action* click_right(editor_display& disp, int x, int y);
+	editor_action_ptr click_right(editor_display& disp, int x, int y);
 
 	/**
 	 * Right click erases the label under the mouse.
 	 */
-	editor_action* up_right(editor_display& disp, int x, int y);
+	editor_action_ptr up_right(editor_display& disp, int x, int y);
 
 	virtual void set_mouse_overlay(editor_display& disp);
 

--- a/src/editor/action/mouse/mouse_action_select.cpp
+++ b/src/editor/action/mouse/mouse_action_select.cpp
@@ -29,30 +29,30 @@ std::set<map_location> mouse_action_select::affected_hexes(
 	}
 }
 
-editor_action* mouse_action_select::key_event(
+editor_action_ptr mouse_action_select::key_event(
 		editor_display& disp, const SDL_Event& event)
 {
-	editor_action* ret = mouse_action::key_event(disp, event);
+	editor_action_ptr ret(mouse_action::key_event(disp, event));
 	update_brush_highlights(disp, previous_move_hex_);
 	return ret;
 }
 
-editor_action* mouse_action_select::click_perform_left(
+editor_action_ptr mouse_action_select::click_perform_left(
 		editor_display& /*disp*/, const std::set<map_location>& hexes)
 {
 	if (has_ctrl_modifier())
-		return new editor_action_chain(new editor_action_deselect(hexes));
+		return editor_action_ptr(new editor_action_chain(editor_action_ptr(new editor_action_deselect(hexes))));
 	else
-		return new editor_action_chain(new editor_action_select(hexes));
+		return editor_action_ptr(new editor_action_chain(editor_action_ptr(new editor_action_select(hexes))));
 }
 
-editor_action* mouse_action_select::click_perform_right(
+editor_action_ptr mouse_action_select::click_perform_right(
 		editor_display& /*disp*/, const std::set<map_location>& /*hexes*/)
 {
 	return nullptr;
 }
 
-editor_action* mouse_action_select::click_right(editor_display& /*disp*/, int /*x*/, int /*y*/)
+editor_action_ptr mouse_action_select::click_right(editor_display& /*disp*/, int /*x*/, int /*y*/)
 {
 	return nullptr;
 }

--- a/src/editor/action/mouse/mouse_action_select.hpp
+++ b/src/editor/action/mouse/mouse_action_select.hpp
@@ -40,23 +40,23 @@ public:
 	/**
 	 * Force a fake "move" event to update brush overlay on key event
 	 */
-	editor_action* key_event(editor_display& disp, const SDL_Event& e) override;
+	editor_action_ptr key_event(editor_display& disp, const SDL_Event& e) override;
 
 	/**
 	 * Left click/drag selects
 	 */
-	editor_action* click_perform_left(editor_display& disp, const std::set<map_location>& hexes) override;
+	editor_action_ptr click_perform_left(editor_display& disp, const std::set<map_location>& hexes) override;
 
 	/**
 	 * Right click does nothing for now
 	 */
-	editor_action* click_right(editor_display& disp, int x, int y) override;
+	editor_action_ptr click_right(editor_display& disp, int x, int y) override;
 
 
 	/**
 	 * Right click/drag
 	 */
-	editor_action* click_perform_right(editor_display& disp, const std::set<map_location>& hexes) override;
+	editor_action_ptr click_perform_right(editor_display& disp, const std::set<map_location>& hexes) override;
 
 	virtual void set_mouse_overlay(editor_display& disp) override;
 

--- a/src/editor/action/mouse/mouse_action_unit.cpp
+++ b/src/editor/action/mouse/mouse_action_unit.cpp
@@ -84,7 +84,7 @@ void mouse_action_unit::move(editor_display& disp, const map_location& hex)
 	}
 }
 
-editor_action* mouse_action_unit::click_left(editor_display& disp, int x, int y)
+editor_action_ptr mouse_action_unit::click_left(editor_display& disp, int x, int y)
 {
 	start_hex_ = disp.hex_clicked_on(x, y);
 	if (!disp.get_map().on_board(start_hex_)) {
@@ -100,14 +100,14 @@ editor_action* mouse_action_unit::click_left(editor_display& disp, int x, int y)
 	return nullptr;
 }
 
-editor_action* mouse_action_unit::drag_left(editor_display& disp, int x, int y, bool& /*partial*/, editor_action* /*last_undo*/)
+editor_action_ptr mouse_action_unit::drag_left(editor_display& disp, int x, int y, bool& /*partial*/, editor_action* /*last_undo*/)
 {
 	map_location hex = disp.hex_clicked_on(x, y);
 	click_ = (hex == start_hex_);
 	return nullptr;
 }
 
-editor_action* mouse_action_unit::up_left(editor_display& disp, int x, int y)
+editor_action_ptr mouse_action_unit::up_left(editor_display& disp, int x, int y)
 {
 	if (!click_) return nullptr;
 	click_ = false;
@@ -133,14 +133,14 @@ editor_action* mouse_action_unit::up_left(editor_display& disp, int x, int y)
 	unit_race::GENDER gender = ut.genders().front();
 
 	unit_ptr new_unit = unit::create(ut, disp.viewing_side(), true, gender);
-	editor_action* action = new editor_action_unit(hex, *new_unit);
+	editor_action_ptr action(new editor_action_unit(hex, *new_unit));
 	return action;
 }
 
-editor_action* mouse_action_unit::drag_end_left(editor_display& disp, int x, int y)
+editor_action_ptr mouse_action_unit::drag_end_left(editor_display& disp, int x, int y)
 {
 	if (click_) return nullptr;
-	editor_action* action = nullptr;
+	editor_action_ptr action = nullptr;
 
 	map_location hex = disp.hex_clicked_on(x, y);
 	if (!disp.get_map().on_board(hex))
@@ -151,7 +151,7 @@ editor_action* mouse_action_unit::drag_end_left(editor_display& disp, int x, int
 	if (unit_it == units.end())
 		return nullptr;
 
-	action = new editor_action_unit_replace(start_hex_, hex);
+	action.reset(new editor_action_unit_replace(start_hex_, hex));
 	return action;
 }
 

--- a/src/editor/action/mouse/mouse_action_unit.hpp
+++ b/src/editor/action/mouse/mouse_action_unit.hpp
@@ -44,22 +44,22 @@ public:
 	/**
 	 * TODO
 	 */
-	editor_action* click_left(editor_display& disp, int x, int y);
+	editor_action_ptr click_left(editor_display& disp, int x, int y);
 
 	/**
 	 * TODO
 	 */
-	editor_action* up_left(editor_display& disp, int x, int y);
+	editor_action_ptr up_left(editor_display& disp, int x, int y);
 
-	editor_action* drag_left(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
+	editor_action_ptr drag_left(editor_display& disp, int x, int y, bool& partial, editor_action* last_undo);
 
 	/**
 	 * Drag end replaces the unit when clicked left, or adjusts
 	 * the facing when clicked right.
 	 */
-	editor_action* drag_end_left(editor_display& disp, int x, int y);
+	editor_action_ptr drag_end_left(editor_display& disp, int x, int y);
 
-	editor_action* click_right(editor_display& /*disp*/, int /*x*/, int /*y*/) {
+	editor_action_ptr click_right(editor_display& /*disp*/, int /*x*/, int /*y*/) {
 		return nullptr;
 	}
 

--- a/src/editor/action/mouse/mouse_action_village.cpp
+++ b/src/editor/action/mouse/mouse_action_village.cpp
@@ -19,22 +19,22 @@
 
 namespace editor {
 
-editor_action* mouse_action_village::up_left(editor_display& disp, int x, int y)
+editor_action_ptr mouse_action_village::up_left(editor_display& disp, int x, int y)
 {
 	map_location hex = disp.hex_clicked_on(x, y);
 	if (!disp.get_map().on_board(hex))   return nullptr;
 	if (!disp.get_map().is_village(hex)) return nullptr;
 
-	return new editor_action_village(hex, disp.playing_team());
+	return editor_action_ptr(new editor_action_village(hex, disp.playing_team()));
 }
 
-editor_action* mouse_action_village::up_right(editor_display& disp, int x, int y)
+editor_action_ptr mouse_action_village::up_right(editor_display& disp, int x, int y)
 {
 	map_location hex = disp.hex_clicked_on(x, y);
 	if (!disp.get_map().on_board(hex))   return nullptr;
 	if (!disp.get_map().is_village(hex)) return nullptr;
 
-	return new editor_action_village_delete(hex);
+	return editor_action_ptr(new editor_action_village_delete(hex));
 }
 
 void mouse_action_village::set_mouse_overlay(editor_display& disp)

--- a/src/editor/action/mouse/mouse_action_village.hpp
+++ b/src/editor/action/mouse/mouse_action_village.hpp
@@ -36,22 +36,22 @@ public:
 	/**
 	 * No action.
 	 */
-	editor_action* click_left(editor_display& /*disp*/, int /*x*/, int /*y*/) {return nullptr;}
+	editor_action_ptr click_left(editor_display& /*disp*/, int /*x*/, int /*y*/) {return nullptr;}
 
 	/**
 	 * If clicked on a village hex field, assigns the ownership of it to the current side.
 	 */
-	editor_action* up_left(editor_display& disp, int x, int y);
+	editor_action_ptr up_left(editor_display& disp, int x, int y);
 
 	/**
 	 * No action.
 	 */
-	editor_action* click_right(editor_display& /*disp*/, int /*x*/, int /*y*/) {return nullptr;}
+	editor_action_ptr click_right(editor_display& /*disp*/, int /*x*/, int /*y*/) {return nullptr;}
 
 	/**
 	 * If clicked on a village hex field, unassigns it's ownership.
 	 */
-	editor_action* up_right(editor_display& disp, int x, int y);
+	editor_action_ptr up_right(editor_display& disp, int x, int y);
 
 	virtual void set_mouse_overlay(editor_display& disp);
 };

--- a/src/editor/controller/editor_controller.cpp
+++ b/src/editor/controller/editor_controller.cpp
@@ -792,7 +792,7 @@ bool editor_controller::do_execute_command(const hotkey::hotkey_command& cmd, in
 		case HOTKEY_DELETE_UNIT:
 		{
 			map_location loc = gui_->mouseover_hex();
-			perform_delete(new editor_action_unit_delete(loc));
+			perform_delete(editor_action_ptr(new editor_action_unit_delete(loc)));
 		}
 		return true;
 		case HOTKEY_EDITOR_CLIPBOARD_PASTE: //paste is somewhat different as it might be "one action then revert to previous mode"
@@ -984,7 +984,7 @@ bool editor_controller::do_execute_command(const hotkey::hotkey_command& cmd, in
 		case HOTKEY_EDITOR_REMOVE_LOCATION: {
 			location_palette* lp = dynamic_cast<location_palette*>(&toolkit_->get_palette_manager()->active_palette());
 			if (lp) {
-				perform_delete(new editor_action_starting_position(map_location(), lp->selected_item()));
+				perform_delete(editor_action_ptr(new editor_action_starting_position(map_location(), lp->selected_item())));
 				// No idea if this is the right thing to call, but it ensures starting
 				// position labels get removed on delete.
 				context_manager_->refresh_after_action();
@@ -1211,18 +1211,16 @@ void editor_controller::export_selection_coords()
 	}
 }
 
-void editor_controller::perform_delete(editor_action* action)
+void editor_controller::perform_delete(editor_action_ptr action)
 {
 	if (action) {
-		const editor_action_ptr action_auto(action);
 		get_current_map_context().perform_action(*action);
 	}
 }
 
-void editor_controller::perform_refresh_delete(editor_action* action, bool drag_part /* =false */)
+void editor_controller::perform_refresh_delete(editor_action_ptr action, bool drag_part /* =false */)
 {
 	if (action) {
-		const editor_action_ptr action_auto(action);
 		context_manager_->perform_refresh(*action, drag_part);
 	}
 }
@@ -1259,7 +1257,7 @@ void editor_controller::mouse_motion(int x, int y, const bool /*browse*/,
 	if (mouse_handler_base::mouse_motion_default(x, y, update)) return;
 	map_location hex_clicked = gui().hex_clicked_on(x, y);
 	if (get_current_map_context().map().on_board_with_border(drag_from_hex_) && is_dragging()) {
-		editor_action* a = nullptr;
+		editor_action_ptr a = nullptr;
 		bool partial = false;
 		editor_action* last_undo = get_current_map_context().last_undo_action();
 		if (dragging_left_ && (SDL_GetMouseState(nullptr, nullptr) & SDL_BUTTON(1)) != 0) {
@@ -1273,7 +1271,6 @@ void editor_controller::mouse_motion(int x, int y, const bool /*browse*/,
 		//last undo action and the controller shouldn't add
 		//anything to the undo stack (hence a different perform_ call)
 		if (a != nullptr) {
-			const editor_action_ptr aa(a);
 			if (partial) {
 				get_current_map_context().perform_partial_action(*a);
 			} else {
@@ -1314,24 +1311,28 @@ bool editor_controller::left_click(int x, int y, const bool browse)
 		return true;
 
 	LOG_ED << "Left click action " << hex_clicked << "\n";
-	editor_action* a = get_mouse_action().click_left(*gui_, x, y);
-	perform_refresh_delete(a, true);
-	if (a) set_button_state();
+	editor_action_ptr a = get_mouse_action().click_left(*gui_, x, y);
+	if (a) {
+		perform_refresh_delete(std::move(a), true);
+		set_button_state();
+	}
 
 	return false;
 }
 
 void editor_controller::left_drag_end(int x, int y, const bool /*browse*/)
 {
-	editor_action* a = get_mouse_action().drag_end_left(*gui_, x, y);
-	perform_delete(a);
+	editor_action_ptr a = get_mouse_action().drag_end_left(*gui_, x, y);
+	perform_delete(std::move(a));
 }
 
 void editor_controller::left_mouse_up(int x, int y, const bool /*browse*/)
 {
-	editor_action* a = get_mouse_action().up_left(*gui_, x, y);
-	perform_delete(a);
-	if (a) set_button_state();
+	editor_action_ptr a = get_mouse_action().up_left(*gui_, x, y);
+	if (a) {
+		perform_delete(std::move(a));
+		set_button_state();
+	}
 	toolkit_->set_mouseover_overlay();
 	context_manager_->refresh_after_action();
 }
@@ -1344,16 +1345,18 @@ bool editor_controller::right_click(int x, int y, const bool browse)
 	map_location hex_clicked = gui().hex_clicked_on(x, y);
 	if (!get_current_map_context().map().on_board_with_border(hex_clicked)) return true;
 	LOG_ED << "Right click action " << hex_clicked << "\n";
-	editor_action* a = get_mouse_action().click_right(*gui_, x, y);
-	perform_refresh_delete(a, true);
-	if (a) set_button_state();
+	editor_action_ptr a = get_mouse_action().click_right(*gui_, x, y);
+	if (a) {
+		perform_refresh_delete(std::move(a), true);
+		set_button_state();
+	}
 	return false;
 }
 
 void editor_controller::right_drag_end(int x, int y, const bool /*browse*/)
 {
-	editor_action* a = get_mouse_action().drag_end_right(*gui_, x, y);
-	perform_delete(a);
+	editor_action_ptr a = get_mouse_action().drag_end_right(*gui_, x, y);
+	perform_delete(std::move(a));
 }
 
 void editor_controller::right_mouse_up(int x, int y, const bool browse)
@@ -1361,9 +1364,11 @@ void editor_controller::right_mouse_up(int x, int y, const bool browse)
 	// Call base method to handle context menus.
 	mouse_handler_base::right_mouse_up(x, y, browse);
 
-	editor_action* a = get_mouse_action().up_right(*gui_, x, y);
-	perform_delete(a);
-	if (a) set_button_state();
+	editor_action_ptr a = get_mouse_action().up_right(*gui_, x, y);
+	if (a) {
+		perform_delete(std::move(a));
+		set_button_state();
+	}
 	toolkit_->set_mouseover_overlay();
 	context_manager_->refresh_after_action();
 }
@@ -1380,8 +1385,8 @@ void editor_controller::terrain_description()
 
 void editor_controller::process_keyup_event(const SDL_Event& event)
 {
-	editor_action* a = get_mouse_action().key_event(gui(), event);
-	perform_refresh_delete(a);
+	editor_action_ptr a = get_mouse_action().key_event(gui(), event);
+	perform_refresh_delete(std::move(a));
 	toolkit_->set_mouseover_overlay();
 }
 

--- a/src/editor/controller/editor_controller.hpp
+++ b/src/editor/controller/editor_controller.hpp
@@ -188,13 +188,13 @@ class editor_controller : public controller_base,
 		 * Perform an action, then delete the action object.
 		 * The pointer can be nullptr, in which case nothing will happen.
 		 */
-		void perform_delete(editor_action* action);
+		void perform_delete(editor_action_ptr action);
 
 		/**
 		 * Peform an action on the current map_context, then refresh the display
 		 * and delete the pointer. The pointer can be nullptr, in which case nothing will happen.
 		 */
-		void perform_refresh_delete(editor_action* action, bool drag_part = false);
+		void perform_refresh_delete(editor_action_ptr action, bool drag_part = false);
 
 
 		virtual std::vector<std::string> additional_actions_pressed() override;


### PR DESCRIPTION
It was [recently noted](https://github.com/wesnoth/wesnoth/pull/5254#discussion_r516381049) that the editor works by passing raw owning `editor_action*` around. This PR changes that.