### PR TITLE
Unit test for resistances, could do with Lua advice

### DIFF
--- a/data/test/scenarios/test_resistances.cfg
+++ b/data/test/scenarios/test_resistances.cfg
@@ -1,0 +1,46 @@
+# wmllint: no translatables
+
+{GENERIC_UNIT_TEST "test_resistances" (
+    [event]
+        name = start
+
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=alice
+        [/store_unit]
+
+        # Elvish archers have a slight malus against arcane
+        {ASSERT {VARIABLE_CONDITIONAL alice.resistance.arcane equals 110}}
+        {ASSERT {VARIABLE_CONDITIONAL alice.resistance.impact equals 100}}
+        {ASSERT {VARIABLE_CONDITIONAL alice.resistance.length equals 1}}
+
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=bob
+        [/store_unit]
+
+        {ASSERT {VARIABLE_CONDITIONAL bob.resistance.arcane equals 100}}
+        {ASSERT {VARIABLE_CONDITIONAL bob.resistance.impact equals 100}}
+
+        # Check that there are exactly 6 resistance types, therefore that
+        # none have been added by a [resistance_defaults] tag.
+        {ASSERT {VARIABLE_CONDITIONAL bob.resistance.length equals 1}}
+        {VARIABLE key_count -1}
+        [lua]
+            code = <<
+                local key_count = 0
+                for k,v in pairs(wml.variables["bob.resistance[0]"]) do
+                    key_count = key_count + 1
+                end
+                wml.variables["key_count"] = key_count
+                >>
+        [/lua]
+        {ASSERT {VARIABLE_CONDITIONAL key_count equals 6}}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -150,6 +150,7 @@
 0 test_elf_longsighted_cave_vision
 0 test_elf_longsighted_cave_and_hills_vision
 0 test_elf_longsighted_cave_slow_cave_vision
+0 test_resistances
 #
 # Attack calculations & codepath tests
 #


### PR DESCRIPTION
Add a unit test for resistances (using the standard 6 damage types)

I'm working on a bugfix for [resistance_defaults] (bug #5308), for which the
unit test is going to be out-of-tree until we support some method of testing
it without affecting other tests. The version here is the part of that which
can be in-tree, because it doesn't change the core unit's stats.

This uses some Lua to check that the units have only the expected
resistance types, but I feel there should be a better way to write it.