### PR TITLE
Encrypt client/server communication using OpenSSL with Boost Asio.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,6 +209,12 @@ fonts/.uuid
 data/**/*.xcf
 data/**/*.psd
 
+# SSL certificates
+certs/*.pem
+certs/*.crt
+certs/*.csr
+certs/*.key
+
 # uncategorized
 revision*
 config.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ if(NOT APPLE)
 else()
 	set(CRYPTO_LIBRARY "-framework Security")
 endif()
+find_package(OpenSSL REQUIRED)
 
 find_package(Boost ${BOOST_VERSION} REQUIRED COMPONENTS iostreams program_options regex system thread random)
 

--- a/SConstruct
+++ b/SConstruct
@@ -391,6 +391,7 @@ if env["prereqs"]:
     if(env["PLATFORM"] != 'darwin'):
         # Otherwise, use Security.framework
         have_server_prereqs = have_server_prereqs & conf.CheckLib("libcrypto")
+        have_server_prereqs = have_server_prereqs & conf.CheckLib("libssl")
 
     env = conf.Finish()
 

--- a/certs/README.md
+++ b/certs/README.md
@@ -1,0 +1,4 @@
+About
+=====
+
+This directory is for the certificates/keys needed for encrypting communication between the wesnoth client and wesnothd/campaignd.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,7 @@ endif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 set(game-external-libs
 	${common-external-libs}
 	${CRYPTO_LIBRARY}
+	${OPENSSL_SSL_LIBRARY}
 	${Boost_SYSTEM_LIBRARIES}
 	${Boost_RANDOM_LIBRARY}
 	${Boost_THREAD_LIBRARY}
@@ -101,6 +102,7 @@ set(server-external-libs
 	${Boost_SYSTEM_LIBRARIES}
 	${Boost_RANDOM_LIBRARY}
 	${CRYPTO_LIBRARY}
+	${OPENSSL_SSL_LIBRARY}
 	${MYSQL_LIBS}
 	-lpthread
 )

--- a/src/network_asio.hpp
+++ b/src/network_asio.hpp
@@ -33,6 +33,7 @@
 #include "exceptions.hpp"
 
 #include <boost/asio.hpp>
+#include <boost/asio/ssl.hpp>
 
 class config;
 
@@ -120,10 +121,12 @@ public:
 private:
 	boost::asio::io_service io_service_;
 
+	boost::asio::ssl::context ssl_ctx_;
+
 	typedef boost::asio::ip::tcp::resolver resolver;
 	resolver resolver_;
 
-	typedef boost::asio::ip::tcp::socket socket;
+	typedef boost::asio::ssl::stream<boost::asio::ip::tcp::socket> socket;
 	socket socket_;
 
 	bool done_;

--- a/src/server/campaignd/server.cpp
+++ b/src/server/campaignd/server.cpp
@@ -305,6 +305,15 @@ void server::load_config()
 	filesystem::scoped_istream in = filesystem::istream_file(cfg_file_);
 	read(cfg_, *in);
 
+	// ssl setup
+	ssl_ = cfg_["ssl"].to_bool();
+	if(ssl_) {
+		setup_ssl(cfg_["crt"], cfg_["private_key"], cfg_["dhparam"]);
+		LOG_CS << "SSL enabled\n";
+	} else {
+		LOG_CS << "SSL not enabled\n";
+	}
+
 	read_only_ = cfg_["read_only"].to_bool(false);
 
 	if(read_only_) {

--- a/src/server/common/send_receive_wml_helpers.ipp
+++ b/src/server/common/send_receive_wml_helpers.ipp
@@ -107,8 +107,8 @@ struct sendfile_op
 	{
 		// Put the underlying socket into non-blocking mode.
 		if (!ec)
-			if (!sock_->native_non_blocking())
-				sock_->native_non_blocking(true, ec);
+			if (!sock_->lowest_layer().native_non_blocking())
+				sock_->lowest_layer().native_non_blocking(true, ec);
 
 		if (!ec)
 		{
@@ -116,7 +116,7 @@ struct sendfile_op
 			{
 				// Try the system call.
 				errno = 0;
-				int n = ::sendfile(sock_->native_handle(), fd_, &offset_, 65536);
+				int n = ::sendfile(sock_->lowest_layer().native_handle(), fd_, &offset_, 65536);
 				ec = boost::system::error_code(n < 0 ? errno : 0,
 											   boost::asio::error::get_system_category());
 				total_bytes_transferred_ += ec ? 0 : n;
@@ -187,7 +187,7 @@ struct sendfile_op
 		bool failed = false;
 		if (!pending_)
 		{
-			BOOL success = TransmitFile(sock_->native_handle(), file_, 0, 0, &overlap_, nullptr, 0);
+			BOOL success = TransmitFile(sock_->lowest_layer().native_handle(), file_, 0, 0, &overlap_, nullptr, 0);
 			if (!success)
 			{
 				int winsock_ec = WSAGetLastError();

--- a/src/server/common/server_base.hpp
+++ b/src/server/common/server_base.hpp
@@ -25,10 +25,12 @@
 #include <map>
 
 #include <boost/asio.hpp>
+#include <boost/asio/ssl.hpp>
 #include <boost/asio/signal_set.hpp>
 #include <boost/shared_array.hpp>
 
-typedef std::shared_ptr<boost::asio::ip::tcp::socket> socket_ptr;
+typedef std::shared_ptr<boost::asio::ssl::stream<boost::asio::ip::tcp::socket>> socket_ptr;
+//typedef std::shared_ptr<boost::asio::ip::tcp::socket> socket_ptr;
 
 struct server_shutdown : public game::error
 {
@@ -45,9 +47,12 @@ public:
 protected:
 	unsigned short port_;
 	bool keep_alive_;
+	bool ssl_;
 	boost::asio::io_service io_service_;
+	boost::asio::ssl::context ssl_ctx_;
 	boost::asio::ip::tcp::acceptor acceptor_v6_;
 	boost::asio::ip::tcp::acceptor acceptor_v4_;
+	void setup_ssl(const std::string& crt, const std::string& private_key, const std::string& dhparam);
 	void setup_acceptor(boost::asio::ip::tcp::acceptor& acceptor, boost::asio::ip::tcp::endpoint endpoint);
 	void start_server();
 	void serve(boost::asio::ip::tcp::acceptor& acceptor);

--- a/src/server/wesnothd/server.hpp
+++ b/src/server/wesnothd/server.hpp
@@ -34,7 +34,7 @@ namespace wesnothd
 class server : public server_base
 {
 public:
-	server(int port, bool keep_alive, const std::string& config_file, std::size_t, std::size_t);
+	server(int port, bool keep_alive, const std::string& config_file);
 
 private:
 	void handle_new_client(socket_ptr socket);

--- a/src/wesnothd_connection.hpp
+++ b/src/wesnothd_connection.hpp
@@ -34,6 +34,7 @@
 #include "wesnothd_connection_error.hpp"
 
 #include <boost/asio.hpp>
+#include <boost/asio/ssl.hpp>
 
 #include <condition_variable>
 #include <deque>
@@ -122,10 +123,12 @@ private:
 
 	boost::asio::io_service io_service_;
 
+	boost::asio::ssl::context ssl_ctx_;
+
 	typedef boost::asio::ip::tcp::resolver resolver;
 	resolver resolver_;
 
-	typedef boost::asio::ip::tcp::socket socket;
+	typedef boost::asio::ssl::stream<boost::asio::ip::tcp::socket> socket;
 	socket socket_;
 
 	boost::system::error_code last_error_;

--- a/utils/travis/docker_run.sh
+++ b/utils/travis/docker_run.sh
@@ -179,6 +179,12 @@ else
         git diff-index --quiet HEAD
     }
 
+# needed for the MP and Boost tests
+      openssl genrsa -out certs/server.key 2048
+      openssl req -new -key certs/server.key -out certs/server.csr -subj "/C=we/ST=wesnoth/L=wesnoth/O=wesnoth/OU=wesnoth/CN=localhost"
+      openssl x509 -req -days 3650 -in certs/server.csr -signkey certs/server.key -out certs/localhost.crt
+      openssl dhparam -out certs/dh2048.pem 2048
+
     if [ "$VALIDATE" = "true" ]; then
         execute "WML validation" ./utils/travis/schema_validation.sh
         execute "WML indentation check" checkindent

--- a/utils/travis/steps/install.sh
+++ b/utils/travis/steps/install.sh
@@ -28,8 +28,8 @@ fi
 
 if [ "$TRAVIS_OS_NAME" = "osx" ]; then
     HOMEBREW_NO_AUTO_UPDATE=1 brew install ccache scons
-    yes | pip3 install paramiko
     export PATH="/usr/local/opt/gettext/bin:/usr/local/opt/ccache/libexec:$PWD/utils/travis:$PATH"
+    yes | pip3 install paramiko
     export CC=ccache-clang
     export CXX=ccache-clang++
     export CCACHE_MAXSIZE=3000M


### PR DESCRIPTION
Re-PR of #5287.

Currently implemented are the MP client connection and wesnothd+campaignd since they both use server_base.  I don't know how to run campaignd locally, but for wesnothd I was able to connect, disconnect, and play a short game between two players using my local instance.  I also confirmed that SSL/TLS was definitely being used via `echo "" | openssl s_client -connect localhost:11111` (11111 is the port my local wesnothd uses), the only issue reported being that the certificate used is self-signed.

Things left to do:

- [x] Implement for the add-ons server client.
- [x] See if I can find out why `shutdown: stream truncated` is printed out whenever a [shutdown()](https://github.com/boostorg/beast/issues/995#issuecomment-359507329) is called on the socket now, or whether it can be [ignored](https://github.com/boostorg/beast/issues/824).
- [ ] How to support either SSL or non-SSL?
- [x] Travis certs - see if it works to generate the necessary files during the travis runs rather than having them in the repo.
- [x] Fix the CI.
- [x] Make sure OpenSSL is ready and able to be packaged as part of the macOS release.
- [ ] Testing. In particular, it will need to be tested if macOS and Windows clients will need any OS-specific code to be able to load the system-provided certs.
- [x] Certs - How do we get or create the actual certs that will be used?  [See this comment.](https://github.com/wesnoth/wesnoth/pull/5299#issuecomment-734408639)
- [ ] A couple other TODO comments I left myself.

This is also the first part of addressing #5132.