### PR TITLE
campaignd: Add strict version check on uploads

### DIFF
--- a/src/addon/validation.cpp
+++ b/src/addon/validation.cpp
@@ -538,6 +538,10 @@ std::string addon_check_status_desc(unsigned int code)
 			N_("Invalid or unspecified add-on type.")
 		},
 		{
+			ADDON_CHECK_STATUS::VERSION_NOT_INCREMENTED,
+			N_("Version number not greater than the latest uploaded version.")
+		},
+		{
 			ADDON_CHECK_STATUS::INVALID_UTF8_ATTRIBUTE,
 			N_("The add-on publish information contains an invalid UTF-8 sequence.")
 		},

--- a/src/addon/validation.hpp
+++ b/src/addon/validation.hpp
@@ -58,6 +58,7 @@ enum class ADDON_CHECK_STATUS : unsigned int
 	NO_PASSPHRASE				= 0x205,		/**< No passphrase specified */
 	TITLE_HAS_MARKUP			= 0x206,		/**< Markup in add-on title */
 	BAD_TYPE					= 0x207,		/**< Bad add-on type */
+	VERSION_NOT_INCREMENTED		= 0x208,		/**< Version number is not an increment */
 	INVALID_UTF8_ATTRIBUTE		= 0x2FF,		/**< Invalid UTF-8 sequence in add-on metadata */
 	//
 	// Server errors

--- a/src/server/campaignd/server.hpp
+++ b/src/server/campaignd/server.hpp
@@ -101,6 +101,8 @@ private:
 	int compress_level_; /**< Used for add-on archives. */
 	time_t update_pack_lifespan_;
 
+	bool strict_versions_;
+
 	/** Default upload size limit in bytes. */
 	static const std::size_t default_document_size_limit = 100 * 1024 * 1024;
 


### PR DESCRIPTION
This makes it so by default campaignd will reject uploads of existing add-ons without a version bump. A server-side configuration flag (strict_versions) can be optionally enabled to lower the strictness and allow re-uploading the same version -- while still disallowing going backwards.

The reason for making it possible to lower the strictness is that very often while testing campaignd itself it becomes necessary to reupload the same add-on over and over. We don't want to get rid of *that* particular use case.

The server does not currently have a mechanism to advertise the different strictness levels, unfortunately, so clients may in fact need to send a 100 MB rock before finding out it's not good enough for upload. Such is life. This might be solved after #5338 is merged into mainline.

Closes #5079.