### PR TITLE
Wesnothd: added a login response, including admin status

### DIFF
--- a/src/game_initialization/multiplayer.cpp
+++ b/src/game_initialization/multiplayer.cpp
@@ -278,6 +278,9 @@ std::pair<std::unique_ptr<wesnothd_connection>, config> open_connection(std::str
 
 					gui2::dialogs::loading_screen::progress(loading_stage::login_response);
 
+					// FIXME: hacky! This needs to be null to break out of the outer loop on a successful login
+					error = &data.child("error");
+
 					if(const config& success = data.child("login_success")) {
 						// Flag us as authenticated, if applicable...
 						preferences::set_admin_authentication(success["is_admin"].to_bool(false));
@@ -285,11 +288,6 @@ std::pair<std::unique_ptr<wesnothd_connection>, config> open_connection(std::str
 						// ... and get out of the login loop
 						break;
 					}
-
-					error = &data.child("error");
-
-					// ... and get us out of here if the server is happy now
-					if(!*error) break;
 				}
 
 				// Providing a password either was not attempted because we did not

--- a/src/game_initialization/multiplayer.cpp
+++ b/src/game_initialization/multiplayer.cpp
@@ -278,16 +278,10 @@ std::pair<std::unique_ptr<wesnothd_connection>, config> open_connection(std::str
 
 					gui2::dialogs::loading_screen::progress(loading_stage::login_response);
 
-					// FIXME: hacky! This needs to be null to break out of the outer loop on a successful login
 					error = &data.child("error");
 
-					if(const config& success = data.child("login_success")) {
-						// Flag us as authenticated, if applicable...
-						preferences::set_admin_authentication(success["is_admin"].to_bool(false));
-
-						// ... and get out of the login loop
-						break;
-					}
+					// ... and get us out of here if the server is happy now
+					if(!*error) break;
 				}
 
 				// Providing a password either was not attempted because we did not
@@ -377,8 +371,11 @@ std::pair<std::unique_ptr<wesnothd_connection>, config> open_connection(std::str
 			if(!*error) break;
 		} // end login loop
 
-		if(data.has_child("join_lobby")) {
+		if(const config& join_lobby = data.child("join_lobby")) {
 			received_join_lobby = true;
+
+			// Flag us as authenticated, if applicable...
+			preferences::set_admin_authentication(join_lobby["is_moderator"].to_bool(false));
 
 			gui2::dialogs::loading_screen::progress(loading_stage::download_lobby_data);
 		}

--- a/src/preferences/game.cpp
+++ b/src/preferences/game.cpp
@@ -190,6 +190,11 @@ void parse_admin_authentication(const std::string& sender, const std::string& me
 	}
 }
 
+void set_admin_authentication(bool authed)
+{
+	authenticated = authed;
+}
+
 admin_authentication_reset::admin_authentication_reset()
 {
 }

--- a/src/preferences/game.hpp
+++ b/src/preferences/game.hpp
@@ -41,6 +41,7 @@ class acquaintance;
 
 	bool is_authenticated();
 	void parse_admin_authentication(const std::string& sender, const std::string& message);
+	void set_admin_authentication(bool authed);
 
 	/**
 	 * Used to reset is_authenticated flag after disconnecting.

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -803,7 +803,7 @@ bool server::is_login_allowed(socket_ptr socket, const simple_wml::node* const l
 	}
 
 	simple_wml::document join_lobby_response;
-	join_lobby_response.root().add_child("join_lobby").set_attr("is_moderator", user_handler_->user_is_moderator(username) ? "yes" : "no");
+	join_lobby_response.root().add_child("join_lobby").set_attr("is_moderator", is_moderator ? "yes" : "no");
 
 	async_send_doc(socket, join_lobby_response, [this, username, registered, version, source](socket_ptr socket) {
 		simple_wml::node& player_cfg = games_and_users_list_.root().add_child("user");

--- a/src/server/wesnothd/server.hpp
+++ b/src/server/wesnothd/server.hpp
@@ -170,7 +170,6 @@ private:
 
 	simple_wml::document version_query_response_;
 	simple_wml::document login_response_;
-	simple_wml::document join_lobby_response_;
 	simple_wml::document games_and_users_list_;
 
 	metrics metrics_;


### PR DESCRIPTION
This is instead of having the server send a message after the login is complete and before the initial gamelist.
Since we wait at the loading screen for the latter (e41534d114437b26c735915f530df2cbc28e6c15), this has needed
to be handled here (2b4ae206ab796934899a628be6d3808a4ccd6c60), but it doesn't make much sense to be handled this
way. Many years ago this message was meant to show up in chat, but after the former change that no longer happened,
(IIRC) and after the latter change it most certainly won't.

This adds a proper [login_response] response from the server on a successful login which includes an `is_admin`
key containing the user's admin status.