### PR TITLE
Refactored use of boost::mpl out of lexical_caster

### DIFF
--- a/src/lexical_cast.hpp
+++ b/src/lexical_cast.hpp
@@ -53,7 +53,6 @@
 #include <sstream>
 #include <type_traits>
 
-#include <boost/mpl/set.hpp>
 #include <boost/optional.hpp>
 
 #define DEBUG_THROW(id)
@@ -194,7 +193,7 @@ struct lexical_caster<
 	  long long
 	, From
 	, void
-	, std::enable_if_t<boost::mpl::has_key<boost::mpl::set<char*, const char*> , From>::value>
+	, std::enable_if_t<std::is_same<std::remove_const_t<From>, char*>::value>
 	>
 {
 	long long operator()(From value, boost::optional<long long> fallback) const
@@ -250,7 +249,7 @@ struct lexical_caster<
 	  To
 	, From
 	, std::enable_if_t<std::is_integral<To>::value && std::is_signed<To>::value && !std::is_same<To, long long>::value>
-	, std::enable_if_t<boost::mpl::has_key<boost::mpl::set<char*, const char*> , From>::value>
+	, std::enable_if_t<std::is_same<std::remove_const_t<From>, char*>::value>
 	>
 {
 	To operator()(From value, boost::optional<To> fallback) const
@@ -308,7 +307,7 @@ struct lexical_caster<
 	  To
 	, From
 	, std::enable_if_t<std::is_floating_point<To>::value>
-	, std::enable_if_t<boost::mpl::has_key<boost::mpl::set<char*, const char*> , From>::value>
+	, std::enable_if_t<std::is_same<std::remove_const_t<From>, char*>::value>
 	>
 {
 	To operator()(From value, boost::optional<To> fallback) const
@@ -377,7 +376,7 @@ struct lexical_caster<
 	  unsigned long long
 	, From
 	, void
-	, std::enable_if_t<boost::mpl::has_key<boost::mpl::set<char*, const char*> , From>::value>
+	, std::enable_if_t<std::is_same<std::remove_const_t<From>, char*>::value>
 	>
 {
 	unsigned long long operator()(From value, boost::optional<unsigned long long> fallback) const
@@ -434,7 +433,7 @@ struct lexical_caster<
 	  To
 	, From
 	, std::enable_if_t<std::is_unsigned<To>::value && !std::is_same<To, unsigned long long>::value>
-	, std::enable_if_t<boost::mpl::has_key<boost::mpl::set<char*, const char*> , From>::value>
+	, std::enable_if_t<std::is_same<std::remove_const_t<From>, char*>::value>
 	>
 {
 	To operator()(From value, boost::optional<To> fallback) const

--- a/src/lexical_cast.hpp
+++ b/src/lexical_cast.hpp
@@ -121,9 +121,6 @@ struct bad_lexical_cast : std::exception
 
 namespace implementation {
 
-template<typename From>
-using constless_ptr_t = std::add_pointer_t<std::remove_const_t<std::remove_pointer_t<From>>>;
-
 /**
  * Base class for the conversion.
  *
@@ -196,7 +193,7 @@ struct lexical_caster<
 	  long long
 	, From
 	, void
-	, std::enable_if_t<std::is_same<constless_ptr_t<From>, char*>::value>
+	, std::enable_if_t<std::is_same<From, const char*>::value || std::is_same<From, char*>::value>
 	>
 {
 	long long operator()(From value, boost::optional<long long> fallback) const
@@ -252,7 +249,7 @@ struct lexical_caster<
 	  To
 	, From
 	, std::enable_if_t<std::is_integral<To>::value && std::is_signed<To>::value && !std::is_same<To, long long>::value>
-	, std::enable_if_t<std::is_same<constless_ptr_t<From>, char*>::value>
+	, std::enable_if_t<std::is_same<From, const char*>::value || std::is_same<From, char*>::value>
 	>
 {
 	To operator()(From value, boost::optional<To> fallback) const
@@ -310,7 +307,7 @@ struct lexical_caster<
 	  To
 	, From
 	, std::enable_if_t<std::is_floating_point<To>::value>
-	, std::enable_if_t<std::is_same<constless_ptr_t<From>, char*>::value>
+	, std::enable_if_t<std::is_same<From, const char*>::value || std::is_same<From, char*>::value>
 	>
 {
 	To operator()(From value, boost::optional<To> fallback) const
@@ -379,7 +376,7 @@ struct lexical_caster<
 	  unsigned long long
 	, From
 	, void
-	, std::enable_if_t<std::is_same<constless_ptr_t<From>, char*>::value>
+	, std::enable_if_t<std::is_same<From, const char*>::value || std::is_same<From, char*>::value>
 	>
 {
 	unsigned long long operator()(From value, boost::optional<unsigned long long> fallback) const
@@ -436,7 +433,7 @@ struct lexical_caster<
 	  To
 	, From
 	, std::enable_if_t<std::is_unsigned<To>::value && !std::is_same<To, unsigned long long>::value>
-	, std::enable_if_t<std::is_same<constless_ptr_t<From>, char*>::value>
+	, std::enable_if_t<std::is_same<From, const char*>::value || std::is_same<From, char*>::value>
 	>
 {
 	To operator()(From value, boost::optional<To> fallback) const

--- a/src/lexical_cast.hpp
+++ b/src/lexical_cast.hpp
@@ -121,6 +121,9 @@ struct bad_lexical_cast : std::exception
 
 namespace implementation {
 
+template<typename From>
+using constless_ptr_t = std::add_pointer_t<std::remove_const_t<std::remove_pointer_t<From>>>;
+
 /**
  * Base class for the conversion.
  *
@@ -193,7 +196,7 @@ struct lexical_caster<
 	  long long
 	, From
 	, void
-	, std::enable_if_t<std::is_same<std::remove_const_t<std::remove_pointer_t<From>>, char>::value>
+	, std::enable_if_t<std::is_same<constless_ptr_t<From>, char*>::value>
 	>
 {
 	long long operator()(From value, boost::optional<long long> fallback) const
@@ -249,7 +252,7 @@ struct lexical_caster<
 	  To
 	, From
 	, std::enable_if_t<std::is_integral<To>::value && std::is_signed<To>::value && !std::is_same<To, long long>::value>
-	, std::enable_if_t<std::is_same<std::remove_const_t<std::remove_pointer_t<From>>, char>::value>
+	, std::enable_if_t<std::is_same<constless_ptr_t<From>, char*>::value>
 	>
 {
 	To operator()(From value, boost::optional<To> fallback) const
@@ -307,7 +310,7 @@ struct lexical_caster<
 	  To
 	, From
 	, std::enable_if_t<std::is_floating_point<To>::value>
-	, std::enable_if_t<std::is_same<std::remove_const_t<std::remove_pointer_t<From>>, char>::value>
+	, std::enable_if_t<std::is_same<constless_ptr_t<From>, char*>::value>
 	>
 {
 	To operator()(From value, boost::optional<To> fallback) const
@@ -376,7 +379,7 @@ struct lexical_caster<
 	  unsigned long long
 	, From
 	, void
-	, std::enable_if_t<std::is_same<std::remove_const_t<std::remove_pointer_t<From>>, char>::value>
+	, std::enable_if_t<std::is_same<constless_ptr_t<From>, char*>::value>
 	>
 {
 	unsigned long long operator()(From value, boost::optional<unsigned long long> fallback) const
@@ -433,7 +436,7 @@ struct lexical_caster<
 	  To
 	, From
 	, std::enable_if_t<std::is_unsigned<To>::value && !std::is_same<To, unsigned long long>::value>
-	, std::enable_if_t<std::is_same<std::remove_const_t<std::remove_pointer_t<From>>, char>::value>
+	, std::enable_if_t<std::is_same<constless_ptr_t<From>, char*>::value>
 	>
 {
 	To operator()(From value, boost::optional<To> fallback) const

--- a/src/lexical_cast.hpp
+++ b/src/lexical_cast.hpp
@@ -193,7 +193,7 @@ struct lexical_caster<
 	  long long
 	, From
 	, void
-	, std::enable_if_t<std::is_same<std::remove_const_t<From>, char*>::value>
+	, std::enable_if_t<std::is_same<std::remove_const_t<std::remove_pointer_t<From>>, char>::value>
 	>
 {
 	long long operator()(From value, boost::optional<long long> fallback) const
@@ -249,7 +249,7 @@ struct lexical_caster<
 	  To
 	, From
 	, std::enable_if_t<std::is_integral<To>::value && std::is_signed<To>::value && !std::is_same<To, long long>::value>
-	, std::enable_if_t<std::is_same<std::remove_const_t<From>, char*>::value>
+	, std::enable_if_t<std::is_same<std::remove_const_t<std::remove_pointer_t<From>>, char>::value>
 	>
 {
 	To operator()(From value, boost::optional<To> fallback) const
@@ -307,7 +307,7 @@ struct lexical_caster<
 	  To
 	, From
 	, std::enable_if_t<std::is_floating_point<To>::value>
-	, std::enable_if_t<std::is_same<std::remove_const_t<From>, char*>::value>
+	, std::enable_if_t<std::is_same<std::remove_const_t<std::remove_pointer_t<From>>, char>::value>
 	>
 {
 	To operator()(From value, boost::optional<To> fallback) const
@@ -376,7 +376,7 @@ struct lexical_caster<
 	  unsigned long long
 	, From
 	, void
-	, std::enable_if_t<std::is_same<std::remove_const_t<From>, char*>::value>
+	, std::enable_if_t<std::is_same<std::remove_const_t<std::remove_pointer_t<From>>, char>::value>
 	>
 {
 	unsigned long long operator()(From value, boost::optional<unsigned long long> fallback) const
@@ -433,7 +433,7 @@ struct lexical_caster<
 	  To
 	, From
 	, std::enable_if_t<std::is_unsigned<To>::value && !std::is_same<To, unsigned long long>::value>
-	, std::enable_if_t<std::is_same<std::remove_const_t<From>, char*>::value>
+	, std::enable_if_t<std::is_same<std::remove_const_t<std::remove_pointer_t<From>>, char>::value>
 	>
 {
 	To operator()(From value, boost::optional<To> fallback) const


### PR DESCRIPTION
Essentially, strip the optional const and ptr types from `From` and check it against `char`.