### PR TITLE
Campaigns menu overhaul

### DIFF
--- a/data/advanced_preferences.cfg
+++ b/data/advanced_preferences.cfg
@@ -167,15 +167,5 @@
     default=no
 [/advanced_preference]
 
-[advanced_preference]
-    field=use_prng
-    name= _ "Use experimental PRNG combat"
-    description= _ "Enables more determinstic chance-to-hit calculations. This is an experimental feature designed to bring the observed hit/miss rate more in line with the displayed percentages.
-
-Note: this option only affects singleplayer, and the ‘Save random seed’ option must also be enabled when creating a game for this to work."
-    type=boolean
-    default=no
-[/advanced_preference]
-
 #ifdef __UNUSED__
 #endif

--- a/data/gui/widget/panel_campaign_menu.cfg
+++ b/data/gui/widget/panel_campaign_menu.cfg
@@ -1,0 +1,79 @@
+#textdomain wesnoth-lib
+###
+### Panel with a configurable background (via label text) for the Campaigns menu.
+###
+
+#define _GUI_RESOLUTION RESOLUTION BORDER
+	[resolution]
+
+		{RESOLUTION}
+
+		left_border = {BORDER}
+		right_border = {BORDER}
+		top_border = {BORDER}
+		bottom_border = {BORDER}
+
+		[background]
+
+			[draw]
+
+				[image]
+					name = "(if(text = '', 'story/landscape-battlefield_nohumans.jpg', text) .. '~O(0.25)')"
+					x = "(max(0, (width - (width / (image_original_width/image_original_height))) / 2))"
+					w = "(width / (image_original_width/image_original_height))"
+					h = "(height * (image_original_width/image_original_height))"
+				[/image]
+
+				[rectangle]
+					x = 0
+					y = 0
+					w = "(width)"
+					h = "(height)"
+
+					border_thickness = 3
+					border_color = "16, 22, 35, 255"
+				[/rectangle]
+
+				[rectangle]
+					x = 1
+					y = 1
+					w = "(width - 2)"
+					h = "(height - 2)"
+
+					border_thickness = 1
+					border_color = {GUI__BORDER_COLOR_DARK}
+				[/rectangle]
+
+				[image]
+					x = 3
+					y = 3
+					w = "(width - 6)"
+					h = "(height - 6)"
+					name = "dialogs/translucent54-background.png"
+				[/image]
+
+			[/draw]
+
+		[/background]
+
+		[foreground]
+
+			[draw]
+
+			[/draw]
+
+		[/foreground]
+
+	[/resolution]
+#enddef
+
+[panel_definition]
+
+	id = "campaign_menu_bg"
+	description = "Definition of the dynamic background panel for the Campaigns menu"
+
+	{_GUI_RESOLUTION () 3}
+
+[/panel_definition]
+
+#undef _GUI_RESOLUTION

--- a/data/gui/widget/panel_campaign_menu.cfg
+++ b/data/gui/widget/panel_campaign_menu.cfg
@@ -32,6 +32,8 @@
 
 					border_thickness = 3
 					border_color = "16, 22, 35, 255"
+
+					fill_color = {GUI__BACKGROUND_COLOR_ENABLED ALPHA=138}
 				[/rectangle]
 
 				[rectangle]
@@ -43,14 +45,6 @@
 					border_thickness = 1
 					border_color = {GUI__BORDER_COLOR_DARK}
 				[/rectangle]
-
-				[image]
-					x = 3
-					y = 3
-					w = "(width - 6)"
-					h = "(height - 6)"
-					name = "dialogs/translucent54-background.png"
-				[/image]
 
 			[/draw]
 

--- a/data/gui/widget/panel_listbox_bg.cfg
+++ b/data/gui/widget/panel_listbox_bg.cfg
@@ -1,0 +1,39 @@
+#textdomain wesnoth-lib
+###
+### Panel with identical background to a default toggle_panel.
+###
+
+[panel_definition]
+
+	id = "panel_listbox_bg"
+	description = "Panel with identical background to a default toggle_panel."
+
+	[resolution]
+
+		[background]
+
+			[draw]
+
+				[rectangle]
+					x = 0
+					y = 0
+					w = "(width)"
+					h = "(height)"
+					fill_color = {GUI__BACKGROUND_COLOR_ENABLED}
+				[/rectangle]
+
+			[/draw]
+
+		[/background]
+
+		[foreground]
+
+			[draw]
+
+			[/draw]
+
+		[/foreground]
+
+	[/resolution]
+
+[/panel_definition]

--- a/data/gui/widget/toggle_button_listbox_header.cfg
+++ b/data/gui/widget/toggle_button_listbox_header.cfg
@@ -4,9 +4,9 @@
 ### Since for this class 'default' is a bit hard we now use the checkbox as default.
 ###
 
-#define _GUI_TEXT FONT_SIZE FONT_COLOR
+#define _GUI_TEXT HORIZONTAL_POSITION FONT_SIZE FONT_COLOR
 	[text]
-		x = 5
+		x = {HORIZONTAL_POSITION}
 		y = {GUI__TEXT_VERTICALLY_CENTRED}
 		w = "(width)"
 		h =  "(text_height)"
@@ -17,6 +17,9 @@
 #enddef
 
 #define _GUI_RESOLUTION RESOLUTION WIDTH HEIGHT FONT_SIZE
+#arg HORIZONTAL_POSITION
+5 #endarg
+
 	[resolution]
 
 		{RESOLUTION}
@@ -38,7 +41,7 @@
 
 			[draw]
 
-				{_GUI_TEXT ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__TITLE}) }
+				{_GUI_TEXT ({HORIZONTAL_POSITION}) ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__TITLE}) }
 
 			[/draw]
 
@@ -48,7 +51,7 @@
 
 			[draw]
 
-				{_GUI_TEXT ({FONT_SIZE}) ({GUI__FONT_COLOR_DISABLED__TITLE}) }
+				{_GUI_TEXT ({HORIZONTAL_POSITION}) ({FONT_SIZE}) ({GUI__FONT_COLOR_DISABLED__TITLE}) }
 
 			[/draw]
 
@@ -66,7 +69,7 @@
 					fill_color = "255, 255, 255, 76"
 				[/rectangle]
 
-				{_GUI_TEXT ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__TITLE}) }
+				{_GUI_TEXT ({HORIZONTAL_POSITION}) ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__TITLE}) }
 
 			[/draw]
 
@@ -90,7 +93,7 @@
 					fill_color = "255, 255, 255, 25"
 				[/rectangle]
 
-				{_GUI_TEXT ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__TITLE}) }
+				{_GUI_TEXT ({HORIZONTAL_POSITION}) ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__TITLE}) }
 
 				[image]
 					x = "(width - 15)"
@@ -104,7 +107,7 @@
 		[disabled]
 
 			[draw]
-				{_GUI_TEXT ({FONT_SIZE}) ({GUI__FONT_COLOR_DISABLED__TITLE}) }
+				{_GUI_TEXT ({HORIZONTAL_POSITION}) ({FONT_SIZE}) ({GUI__FONT_COLOR_DISABLED__TITLE}) }
 
 				[image]
 					x = "(width - 15)"
@@ -128,7 +131,7 @@
 					fill_color = "255, 255, 255, 76"
 				[/rectangle]
 
-				{_GUI_TEXT ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__TITLE}) }
+				{_GUI_TEXT ({HORIZONTAL_POSITION}) ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__TITLE}) }
 
 				[image]
 					x = "(width - 15)"
@@ -157,7 +160,7 @@
 					fill_color = "255, 255, 255, 25"
 				[/rectangle]
 
-				{_GUI_TEXT ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__TITLE}) }
+				{_GUI_TEXT ({HORIZONTAL_POSITION}) ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__TITLE}) }
 
 				[image]
 					x = "(width - 15)"
@@ -171,7 +174,7 @@
 		[disabled]
 
 			[draw]
-				{_GUI_TEXT ({FONT_SIZE}) ({GUI__FONT_COLOR_DISABLED__TITLE}) }
+				{_GUI_TEXT ({HORIZONTAL_POSITION}) ({FONT_SIZE}) ({GUI__FONT_COLOR_DISABLED__TITLE}) }
 
 				[image]
 					x = "(width - 15)"
@@ -195,7 +198,7 @@
 					fill_color = "255, 255, 255, 76"
 				[/rectangle]
 
-				{_GUI_TEXT ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__TITLE}) }
+				{_GUI_TEXT ({HORIZONTAL_POSITION}) ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__TITLE}) }
 
 				[image]
 					x = "(width - 15)"
@@ -217,6 +220,15 @@
 	description = "Checkbox."
 
 	{_GUI_RESOLUTION () 30 20 ({GUI_FONT_SIZE_SMALL}) }
+
+[/toggle_button_definition]
+
+[toggle_button_definition]
+
+	id = "listbox_header_centered"
+	description = "Checkbox, centered."
+
+	{_GUI_RESOLUTION () 30 20 ({GUI_FONT_SIZE_SMALL}) HORIZONTAL_POSITION={GUI__TEXT_HORIZONTALLY_CENTRED}}
 
 [/toggle_button_definition]
 

--- a/data/gui/widget/toggle_button_listbox_header_bg.cfg
+++ b/data/gui/widget/toggle_button_listbox_header_bg.cfg
@@ -1,0 +1,228 @@
+#textdomain wesnoth-lib
+###
+### Definition of the default toggle button.
+### Since for this class 'default' is a bit hard we now use the checkbox as default.
+###
+
+#define _GUI_TEXT HORIZONTAL_POSITION FONT_SIZE FONT_COLOR
+	[text]
+		x = {HORIZONTAL_POSITION}
+		y = {GUI__TEXT_VERTICALLY_CENTRED}
+		w = "(width)"
+		h =  "(text_height)"
+		font_size = {FONT_SIZE}
+		color = {FONT_COLOR}
+		text = "(text)"
+	[/text]
+#enddef
+
+#define _GUI_BG BACKGROUND_COLOR
+	[rectangle]
+		x = 0
+		y = 0
+		w = "(width)"
+		h = "(height)"
+		fill_color = {BACKGROUND_COLOR}
+	[/rectangle]
+#enddef
+
+#define _GUI_RESOLUTION RESOLUTION WIDTH HEIGHT FONT_SIZE
+#arg HORIZONTAL_POSITION
+5 #endarg
+
+	[resolution]
+
+		{RESOLUTION}
+
+		min_width = {WIDTH}
+		min_height = {HEIGHT}
+
+		default_width = {WIDTH}
+		default_height = {HEIGHT}
+
+		max_width = 0
+		max_height = {HEIGHT}
+
+		text_extra_width = 0
+		text_font_size = {FONT_SIZE}
+
+		[state]
+			[enabled]
+
+				[draw]
+
+					{_GUI_BG ({GUI__BACKGROUND_COLOR_ENABLED})}
+
+					{_GUI_TEXT ({HORIZONTAL_POSITION}) ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__TITLE}) }
+
+				[/draw]
+
+			[/enabled]
+
+			[disabled]
+
+				[draw]
+
+					{_GUI_BG ({GUI__BACKGROUND_COLOR_ENABLED})}
+
+					{_GUI_TEXT ({HORIZONTAL_POSITION}) ({FONT_SIZE}) ({GUI__FONT_COLOR_DISABLED__TITLE}) }
+
+				[/draw]
+
+			[/disabled]
+
+			[focused]
+
+				[draw]
+
+					{_GUI_BG ({GUI__BACKGROUND_COLOR_ENABLED})}
+
+					{_GUI_TEXT ({HORIZONTAL_POSITION}) ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__TITLE}) }
+
+				[/draw]
+
+			[/focused]
+		[/state]
+
+		###
+		### Down
+		###
+
+		[state]
+			[enabled]
+
+				[draw]
+
+					{_GUI_BG ({GUI__BACKGROUND_COLOR_ENABLED})}
+
+					{_GUI_TEXT ({HORIZONTAL_POSITION}) ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__TITLE}) }
+
+					[image]
+						x = "(width - 15)"
+						y = "(height / 3)"
+						name = "buttons/sliders/slider_arrow_blue.png"
+					[/image]
+				[/draw]
+
+			[/enabled]
+
+			[disabled]
+
+				[draw]
+
+					{_GUI_BG ({GUI__BACKGROUND_COLOR_ENABLED})}
+
+					{_GUI_TEXT ({HORIZONTAL_POSITION}) ({FONT_SIZE}) ({GUI__FONT_COLOR_DISABLED__TITLE}) }
+
+					[image]
+						x = "(width - 15)"
+						y = "(height / 3)"
+						name = "buttons/sliders/slider_arrow_blue.png~GS()"
+					[/image]
+
+				[/draw]
+
+			[/disabled]
+
+			[focused]
+
+				[draw]
+
+					{_GUI_BG ({GUI__BACKGROUND_COLOR_ENABLED})}
+
+					{_GUI_TEXT ({HORIZONTAL_POSITION}) ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__TITLE}) }
+
+					[image]
+						x = "(width - 15)"
+						y = "(height / 3)"
+						name = "buttons/sliders/slider_arrow_blue.png"
+					[/image]
+
+				[/draw]
+
+			[/focused]
+		[/state]
+
+		###
+		### Up
+		###
+
+		[state]
+			[enabled]
+
+				[draw]
+
+					{_GUI_BG ({GUI__BACKGROUND_COLOR_ENABLED})}
+
+					{_GUI_TEXT ({HORIZONTAL_POSITION}) ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__TITLE}) }
+
+					[image]
+						x = "(width - 15)"
+						y = "(height / 3)"
+						name = "buttons/sliders/slider_arrow_blue.png~ROTATE(180)"
+					[/image]
+				[/draw]
+
+			[/enabled]
+
+			[disabled]
+
+				[draw]
+
+					{_GUI_BG ({GUI__BACKGROUND_COLOR_ENABLED})}
+
+					{_GUI_TEXT ({HORIZONTAL_POSITION}) ({FONT_SIZE}) ({GUI__FONT_COLOR_DISABLED__TITLE}) }
+
+					[image]
+						x = "(width - 15)"
+						y = "(height / 3)"
+						name = "buttons/sliders/slider_arrow_blue.png~ROTATE(180)~GS()"
+					[/image]
+
+				[/draw]
+
+			[/disabled]
+
+			[focused]
+
+				[draw]
+
+					{_GUI_BG ({GUI__BACKGROUND_COLOR_ENABLED})}
+
+					{_GUI_TEXT ({HORIZONTAL_POSITION}) ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__TITLE}) }
+
+					[image]
+						x = "(width - 15)"
+						y = "(height / 3)"
+						name = "buttons/sliders/slider_arrow_blue.png~ROTATE(180)"
+					[/image]
+
+				[/draw]
+
+			[/focused]
+		[/state]
+
+	[/resolution]
+#enddef
+
+[toggle_button_definition]
+
+	id = "listbox_header_bg"
+	description = "Checkbox."
+
+	{_GUI_RESOLUTION () 30 20 ({GUI_FONT_SIZE_SMALL}) }
+
+[/toggle_button_definition]
+
+[toggle_button_definition]
+
+	id = "listbox_header_centered_bg"
+	description = "Checkbox, centered."
+
+	{_GUI_RESOLUTION () 30 20 ({GUI_FONT_SIZE_SMALL}) HORIZONTAL_POSITION={GUI__TEXT_HORIZONTALLY_CENTRED}}
+
+[/toggle_button_definition]
+
+#undef _GUI_BG
+#undef _GUI_TEXT
+#undef _GUI_RESOLUTION

--- a/data/gui/window/campaign_dialog.cfg
+++ b/data/gui/window/campaign_dialog.cfg
@@ -227,7 +227,7 @@
 										[toggle_button]
 											definition = "listbox_header_centered"
 											id = "sort_time"
-											label = _"Dates"
+											label = _"Timeline"
 											tooltip = _"Sort in approximate chronological order of story events"
 										[/toggle_button]
 									[/column]

--- a/data/gui/window/campaign_dialog.cfg
+++ b/data/gui/window/campaign_dialog.cfg
@@ -126,6 +126,246 @@
 	[/tree_view]
 #enddef
 
+#define _GUI_CAMPAIGN_DESCRIPTION
+	[row]
+		grow_factor = 0
+		[column]
+			horizontal_grow = true
+			vertical_alignment = "top"
+			border = "all"
+			border_size = 5
+
+			[label]
+				id = "description"
+				wrap = true
+				link_aware = true
+			[/label]
+		[/column]
+	[/row]
+
+	[row]
+		grow_factor = 1
+		[column]
+			horizontal_alignment = "center"
+			vertical_alignment = "center"
+			border = "all"
+			border_size = 5
+
+			[image]
+				id = "image"
+			[/image]
+		[/column]
+	[/row]
+#enddef
+
+#define _GUI_CAMPAIGN_RIGHT_PANE
+	[multi_page]
+		id = "campaign_details"
+		horizontal_scrollbar_mode = "never"
+
+		[page_definition]
+			[row]
+				[column]
+					horizontal_grow = true
+					vertical_grow = true
+
+					[scrollbar_panel]
+						[definition]
+							{_GUI_CAMPAIGN_DESCRIPTION}
+						[/definition]
+					[/scrollbar_panel]
+				[/column]
+			[/row]
+		[/page_definition]
+	[/multi_page]
+#enddef
+
+#define _GUI_CAMPAIGN_SELECTION_CONTAINER
+	[grid]
+		[row]
+			#
+			# Campaign list column
+			#
+			[column]
+				grow_factor = 1
+				horizontal_grow = true
+				[grid]
+					#
+					# Campaign list sorting header
+					#
+					[row]
+						grow_factor = 1
+						[column]
+							grow_factor = 0
+							horizontal_grow = true
+							border = "left,right,top"
+							border_size = 5
+							[panel]
+								definition = "panel_listbox_bg"
+								[grid]
+								[row]
+									[column]
+										grow_factor = 1
+										horizontal_grow = true
+										border = "all"
+										border_size = 5
+
+										[toggle_button]
+											definition = "listbox_header_centered"
+											id = "sort_name"
+											label = _"Name"
+											tooltip = _"Sort by full campaign name in alphabetical order"
+										[/toggle_button]
+									[/column]
+
+									[column]
+										grow_factor = 1
+										horizontal_grow = true
+										border = "all"
+										border_size = 5
+
+										[toggle_button]
+											definition = "listbox_header_centered"
+											id = "sort_time"
+											label = _"Dates"
+											tooltip = _"Sort in approximate chronological order of story events"
+										[/toggle_button]
+									[/column]
+								[/row]
+								[/grid]
+							[/panel]
+						[/column]
+					[/row]
+					#
+					# Campaign list tree view
+					#
+					[row]
+						grow_factor = 1
+						[column]
+							grow_factor = 0
+							horizontal_grow = true
+							border = "left,bottom,right"
+							border_size = 5
+
+							{_GUI_CAMPAIGN_TREE}
+						[/column]
+					[/row]
+				[/grid]
+			[/column]
+			#
+			# Campaign description column
+			#
+			[column]
+				grow_factor = 1
+				horizontal_grow = true
+				border = "all"
+				border_size = 5
+
+				{_GUI_CAMPAIGN_RIGHT_PANE}
+			[/column]
+		[/row]
+	[/grid]
+#enddef
+
+#define _GUI_CAMPAIGN_OPTIONS_CONTAINER
+	[grid]
+		[row]
+			[column]
+				grow_factor = 0
+				horizontal_alignment = "right"
+				border = "all"
+				border_size = 5
+
+				[label]
+					definition = "default_small"
+					label = _ "Modifications:"
+				[/label]
+			[/column]
+
+			[column]
+				grow_factor = 0
+				horizontal_grow = true
+				border = "all"
+				border_size = 5
+
+				[multimenu_button]
+					id = "mods_menu"
+				[/multimenu_button]
+			[/column]
+
+			[column]
+				grow_factor = 0
+				horizontal_alignment = "right"
+				border = "all"
+				border_size = 5
+
+				[label]
+					definition = "default_small"
+					label = _ "Combat:"
+				[/label]
+			[/column]
+
+			[column]
+				grow_factor = 0
+				horizontal_grow = true
+				border = "all"
+				border_size = 5
+
+				[menu_button]
+					id = "rng_menu"
+					use_markup = true
+
+					[option]
+						label = _ "Default RNG"
+						details = "<span color='#777'>" + _ "Reloading alters future combat outcomes" + "</span>"
+					[/option]
+					[option]
+						label = _ "Predictable RNG"
+						details = "<span color='#777'>" + _ "Combat outcomes remain constant when reloading" + "</span>"
+					[/option]
+					#[option]
+					#	label = _ "Biased RNG"
+					#	details = "<span color='#777'>" + _ "Combat outcomes are more in line with displayed probabilities and unaffected by reloading" + "</span>"
+					#[/option]
+				[/menu_button]
+			[/column]
+
+			[column]
+				grow_factor = 0
+				horizontal_alignment = "right"
+				border = "all"
+				border_size = 5
+
+				[label]
+					definition = "default_small"
+					label = _ "Difficulty:"
+				[/label]
+			[/column]
+
+			[column]
+				grow_factor = 0
+				horizontal_grow = true
+				border = "all"
+				border_size = 5
+
+				[menu_button]
+					id = "difficulty_menu"
+
+					[option]
+						label = _ "Easy"
+					[/option]
+					[option]
+						label = _ "Normal"
+					[/option]
+					[option]
+						label = _ "Hard"
+					[/option]
+				[/menu_button]
+			[/column]
+		[/row]
+	[/grid]
+#enddef
+
 [window]
 	id = "campaign_selection"
 	description = "Campaign selection dialog."
@@ -158,326 +398,112 @@
 		[/helptip]
 
 		[grid]
-
+			#
+			# Caption/search row
+			#
 			[row]
-
 				[column]
-					grow_factor = 0
-					border = "all"
-					border_size = 5
-					horizontal_alignment = "left"
-					vertical_alignment = "top"
-
-					[label]
-						definition = "title"
-						label = _ "Play a Campaign"
-					[/label]
-
-				[/column]
-
-				[column]
-					grow_factor = 1
-					border = "all"
-					border_size = 5
-					horizontal_alignment = "right"
-
-					[text_box]
-						id = "filter_box"
-						definition = "default"
-						{FILTER_TEXT_BOX_HINT}
-					[/text_box]
-
-				[/column]
-
-			[/row]
-
-			[row]
-				grow_factor = 1
-
-				[column]
-					grow_factor = 1
-
 					horizontal_grow = true
-
 					[grid]
-
 						[row]
-
 							[column]
 								grow_factor = 0
-
-								[grid]
-
-									[row]
-										grow_factor = 1
-
-										[column]
-											grow_factor = 0
-											horizontal_grow = true
-
-											[grid]
-
-												[row]
-
-													[column]
-														grow_factor = 1
-														border = "all"
-														border_size = 5
-														horizontal_grow = true
-
-														[toggle_button]
-															definition = "listbox_header"
-															id = "sort_name"
-															label = _"Name"
-															tooltip = _"Sort by full campaign name in alphabetical order"
-														[/toggle_button]
-													[/column]
-
-													[column]
-														grow_factor = 1
-														border = "all"
-														border_size = 5
-														horizontal_grow = true
-
-														[toggle_button]
-															definition = "listbox_header"
-															id = "sort_time"
-															label = _"Dates"
-															tooltip = _"Sort in approximate chronological order of story events"
-														[/toggle_button]
-													[/column]
-
-												[/row]
-
-											[/grid]
-
-										[/column]
-
-									[/row]
-
-									[row]
-										grow_factor = 1
-
-										[column]
-											grow_factor = 0
-
-											border = "all"
-											border_size = 5
-											horizontal_grow = true
-
-											{_GUI_CAMPAIGN_TREE}
-
-										[/column]
-
-									[/row]
-
-									[row]
-
-										[column]
-											grow_factor = 1
-											horizontal_grow = true
-											border = "all"
-											border_size = 5
-
-											[label]
-												definition = "default"
-												label = _ "Modifications"
-											[/label]
-
-										[/column]
-
-									[/row]
-
-									[row]
-
-										[column]
-											grow_factor = 1
-											horizontal_grow = true
-											border = "all"
-											border_size = 5
-
-											[multimenu_button]
-												id = "mods_menu"
-												definition = "default"
-											[/multimenu_button]
-
-										[/column]
-
-									[/row]
-
-								[/grid]
-
-							[/column]
-
-						[/row]
-
-					[/grid]
-
-				[/column]
-
-				[column]
-
-					[grid]
-
-						[row]
-
-							[column]
-								grow_factor = 1
-								horizontal_grow = true
-
+								horizontal_alignment = "left"
+								vertical_alignment = "top"
 								border = "all"
 								border_size = 5
-								vertical_alignment = "top"
 
-								[multi_page]
-									id = "campaign_details"
-									definition = "default"
-
-									horizontal_scrollbar_mode = "never"
-
-									[page_definition]
-
-										[row]
-
-											[column]
-												horizontal_grow = true
-												vertical_alignment = "top"
-
-												[scrollbar_panel]
-
-													[definition]
-
-														[row]
-															grow_factor = 0
-
-															[column]
-																border = "all"
-																border_size = 5
-																horizontal_grow = true
-																vertical_alignment = "top"
-
-																[label]
-																	id = "description"
-																	definition = "default"
-
-																	wrap = true
-																	link_aware = true
-																[/label]
-
-															[/column]
-
-														[/row]
-
-														[row]
-															grow_factor = 1
-
-															[column]
-																border = "all"
-																border_size = 5
-																horizontal_alignment = "center"
-																vertical_alignment = "top"
-
-																[image]
-																	id = "image"
-																	definition = "default"
-																[/image]
-
-															[/column]
-
-														[/row]
-
-													[/definition]
-
-												[/scrollbar_panel]
-
-											[/column]
-
-										[/row]
-
-									[/page_definition]
-
-								[/multi_page]
-
+								[label]
+									definition = "title"
+									label = _ "Play a Campaign"
+								[/label]
 							[/column]
-
-						[/row]
-
-						[row]
-							grow_factor = 0
 
 							[column]
 								grow_factor = 1
-								horizontal_grow = true
+								horizontal_alignment = "right"
+								border = "all"
+								border_size = 5
 
-								[grid]
+								[text_box]
+									id = "filter_box"
+									definition = "default"
+									{FILTER_TEXT_BOX_HINT}
+								[/text_box]
+							[/column]
+						[/row]
+					[/grid]
+				[/column]
+			[/row]
+			#
+			# Central (list/description pane) row
+			#
+			[row]
+				grow_factor = 1
+				[column]
+					horizontal_alignment = "center"
+					border = "all"
+					border_size = 5
 
-									[row]
-										grow_factor = 0
+					[panel]
+						id = "campaign_background"
+						definition = "campaign_menu_bg"
 
-										[column]
-											border = "all"
-											border_size = 5
+						{_GUI_CAMPAIGN_SELECTION_CONTAINER}
+					[/panel]
+				[/column]
+			[/row]
+			#
+			# Settings row
+			#
+			[row]
+				[column]
+					horizontal_grow = true
 
-											grow_factor = 1
-											horizontal_alignment = "left"
-											vertical_alignment = "bottom"
+					{_GUI_CAMPAIGN_OPTIONS_CONTAINER}
+				[/column]
+			[/row]
+			#
+			# Control box
+			#
+			[row]
+				[column]
+					horizontal_alignment = "right"
+					[grid]
+						[row]
+							[column]
+								horizontal_alignment = "right"
+								border = "all"
+								border_size = 5
 
-											[toggle_button]
-												id = "checkbox_deterministic"
-												label = _ "Save random seed"
-												definition = "default"
-												tooltip = _ "Makes the random number generator yield the same results even after reloading a game"
-											[/toggle_button]
-
-										[/column]
-
-										[column]
-											border = "all"
-											border_size = 5
-
-											horizontal_alignment = "right"
-
-											[button]
-												id = "ok"
-												definition = "really_large"
-
-												label = _ "game^Play"
-											[/button]
-
-										[/column]
-
-										[column]
-											border = "all"
-											border_size = 5
-											horizontal_alignment = "right"
-
-											[button]
-												id = "cancel"
-												definition = "default"
-
-												label = _ "Cancel"
-											[/button]
-
-										[/column]
-
-									[/row]
-
-								[/grid]
-
+								[button]
+									id = "ok"
+									definition = "really_large"
+									label = _ "game^Play"
+								[/button]
 							[/column]
 
+							[column]
+								horizontal_alignment = "right"
+								border = "all"
+								border_size = 5
+
+								[button]
+									id = "cancel"
+									label = _ "Cancel"
+								[/button]
+							[/column]
 						[/row]
-
 					[/grid]
-
 				[/column]
-
 			[/row]
-
 		[/grid]
-
 	[/resolution]
 
 [/window]
 
+#undef _GUI_CAMPAIGN_OPTIONS_CONTAINER
+#undef _GUI_CAMPAIGN_SELECTION_CONTAINER
+#undef _GUI_CAMPAIGN_RIGHT_PANE
+#undef _GUI_CAMPAIGN_DESCRIPTION
 #undef _GUI_CAMPAIGN_TREE

--- a/data/gui/window/campaign_dialog.cfg
+++ b/data/gui/window/campaign_dialog.cfg
@@ -272,7 +272,7 @@
 		[row]
 			[column]
 				grow_factor = 0
-				horizontal_alignment = "right"
+				horizontal_alignment = "left"
 				border = "all"
 				border_size = 5
 
@@ -283,7 +283,7 @@
 			[/column]
 
 			[column]
-				grow_factor = 0
+				grow_factor = 1
 				horizontal_grow = true
 				border = "all"
 				border_size = 5
@@ -292,6 +292,8 @@
 					id = "mods_menu"
 				[/multimenu_button]
 			[/column]
+
+			{GUI_FILLER WIDTH=10}
 
 			[column]
 				grow_factor = 0
@@ -306,7 +308,7 @@
 			[/column]
 
 			[column]
-				grow_factor = 0
+				grow_factor = 1
 				horizontal_grow = true
 				border = "all"
 				border_size = 5
@@ -317,18 +319,20 @@
 
 					[option]
 						label = _ "Default RNG"
-						details = "<span color='#777'>" + _ "Reloading alters future combat outcomes" + "</span>"
+						tooltip = _ "Reloading alters future combat outcomes"
 					[/option]
 					[option]
 						label = _ "Predictable RNG"
-						details = "<span color='#777'>" + _ "Combat outcomes remain constant when reloading" + "</span>"
+						tooltip = _ "Combat outcomes remain constant when reloading"
 					[/option]
 					[option]
 						label = _ "Biased RNG (experimental)"
-						details = "<span color='#777'>" + _ "Combat outcomes are more in line with displayed probabilities and unaffected by reloading" + "</span>"
+						tooltip = _ "Combat outcomes are more in line with displayed probabilities and unaffected by reloading"
 					[/option]
 				[/menu_button]
 			[/column]
+
+			{GUI_FILLER WIDTH=10}
 
 			[column]
 				grow_factor = 0
@@ -343,7 +347,7 @@
 			[/column]
 
 			[column]
-				grow_factor = 0
+				grow_factor = 1
 				horizontal_grow = true
 				border = "all"
 				border_size = 5

--- a/data/gui/window/campaign_dialog.cfg
+++ b/data/gui/window/campaign_dialog.cfg
@@ -323,10 +323,10 @@
 						label = _ "Predictable RNG"
 						details = "<span color='#777'>" + _ "Combat outcomes remain constant when reloading" + "</span>"
 					[/option]
-					#[option]
-					#	label = _ "Biased RNG"
-					#	details = "<span color='#777'>" + _ "Combat outcomes are more in line with displayed probabilities and unaffected by reloading" + "</span>"
-					#[/option]
+					[option]
+						label = _ "Biased RNG (experimental)"
+						details = "<span color='#777'>" + _ "Combat outcomes are more in line with displayed probabilities and unaffected by reloading" + "</span>"
+					[/option]
 				[/menu_button]
 			[/column]
 

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -25,6 +25,7 @@
 #include "ai/lua/aspect_advancements.hpp"
 #include "formula/callable_objects.hpp"
 #include "formula/formula.hpp"
+#include "game_classification.hpp"
 #include "game_config.hpp"
 #include "game_data.hpp"
 #include "game_events/pump.hpp"
@@ -861,7 +862,7 @@ attack::attack(const map_location& attacker,
 	, OOS_error_(false)
 
 	//new experimental prng mode.
-	, use_prng_(preferences::get("use_prng") == "yes" && randomness::generator->is_networked() == false)
+	, use_prng_(resources::classification->random_mode == "biased" && randomness::generator->is_networked() == false)
 {
 	if(use_prng_) {
 		std::cerr << "Using experimental PRNG for combat\n";

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -865,7 +865,7 @@ attack::attack(const map_location& attacker,
 	, use_prng_(resources::classification->random_mode == "biased" && randomness::generator->is_networked() == false)
 {
 	if(use_prng_) {
-		std::cerr << "Using experimental PRNG for combat\n";
+		LOG_NG << "Using experimental PRNG for combat\n";
 	}
 }
 

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -863,6 +863,8 @@ attack::attack(const map_location& attacker,
 
 	//new experimental prng mode.
 	, use_prng_(resources::classification->random_mode == "biased" && randomness::generator->is_networked() == false)
+	, prng_attacker_()
+	, prng_defender_()
 {
 	if(use_prng_) {
 		LOG_NG << "Using experimental PRNG for combat\n";

--- a/src/game_initialization/singleplayer.cpp
+++ b/src/game_initialization/singleplayer.cpp
@@ -60,8 +60,16 @@ bool enter_create_mode(saved_game& state, jump_to_campaign_info jump_to_campaign
 				return false;
 			}
 
-			if(dlg.get_rng_mode() != gui2::dialogs::campaign_selection::RNG_DEFAULT) {
-				random_mode = "deterministic";
+			switch(dlg.get_rng_mode()) {
+				case gui2::dialogs::campaign_selection::RNG_DEFAULT:
+					random_mode = "";
+					break;
+				case gui2::dialogs::campaign_selection::RNG_SAVE_SEED:
+					random_mode = "deterministic";
+					break;
+				case gui2::dialogs::campaign_selection::RNG_BIASED:
+					random_mode = "biased";
+					break;
 			}
 
 			difficulty = dlg.get_difficulty();

--- a/src/game_initialization/singleplayer.cpp
+++ b/src/game_initialization/singleplayer.cpp
@@ -43,7 +43,7 @@ bool enter_create_mode(saved_game& state, jump_to_campaign_info jump_to_campaign
 			return false;
 		}
 
-		std::string random_mode = "";
+		std::string random_mode = "", difficulty = "";
 
 		// No campaign selected from command line
 		if(jump_to_campaign.campaign_id_.empty()) {
@@ -60,9 +60,11 @@ bool enter_create_mode(saved_game& state, jump_to_campaign_info jump_to_campaign
 				return false;
 			}
 
-			if(dlg.get_deterministic()) {
+			if(dlg.get_rng_mode() != gui2::dialogs::campaign_selection::RNG_DEFAULT) {
 				random_mode = "deterministic";
 			}
+
+			difficulty = dlg.get_difficulty();
 		} else {
 			// Don't reset the campaign_id_ so we can know
 			// if we should quit the game or return to the main menu
@@ -83,7 +85,7 @@ bool enter_create_mode(saved_game& state, jump_to_campaign_info jump_to_campaign
 
 		state.classification().random_mode = random_mode;
 
-		const std::string selected_difficulty = create_eng.select_campaign_difficulty(jump_to_campaign.difficulty_);
+		const auto selected_difficulty = difficulty;
 
 		if(selected_difficulty == "FAIL") return false;
 		if(selected_difficulty == "CANCEL") {

--- a/src/gui/dialogs/campaign_selection.cpp
+++ b/src/gui/dialogs/campaign_selection.cpp
@@ -118,7 +118,7 @@ void campaign_selection::campaign_selected()
 
 		if(!diff_config.empty()) {
 			std::vector<config> entry_list;
-			unsigned n = 0, selection = 0;
+			unsigned n = 0, selection = 0, max_n = diff_config.child_count("difficulty");
 
 			for(const auto& cfg : diff_config.child_range("difficulty")) {
 				config entry;
@@ -126,6 +126,20 @@ void campaign_selection::campaign_selected()
 				// FIXME: description may have markup that will display weird on the menu_button proper
 				entry["label"] = cfg["label"].str() + " (" + cfg["description"].str() + ")";
 				entry["image"] = cfg["image"].str("misc/blank-hex.png");
+
+				if(preferences::is_campaign_completed(tree.selected_item()->id(), cfg["define"])) {
+					std::string laurel;
+
+					if(n + 1 >= max_n) {
+						laurel = game_config::images::victory_laurel_hardest;
+					} else if(n == 0) {
+						laurel = game_config::images::victory_laurel_easy;
+					} else {
+						laurel = game_config::images::victory_laurel;
+					}
+
+					entry["image"] = laurel + "~BLIT(" + entry["image"] + ")";
+				}
 
 				if(!cfg["description"].empty()) {
 					std::string desc;

--- a/src/gui/dialogs/campaign_selection.cpp
+++ b/src/gui/dialogs/campaign_selection.cpp
@@ -16,10 +16,13 @@
 
 #include "gui/dialogs/campaign_selection.hpp"
 
+#include "font/text_formatting.hpp"
+#include "gui/dialogs/campaign_difficulty.hpp"
 #include "gui/auxiliary/find_widget.hpp"
 #include "gui/widgets/button.hpp"
 #include "gui/widgets/image.hpp"
 #include "gui/widgets/listbox.hpp"
+#include "gui/widgets/menu_button.hpp"
 #include "gui/widgets/multi_page.hpp"
 #include "gui/widgets/multimenu_button.hpp"
 #include "gui/widgets/scroll_label.hpp"
@@ -39,6 +42,7 @@ namespace gui2
 {
 namespace dialogs
 {
+
 /*WIKI
  * @page = GUIWindowDefinitionWML
  * @order = 2_campaign_selection
@@ -79,7 +83,7 @@ namespace dialogs
 
 REGISTER_DIALOG(campaign_selection)
 
-void campaign_selection::campaign_selected() const
+void campaign_selection::campaign_selected()
 {
 	tree_view& tree = find_widget<tree_view>(get_window(), "campaign_tree", false);
 	if(tree.empty()) {
@@ -100,10 +104,73 @@ void campaign_selection::campaign_selected() const
 		pages.select_page(choice);
 
 		engine_.set_current_level(choice);
+
+		styled_widget& background = find_widget<styled_widget>(get_window(), "campaign_background", false);
+		background.set_label(engine_.current_level().data()["background"].str());
+
+		// Rebuild difficulty menu
+		difficulties_.clear();
+
+		auto& diff_menu = find_widget<menu_button>(get_window(), "difficulty_menu", false);
+
+		const auto& diff_config = generate_difficulty_config(engine_.current_level().data());
+		diff_menu.set_active(diff_config.child_count("difficulty") > 1);
+
+		if(!diff_config.empty()) {
+			std::vector<config> entry_list;
+			unsigned n = 0, selection = 0;
+
+			for(const auto& cfg : diff_config.child_range("difficulty")) {
+				config entry;
+
+				// FIXME: description may have markup that will display weird on the menu_button proper
+				entry["label"] = cfg["label"].str() + " (" + cfg["description"].str() + ")";
+				entry["image"] = cfg["image"].str("misc/blank-hex.png");
+
+				if(!cfg["description"].empty()) {
+					std::string desc;
+					if(cfg["auto_markup"].to_bool(true) == false) {
+						desc = cfg["description"].str();
+					} else {
+						//desc = "<small>";
+						if(!cfg["old_markup"].to_bool()) {
+							desc += font::span_color(font::GRAY_COLOR) + "(" + cfg["description"].str() + ")</span>";
+						} else {
+							desc += font::span_color(font::GRAY_COLOR) + cfg["description"].str() + "</span>";
+						}
+						//desc += "</small>";
+					}
+
+					// Icons get displayed instead of the labels on the dropdown menu itself,
+					// so we want to prepend each label to its description here
+					desc = cfg["label"].str() + "\n" + desc;
+
+					entry["details"] = std::move(desc);
+				}
+
+				entry_list.emplace_back(std::move(entry));
+				difficulties_.emplace_back(cfg["define"].str());
+
+				if(cfg["default"].to_bool(false)) {
+					selection = n;
+				}
+
+				++n;
+			}
+
+			diff_menu.set_values(entry_list);
+			diff_menu.set_selected(selection);
+		}
 	}
 }
 
-void campaign_selection::sort_campaigns(campaign_selection::CAMPAIGN_ORDER order, bool ascending) const
+void campaign_selection::difficulty_selected()
+{
+	const std::size_t selection = find_widget<menu_button>(get_window(), "difficulty_menu", false).get_value();
+	current_difficulty_ = difficulties_.at(std::min(difficulties_.size() - 1, selection));
+}
+
+void campaign_selection::sort_campaigns(campaign_selection::CAMPAIGN_ORDER order, bool ascending)
 {
 	using level_ptr = ng::create_engine::level_ptr;
 
@@ -323,6 +390,14 @@ void campaign_selection::pre_show(window& window)
 		mods_menu.set_label(_("active_modifications^None"));
 	}
 
+	//
+	// Set up Difficulty dropdown
+	//
+	menu_button& diff_menu = find_widget<menu_button>(get_window(), "difficulty_menu", false);
+
+	diff_menu.set_use_markup(true);
+	connect_signal_notify_modified(diff_menu, std::bind(&campaign_selection::difficulty_selected, this));
+
 	campaign_selected();
 }
 
@@ -389,7 +464,8 @@ void campaign_selection::post_show(window& window)
 		}
 	}
 
-	deterministic_ = find_widget<toggle_button>(&window, "checkbox_deterministic", false).get_value_bool();
+
+	rng_mode_ = RNG_MODE(utils::clamp<unsigned>(find_widget<menu_button>(&window, "rng_menu", false).get_value(), RNG_DEFAULT, RNG_USE_PRNG));
 
 	preferences::set_modifications(engine_.active_mods(), false);
 }

--- a/src/gui/dialogs/campaign_selection.cpp
+++ b/src/gui/dialogs/campaign_selection.cpp
@@ -465,7 +465,7 @@ void campaign_selection::post_show(window& window)
 	}
 
 
-	rng_mode_ = RNG_MODE(utils::clamp<unsigned>(find_widget<menu_button>(&window, "rng_menu", false).get_value(), RNG_DEFAULT, RNG_USE_PRNG));
+	rng_mode_ = RNG_MODE(utils::clamp<unsigned>(find_widget<menu_button>(&window, "rng_menu", false).get_value(), RNG_DEFAULT, RNG_BIASED));
 
 	preferences::set_modifications(engine_.active_mods(), false);
 }

--- a/src/gui/dialogs/campaign_selection.hpp
+++ b/src/gui/dialogs/campaign_selection.hpp
@@ -40,7 +40,7 @@ public:
 	{
 		RNG_DEFAULT,
 		RNG_SAVE_SEED,
-		RNG_USE_PRNG,
+		RNG_BIASED,
 	};
 
 	explicit campaign_selection(ng::create_engine& eng)

--- a/src/gui/dialogs/campaign_selection.hpp
+++ b/src/gui/dialogs/campaign_selection.hpp
@@ -30,12 +30,27 @@ class campaign_selection : public modal_dialog
 {
 	enum CAMPAIGN_ORDER {RANK, DATE, NAME};
 public:
+	/**
+	 * RNG mode selection values.
+	 *
+	 * @note The contents of this enum must match the order of the options
+	 *       defined in the WML for the "rng_menu" widget of this dialog.
+	 */
+	enum RNG_MODE
+	{
+		RNG_DEFAULT,
+		RNG_SAVE_SEED,
+		RNG_USE_PRNG,
+	};
+
 	explicit campaign_selection(ng::create_engine& eng)
 		: engine_(eng)
 		, choice_(-1)
-		, deterministic_(false)
+		, rng_mode_(RNG_DEFAULT)
 		, mod_states_()
 		, page_ids_()
+		, difficulties_()
+		, current_difficulty_()
 		, current_sorting_(RANK)
 		, currently_sorted_asc_(true)
 	{
@@ -49,14 +64,22 @@ public:
 		return choice_;
 	}
 
-	bool get_deterministic() const
+	RNG_MODE get_rng_mode() const
 	{
-		return deterministic_;
+		return rng_mode_;
+	}
+
+	const std::string& get_difficulty() const
+	{
+		return current_difficulty_;
 	}
 
 private:
 	/** Called when another campaign is selected. */
-	void campaign_selected() const;
+	void campaign_selected();
+
+	/** Called when the difficulty selection changes. */
+	void difficulty_selected();
 
 	/** Inherited from modal_dialog, implemented by REGISTER_DIALOG. */
 	virtual const std::string& window_id() const override;
@@ -67,7 +90,7 @@ private:
 	/** Inherited from modal_dialog. */
 	virtual void post_show(window& window) override;
 
-	void sort_campaigns(CAMPAIGN_ORDER order, bool ascending) const;
+	void sort_campaigns(CAMPAIGN_ORDER order, bool ascending);
 
 	void add_campaign_to_tree(const config& campaign) const;
 
@@ -83,11 +106,15 @@ private:
 	int choice_;
 
 	/** whether the player checked the "Deterministic" checkbox. */
-	bool deterministic_;
+	RNG_MODE rng_mode_;
 
 	boost::dynamic_bitset<> mod_states_;
 
 	std::vector<std::string> page_ids_;
+
+	std::vector<std::string> difficulties_;
+
+	std::string current_difficulty_;
 
 	CAMPAIGN_ORDER current_sorting_;
 

--- a/src/synced_context.cpp
+++ b/src/synced_context.cpp
@@ -233,7 +233,7 @@ void synced_context::send_user_choice()
 std::shared_ptr<randomness::rng> synced_context::get_rng_for_action()
 {
 	const std::string& mode = resources::classification->random_mode;
-	if(mode == "deterministic") {
+	if(mode == "deterministic" || mode == "biased") {
 		return std::make_shared<randomness::rng_deterministic>(resources::gamedata->rng());
 	} else {
 		return std::make_shared<randomness::synced_rng>(generate_random_seed);


### PR DESCRIPTION
This overhauls the game's Campaigns menu following some of the directions previously suggested in issue #4543.

Requesting reviews from @Vultraz for the UI layout and code changes, @gfgtdf for the engine changes, and @Pentarctagon and @nemaara for the core changes to the single-player campaign UI flow.

## User interface changes

![Screenshot_20201215_002624](https://user-images.githubusercontent.com/489895/102167188-a9238700-3e6c-11eb-903e-5db72a93c7f4.png)
![Screenshot_20201215_003209](https://user-images.githubusercontent.com/489895/102167343-fdc70200-3e6c-11eb-8809-7e67cebe3ee8.png)
![Screenshot_20201215_003039](https://user-images.githubusercontent.com/489895/102167303-eab43200-3e6c-11eb-8664-0484ef1448b0.png)

* The main area of the dialog is rearranged into four distinct sections:
  * The caption row, with the dialog caption and search box
  * The main panel, with the list of campaigns on the left, the campaign description and image on the right, and an image background.
  * The settings row, with the Modifications, Combat (RNG) and Difficulty menus arranged in that order.
  * The control row, with the Play and Cancel buttons.
* The toggle buttons serving as the headers for the list of campaigns have their text centered in order to make the list header seem more tidy in general.
* The **Difficulty menu** is integrated into the dialog in the form of a dropdown menu button. The old standalone menu remains available for use by Load Game and others that may need it.
* The Save random seed option is replaced with a new **Combat** dropdown menu button allowing the player to choose between Default RNG, Predictable RNG (identical to Save random seed), and Biased RNG (identical to the Advanced Preferences experimental PRNG option, **removed** by this PR).

## WML changes

* A new attribute, `background=<image path>` is added to top-level `[campaign]` to allow specifying a custom background image for the main panel. In the absence of this, a default image is used (currently `story/landscape-battlefield_nohumans.jpg`).
* The `random_mode=` attribute in game classification has a new possible value, `biased`, which selects the predictable RNG as with the Save random seed option before but also enables the RNG bias logic in the attack engine (previously the experimental PRNG option). The logic in the `attack` constructor may now be slightly redundant since it shouldn't be possible for `random_mode` to be `biased` and `randomness::generator->is_networked()` to return true (@gfgtdf may want to confirm this).
* `toggle_button` widgets gain new definitions: `listbox_header_centered` (unused), `listbox_header_bg` (unused), `listbox_header_centered_bg` (used by this PR for the campaign list header row).
* `panel` widgets gain new definitions: `panel_listbox_bg` (used by this PR for the campaign list header row), `campaign_menu_bg` (used by this PR for the main campaign menu panel).

## Known issues

* The Difficulty menu button has to compose labels from the label proper specified in `[difficulty]` WML as well as the description in order for the labels to make sense (e.g. for HttT, the difficulty labels would be the rather meaningless "Fighter", "Commander", "Lord" otherwise). The problem arises from the possibility of `[difficulty]` descriptions using Pango markup that will look plain wrong on the menu button proper's label. We don't seem to have a function to unescape markup entities **and** strip Pango markup at the moment, so this is left unsolved in the PR for the time being.
* The Combat menu button has overlong descriptions resulting in a messy dropdown display as seen in the third screenshot above. I'm not entirely sure what to do about this without losing the intended conveyance of information — tooltips perhaps?
* The dialog has layout issues on low resolution (< 1024 px horizontal) modes and other situations where overlong text crops up.on the game settings row at the bottom. I want to fix this, **ideally before merging**.
* There is no way to set modification options from the dialog itself. If this is wanted it could be worked on at a later date, preferably with the help of someone who knows better how modifications work (such as @gfgtdf).
* The idea suggested in issue #4543 of adding a separate tab for tutorials is not implemented yet. There does not seem to be a use case for it yet either since the tutorial only has two scenarios at the moment. I also largely ignore if it's possible to instruct the game to skip to a scenario other than `first_scenario`. I would greatly appreciate some input on this particular point for this PR and others.
* Mainline campaigns have no custom backgrounds defined yet. Below is attached a patch I used to test the feature only, with no real thematic coherence intended ­— save perhaps for HttT, where my best option was the antiquated 1.0 story art used for the Battle for Wesnoth scenario.
* Campaign images (often portraits) are currently allowed to jump around even when the text doesn't take enough space for them to need to do so. Perhaps anchor them to the bottom of the right pane? (Note that @Vultraz seems to be of the opinion that we should do away with the images themselves. I do not agree with this.)
* Campaign descriptions may suffer from text contrast issues when a sufficiently bright background is selected. Currently this is partly alleviated by using a dark translucent overlay on the background (see the `campaign_menu_bg` definition for `panel`). I don't feel we can do anything about this short of adding shadows or (preferably) outlines to the text.
* Long campaign descriptions predictably cause a vertical scrollbar to appear. `multi_page` remembers the scrollbar position for each page and I can't quite decide if this is desirable behaviour or not.

## Reference/test material

### Original Experimental PRNG option patch

See commit 3f06813fcf597b63271e26c9a3a9aa1480020cca and the [forum thread](https://forums.wesnoth.org/viewtopic.php?f=6&t=48160), both by Dave.

### Background image test patch

See https://gist.github.com/shikadiqueen/e66d433d9ee0d6dd4915f986d6658c38.