### PR TITLE
Unit: removed use of boost::ptr_vector

### DIFF
--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -111,8 +111,6 @@
 #include "deprecation.hpp"
 
 #include <functional>               // for bind_t, bind
-#include <boost/range/algorithm/copy.hpp>    // boost::copy
-#include <boost/range/adaptors.hpp>     // boost::adaptors::filtered
 #include <array>
 #include <cassert>                      // for assert
 #include <cstring>                      // for strcmp
@@ -1879,10 +1877,6 @@ int game_lua_kernel::intf_find_reach(lua_State *L)
 	return 1;
 }
 
-static bool intf_find_cost_map_helper(const unit * ptr) {
-	return ptr->get_location().valid();
-}
-
 template<typename T> // This is only a template so I can avoid typing out the long typename. >_>
 static int load_fake_units(lua_State* L, int arg, T& fake_units)
 {
@@ -1952,7 +1946,11 @@ int game_lua_kernel::intf_find_cost_map(lua_State *L)
 	}
 	else if (!filter.null())  // 1. arg - filter
 	{
-		boost::copy(unit_filter(filter).all_matches_on_map() | boost::adaptors::filtered(&intf_find_cost_map_helper), std::back_inserter(real_units));
+		for(const ::unit* match : unit_filter(filter).all_matches_on_map()) {
+			if(match->get_location().valid()) {
+				real_units.push_back(match);
+			}
+		}
 	}
 	else  // 1. arg - coordinates
 	{

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -578,7 +578,7 @@ void unit::init(const config& cfg, bool use_traits, const vconfig* vcfg)
 	// If cfg specifies [advancement]s, replace this [advancement]s with them.
 	if(cfg.has_child("advancement")) {
 		set_attr_changed(UA_ADVANCEMENTS);
-		this->advancements_.clear();
+		advancements_.clear();
 		for(const config& adv : cfg.child_range("advancement")) {
 			advancements_.push_back(adv);
 		}
@@ -590,7 +590,7 @@ void unit::init(const config& cfg, bool use_traits, const vconfig* vcfg)
 		set_attr_changed(UA_ABILITIES);
 		abilities_.clear();
 		for(const config& abilities : cfg_range) {
-			this->abilities_.append(abilities);
+			abilities_.append(abilities);
 		}
 	}
 
@@ -1375,7 +1375,7 @@ void unit::set_state(const std::string& state, bool value)
 
 bool unit::has_ability_by_id(const std::string& ability) const
 {
-	for(const config::any_child &ab : this->abilities_.all_children_range()) {
+	for(const config::any_child &ab : abilities_.all_children_range()) {
 		if(ab.cfg["id"] == ability) {
 			return true;
 		}
@@ -1387,10 +1387,10 @@ bool unit::has_ability_by_id(const std::string& ability) const
 void unit::remove_ability_by_id(const std::string& ability)
 {
 	set_attr_changed(UA_ABILITIES);
-	config::all_children_iterator i = this->abilities_.ordered_begin();
-	while (i != this->abilities_.ordered_end()) {
+	config::all_children_iterator i = abilities_.ordered_begin();
+	while (i != abilities_.ordered_end()) {
 		if(i->cfg["id"] == ability) {
-			i = this->abilities_.erase(i);
+			i = abilities_.erase(i);
 		} else {
 			++i;
 		}
@@ -1563,7 +1563,7 @@ void unit::write(config& cfg, bool write_all) const
 	}
 	if(write_all || get_attr_changed(UA_ADVANCEMENTS)) {
 		cfg.clear_children("advancement");
-		for(const config& advancement : this->advancements_) {
+		for(const config& advancement : advancements_) {
 			if(!advancement.empty()) {
 				cfg.add_child("advancement", advancement);
 			}
@@ -2089,7 +2089,7 @@ void unit::apply_builtin_effect(std::string apply_to, const config& effect)
 					to_append.add_child(ab.key, ab.cfg);
 				}
 			}
-			this->abilities_.append(to_append);
+			abilities_.append(to_append);
 		}
 	} else if(apply_to == "remove_ability") {
 		if(const config& ab_effect = effect.child("abilities")) {

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -25,7 +25,6 @@
 
 #include <bitset>
 #include <boost/dynamic_bitset_fwd.hpp>
-#include <boost/ptr_container/ptr_vector.hpp>
 #include <boost/variant.hpp>
 
 class display;
@@ -310,9 +309,8 @@ public:
 	 */
 	std::vector<std::pair<std::string, std::string>> amla_icons() const;
 
-	using advancements_list= boost::ptr_vector<config>;
 	/** The raw, unparsed data for modification advancements. */
-	const advancements_list& modification_advancements() const
+	const std::vector<config>& modification_advancements() const
 	{
 		return advancements_;
 	}
@@ -1882,7 +1880,7 @@ private:
 	config modifications_;
 	config abilities_;
 
-	advancements_list advancements_;
+	std::vector<config> advancements_;
 
 	t_string description_;
 	std::vector<t_string> special_notes_;


### PR DESCRIPTION
There really seems no reason to use this. Also removes a stray use of `boost::copy` in `game_lua_kernel`.