### PR TITLE
campaignd: [server_id] request

### DIFF
--- a/data/gui/window/addon_license_prompt.cfg
+++ b/data/gui/window/addon_license_prompt.cfg
@@ -1,0 +1,123 @@
+#textdomain wesnoth-lib
+###
+### Definition of the Add-ons Manager license promnpt dialog
+###
+
+[window]
+	id = "addon_license_prompt"
+	description = "Add-ons Manager content license prompt displayed during uploads."
+
+	[resolution]
+		definition = "default"
+
+		automatic_placement = true
+		vertical_placement = "center"
+		horizontal_placement = "center"
+
+		maximum_width = 800
+		#maximum_height = 600
+
+		[tooltip]
+			id = "tooltip"
+		[/tooltip]
+
+		[helptip]
+			id = "tooltip"
+		[/helptip]
+
+		[grid]
+			[row]
+				grow_factor = 0
+				[column]
+					grow_factor = 1
+					horizontal_alignment = "left"
+					border = "all"
+					border_size = 5
+
+					[label]
+						definition = "title"
+						label = _ "addons_server^Server Rules"
+					[/label]
+				[/column]
+			[/row]
+
+			[row]
+				grow_factor = 0
+				[column]
+					grow_factor = 1
+					horizontal_alignment = "left"
+					border = "all"
+					border_size = 5
+
+					[label]
+						id = "message"
+						label = "Before uploading content to this server, you must accept the following distribution terms by choosing “I Agree”."
+						wrap = true
+					[/label]
+				[/column]
+			[/row]
+
+			[row]
+				grow_factor = 0
+				[column]
+					horizontal_grow = true
+					border = "all"
+					border_size = 5
+
+					[panel]
+						definition = "box_display_no_blur_no_border"
+						[grid]
+							[row]
+								[column]
+									horizontal_grow = true
+									border = "all"
+									border_size = 5
+
+									[scroll_label]
+										id = "terms"
+										definition = "description"
+										label = "server terms placeholder"
+									[/scroll_label]
+								[/column]
+							[/row]
+						[/grid]
+					[/panel]
+				[/column]
+			[/row]
+
+			[row]
+				grow_factor = 0
+				[column]
+					horizontal_alignment = "right"
+
+					[grid]
+						[row]
+							grow_factor = 0
+							[column]
+								horizontal_alignment = "right"
+								border = "all"
+								border_size = 5
+
+								[button]
+									id = "ok"
+									label = _ "I Agree"
+								[/button]
+							[/column]
+
+							[column]
+								horizontal_alignment = "right"
+								border = "all"
+								border_size = 5
+
+								[button]
+									id = "cancel"
+									label = _ "Cancel"
+								[/button]
+							[/column]
+						[/row]
+					[/grid]
+				[/column]
+			[/row]
+		[/grid]
+	[/resolution]
+[/window]

--- a/projectfiles/VC16/wesnoth.vcxproj
+++ b/projectfiles/VC16/wesnoth.vcxproj
@@ -1478,6 +1478,13 @@
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Debug|x64'">$(IntDir)Gui\Dialogs\Addon\</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Release|x64'">$(IntDir)Gui\Dialogs\Addon\</ObjectFileName>
     </ClCompile>
+    <ClCompile Include="..\..\src\gui\dialogs\addon\license_prompt.cpp">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)Gui\Dialogs\Addon\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='ReleaseDEBUG|x64'">$(IntDir)Gui\Dialogs\Addon\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)Gui\Dialogs\Addon\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Debug|x64'">$(IntDir)Gui\Dialogs\Addon\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Release|x64'">$(IntDir)Gui\Dialogs\Addon\</ObjectFileName>
+    </ClCompile>
     <ClCompile Include="..\..\src\gui\dialogs\addon\manager.cpp">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)Gui\Dialogs\Addon\</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='ReleaseDEBUG|x64'">$(IntDir)Gui\Dialogs\Addon\</ObjectFileName>
@@ -3803,6 +3810,7 @@
     <ClInclude Include="..\..\src\gui\core\window_builder\instance.hpp" />
     <ClInclude Include="..\..\src\gui\dialogs\addon\connect.hpp" />
     <ClInclude Include="..\..\src\gui\dialogs\addon\install_dependencies.hpp" />
+    <ClInclude Include="..\..\src\gui\dialogs\addon\license_prompt.hpp" />
     <ClInclude Include="..\..\src\gui\dialogs\addon\manager.hpp" />
     <ClInclude Include="..\..\src\gui\dialogs\addon\uninstall_list.hpp" />
     <ClInclude Include="..\..\src\gui\dialogs\attack_predictions.hpp" />

--- a/projectfiles/VC16/wesnoth.vcxproj.filters
+++ b/projectfiles/VC16/wesnoth.vcxproj.filters
@@ -704,6 +704,9 @@
     <ClCompile Include="..\..\src\gui\dialogs\addon\install_dependencies.cpp">
       <Filter>Gui\Dialogs\Addon</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\gui\dialogs\addon\license_prompt.cpp">
+      <Filter>Gui\Dialogs\Addon</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\gui\dialogs\addon\manager.cpp">
       <Filter>Gui\Dialogs\Addon</Filter>
     </ClCompile>
@@ -2148,6 +2151,9 @@
       <Filter>Gui\Dialogs\Addon</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\gui\dialogs\addon\install_dependencies.hpp">
+      <Filter>Gui\Dialogs\Addon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\gui\dialogs\addon\license_prompt.hpp">
       <Filter>Gui\Dialogs\Addon</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\gui\dialogs\addon\manager.hpp">

--- a/source_lists/wesnoth
+++ b/source_lists/wesnoth
@@ -164,6 +164,7 @@ gui/core/window_builder/helper.cpp
 gui/core/window_builder/instance.cpp
 gui/dialogs/addon/connect.cpp
 gui/dialogs/addon/install_dependencies.cpp
+gui/dialogs/addon/license_prompt.cpp
 gui/dialogs/addon/manager.cpp
 gui/dialogs/addon/uninstall_list.cpp
 gui/dialogs/attack_predictions.cpp

--- a/src/addon/client.cpp
+++ b/src/addon/client.cpp
@@ -643,6 +643,15 @@ void addons_client::clear_last_error()
 	last_error_data_.clear();
 }
 
+void addons_client::clear_server_info()
+{
+	server_version_.clear();
+	server_capabilities_.clear();
+	server_url_.clear();
+	license_notice_.clear();
+	license_url_.clear();
+}
+
 void addons_client::check_connected() const
 {
 	assert(conn_ != nullptr);

--- a/src/addon/client.cpp
+++ b/src/addon/client.cpp
@@ -54,7 +54,6 @@ addons_client::addons_client(const std::string& address)
 	, server_capabilities_()
 	, server_url_()
 	, license_notice_()
-	, license_url_()
 {
 	try {
 		std::tie(host_, port_) = parse_network_address(addr_, std::to_string(default_campaignd_port));
@@ -90,7 +89,6 @@ void addons_client::connect()
 			}
 
 			server_url_ = info["url"].str();
-			license_url_ = info["license_url"].str();
 			license_notice_ = info["license_notice"].str();
 		}
 	} else {
@@ -649,7 +647,6 @@ void addons_client::clear_server_info()
 	server_capabilities_.clear();
 	server_url_.clear();
 	license_notice_.clear();
-	license_url_.clear();
 }
 
 void addons_client::check_connected() const

--- a/src/addon/client.hpp
+++ b/src/addon/client.hpp
@@ -19,6 +19,8 @@
 #include "gui/dialogs/network_transmission.hpp"
 #include "network_asio.hpp"
 
+#include <set>
+
 /**
  * Add-ons (campaignd) client class.
  *
@@ -127,6 +129,30 @@ public:
 	 */
 	bool delete_remote_addon(const std::string& id, std::string& response_message);
 
+	/**
+	 * Returns whether the server supports the given named capability.
+	 */
+	bool server_supports(const std::string& cap_id) const
+	{
+		return server_capabilities_.find(cap_id) != server_capabilities_.end();
+	}
+
+	/**
+	 * Returns whether the server supports incremental (delta) downloads and uploads.
+	 */
+	bool server_supports_delta() const
+	{
+		return server_supports("delta");
+	}
+
+	/**
+	 * Returns whether the server supports passphrase authentication on an add-on basis.
+	 */
+	bool server_supports_legacy_auth() const
+	{
+		return server_supports("auth:legacy");
+	}
+
 private:
 	enum class transfer_mode {download, connect, upload};
 
@@ -136,6 +162,9 @@ private:
 	std::unique_ptr<network_asio::connection> conn_;
 	std::string last_error_;
 	std::string last_error_data_;
+
+	std::string server_version_;
+	std::set<std::string> server_capabilities_;
 
 	/**
 	* Downloads the specified add-on from the server.
@@ -213,4 +242,6 @@ private:
 	void wait_for_transfer_done(const std::string& status_message, transfer_mode mode = transfer_mode::download);
 
 	bool update_last_error(config& response_cfg);
+
+	void clear_last_error();
 };

--- a/src/addon/client.hpp
+++ b/src/addon/client.hpp
@@ -102,14 +102,6 @@ public:
 	bool request_distribution_terms(std::string& terms);
 
 	/**
-	 * Retrieves the content licensing information page URL if available.
-	 */
-	const std::string& distribution_terms_url() const
-	{
-		return license_url_;
-	}
-
-	/**
 	* Do a 'smart' fetch of an add-on, checking to avoid overwrites for devs and resolving dependencies, using gui interaction to handle issues that arise
 	* Returns: outcome: abort in case the user chose to abort because of an issue
 	*                   failure in case we resolved checks and dependencies, but fetching this particular add-on failed
@@ -188,7 +180,6 @@ private:
 	std::set<std::string> server_capabilities_;
 	std::string server_url_;
 	std::string license_notice_;
-	std::string license_url_;
 
 	/**
 	* Downloads the specified add-on from the server.

--- a/src/addon/client.hpp
+++ b/src/addon/client.hpp
@@ -84,9 +84,25 @@ public:
 	bool request_addons_list(config& cfg);
 
 	/**
+	 * Retrieves the add-ons server web URL if available.
+	 */
+	const std::string& server_url() const
+	{
+		return server_url_;
+	}
+
+	/**
 	 * Request the add-ons server distribution terms message.
 	 */
 	bool request_distribution_terms(std::string& terms);
+
+	/**
+	 * Retrieves the content licensing information page URL if available.
+	 */
+	const std::string& distribution_terms_url() const
+	{
+		return license_url_;
+	}
 
 	/**
 	* Do a 'smart' fetch of an add-on, checking to avoid overwrites for devs and resolving dependencies, using gui interaction to handle issues that arise
@@ -165,6 +181,9 @@ private:
 
 	std::string server_version_;
 	std::set<std::string> server_capabilities_;
+	std::string server_url_;
+	std::string license_notice_;
+	std::string license_url_;
 
 	/**
 	* Downloads the specified add-on from the server.

--- a/src/addon/client.hpp
+++ b/src/addon/client.hpp
@@ -62,7 +62,12 @@ public:
 	/**
 	 * Disconnect from the add-on server.
 	 */
-	void disconnect() { conn_.reset(); }
+	void disconnect()
+	{
+		conn_.reset();
+		clear_last_error();
+		clear_server_info();
+	}
 
 	/** Returns the last error message sent by the server, or an empty string. */
 	const std::string& get_last_server_error() const { return last_error_; }
@@ -263,4 +268,6 @@ private:
 	bool update_last_error(config& response_cfg);
 
 	void clear_last_error();
+
+	void clear_server_info();
 };

--- a/src/gui/dialogs/addon/license_prompt.cpp
+++ b/src/gui/dialogs/addon/license_prompt.cpp
@@ -1,0 +1,42 @@
+/*
+   Copyright (C) 2020 by Iris Morelle <shadowm@wesnoth.org>
+   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#define GETTEXT_DOMAIN "wesnoth-lib"
+
+#include "gui/dialogs/addon/license_prompt.hpp"
+
+#include "gettext.hpp"
+#include "gui/auxiliary/find_widget.hpp"
+#include "gui/widgets/button.hpp"
+#include "gui/widgets/settings.hpp"
+#include "gui/widgets/window.hpp"
+
+namespace gui2 {
+namespace dialogs {
+
+REGISTER_DIALOG(addon_license_prompt)
+
+addon_license_prompt::addon_license_prompt(const std::string& license_terms)
+	: license_terms_(license_terms)
+{
+}
+
+void addon_license_prompt::pre_show(window& window)
+{
+	styled_widget& terms = find_widget<styled_widget>(&window, "terms", false);
+	terms.set_use_markup(true);
+	terms.set_label(license_terms_);
+}
+
+}} // end namespace gui2::dialogs

--- a/src/gui/dialogs/addon/license_prompt.hpp
+++ b/src/gui/dialogs/addon/license_prompt.hpp
@@ -1,0 +1,45 @@
+/*
+   Copyright (C) 2020 by Iris Morelle <shadowm@wesnoth.org>
+   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#pragma once
+
+#include "gui/dialogs/modal_dialog.hpp"
+
+namespace gui2 {
+namespace dialogs {
+
+class addon_license_prompt : public modal_dialog
+{
+public:
+	/** Constructor. */
+	explicit addon_license_prompt(const std::string& license_terms);
+
+	/**
+	 * The execute function.
+	 *
+	 * See @ref modal_dialog for more information.
+	 */
+	DEFINE_SIMPLE_EXECUTE_WRAPPER(addon_license_prompt)
+
+private:
+	/** Inherited from modal_dialog, implemented by REGISTER_DIALOG. */
+	virtual const std::string& window_id() const override;
+
+	/** Inherited from modal_dialog. */
+	virtual void pre_show(window& window) override;
+
+	std::string license_terms_;
+};
+
+}} // end namespace gui2::dialogs

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -27,6 +27,7 @@
 #include "gettext.hpp"
 #include "gui/auxiliary/filter.hpp"
 #include "gui/auxiliary/find_widget.hpp"
+#include "gui/dialogs/addon/license_prompt.hpp"
 #include "gui/dialogs/message.hpp"
 #include "gui/dialogs/transient_message.hpp"
 #include "gui/widgets/button.hpp"
@@ -796,7 +797,7 @@ void addon_manager::publish_addon(const addon_info& addon)
 	} else if(!client_.request_distribution_terms(server_msg)) {
 		gui2::show_error_message(
 			_("The server responded with an error:") + "\n" + client_.get_last_server_error());
-	} else if(gui2::show_message(_("Terms"), server_msg, gui2::dialogs::message::ok_cancel_buttons, true) == gui2::retval::OK) {
+	} else if(gui2::dialogs::addon_license_prompt::execute(server_msg)) {
 		if(!client_.upload_addon(addon_id, server_msg, cfg, tracking_info_[addon_id].state == ADDON_INSTALLED_LOCAL_ONLY)) {
 			const std::string& msg = _("The add-on was rejected by the server:") +
 			                         "\n\n" + client_.get_last_server_error();

--- a/src/server/campaignd/server.cpp
+++ b/src/server/campaignd/server.cpp
@@ -90,11 +90,6 @@ const std::set<std::string> cap_defaults = {
 const std::string default_web_url = "https://add-ons.wesnoth.org/";
 
 /**
- * Default URL to a page with additional information on license terms for content uploaded to the server.
- */
-const std::string default_license_url = "https://wiki.wesnoth.org/Wesnoth:Copyrights";
-
-/**
  * Default license terms for content uploaded to the server.
  *
  * This used by both the @a [server_id] command and @a [request_terms] in
@@ -289,7 +284,6 @@ server::server(const std::string& cfg_file, unsigned short port)
 	, feedback_url_format_()
 	, web_url_()
 	, license_notice_()
-	, license_url_()
 	, blacklist_()
 	, blacklist_file_()
 	, stats_exempt_ips_()
@@ -350,7 +344,6 @@ void server::load_config()
 		feedback_url_format_ = svinfo_cfg["feedback_url_format"].str();
 		web_url_ = svinfo_cfg["web_url"].str(default_web_url);
 		license_notice_ = svinfo_cfg["license_notice"].str(default_license_notice);
-		license_url_ = svinfo_cfg["license_url"].str(default_license_url);
 	}
 
 	blacklist_file_ = cfg_["blacklist_file"].str();
@@ -859,7 +852,6 @@ void server::handle_server_id(const server::request& req)
 		"cap",					utils::join(capabilities_),
 		"version",				game_config::revision,
 		"url",					web_url_,
-		"license_url",			license_url_,
 		"license_notice",		license_notice_,
 	}});
 

--- a/src/server/campaignd/server.cpp
+++ b/src/server/campaignd/server.cpp
@@ -98,15 +98,23 @@ const std::string default_web_url = "https://add-ons.wesnoth.org/";
  * The text is intended for display on the client with Pango markup enabled and
  * sent by the server as-is, so it ought to be formatted accordingly.
  */
-const std::string default_license_notice = R"""(All content within add-ons uploaded to this server must be licensed under the terms of the GNU General Public License (GPL), with the sole exception of graphics and audio explicitly denoted as released under a Creative Commons license either in:
+const std::string default_license_notice = R"""(<span size='x-large'>General Rules</span>
 
-    a) a combined toplevel file, e.g. “My_Addon/ART_LICENSE”; <b>or</b>
-    b) a file with the same path as the asset with “.license” appended, e.g. “My_Addon/images/units/axeman.png.license”.
+The current version of the server rules can be found at: https://r.wesnoth.org/t51347
+
+<span color='#f88'>Any content that does not conform to the rules listed on the link, as well as the licensing terms below, may be removed at any time without prior notice.</span>
+
+<span size='x-large'>Licensing</span>
+
+All content within add-ons uploaded to this server must be licensed under the terms of the GNU General Public License (GPL), with the sole exception of graphics and audio explicitly denoted as released under a Creative Commons license either in:
+
+  a) a combined toplevel file, e.g. “<span font_family='monospace'>My_Addon/ART_LICENSE</span>”; <b>or</b>
+  b) a file with the same path as the asset with “<span font_family='monospace'>.license</span>” appended, e.g. “<span font_family='monospace'>My_Addon/images/units/axeman.png.license</span>”.
 
 <b>By uploading content to this server, you certify that you have the right to:</b>
 
-    a) release all included art and audio explicitly denoted with a Creative Commons license in the proscribed manner under that license; <b>and</b>
-    b) release all other included content under the terms of the GPL; and that you choose to do so.)""";
+  a) release all included art and audio explicitly denoted with a Creative Commons license in the proscribed manner under that license; <b>and</b>
+  b) release all other included content under the terms of the GPL; and that you choose to do so.)""";
 
 bool timing_reports_enabled = false;
 

--- a/src/server/campaignd/server.hpp
+++ b/src/server/campaignd/server.hpp
@@ -116,7 +116,6 @@ private:
 
 	std::string web_url_;
 	std::string license_notice_;
-	std::string license_url_;
 
 	blacklist blacklist_;
 	std::string blacklist_file_;

--- a/src/server/campaignd/server.hpp
+++ b/src/server/campaignd/server.hpp
@@ -25,6 +25,7 @@
 #include <chrono>
 #include <functional>
 #include <iosfwd>
+#include <set>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -87,6 +88,8 @@ private:
 
 	typedef std::function<void (server*, const request& req)> request_handler;
 	typedef std::map<std::string, request_handler> request_handlers_table;
+
+	std::set<std::string> capabilities_;
 
 	/**The hash map of addons metadata*/
 	std::unordered_map<std::string, config> addons_;
@@ -207,6 +210,7 @@ private:
 	 */
 	void register_handlers();
 
+	void handle_server_id(const request&);
 	void handle_request_campaign_list(const request&);//#TODO: rename with 'addon' later?
 	void handle_request_campaign(const request&);
 	void handle_request_campaign_hash(const request&);

--- a/src/server/campaignd/server.hpp
+++ b/src/server/campaignd/server.hpp
@@ -114,6 +114,10 @@ private:
 
 	std::string feedback_url_format_;
 
+	std::string web_url_;
+	std::string license_notice_;
+	std::string license_url_;
+
 	blacklist blacklist_;
 	std::string blacklist_file_;
 

--- a/src/tests/gui/test_gui2.cpp
+++ b/src/tests/gui/test_gui2.cpp
@@ -34,6 +34,7 @@
 #include "gui/core/layout_exception.hpp"
 #include "gui/dialogs/addon/connect.hpp"
 #include "gui/dialogs/addon/install_dependencies.hpp"
+#include "gui/dialogs/addon/license_prompt.hpp"
 #include "gui/dialogs/addon/manager.hpp"
 #include "gui/dialogs/attack_predictions.hpp"
 #include "gui/dialogs/campaign_difficulty.hpp"
@@ -415,6 +416,7 @@ BOOST_AUTO_TEST_CASE(test_gui2)
 
 	/* The modal_dialog classes. */
 	test<addon_connect>();
+	test<addon_license_prompt>();
 	//test<addon_manager>();
 	//test<attack_predictions>();
 	test<campaign_difficulty>();
@@ -577,6 +579,18 @@ struct dialog_tester<addon_connect>
 	addon_connect* create()
 	{
 		return new addon_connect(host_name, true);
+	}
+};
+
+template<>
+struct dialog_tester<addon_license_prompt>
+{
+	std::string license_terms = R"""(Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis ante nibh, dignissim ullamcorper tristique eget, condimentum sit amet enim. Aenean dictum pulvinar lacinia. Etiam eleifend, leo sed efficitur consectetur, augue nulla ornare lectus, vitae molestie lacus risus vitae libero. Quisque odio nunc, porttitor eget fermentum sit amet, faucibus eu risus. Praesent sit amet lacus tortor. Suspendisse volutpat quam vitae ipsum fermentum, in vulputate metus egestas. Nulla id consequat ex. Nulla ac dignissim nisl, nec euismod lectus. Duis vitae dolor ornare, convallis justo in, porta dui.
+
+Sed faucibus nibh sit amet ligula porta, non malesuada nibh tristique. Maecenas aliquam diam non eros convallis mattis. Proin rhoncus condimentum leo, sed condimentum magna. Phasellus cursus condimentum lacus, sed sodales lacus. Sed pharetra dictum metus, eget dictum nibh lobortis imperdiet. Nunc tempus sollicitudin bibendum. In porttitor interdum orci. Curabitur vitae nibh vestibulum, condimentum lectus quis, condimentum dui. In quis cursus nisl. Maecenas semper neque eu ipsum aliquam, id porta ligula lacinia. Integer sed blandit ex, eu accumsan magna.)""";
+	addon_license_prompt* create()
+	{
+		return new addon_license_prompt(license_terms);
 	}
 };
 


### PR DESCRIPTION
This new commands allows clients to request some identification and feature capability information from the server, intended to allow clients to find out what features the server supports and enable or disable UI elements accordingly while preserving compatibility where desired.

Currently this results in a response like this:

```
[server_id]
    version="1.15.7+dev (c7643e0785b-Modified)"
    cap="auth:legacy,delta"
[/server_id]
```

More information might be added later, such as a website URL and a link to a web listing for the particular server (e.g. <https://add-ons.wesnoth.org/1.16/>), more details on add-on licensing, or even doing away with the need to send `[request_terms]` before displaying the prompt on the client side.

Note: clients assume `cap=auth:legacy` for servers that can't respond to the query in this version. This accurately reflects the situation for Wesnoth 1.14 and earlier. The 1.15.x server will be updated once this feature goes live so that 1.15.8+ clients don't assume that delta packs are not supported even though they very much are since 1.15.6.

Also note that the client support is an early WIP right now. Ideally the code paths that prod the server to find out if delta uploads/downloads are supported will be replaced with a capability check instead. The API for this (`addons_client::server_supports()`) is not in the patchset yet.