### PR TITLE
Converted uses of boost::optional to utils::optional

### DIFF
--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -50,6 +50,7 @@
 #include "units/udisplay.hpp"
 #include "units/unit.hpp"
 #include "units/types.hpp"
+#include "utils/optional_fwd.hpp"
 #include "whiteboard/manager.hpp"
 #include "wml_exception.hpp"
 
@@ -135,7 +136,7 @@ battle_context_unit_stats::battle_context_unit_stats(nonempty_unit_const_ptr up,
 
 	// Get the weapon characteristics as appropriate.
 	auto ctx = weapon->specials_context(up, oppp, u_loc, opp_loc, attacking, opp_weapon);
-	boost::optional<decltype(ctx)> opp_ctx;
+	utils::optional<decltype(ctx)> opp_ctx;
 
 	if(opp_weapon) {
 		opp_ctx.emplace(opp_weapon->specials_context(oppp, up, opp_loc, u_loc, !attacking, weapon));
@@ -297,7 +298,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 
 	// Get the weapon characteristics as appropriate.
 	auto ctx = weapon->specials_context(*u_type, map_location::null_location(), attacking);
-	boost::optional<decltype(ctx)> opp_ctx;
+	utils::optional<decltype(ctx)> opp_ctx;
 
 	if(opp_weapon) {
 		opp_ctx.emplace(opp_weapon->specials_context(*opp_type, map_location::null_location(), !attacking));
@@ -877,7 +878,7 @@ void attack::fire_event(const std::string& n)
 	config& d_weapon_cfg = ev_data.add_child("second");
 
 	// Need these to ensure weapon filters work correctly
-	boost::optional<attack_type::specials_context_t> a_ctx, d_ctx;
+	utils::optional<attack_type::specials_context_t> a_ctx, d_ctx;
 
 	if(a_stats_->weapon != nullptr && a_.valid()) {
 		if(d_stats_->weapon != nullptr && d_.valid()) {

--- a/src/commandline_options.hpp
+++ b/src/commandline_options.hpp
@@ -14,7 +14,8 @@
 
 #pragma once
 
-#include <boost/optional.hpp>           // for optional
+#include "utils/optional_fwd.hpp"
+
 #include <boost/program_options/options_description.hpp>
 #include <iosfwd>                       // for ostream
 #include <string>                       // for string
@@ -50,88 +51,88 @@ public:
 	bool any_validation_option() const;
 
 	/// Non-empty if --bunzip2 was given on the command line. Uncompresses a .bz2 file and exits.
-	boost::optional<std::string> bunzip2;
+	utils::optional<std::string> bunzip2;
 	/// Non-empty if --bzip2 was given on the command line. Compresses a file to .bz2 and exits.
-	boost::optional<std::string> bzip2;
+	utils::optional<std::string> bzip2;
 	/// Non-empty if --campaign was given on the command line. ID of the campaign we want to start.
-	boost::optional<std::string> campaign;
+	utils::optional<std::string> campaign;
 	/// Non-empty if --campaign-difficulty was given on the command line. Numerical difficulty of the campaign to be played. Dependent on --campaign.
-	boost::optional<int> campaign_difficulty;
+	utils::optional<int> campaign_difficulty;
 	/// Non-empty if --campaign-scenario was given on the command line. Chooses starting scenario in the campaign to be played. Dependent on --campaign.
-	boost::optional<std::string> campaign_scenario;
+	utils::optional<std::string> campaign_scenario;
 	/// True if --skip-story was given on the command line. Skips [story] and [message]s through the end of the "start" event. Dependent on --campaign.
 	bool campaign_skip_story;
 	/// True if --clock was given on the command line. Enables
 	bool clock;
 	/// Non-empty if --core was given on the command line. Chooses the core to be loaded.
-	boost::optional<std::string> core_id;
+	utils::optional<std::string> core_id;
 	/// True if --data-path was given on the command line. Prints path to data directory and exits.
 	bool data_path;
 	/// Non-empty if --data-dir was given on the command line. Sets the config dir to the specified one.
-	boost::optional<std::string> data_dir;
+	utils::optional<std::string> data_dir;
 	/// True if --debug was given on the command line. Enables debug mode.
 	bool debug;
 	/// True if --debug-lua was given in the commandline. Enables some Lua debugging mechanisms.
 	bool debug_lua;
 #ifdef DEBUG_WINDOW_LAYOUT_GRAPHS
 	/// Non-empty if --debug-dot-domain was given on the command line.
-	boost::optional<std::string> debug_dot_domain;
+	utils::optional<std::string> debug_dot_domain;
 	/// Non-empty if --debug-dot-level was given on the command line.
-	boost::optional<std::string> debug_dot_level;
+	utils::optional<std::string> debug_dot_level;
 #endif
 	/// Non-empty if --editor was given on the command line. Goes directly into editor. If string is longer than 0, it contains path to the file to edit.
-	boost::optional<std::string> editor;
+	utils::optional<std::string> editor;
 	/// True if --fps was given on the command line. Shows number of fps.
 	bool fps;
 	/// True if --fullscreen was given on the command line. Starts Wesnoth in fullscreen mode.
 	bool fullscreen;
 	/// Non-empty if --gunzip was given on the command line. Uncompresses a .gz file and exits.
-	boost::optional<std::string> gunzip;
+	utils::optional<std::string> gunzip;
 	/// Non-empty if --gzip was given on the command line. Compresses a file to .gz and exits.
-	boost::optional<std::string> gzip;
+	utils::optional<std::string> gzip;
 	/// True if --help was given on the command line. Prints help and exits.
 	bool help;
 	/// Non-empty if --language was given on the command line. Sets the language for this session.
-	boost::optional<std::string> language;
+	utils::optional<std::string> language;
 	/// Contains parsed arguments of --log-* (e.g. --log-debug).
 	/// Vector of pairs (severity, log domain).
-	boost::optional<std::vector<std::pair<int, std::string>> > log;
+	utils::optional<std::vector<std::pair<int, std::string>> > log;
 	/// Non-empty if --log-strict was given
-	boost::optional<int> log_strict_level;
+	utils::optional<int> log_strict_level;
 	/// Non-empty if --load was given on the command line. Savegame specified to load after start.
-	boost::optional<std::string> load;
+	utils::optional<std::string> load;
 	/// Non-empty if --logdomains was given on the command line. Prints possible logdomains filtered by given string and exits.
-	boost::optional<std::string> logdomains;
+	utils::optional<std::string> logdomains;
 	/// True if --log-precise was given on the command line. Shows timestamps in log with more precision.
 	bool log_precise_timestamps;
 	/// True if --multiplayer was given on the command line. Goes directly into multiplayer mode.
 	bool multiplayer;
 	/// Non-empty if --ai-config was given on the command line. Vector of pairs (side number, value). Dependent on --multiplayer.
-	boost::optional<std::vector<std::pair<unsigned int, std::string>> > multiplayer_ai_config;
+	utils::optional<std::vector<std::pair<unsigned int, std::string>> > multiplayer_ai_config;
 	/// Non-empty if --algorithm was given on the command line. Vector of pairs (side number, value). Dependent on --multiplayer.
-	boost::optional<std::vector<std::pair<unsigned int, std::string>> > multiplayer_algorithm;
+	utils::optional<std::vector<std::pair<unsigned int, std::string>> > multiplayer_algorithm;
 	/// Non-empty if --controller was given on the command line. Vector of pairs (side number, controller). Dependent on --multiplayer.
-	boost::optional<std::vector<std::pair<unsigned int, std::string>> > multiplayer_controller;
+	utils::optional<std::vector<std::pair<unsigned int, std::string>> > multiplayer_controller;
 	/// Non-empty if --era was given on the command line. Dependent on --multiplayer.
-	boost::optional<std::string> multiplayer_era;
+	utils::optional<std::string> multiplayer_era;
 	/// True if --exit-at-and was given on the command line. Dependent on --multiplayer.
 	bool multiplayer_exit_at_end;
 	/// True if --ignore-map-settings was given at the command line.  Do not use map settings.
 	bool multiplayer_ignore_map_settings;
 	/// Non-empty if --label was given on the command line. Dependent on --multiplayer.
-	boost::optional<std::string> multiplayer_label;
+	utils::optional<std::string> multiplayer_label;
 	/// Non-empty if --parm was given on the command line. Vector of pairs (side number, parm name, parm value). Dependent on --multiplayer.
-	boost::optional<std::vector<std::tuple<unsigned int, std::string, std::string>> > multiplayer_parm;
+	utils::optional<std::vector<std::tuple<unsigned int, std::string, std::string>> > multiplayer_parm;
 	/// Repeats specified by --multiplayer-repeat option. Repeats a multiplayer game after it is finished. Dependent on --multiplayer.
-	boost::optional<unsigned int> multiplayer_repeat;
+	utils::optional<unsigned int> multiplayer_repeat;
 	/// Non-empty if --scenario was given on the command line. Dependent on --multiplayer.
-	boost::optional<std::string> multiplayer_scenario;
+	utils::optional<std::string> multiplayer_scenario;
 	/// Non-empty if --side was given on the command line. Vector of pairs (side number, faction id). Dependent on --multiplayer.
-	boost::optional<std::vector<std::pair<unsigned int, std::string>> > multiplayer_side;
+	utils::optional<std::vector<std::pair<unsigned int, std::string>> > multiplayer_side;
 	/// Non-empty if --turns was given on the command line. Dependent on --multiplayer.
-	boost::optional<std::string> multiplayer_turns;
+	utils::optional<std::string> multiplayer_turns;
 	/// Max FPS specified by --max-fps option.
-	boost::optional<int> max_fps;
+	utils::optional<int> max_fps;
 	/// True if --noaddons was given on the command line. Disables the loading of all add-ons.
 	bool noaddons;
 	/// True if --nocache was given on the command line. Disables cache usage.
@@ -149,45 +150,45 @@ public:
 	/// True if --preprocess was given on the command line. Starts Wesnoth in preprocessor-only mode.
 	bool preprocess;
 	/// Defines that were given to the --preprocess option.
-	boost::optional<std::vector<std::string>> preprocess_defines;
+	utils::optional<std::vector<std::string>> preprocess_defines;
 	/// Non-empty if --preprocess-input-macros was given on the command line. Specifies a file that contains [preproc_define]s to be included before preprocessing. Dependent on --preprocess.
-	boost::optional<std::string> preprocess_input_macros;
+	utils::optional<std::string> preprocess_input_macros;
 	/// Non-empty if --preprocess-output-macros was given on the command line. Outputs all preprocessed macros to the specified file. Dependent on --preprocess.
-	boost::optional<std::string> preprocess_output_macros;
+	utils::optional<std::string> preprocess_output_macros;
 	/// Path to parse that was given to the --preprocess option.
-	boost::optional<std::string> preprocess_path;
+	utils::optional<std::string> preprocess_path;
 	/// Target (output) path that was given to the --preprocess option.
-	boost::optional<std::string> preprocess_target;
+	utils::optional<std::string> preprocess_target;
 	/// Pair of AxB values specified after --resolution. Changes Wesnoth resolution.
-	boost::optional<std::pair<int,int>> resolution;
+	utils::optional<std::pair<int,int>> resolution;
 	/// RNG seed specified by --rng-seed option. Initializes RNG with given seed.
-	boost::optional<unsigned int> rng_seed;
+	utils::optional<unsigned int> rng_seed;
 	/// Non-empty if --server was given on the command line.  Connects Wesnoth to specified server. If no server was specified afterwards, contains an empty string.
-	boost::optional<std::string> server;
+	utils::optional<std::string> server;
 	/// Non-empty if --username was given on the command line. Forces Wesnoth to use this network username.
-	boost::optional<std::string> username;
+	utils::optional<std::string> username;
 	/// Non-empty if --password was given on the command line. Forces Wesnoth to use this network password.
-	boost::optional<std::string> password;
+	utils::optional<std::string> password;
 	/// Image path to render. First parameter after --render-image
-	boost::optional<std::string> render_image;
+	utils::optional<std::string> render_image;
 	/// Output file to put rendered image path in. Optional second parameter after --render-image
-	boost::optional<std::string> render_image_dst;
+	utils::optional<std::string> render_image_dst;
 	/// True if --screenshot was given on the command line. Starts Wesnoth in screenshot mode.
 	bool screenshot;
 	/// Map file to make a screenshot of. First parameter given after --screenshot.
-	boost::optional<std::string> screenshot_map_file;
+	utils::optional<std::string> screenshot_map_file;
 	/// Output file to put screenshot in. Second parameter given after --screenshot.
-	boost::optional<std::string> screenshot_output_file;
+	utils::optional<std::string> screenshot_output_file;
 	/// File to load lua script from.
-	boost::optional<std::string> script_file;
+	utils::optional<std::string> script_file;
 	/// File to load a lua plugin (similar to a script) from. Experimental / may replace script.
-	boost::optional<std::string> plugin_file;
+	utils::optional<std::string> plugin_file;
 	/// Whether to load the "package" package for the scripting environment. (This allows to load arbitrary lua packages, and gives untrusted lua the same permissions as wesnoth executable)
 	bool script_unsafe_mode;
 	/// True if --strict-validation was given on the command line. Makes Wesnoth trust validation errors as fatal WML errors and create WML exception, if so.
 	bool strict_validation;
 	/// Non-empty if --test was given on the command line. Goes directly into test mode, into a scenario, if specified.
-	boost::optional<std::string> test;
+	utils::optional<std::string> test;
 	/// Non-empty if --unit was given on the command line. Goes directly into unit test mode, into a scenario, if specified.
 	std::vector<std::string> unit_test;
 	/// True if --unit is used and --showgui is not present.
@@ -199,25 +200,25 @@ public:
 	/// True if --userconfig-path was given on the command line. Prints path to user config directory and exits.
 	bool userconfig_path;
 	/// Non-empty if --userconfig-dir was given on the command line. Sets the user config dir to the specified one.
-	boost::optional<std::string> userconfig_dir;
+	utils::optional<std::string> userconfig_dir;
 	/// True if --userdata-path was given on the command line. Prints path to user data directory and exits.
 	bool userdata_path;
 	/// Non-empty if --userdata-dir was given on the command line. Sets the user data dir to the specified one.
-	boost::optional<std::string> userdata_dir;
+	utils::optional<std::string> userdata_dir;
 	/// True if --validcache was given on the command line. Makes Wesnoth assume the cache is valid.
 	bool validcache;
 	/// True if --validate-core was given on the command line. Makes Wesnoth validate the core WML.
 	bool validate_core;
 	/// Non-empty if --validate-addon was given on the command line. Makes Wesnoth validate an addon's WML.
-	boost::optional<std::string> validate_addon;
+	utils::optional<std::string> validate_addon;
 	/// Non-empty if --validate-schema was given on the command line. Makes Wesnoth validate a WML schema.
-	boost::optional<std::string> validate_schema;
+	utils::optional<std::string> validate_schema;
 	/// Non-empty if --validate was given on the command line. Makes Wesnoth validate a WML file against a schema.
-	boost::optional<std::string> validate_wml;
+	utils::optional<std::string> validate_wml;
 	/// Non-empty if --use-schema was given on the command line. Specifies the schema for use with --validate.
-	boost::optional<std::string> validate_with;
+	utils::optional<std::string> validate_with;
 	/// Output filename for WML diff or preprocessing
-	boost::optional<std::string> output_file;
+	utils::optional<std::string> output_file;
 	bool do_diff, do_patch;
 	/// Files for diffing or patching
 	std::string diff_left, diff_right;
@@ -230,7 +231,7 @@ public:
 	/// True if --with-replay was given on the command line. Shows replay of the loaded file.
 	bool with_replay;
 	/// Non-empty if --all-translations or --translations-over is given on the command line.
-	boost::optional<unsigned int> translation_percent;
+	utils::optional<unsigned int> translation_percent;
 private:
 	void parse_log_domains_(const std::string &domains_string, const int severity);
 	void parse_log_strictness (const std::string &severity);

--- a/src/editor/map/map_context.hpp
+++ b/src/editor/map/map_context.hpp
@@ -14,18 +14,17 @@
 
 #pragma once
 
+#include "display_context.hpp"
 #include "editor/map/editor_map.hpp"
 #include "game_classification.hpp"
 #include "map/label.hpp"
 #include "mp_game_settings.hpp"
+#include "overlay.hpp"
 #include "sound_music_track.hpp"
 #include "team.hpp"
 #include "tod_manager.hpp"
 #include "units/map.hpp"
-#include "overlay.hpp"
-#include "display_context.hpp"
-
-#include <boost/optional.hpp>
+#include "utils/optional_fwd.hpp"
 
 #include <vector>
 class game_config_view;
@@ -314,7 +313,7 @@ public:
 
 	const t_string get_default_context_name() const;
 
-	boost::optional<int> get_xp_mod() const { return xp_mod_; }
+	utils::optional<int> get_xp_mod() const { return xp_mod_; }
 
 	bool random_start_time() const { return random_time_; }
 	bool victory_defeated() const { return !victory_defeated_ || *victory_defeated_; }
@@ -496,8 +495,8 @@ private:
 
 	std::string scenario_id_, scenario_name_, scenario_description_;
 
-	boost::optional<int> xp_mod_;
-	boost::optional<bool> victory_defeated_;
+	utils::optional<int> xp_mod_;
+	utils::optional<bool> victory_defeated_;
 	bool random_time_;
 
 	int active_area_;

--- a/src/font/font_description.hpp
+++ b/src/font/font_description.hpp
@@ -17,8 +17,8 @@
 #include "config.hpp"
 #include "lexical_cast.hpp"
 #include "serialization/string_utils.hpp"
+#include "utils/optional_fwd.hpp"
 
-#include <boost/optional.hpp>
 #include <string>
 #include <utility>
 #include <vector>
@@ -53,8 +53,8 @@ struct subset_descriptor
 	}
 
 	std::string name;
-	boost::optional<std::string> bold_name; //If we are using another font for styled characters in this font, rather than SDL TTF method
-	boost::optional<std::string> italic_name;
+	utils::optional<std::string> bold_name; //If we are using another font for styled characters in this font, rather than SDL TTF method
+	utils::optional<std::string> italic_name;
 };
 
 } // end namespace font

--- a/src/game_board.cpp
+++ b/src/game_board.cpp
@@ -258,8 +258,8 @@ bool game_board::try_add_unit_to_recall_list(const map_location&, const unit_ptr
 	return true;
 }
 
-boost::optional<std::string> game_board::replace_map(const gamemap & newmap) {
-	boost::optional<std::string> ret = boost::optional<std::string> ();
+utils::optional<std::string> game_board::replace_map(const gamemap & newmap) {
+	utils::optional<std::string> ret;
 
 	/* Remember the locations where a village is owned by a side. */
 	std::map<map_location, int> villages;
@@ -273,7 +273,7 @@ boost::optional<std::string> game_board::replace_map(const gamemap & newmap) {
 	for (unit_map::iterator itor = units_.begin(); itor != units_.end(); ) {
 		if (!newmap.on_board(itor->get_location())) {
 			if (!try_add_unit_to_recall_list(itor->get_location(), itor.get_shared_ptr())) {
-				*ret = std::string("replace_map: Cannot add a unit that would become off-map to the recall list\n");
+				ret = std::string("replace_map: Cannot add a unit that would become off-map to the recall list\n");
 			}
 			units_.erase(itor++);
 		} else {

--- a/src/game_board.hpp
+++ b/src/game_board.hpp
@@ -19,8 +19,8 @@
 #include "terrain/type_data.hpp"
 #include "units/map.hpp"
 #include "units/id.hpp"
+#include "utils/optional_fwd.hpp"
 
-#include <boost/optional.hpp>
 #include <set>
 #include <vector>
 
@@ -160,7 +160,7 @@ public:
 	// Manipulator from actionwml
 
 	bool try_add_unit_to_recall_list(const map_location& loc, const unit_ptr u);
-	boost::optional<std::string> replace_map(const gamemap & r);
+	utils::optional<std::string> replace_map(const gamemap & r);
 
 	bool change_terrain(const map_location &loc, const std::string &t,
 	                    const std::string & mode, bool replace_if_failed); //used only by lua and debug commands

--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -131,7 +131,7 @@ bool map_includes(const preproc_map& general, const preproc_map& special)
 
 void game_config_manager::load_game_config_with_loadscreen(FORCE_RELOAD_CONFIG force_reload,
 	game_classification const*,
-	boost::optional<std::set<std::string>> active_addons)
+	utils::optional<std::set<std::string>> active_addons)
 {
 	if (!lg::info().dont_log(log_config)) {
 		auto out = formatter();
@@ -150,7 +150,7 @@ void game_config_manager::load_game_config_with_loadscreen(FORCE_RELOAD_CONFIG f
 		}
 		out << "\n";
 		FORCE_LOG_TO(lg::info(), log_config) << out.str();
-	} 
+	}
 
 
 	game_config::scoped_preproc_define debug_mode("DEBUG_MODE",

--- a/src/game_config_manager.hpp
+++ b/src/game_config_manager.hpp
@@ -14,14 +14,13 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
-
 #include "commandline_options.hpp"
+#include "config.hpp"
 #include "config_cache.hpp"
 #include "filesystem.hpp"
-#include "terrain/type_data.hpp"
-#include "config.hpp"
 #include "game_config_view.hpp"
+#include "terrain/type_data.hpp"
+#include "utils/optional_fwd.hpp"
 
 class game_classification;
 class game_config_manager
@@ -63,7 +62,7 @@ private:
 	void load_game_config(bool reload_everything);
 
 	void load_game_config_with_loadscreen(FORCE_RELOAD_CONFIG force_reload,
-		game_classification const* classification = nullptr, boost::optional<std::set<std::string>> active_addons = boost::optional<std::set<std::string>>());
+		game_classification const* classification = nullptr, utils::optional<std::set<std::string>> active_addons = utils::nullopt);
 
 	// load_game_config() helper functions.
 	void load_addons_cfg();
@@ -77,7 +76,7 @@ private:
 	game_config_view game_config_view_;
 
 	std::map<std::string, config> addon_cfgs_;
-	boost::optional<std::set<std::string>> active_addons_;
+	utils::optional<std::set<std::string>> active_addons_;
 
 	preproc_map old_defines_map_;
 

--- a/src/game_events/action_wml.cpp
+++ b/src/game_events/action_wml.cpp
@@ -627,7 +627,7 @@ WML_HANDLER_FUNCTION(replace_map,, cfg)
 		}
 	}
 
-	boost::optional<std::string> errmsg = resources::gameboard->replace_map(map);
+	utils::optional<std::string> errmsg = resources::gameboard->replace_map(map);
 
 	if (errmsg) {
 		lg::wml_error() << *errmsg << std::endl;

--- a/src/game_state.cpp
+++ b/src/game_state.cpp
@@ -273,7 +273,7 @@ void game_state::write(config& cfg) const
 	// Preserve the undo stack so that fog/shroud clearing is kept accurate.
 	undo_stack_->write(cfg.add_child("undo_stack"));
 
-	if(end_level_data_.get_ptr() != nullptr) {
+	if(end_level_data_) {
 		end_level_data_->write(cfg.add_child("end_level_data"));
 	}
 }

--- a/src/game_state.hpp
+++ b/src/game_state.hpp
@@ -59,7 +59,7 @@ public:
 	/// True if healing should be done at the beginning of the next side turn
 	bool do_healing_;
 
-	boost::optional<end_level_data> end_level_data_;
+	utils::optional<end_level_data> end_level_data_;
 	bool init_side_done_;
 	bool start_event_fired_;
 	// used to sync with the mpserver

--- a/src/generators/cave_map_generator.cpp
+++ b/src/generators/cave_map_generator.cpp
@@ -69,19 +69,19 @@ std::size_t cave_map_generator::cave_map_generator_job::translate_y(std::size_t 
 	return y;
 }
 
-std::string cave_map_generator::create_map(boost::optional<uint32_t> randomseed)
+std::string cave_map_generator::create_map(utils::optional<uint32_t> randomseed)
 {
 	const config res = create_scenario(randomseed);
 	return res["map_data"];
 }
 
-config cave_map_generator::create_scenario(boost::optional<uint32_t> randomseed)
+config cave_map_generator::create_scenario(utils::optional<uint32_t> randomseed)
 {
 	cave_map_generator_job job(*this, randomseed);
 	return job.res_;
 }
 
-cave_map_generator::cave_map_generator_job::cave_map_generator_job(const cave_map_generator& pparams, boost::optional<uint32_t> randomseed)
+cave_map_generator::cave_map_generator_job::cave_map_generator_job(const cave_map_generator& pparams, utils::optional<uint32_t> randomseed)
 	: params(pparams)
 	, flipx_(false)
 	, flipy_(false)
@@ -101,7 +101,7 @@ cave_map_generator::cave_map_generator_job::cave_map_generator_job(const cave_ma
 			"message", "Use the Lua cave generator instead, with scenario_generation=lua and create_scenario= (see wiki for details).",
 		},
 	});
-	uint32_t seed = randomseed.get_ptr() ? *randomseed.get_ptr() : seed_rng::next_seed();
+	uint32_t seed = randomseed ? randomseed.value() : seed_rng::next_seed();
 	rng_.seed(seed);
 	LOG_NG << "creating random cave with seed: " << seed << '\n';
 	flipx_ = static_cast<int>(rng_() % 100) < params.flipx_chance_;

--- a/src/generators/cave_map_generator.hpp
+++ b/src/generators/cave_map_generator.hpp
@@ -19,9 +19,9 @@
 #include "config.hpp"
 #include "generators/map_generator.hpp"
 #include "terrain/translation.hpp"
+#include "utils/optional_fwd.hpp"
 
 #include <set>
-#include <boost/optional.hpp>
 #include <random>
 
 class cave_map_generator : public map_generator
@@ -33,13 +33,13 @@ public:
 
 	std::string config_name() const;
 
-	std::string create_map(boost::optional<uint32_t> randomseed = boost::none);
-	config create_scenario(boost::optional<uint32_t> randomseed = boost::none);
+	std::string create_map(utils::optional<uint32_t> randomseed = utils::nullopt);
+	config create_scenario(utils::optional<uint32_t> randomseed = utils::nullopt);
 
 private:
 	struct cave_map_generator_job
 	{
-		cave_map_generator_job(const cave_map_generator& params, boost::optional<uint32_t> randomseed = boost::none);
+		cave_map_generator_job(const cave_map_generator& params, utils::optional<uint32_t> randomseed = utils::nullopt);
 
 		struct chamber {
 			chamber()

--- a/src/generators/default_map_generator.cpp
+++ b/src/generators/default_map_generator.cpp
@@ -72,16 +72,16 @@ std::string default_map_generator::config_name() const
 	return std::string();
 }
 
-std::string default_map_generator::create_map(boost::optional<uint32_t> randomseed)
+std::string default_map_generator::create_map(utils::optional<uint32_t> randomseed)
 {
 	return generate_map(nullptr, randomseed);
 }
 
-std::string default_map_generator::generate_map(std::map<map_location,std::string>* labels, boost::optional<uint32_t> randomseed)
+std::string default_map_generator::generate_map(std::map<map_location,std::string>* labels, utils::optional<uint32_t> randomseed)
 {
 	uint32_t seed;
-	if(const uint32_t* pseed = randomseed.get_ptr()) {
-		seed = *pseed;
+	if(randomseed) {
+		seed = randomseed.value();
 	} else {
 		seed = seed_rng::next_seed();
 	}
@@ -165,7 +165,7 @@ std::string default_map_generator::generate_map(std::map<map_location,std::strin
 	return map;
 }
 
-config default_map_generator::create_scenario(boost::optional<uint32_t> randomseed)
+config default_map_generator::create_scenario(utils::optional<uint32_t> randomseed)
 {
 	DBG_NG << "creating scenario...\n";
 

--- a/src/generators/default_map_generator.hpp
+++ b/src/generators/default_map_generator.hpp
@@ -49,11 +49,11 @@ public:
 
 	std::string config_name() const override;
 
-	std::string create_map(boost::optional<uint32_t> randomseed) override;
-	config create_scenario(boost::optional<uint32_t> randomseed) override;
+	std::string create_map(utils::optional<uint32_t> randomseed) override;
+	config create_scenario(utils::optional<uint32_t> randomseed) override;
 
 private:
-	std::string generate_map(std::map<map_location,std::string>* labels, boost::optional<uint32_t> randomseed);
+	std::string generate_map(std::map<map_location,std::string>* labels, utils::optional<uint32_t> randomseed);
 
 	config cfg_;
 

--- a/src/generators/lua_map_generator.cpp
+++ b/src/generators/lua_map_generator.cpp
@@ -58,7 +58,7 @@ void lua_map_generator::user_config()
 	}
 }
 
-std::string lua_map_generator::create_map(boost::optional<uint32_t> seed)
+std::string lua_map_generator::create_map(utils::optional<uint32_t> seed)
 {
 	if(create_map_.empty()) {
 		return map_generator::create_map(seed);
@@ -74,7 +74,7 @@ std::string lua_map_generator::create_map(boost::optional<uint32_t> seed)
 	}
 }
 
-config lua_map_generator::create_scenario(boost::optional<uint32_t> seed)
+config lua_map_generator::create_scenario(utils::optional<uint32_t> seed)
 {
 	if(create_scenario_.empty()) {
 		return map_generator::create_scenario(seed);

--- a/src/generators/lua_map_generator.hpp
+++ b/src/generators/lua_map_generator.hpp
@@ -34,8 +34,8 @@ public:
 	std::string config_name() const override { return config_name_; }
 
 	virtual void user_config() override;
-	virtual std::string create_map(boost::optional<uint32_t> randomseed) override;
-	virtual config create_scenario(boost::optional<uint32_t> randomseed) override;
+	virtual std::string create_map(utils::optional<uint32_t> randomseed) override;
+	virtual config create_scenario(utils::optional<uint32_t> randomseed) override;
 
 private:
 	std::string id_, config_name_;

--- a/src/generators/map_generator.cpp
+++ b/src/generators/map_generator.cpp
@@ -27,13 +27,13 @@ static lg::log_domain log_mapgen("mapgen");
 #define ERR_NG LOG_STREAM(err, log_mapgen)
 #define LOG_NG LOG_STREAM(info, log_mapgen)
 
-config map_generator::create_scenario(boost::optional<uint32_t> randomseed)
+config map_generator::create_scenario(utils::optional<uint32_t> randomseed)
 {
 	config res;
 	res["map_data"] = create_map(randomseed);
 	return res;
 }
-std::string map_generator::create_map(boost::optional<uint32_t> randomseed)
+std::string map_generator::create_map(utils::optional<uint32_t> randomseed)
 {
 	return create_scenario(randomseed)["map_data"];
 }

--- a/src/generators/map_generator.hpp
+++ b/src/generators/map_generator.hpp
@@ -20,8 +20,8 @@ class config;
 
 #include "exceptions.hpp"
 #include "map/location.hpp"
+#include "utils/optional_fwd.hpp"
 
-#include <boost/optional.hpp>
 #include <cstdint>
 
 struct mapgen_exception : public game::error
@@ -65,7 +65,7 @@ public:
 	 * Creates a new map and returns it.
 	 * args may contain arguments to the map generator.
 	 */
-	virtual std::string create_map(boost::optional<uint32_t> randomseed = boost::none) = 0;
+	virtual std::string create_map(utils::optional<uint32_t> randomseed = utils::nullopt) = 0;
 
-	virtual config create_scenario(boost::optional<uint32_t> randomseed = boost::none);
+	virtual config create_scenario(utils::optional<uint32_t> randomseed = utils::nullopt);
 };

--- a/src/gui/dialogs/attack_predictions.cpp
+++ b/src/gui/dialogs/attack_predictions.cpp
@@ -128,7 +128,7 @@ void attack_predictions::set_data(window& window, const combatant_data& attacker
 	// Set specials context (for safety, it should not have changed normally).
 	const_attack_ptr weapon = attacker.stats_.weapon, opp_weapon = defender.stats_.weapon;
 	auto ctx = weapon->specials_context(attacker.unit_, defender.unit_, attacker.unit_->get_location(), defender.unit_->get_location(), attacker.stats_.is_attacker, opp_weapon);
-	boost::optional<decltype(ctx)> opp_ctx;
+	utils::optional<decltype(ctx)> opp_ctx;
 
 	if(opp_weapon) {
 		opp_ctx.emplace(opp_weapon->specials_context(defender.unit_, attacker.unit_, defender.unit_->get_location(), attacker.unit_->get_location(), defender.stats_.is_attacker, weapon));

--- a/src/gui/dialogs/editor/generate_map.cpp
+++ b/src/gui/dialogs/editor/generate_map.cpp
@@ -139,13 +139,13 @@ void editor_generate_map::pre_show(window& window)
 			std::bind(&editor_generate_map::do_settings,this));
 }
 
-boost::optional<uint32_t> editor_generate_map::get_seed()
+utils::optional<uint32_t> editor_generate_map::get_seed()
 {
 	try {
 		return lexical_cast<uint32_t>(random_seed_);
 	}
 	catch(const bad_lexical_cast& ) {
-		return boost::none;
+		return utils::nullopt;
 	}
 }
 

--- a/src/gui/dialogs/editor/generate_map.hpp
+++ b/src/gui/dialogs/editor/generate_map.hpp
@@ -15,8 +15,8 @@
 #pragma once
 
 #include "gui/dialogs/modal_dialog.hpp"
+#include "utils/optional_fwd.hpp"
 
-#include <boost/optional/optional.hpp>
 #include <cstdint>
 #include <memory>
 
@@ -43,7 +43,7 @@ public:
 
 	void select_map_generator(map_generator* mg);
 
-	boost::optional<uint32_t> get_seed();
+	utils::optional<uint32_t> get_seed();
 
 private:
 	/** Inherited from modal_dialog, implemented by REGISTER_DIALOG. */

--- a/src/gui/widgets/listbox.cpp
+++ b/src/gui/widgets/listbox.cpp
@@ -33,8 +33,7 @@
 #include "gui/widgets/window.hpp"
 #include "sdl/rect.hpp"
 #include "utils/functional.hpp"
-
-#include <boost/optional.hpp>
+#include "utils/optional_fwd.hpp"
 
 #define LOG_SCOPE_HEADER get_control_type() + " [" + id() + "] " + __func__
 #define LOG_HEADER LOG_SCOPE_HEADER + ':'
@@ -352,7 +351,7 @@ bool listbox::update_content_size()
 
 void listbox::place(const point& origin, const point& size)
 {
-	boost::optional<unsigned> vertical_scrollbar_position, horizontal_scrollbar_position;
+	utils::optional<unsigned> vertical_scrollbar_position, horizontal_scrollbar_position;
 
 	// Check if this is the first time placing the list box
 	if(get_origin() != point {-1, -1}) {

--- a/src/help/help_impl.cpp
+++ b/src/help/help_impl.cpp
@@ -1500,15 +1500,15 @@ unsigned image_width(const std::string &filename)
 	return 0;
 }
 
-void push_tab_pair(std::vector<help::item> &v, const std::string &s, const boost::optional<std::string> &image, unsigned padding)
+void push_tab_pair(std::vector<help::item> &v, const std::string &s, const utils::optional<std::string> &image, unsigned padding)
 {
 	help::item item(s, font::line_width(s, normal_font_size));
 	if (image) {
 		// If the image doesn't exist, don't add padding.
-		auto width = image_width(image.get());
+		auto width = image_width(image.value());
 		padding = (width ? padding : 0);
 
-		item.first = "<img>src='" + image.get() + "'</img>" + (padding ? jump(padding) : "") + s;
+		item.first = "<img>src='" + image.value() + "'</img>" + (padding ? jump(padding) : "") + s;
 		item.second += width + padding;
 	}
 	v.emplace_back(item);

--- a/src/help/help_impl.hpp
+++ b/src/help/help_impl.hpp
@@ -34,6 +34,7 @@
 #include "exceptions.hpp"               // for error
 #include "font/sdl_ttf.hpp"             // for line_width, relative_size
 #include "gettext.hpp"
+#include "utils/optional_fwd.hpp"
 #include <cstring>
 #include <list>                         // for list
 #include <memory>
@@ -43,7 +44,6 @@
 #include <vector>                       // for vector, etc
 #include <SDL2/SDL.h>                  // for SDL_Surface
 #include <boost/logic/tribool.hpp>
-#include <boost/optional.hpp>
 
 class game_config_view;
 class config;
@@ -394,6 +394,6 @@ std::string generate_table(const table_spec &tab, const unsigned int spacing=fon
 unsigned image_width(const std::string &filename);
 
 // Add to the vector v an help::item for the string s, preceded by the given image if any.
-void push_tab_pair(std::vector<help::item> &v, const std::string &s, const boost::optional<std::string> &image = {}, unsigned padding = 0);
+void push_tab_pair(std::vector<help::item> &v, const std::string &s, const utils::optional<std::string> &image = {}, unsigned padding = 0);
 
 } // end namespace help

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -30,9 +30,9 @@
 #include "tstring.hpp"                  // for t_string, operator<<
 #include "units/helper.hpp"             // for resistance_color
 #include "units/types.hpp"              // for unit_type, unit_type_data, etc
+#include "utils/optional_fwd.hpp"
 #include "video.hpp"                    // fore current_resolution
 
-#include <boost/optional.hpp>  // for optional
 #include <iostream>                     // for operator<<, basic_ostream, etc
 #include <map>                          // for map, etc
 #include <set>
@@ -75,7 +75,7 @@ static std::string print_behavior_description(ter_iter start, ter_iter end, cons
 	if (start == end) return "";
 	if (*start == t_translation::MINUS || *start == t_translation::PLUS) return print_behavior_description(start+1, end, tdata, first_level, *start == t_translation::PLUS); //absorb any leading mode changes by calling again, with a new default value begin_best.
 
-	boost::optional<ter_iter> last_change_pos;
+	utils::optional<ter_iter> last_change_pos;
 
 	bool best = begin_best;
 	for (ter_iter i = start; i != end; ++i) {

--- a/src/lexical_cast.hpp
+++ b/src/lexical_cast.hpp
@@ -46,6 +46,7 @@
 #endif
 
 #include "global.hpp"
+#include "utils/optional_fwd.hpp"
 
 #include <cstdlib>
 #include <limits>
@@ -54,7 +55,6 @@
 #include <type_traits>
 
 #include <boost/mpl/set.hpp>
-#include <boost/optional.hpp>
 
 #define DEBUG_THROW(id)
 #endif
@@ -91,7 +91,7 @@ namespace implementation {
 template<typename To, typename From>
 inline To lexical_cast(From value)
 {
-	return implementation::lexical_caster<To, From>().operator()(value, boost::none);
+	return implementation::lexical_caster<To, From>().operator()(value, utils::nullopt);
 }
 
 /**
@@ -141,7 +141,7 @@ template<
 >
 struct lexical_caster
 {
-	To operator()(From value, boost::optional<To> fallback) const
+	To operator()(From value, utils::optional<To> fallback) const
 	{
 		DEBUG_THROW("generic");
 
@@ -149,7 +149,7 @@ struct lexical_caster
 		std::stringstream sstr;
 
 		if(!(sstr << value && sstr >> result)) {
-			if(fallback) { return fallback.get(); }
+			if(fallback) { return fallback.value(); }
 
 			throw bad_lexical_cast();
 		} else {
@@ -172,7 +172,7 @@ struct lexical_caster<
 	, std::enable_if_t<std::is_integral<std::remove_pointer_t<From>>::value>
 >
 {
-	std::string operator()(From value, boost::optional<std::string>) const
+	std::string operator()(From value, utils::optional<std::string>) const
 	{
 		DEBUG_THROW("specialized - To std::string - From integral (pointer)");
 
@@ -197,12 +197,12 @@ struct lexical_caster<
 	, std::enable_if_t<boost::mpl::has_key<boost::mpl::set<char*, const char*> , From>::value>
 	>
 {
-	long long operator()(From value, boost::optional<long long> fallback) const
+	long long operator()(From value, utils::optional<long long> fallback) const
 	{
 		DEBUG_THROW("specialized - To long long - From (const) char*");
 
 		if(fallback) {
-			return lexical_cast_default<long long>(std::string(value), fallback.get());
+			return lexical_cast_default<long long>(std::string(value), fallback.value());
 		} else {
 			return lexical_cast<long long>(std::string(value));
 		}
@@ -222,7 +222,7 @@ struct lexical_caster<
 	, std::string
 	>
 {
-	long long operator()(const std::string& value, boost::optional<long long> fallback) const
+	long long operator()(const std::string& value, utils::optional<long long> fallback) const
 	{
 		DEBUG_THROW("specialized - To long long - From std::string");
 
@@ -233,7 +233,7 @@ struct lexical_caster<
 		}
 
 		if(fallback) {
-			return fallback.get();
+			return fallback.value();
 		} else {
 			throw bad_lexical_cast();
 		}
@@ -253,12 +253,12 @@ struct lexical_caster<
 	, std::enable_if_t<boost::mpl::has_key<boost::mpl::set<char*, const char*> , From>::value>
 	>
 {
-	To operator()(From value, boost::optional<To> fallback) const
+	To operator()(From value, utils::optional<To> fallback) const
 	{
 		DEBUG_THROW("specialized - To signed - From (const) char*");
 
 		if(fallback) {
-			return lexical_cast_default<To>(std::string(value), fallback.get());
+			return lexical_cast_default<To>(std::string(value), fallback.value());
 		} else {
 			return lexical_cast<To>(std::string(value));
 		}
@@ -277,7 +277,7 @@ struct lexical_caster<
 	, std::enable_if_t<std::is_integral<To>::value && std::is_signed<To>::value && !std::is_same<To, long long>::value>
 	>
 {
-	To operator()(const std::string& value, boost::optional<To> fallback) const
+	To operator()(const std::string& value, utils::optional<To> fallback) const
 	{
 		DEBUG_THROW("specialized - To signed - From std::string");
 
@@ -291,7 +291,7 @@ struct lexical_caster<
 		}
 
 		if(fallback) {
-			return fallback.get();
+			return fallback.value();
 		} else {
 			throw bad_lexical_cast();
 		}
@@ -311,12 +311,12 @@ struct lexical_caster<
 	, std::enable_if_t<boost::mpl::has_key<boost::mpl::set<char*, const char*> , From>::value>
 	>
 {
-	To operator()(From value, boost::optional<To> fallback) const
+	To operator()(From value, utils::optional<To> fallback) const
 	{
 		DEBUG_THROW("specialized - To floating point - From (const) char*");
 
 		if(fallback) {
-			return lexical_cast_default<To>(std::string(value), fallback.get());
+			return lexical_cast_default<To>(std::string(value), fallback.value());
 		} else {
 			return lexical_cast<To>(std::string(value));
 		}
@@ -335,14 +335,14 @@ struct lexical_caster<
 	, std::enable_if_t<std::is_floating_point<To>::value>
 	>
 {
-	To operator()(const std::string& value, boost::optional<To> fallback) const
+	To operator()(const std::string& value, utils::optional<To> fallback) const
 	{
 		DEBUG_THROW("specialized - To floating point - From std::string");
 
 		// Explicitly reject hexadecimal values. Unit tests of the config class require that.
 		if(value.find_first_of("Xx") != std::string::npos) {
 			if(fallback) {
-				return fallback.get();
+				return fallback.value();
 			} else {
 				throw bad_lexical_cast();
 			}
@@ -358,7 +358,7 @@ struct lexical_caster<
 		}
 
 		if(fallback) {
-			return fallback.get();
+			return fallback.value();
 		} else {
 			throw bad_lexical_cast();
 		}
@@ -380,13 +380,13 @@ struct lexical_caster<
 	, std::enable_if_t<boost::mpl::has_key<boost::mpl::set<char*, const char*> , From>::value>
 	>
 {
-	unsigned long long operator()(From value, boost::optional<unsigned long long> fallback) const
+	unsigned long long operator()(From value, utils::optional<unsigned long long> fallback) const
 	{
 		DEBUG_THROW(
 				"specialized - To unsigned long long - From (const) char*");
 
 		if(fallback) {
-			return lexical_cast_default<unsigned long long>(std::string(value), fallback.get());
+			return lexical_cast_default<unsigned long long>(std::string(value), fallback.value());
 		} else {
 			return lexical_cast<unsigned long long>(std::string(value));
 		}
@@ -406,7 +406,7 @@ struct lexical_caster<
 	, std::string
 	>
 {
-	unsigned long long operator()(const std::string& value, boost::optional<unsigned long long> fallback) const
+	unsigned long long operator()(const std::string& value, utils::optional<unsigned long long> fallback) const
 	{
 		DEBUG_THROW("specialized - To unsigned long long - From std::string");
 
@@ -417,7 +417,7 @@ struct lexical_caster<
 		}
 
 		if(fallback) {
-			return fallback.get();
+			return fallback.value();
 		} else {
 			throw bad_lexical_cast();
 		}
@@ -437,12 +437,12 @@ struct lexical_caster<
 	, std::enable_if_t<boost::mpl::has_key<boost::mpl::set<char*, const char*> , From>::value>
 	>
 {
-	To operator()(From value, boost::optional<To> fallback) const
+	To operator()(From value, utils::optional<To> fallback) const
 	{
 		DEBUG_THROW("specialized - To unsigned - From (const) char*");
 
 		if(fallback) {
-			return lexical_cast_default<To>(std::string(value), fallback.get());
+			return lexical_cast_default<To>(std::string(value), fallback.value());
 		} else {
 			return lexical_cast<To>(std::string(value));
 		}
@@ -461,7 +461,7 @@ struct lexical_caster<
 	, std::enable_if_t<std::is_unsigned<To>::value>
 	>
 {
-	To operator()(const std::string& value, boost::optional<To> fallback) const
+	To operator()(const std::string& value, utils::optional<To> fallback) const
 	{
 		DEBUG_THROW("specialized - To unsigned - From std::string");
 
@@ -476,7 +476,7 @@ struct lexical_caster<
 		}
 
 		if(fallback) {
-			return fallback.get();
+			return fallback.value();
 		} else {
 			throw bad_lexical_cast();
 		}

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -32,8 +32,6 @@
 #include <sstream>
 #include <utility>
 
-#include <boost/optional.hpp>
-
 static lg::log_domain log_config("config");
 #define ERR_CF LOG_STREAM(err, log_config)
 #define LOG_G LOG_STREAM(info, lg::general())

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -21,8 +21,7 @@ class config;
 #include "map/location.hpp"
 #include "terrain/translation.hpp"
 #include "terrain/type_data.hpp"
-
-#include <boost/optional.hpp>
+#include "utils/optional_fwd.hpp"
 
 //class terrain_type_data; Can't forward declare because of enum
 
@@ -90,7 +89,7 @@ public:
 		t_translation::ter_list old_;
 		t_translation::ter_list new_;
 		terrain_type_data::merge_mode mode_;
-		boost::optional<t_translation::terrain_code> terrain_;
+		utils::optional<t_translation::terrain_code> terrain_;
 		bool use_old_;
 		bool replace_if_failed_;
 

--- a/src/mp_game_settings.cpp
+++ b/src/mp_game_settings.cpp
@@ -207,7 +207,7 @@ void mp_game_settings::update_addon_requirements(const config & cfg) {
 	} else {
 		// Didn't find this addon-id in the map, so make a new entry without setting the min_version.
 		if(!new_data.required) {
-			new_data.min_version = boost::none;
+			new_data.min_version = utils::nullopt;
 		}
 		addons.emplace(cfg["id"].str(), new_data);
 	}

--- a/src/mp_game_settings.cpp
+++ b/src/mp_game_settings.cpp
@@ -207,7 +207,7 @@ void mp_game_settings::update_addon_requirements(const config & cfg) {
 	} else {
 		// Didn't find this addon-id in the map, so make a new entry without setting the min_version.
 		if(!new_data.required) {
-			new_data.min_version = utils::nullopt;
+			new_data.min_version.reset();
 		}
 		addons.emplace(cfg["id"].str(), new_data);
 	}

--- a/src/mp_game_settings.hpp
+++ b/src/mp_game_settings.hpp
@@ -17,11 +17,10 @@
 #pragma once
 
 #include "config.hpp"
+#include "game_version.hpp"
 #include "gettext.hpp"
 #include "utils/make_enum.hpp"
-#include "game_version.hpp"
-
-#include <boost/optional.hpp>
+#include "utils/optional_fwd.hpp"
 
 struct mp_game_settings
 {
@@ -88,8 +87,8 @@ struct mp_game_settings
 
 	struct addon_version_info
 	{
-		boost::optional<version_info> version;
-		boost::optional<version_info> min_version;
+		utils::optional<version_info> version;
+		utils::optional<version_info> min_version;
 		std::string name;
 		bool required;
 		std::vector<addon_content> content;

--- a/src/play_controller.hpp
+++ b/src/play_controller.hpp
@@ -25,6 +25,7 @@
 #include "terrain/type_data.hpp"
 #include "tod_manager.hpp"
 #include "game_state.hpp"
+#include "utils/optional_fwd.hpp"
 
 #include <set>
 
@@ -132,10 +133,14 @@ public:
 		gamestate().end_level_data_ = data;
 	}
 	void reset_end_level_data() {
-		gamestate().end_level_data_ = boost::none;
+		gamestate().end_level_data_ = utils::nullopt;
 	}
 	bool is_regular_game_end() const {
-		return gamestate().end_level_data_.get_ptr() != nullptr;
+#if defined HAVE_CXX17 || BOOST_VERSION >= 106800
+		return gamestate().end_level_data_.has_value();
+#else
+		return gamestate().end_level_data_ != utils::nullopt;
+#endif
 	}
 	const end_level_data& get_end_level_data_const() const {
 		return *gamestate().end_level_data_;

--- a/src/play_controller.hpp
+++ b/src/play_controller.hpp
@@ -133,7 +133,7 @@ public:
 		gamestate().end_level_data_ = data;
 	}
 	void reset_end_level_data() {
-		gamestate().end_level_data_ = utils::nullopt;
+		gamestate().end_level_data_.reset();
 	}
 	bool is_regular_game_end() const {
 #if defined HAVE_CXX17 || BOOST_VERSION >= 106800

--- a/src/replay_controller.hpp
+++ b/src/replay_controller.hpp
@@ -47,7 +47,13 @@ public:
 	bool recorder_at_end() const;
 	bool should_stop() const { return stop_condition_->should_stop(); }
 	bool can_execute_command(const hotkey::hotkey_command& cmd, int index) const;
-	bool is_controlling_view() const { return vision_.is_initialized(); }
+	bool is_controlling_view() const {
+#if defined HAVE_CXX17 || BOOST_VERSION >= 106800
+		return vision_.has_value();
+#else
+		return vision_ != utils::nullopt;
+#endif
+	}
 	bool allow_reset_replay() const { return reset_state_.get() != nullptr; }
 	const std::shared_ptr<config>& get_reset_state() const { return reset_state_; }
 	void return_to_play_side(bool r = true) { return_to_play_side_ = r; }
@@ -84,7 +90,7 @@ private:
 		CURRENT_TEAM,
 		SHOW_ALL,
 	};
-	boost::optional<REPLAY_VISION> vision_;
+	utils::optional<REPLAY_VISION> vision_;
 	std::shared_ptr<config> reset_state_;
 	std::function<void()> on_end_replay_;
 	bool return_to_play_side_;

--- a/src/scripting/lua_audio.cpp
+++ b/src/scripting/lua_audio.cpp
@@ -98,7 +98,7 @@ static int impl_music_get(lua_State* L) {
 	if(strcmp(m, "current_i") == 0) {
 		auto current_index = sound::get_current_track_index();
 		if(current_index) {
-			lua_pushinteger(L, current_index.get() + 1);
+			lua_pushinteger(L, current_index.value() + 1);
 		} else {
 			lua_pushnil(L);
 		}

--- a/src/scripting/lua_gui2.cpp
+++ b/src/scripting/lua_gui2.cpp
@@ -40,11 +40,11 @@
 #include "game_state.hpp"
 
 #include "utils/functional.hpp"
+#include "utils/optional_fwd.hpp"
 
 #include <map>
 #include <utility>
 #include <vector>
-#include <boost/optional.hpp>
 
 #include "lua/lauxlib.h"                // for luaL_checkinteger, etc
 #include "lua/lua.h"                    // for lua_setfield, etc
@@ -211,7 +211,7 @@ int show_message_box(lua_State* L) {
 	std::transform(button.begin(), button.end(), std::inserter(btn_style, btn_style.begin()), [](char c) { return std::tolower(c); });
 	bool markup = lua_isnoneornil(L, 3) ? luaW_toboolean(L, 3) : luaW_toboolean(L, 4);
 	using button_style = gui2::dialogs::message::button_style;
-	boost::optional<button_style> style;
+	utils::optional<button_style> style;
 	if(btn_style.empty()) {
 		style = button_style::auto_close;
 	} else if(btn_style == "ok") {

--- a/src/scripting/lua_widget_attributes.cpp
+++ b/src/scripting/lua_widget_attributes.cpp
@@ -52,7 +52,6 @@
 #include <map>
 #include <utility>
 #include <vector>
-#include <boost/optional.hpp>
 
 #include "lua/lauxlib.h"                // for luaL_checkinteger, etc
 #include "lua/lua.h"                    // for lua_setfield, etc

--- a/src/scripting/lua_widget_methods.cpp
+++ b/src/scripting/lua_widget_methods.cpp
@@ -47,7 +47,6 @@
 #include <map>
 #include <utility>
 #include <vector>
-#include <boost/optional.hpp>
 
 #include "lua/lauxlib.h"
 #include "lua/lua.h"

--- a/src/scripting/mapgen_lua_kernel.cpp
+++ b/src/scripting/mapgen_lua_kernel.cpp
@@ -261,7 +261,7 @@ int mapgen_lua_kernel::intf_get_variable(lua_State *L)
 	variable_access_const v(m, vars_ ? *vars_ : empty_cfg);
 	return luaW_pushvariable(L, v) ? 1 : 0;
 }
-std::string mapgen_lua_kernel::create_map(const char * prog, const config & generator, boost::optional<uint32_t> seed) // throws game::lua_error
+std::string mapgen_lua_kernel::create_map(const char * prog, const config & generator, utils::optional<uint32_t> seed) // throws game::lua_error
 {
 	random_seed_ = seed;
 	default_rng_ = std::mt19937(get_random_seed());
@@ -277,7 +277,7 @@ std::string mapgen_lua_kernel::create_map(const char * prog, const config & gene
 	return lua_tostring(mState, -1);
 }
 
-config mapgen_lua_kernel::create_scenario(const char * prog, const config & generator, boost::optional<uint32_t> seed) // throws game::lua_error
+config mapgen_lua_kernel::create_scenario(const char * prog, const config & generator, utils::optional<uint32_t> seed) // throws game::lua_error
 {
 	random_seed_ = seed;
 	default_rng_ = std::mt19937(get_random_seed());
@@ -300,8 +300,8 @@ config mapgen_lua_kernel::create_scenario(const char * prog, const config & gene
 
 uint32_t mapgen_lua_kernel::get_random_seed()
 {
-	if(uint32_t* pint = random_seed_.get_ptr()) {
-		return (*pint)++;
+	if(random_seed_) {
+		return random_seed_.value()++;
 	}
 	else {
 		return lua_kernel_base::get_random_seed();

--- a/src/scripting/mapgen_lua_kernel.hpp
+++ b/src/scripting/mapgen_lua_kernel.hpp
@@ -15,7 +15,8 @@
 #pragma once
 
 #include "scripting/lua_kernel_base.hpp"
-#include <boost/optional.hpp>
+#include "utils/optional_fwd.hpp"
+
 #include <cstdint>
 #include <random>
 
@@ -30,15 +31,15 @@ public:
 	virtual std::string my_name() { return "Mapgen Lua Kernel"; }
 
 	void user_config(const char * prog, const config & generator); // throws game::lua_error
-	std::string create_map(const char * prog, const config & generator, boost::optional<uint32_t> seed); // throws game::lua_error
-	config create_scenario(const char * prog, const config & generator, boost::optional<uint32_t> seed); // throws game::lua_error
+	std::string create_map(const char * prog, const config & generator, utils::optional<uint32_t> seed); // throws game::lua_error
+	config create_scenario(const char * prog, const config & generator, utils::optional<uint32_t> seed); // throws game::lua_error
 
 	virtual uint32_t get_random_seed();
 	std::mt19937& get_default_rng();
 private:
 	void run_generator(const char * prog, const config & generator);
 	int intf_get_variable(lua_State *L);
-	boost::optional<uint32_t> random_seed_;
-	boost::optional<std::mt19937> default_rng_;
+	utils::optional<uint32_t> random_seed_;
+	utils::optional<std::mt19937> default_rng_;
 	const config* vars_;
 };

--- a/src/serialization/preprocessor.cpp
+++ b/src/serialization/preprocessor.cpp
@@ -1157,7 +1157,7 @@ bool preprocessor_data::get_chunk()
 			std::string symbol = items.front();
 			items.erase(items.begin());
 			int found_arg = 0, found_enddef = 0, found_deprecate = 0;
-			utils::optional<DEP_LEVEL> deprecation_level = utils::nullopt;
+			utils::optional<DEP_LEVEL> deprecation_level;
 			std::string buffer, deprecation_detail;
 			version_info deprecation_version = game_config::wesnoth_version;
 			for(;;) {

--- a/src/serialization/preprocessor.cpp
+++ b/src/serialization/preprocessor.cpp
@@ -1157,7 +1157,7 @@ bool preprocessor_data::get_chunk()
 			std::string symbol = items.front();
 			items.erase(items.begin());
 			int found_arg = 0, found_enddef = 0, found_deprecate = 0;
-			boost::optional<DEP_LEVEL> deprecation_level = boost::none;
+			utils::optional<DEP_LEVEL> deprecation_level = utils::nullopt;
 			std::string buffer, deprecation_detail;
 			version_info deprecation_version = game_config::wesnoth_version;
 			for(;;) {

--- a/src/serialization/preprocessor.hpp
+++ b/src/serialization/preprocessor.hpp
@@ -88,7 +88,7 @@ struct preproc_define
 
 	std::string deprecation_message;
 
-	utils::optional<DEP_LEVEL> deprecation_level = utils::nullopt;
+	utils::optional<DEP_LEVEL> deprecation_level;
 
 	version_info deprecation_version;
 

--- a/src/serialization/preprocessor.hpp
+++ b/src/serialization/preprocessor.hpp
@@ -17,15 +17,15 @@
 
 #pragma once
 
+#include "deprecation.hpp"
+#include "exceptions.hpp"
 #include "filesystem.hpp"
+#include "game_version.hpp"
+#include "utils/optional_fwd.hpp"
+
 #include <iosfwd>
 #include <map>
 #include <vector>
-#include <boost/optional.hpp>
-
-#include "exceptions.hpp"
-#include "game_version.hpp"
-#include "deprecation.hpp"
 
 class config_writer;
 class config;
@@ -61,7 +61,7 @@ struct preproc_define
 			int line,
 			const std::string& loc,
 			const std::string& dep_msg,
-			boost::optional<DEP_LEVEL> dep_lvl, const version_info& dep_ver)
+			utils::optional<DEP_LEVEL> dep_lvl, const version_info& dep_ver)
 		: value(val)
 		, arguments(args)
 		, optional_arguments(optargs)
@@ -88,12 +88,16 @@ struct preproc_define
 
 	std::string deprecation_message;
 
-	boost::optional<DEP_LEVEL> deprecation_level = boost::none;
+	utils::optional<DEP_LEVEL> deprecation_level = utils::nullopt;
 
 	version_info deprecation_version;
 
 	bool is_deprecated() const {
-		return deprecation_level != boost::none;
+#if defined HAVE_CXX17 || BOOST_VERSION >= 106800
+		return deprecation_level.has_value();
+#else
+		return deprecation_level != utils::nullopt;
+#endif
 	}
 
 	void write(config_writer&, const std::string&) const;

--- a/src/serialization/schema/type.cpp
+++ b/src/serialization/schema/type.cpp
@@ -18,9 +18,9 @@
  */
 
 #include "serialization/schema/type.hpp"
-#include "boost/optional.hpp"
 
 #include "config.hpp"
+#include "utils/optional_fwd.hpp"
 
 namespace schema_validation
 {
@@ -39,7 +39,7 @@ namespace schema_validation
  */
 std::shared_ptr<wml_type> wml_type::from_config(const config& cfg)
 {
-	boost::optional<config::const_child_itors> composite_range;
+	utils::optional<config::const_child_itors> composite_range;
 	std::shared_ptr<wml_type> type;
 	if(cfg.has_child("union")) {
 		type = std::make_shared<wml_type_union>(cfg["name"]);

--- a/src/server/campaignd/options.hpp
+++ b/src/server/campaignd/options.hpp
@@ -19,7 +19,8 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
+#include "utils/optional_fwd.hpp"
+
 #include <boost/program_options/options_description.hpp>
 #include <map>
 
@@ -50,11 +51,11 @@ public:
 	bool version;
 
 	/** Path to the add-ons server configuration file. */
-	boost::optional<std::string> config_file;
+	utils::optional<std::string> config_file;
 	/** Path to the add-ons server storage dir. */
-	boost::optional<std::string> server_dir;
+	utils::optional<std::string> server_dir;
 	/** Port number on which the server will listen for incoming connections. */
-	boost::optional<unsigned short> port;
+	utils::optional<unsigned short> port;
 
 	/** True if --logdomains was passed. */
 	bool show_log_domains;

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -197,7 +197,7 @@ void flush_cache()
 	music_cache.clear();
 }
 
-boost::optional<unsigned int> get_current_track_index()
+utils::optional<unsigned int> get_current_track_index()
 {
 	if(current_track_index >= current_track_list.size()){
 		return {};

--- a/src/sound.hpp
+++ b/src/sound.hpp
@@ -16,8 +16,8 @@
 
 #include "events.hpp"
 #include "sound_music_track.hpp"
+#include "utils/optional_fwd.hpp"
 
-#include <boost/optional.hpp>
 #include <string>
 
 class config;
@@ -119,7 +119,7 @@ void set_sound_volume(int vol);
 void set_bell_volume(int vol);
 void set_UI_volume(int vol);
 
-boost::optional<unsigned int> get_current_track_index();
+utils::optional<unsigned int> get_current_track_index();
 std::shared_ptr<sound::music_track> get_current_track();
 std::shared_ptr<sound::music_track> get_previous_music_track();
 void set_previous_track(std::shared_ptr<music_track>);

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -35,8 +35,6 @@
 #include "formula/string_utils.hpp"
 #include "resources.hpp"
 
-#include <boost/optional.hpp>
-
 static lg::log_domain log_config("config");
 #define ERR_CF LOG_STREAM(err, log_config)
 #define WRN_CF LOG_STREAM(warn, log_config)

--- a/src/units/frame.hpp
+++ b/src/units/frame.hpp
@@ -24,9 +24,9 @@
 #include "color.hpp"
 #include "halo.hpp"
 #include "picture.hpp"
+#include "utils/optional_fwd.hpp"
 
 #include <boost/logic/tribool.hpp>
-#include <boost/optional.hpp>
 
 class config;
 
@@ -50,8 +50,8 @@ struct frame_parameters
 	std::string sound;
 	std::string text;
 
-	boost::optional<color_t> text_color;
-	boost::optional<color_t> blend_with;
+	utils::optional<color_t> text_color;
+	utils::optional<color_t> blend_with;
 
 	double blend_ratio;
 	double highlight_ratio;
@@ -115,8 +115,8 @@ private:
 	std::string sound_;
 	std::string text_;
 
-	boost::optional<color_t> text_color_;
-	boost::optional<color_t> blend_with_;
+	utils::optional<color_t> text_color_;
+	utils::optional<color_t> blend_with_;
 
 	std::string blend_ratio_;
 	std::string highlight_ratio_;
@@ -177,8 +177,8 @@ private:
 	std::string sound_;
 	std::string text_;
 
-	boost::optional<color_t> text_color_;
-	boost::optional<color_t> blend_with_;
+	utils::optional<color_t> text_color_;
+	utils::optional<color_t> blend_with_;
 
 	progressive_double blend_ratio_;
 	progressive_double highlight_ratio_;

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -364,7 +364,7 @@ static int process_command_args(const commandline_options& cmdline_opts)
 	// Options that don't change behavior based on any others should be checked alphabetically below.
 
 	if(cmdline_opts.log) {
-		for(const auto& log_pair : cmdline_opts.log.get()) {
+		for(const auto& log_pair : cmdline_opts.log.value()) {
 			const std::string log_domain = log_pair.second;
 			const int severity = log_pair.first;
 			if(!lg::set_log_domain_severity(log_domain, severity)) {
@@ -554,7 +554,8 @@ static int process_command_args(const commandline_options& cmdline_opts)
 		}
 		schema_validation::schema_validator validator(schema_path);
 		validator.set_create_exceptions(false); // Don't crash if there's an error, just go ahead anyway
-		return handle_validate_command(*cmdline_opts.validate_wml, validator, boost::get_optional_value_or(cmdline_opts.preprocess_defines, {}));
+		return handle_validate_command(*cmdline_opts.validate_wml, validator,
+			cmdline_opts.preprocess_defines.value_or<decltype(cmdline_opts.preprocess_defines)::value_type>({}));
 	}
 
 	if(cmdline_opts.preprocess_defines || cmdline_opts.preprocess_input_macros || cmdline_opts.preprocess_path) {


### PR DESCRIPTION
Coverts usecases of `boost::optional` to `utils::optional`. Doesn't touch the few optional references since those aren't supported with std::optional except via `std::reference_wrapper` which adds an extra layer of indirection that makes conditional compilation difficult.