### PR TITLE
Tell other clients about controller type changes from :droid

### DIFF
--- a/src/game_board.cpp
+++ b/src/game_board.cpp
@@ -214,10 +214,19 @@ void game_board::side_drop_to(int side_num, team::CONTROLLER ctrl, team::PROXY_C
 	if (leader.valid()) leader->rename(ctrl.to_string() + std::to_string(side_num));
 }
 
-void game_board::side_change_controller(int side_num, bool is_local, const std::string& pname) {
+void game_board::side_change_controller(int side_num, bool is_local, const std::string& pname, const std::string& controller_type) {
 	team &tm = get_team(side_num);
 
 	tm.set_local(is_local);
+
+	// only changing the type of controller
+	if(controller_type == team::CONTROLLER::enum_to_string(team::CONTROLLER::AI) && !tm.is_ai()) {
+		tm.make_ai();
+		return;
+	} else if(controller_type == team::CONTROLLER::enum_to_string(team::CONTROLLER::HUMAN) && !tm.is_human()) {
+		tm.make_human();
+		return;
+	}
 
 	if (pname.empty() || !tm.is_human()) {
 		return;

--- a/src/game_board.hpp
+++ b/src/game_board.hpp
@@ -155,7 +155,7 @@ public:
 	// Manipulator from playturn
 
 	void side_drop_to (int side_num, team::CONTROLLER ctrl, team::PROXY_CONTROLLER proxy = team::PROXY_CONTROLLER::PROXY_HUMAN);
-	void side_change_controller (int side_num, bool is_local, const std::string& pname = "");
+	void side_change_controller (int side_num, bool is_local, const std::string& pname, const std::string& controller_type);
 
 	// Manipulator from actionwml
 

--- a/src/playturn.cpp
+++ b/src/playturn.cpp
@@ -178,6 +178,7 @@ turn_info::PROCESS_DATA_RESULT turn_info::process_network_data(const config& cfg
 		const int side = change["side"].to_int();
 		const bool is_local = change["is_local"].to_bool();
 		const std::string player = change["player"];
+		const std::string controller_type = change["controller"];
 		const std::size_t index = side - 1;
 		if(index >= resources::gameboard->teams().size()) {
 			ERR_NW << "Bad [change_controller] signal from server, side out of bounds: " << change.debug() << std::endl;
@@ -187,7 +188,7 @@ turn_info::PROCESS_DATA_RESULT turn_info::process_network_data(const config& cfg
 		const team & tm = resources::gameboard->teams().at(index);
 		const bool was_local = tm.is_local();
 
-		resources::gameboard->side_change_controller(side, is_local, player);
+		resources::gameboard->side_change_controller(side, is_local, player, controller_type);
 
 		if (!was_local && tm.is_local()) {
 			resources::controller->on_not_observer();

--- a/src/server/wesnothd/game.hpp
+++ b/src/server/wesnothd/game.hpp
@@ -387,6 +387,9 @@ private:
 			const socket_ptr& sock,
 			const std::string& player_name,
 			const bool player_left = true);
+	std::unique_ptr<simple_wml::document> change_controller_type(const std::size_t side_num,
+			const socket_ptr& sock,
+			const std::string& player_name);
 	void transfer_ai_sides(const socket_ptr& player);
 	void send_leave_game(const socket_ptr& user) const;
 


### PR DESCRIPTION
If one client changes the controller type of a side it controls from human -> AI or vice versa, the other clients need to know about it in case there's WML/lua that uses the controller type to determine what to do. This also means that droiding a side you own can now only be done when it's your turn.

Fixes #4996