### PR TITLE
Fix [resistance_defaults] and [terrain_defaults] (fixes #5308)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,8 +13,9 @@
    * Some standing/bobbing animations now filtered for low HP (depicting exhaustion) (PR #5388)
  ### User interface
  ### WML Engine
-   * New [set_variable] options: reverse=yes, min=list, max=list
+   * New `[set_variable]` options: reverse=yes, min=list, max=list
  ### Miscellaneous and Bug Fixes
+   * Fixed `[terrain_defaults]` and `[resistance_defaults]` (issue #5308).
 
 ## Version 1.15.8
  ### Add-ons client

--- a/data/schema/units/movetypes.cfg
+++ b/data/schema/units/movetypes.cfg
@@ -27,6 +27,8 @@
 	[/tag]
 [/tag]
 
+# For adding a new terrain type or resistance type, forgetting to add a default is probably an error.
+# Vision and jamming are exceptions to this, as they fallback to the movement costs.
 #define MOVETYPE_PATCHING
 	{REQUIRED_KEY default f_int}
 	{ANY_KEY f_int}
@@ -34,12 +36,14 @@
 
 [tag]
 	name="resistance_defaults"
+	max=infinite
 	{REQUIRED_KEY id string}
 	{MOVETYPE_PATCHING}
 [/tag]
 
 [tag]
 	name="terrain_defaults"
+	max=infinite
 	{REQUIRED_KEY id string}
 	[tag]
 		name="defense"
@@ -51,10 +55,10 @@
 	[/tag]
 	[tag]
 		name="jamming_costs"
-		{MOVETYPE_PATCHING}
+		{ANY_KEY f_int}
 	[/tag]
 	[tag]
 		name="vision_costs"
-		{MOVETYPE_PATCHING}
+		{ANY_KEY f_int}
 	[/tag]
 [/tag]

--- a/src/movetype.cpp
+++ b/src/movetype.cpp
@@ -885,6 +885,9 @@ void movetype::merge(const config & new_cfg, const std::string & applies_to, boo
 	else if(applies_to == "resistance") {
 		resist_.merge(new_cfg, overwrite);
 	}
+	else {
+		ERR_CF << "movetype::merge with unknown applies_to: " << applies_to << std::endl;
+	}
 }
 
 /**


### PR DESCRIPTION
The draft version included the testing which I'm going to keep out-of-tree, that's now in my stevecotton:debugging/testing_i2486 branch.

These now work:

	[resistance_defaults]
		id="special_res_for_test"
		default="30"
	[/resistance_defaults]

	[resistance_defaults]
		id="copy_of_arcane"
		default="(arcane)"
	[/resistance_defaults]

and so do these:

	[terrain_defaults]
		id="special_terrain_for_test"
		[movement_costs]
			default="(swamp_water + 1)"
			orcishfoot="(vision_costs.swamp_water * 2)"
		[/movement_costs]
	[/terrain_defaults]
	[terrain_defaults]
		id="special_terrain_for_test"
		[defense]
			default="(20 + 7 * movement_costs.special_terrain_for_test)"
		[/defense]
	[/terrain_defaults]

For [terrain_defaults], I've approached it as a new feature rather than a
simple fix. The subtags now use the same names as the [movetype] subtags and
[effect]'s `apply_to` attribute, so [terrain_defaults][movement_costs] instead
of [terrain_defaults][movement].

The formula handling will now recognise "resistance", "movement_costs",
"vision_costs", "jamming_costs" and "defense". For [resistance_defaults], the
formula will recognise both "(arcane)" and "(resistance.arcane)" as equivalent,
similarly for [terrain_defaults] "(swamp_water)" is a shorthand for whichever
subtag is being patched.

A [terrain_defaults] tag may use data added in a previous [terrain_defaults],
as in the examples above where the second tag's [defense] is based on the first
tag's [movement_costs], this gives orcish grunts on the special terrain a 62%
chance to be hit. However, if the [movement_costs] and [defense] were in a
single [terrain_defaults] tag then the result would be implementation defined,
because no guarantee is made of the order in which the children of the tag are
processed.

The schema gets fixed for [resistance_defaults] and [terrain_defaults], as it
only allowed one instance of each tag. The subtags of [terrain_defaults]
already had the new names.