### PR TITLE
gui2/addon_manager: Replace URL widgets with a single link label

### DIFF
--- a/data/gui/window/addon_manager.cfg
+++ b/data/gui/window/addon_manager.cfg
@@ -576,82 +576,14 @@
 
 									[column]
 										grow_factor = 1
+										border = "all"
+										border_size = 5
 										horizontal_grow = true
 
-										[stacked_widget]
-											id = "feedback_stack"
-
-											[layer]
-
-												[row]
-
-													[column]
-														border = "all"
-														border_size = 5
-														horizontal_alignment = "left"
-
-														[label]
-															id = "url_none"
-															label = _ "url^None"
-															definition = "default_small"
-														[/label]
-
-													[/column]
-
-												[/row]
-
-											[/layer]
-
-											[layer]
-
-												[row]
-
-													[column]
-														grow_factor = 1
-														border = "all"
-														border_size = 5
-														horizontal_grow = true
-
-														[text_box]
-															id = "url"
-															definition = "default"
-														[/text_box]
-
-													[/column]
-
-													[column]
-														border = "all"
-														border_size = 5
-														horizontal_alignment = "right"
-
-														[button]
-															id = "url_copy"
-															definition = "action_copy"
-															label = _ "url^Copy"
-															tooltip = _ "Copy this URL to clipboard"
-														[/button]
-
-													[/column]
-
-													[column]
-														border = "all"
-														border_size = 5
-														horizontal_alignment = "right"
-
-														[button]
-															id = "url_go"
-															definition = "action_go"
-															label = _ "url^Go"
-															tooltip = _ "Visit this URL with a web browser"
-														[/button]
-
-													[/column]
-
-												[/row]
-
-											[/layer]
-
-										[/stacked_widget]
+										[label]
+											id = "url"
+											definition = "default_small"
+										[/label]
 
 									[/column]
 

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -401,22 +401,10 @@ void addon_manager::pre_show(window& window)
 	connect_signal_notify_modified(order_dropdown,
 		std::bind(&addon_manager::order_addons, this));
 
-	button& url_go_button = find_widget<button>(&window, "url_go", false);
-	button& url_copy_button = find_widget<button>(&window, "url_copy", false);
-	text_box& url_textbox = find_widget<text_box>(&window, "url", false);
+	label& url_label = find_widget<label>(&window, "url", false);
 
-	url_textbox.set_active(false);
-
-	if(!desktop::clipboard::available()) {
-		url_copy_button.set_active(false);
-		url_copy_button.set_tooltip(_("Clipboard support not found, contact your packager"));
-	}
-
-	if(!desktop::open_object_is_supported()) {
-		// No point in displaying the button on platforms that can't do
-		// open_object().
-		url_go_button.set_visible(widget::visibility::invisible);
-	}
+	url_label.set_use_markup(true);
+	url_label.set_link_aware(true);
 
 	connect_signal_mouse_left_click(
 		find_widget<button>(&window, "install", false),
@@ -441,14 +429,6 @@ void addon_manager::pre_show(window& window)
 	connect_signal_mouse_left_click(
 		find_widget<button>(&window, "update_all", false),
 		std::bind(&addon_manager::update_all_addons, this));
-
-	connect_signal_mouse_left_click(
-		url_go_button,
-		std::bind(&addon_manager::browse_url_callback, this, std::ref(url_textbox)));
-
-	connect_signal_mouse_left_click(
-		url_copy_button,
-		std::bind(&addon_manager::copy_url_callback, this, std::ref(url_textbox)));
 
 	connect_signal_mouse_left_click(
 		find_widget<button>(&window, "show_help", false),
@@ -882,17 +862,6 @@ void addon_manager::show_help()
 	help::show_help("installing_addons");
 }
 
-void addon_manager::browse_url_callback(text_box& url_box)
-{
-	/* TODO: ask for confirmation */
-	desktop::open_object(url_box.get_value());
-}
-
-void addon_manager::copy_url_callback(text_box& url_box)
-{
-	desktop::clipboard::copy_to_clipboard(url_box.get_value(), false);
-}
-
 static std::string format_addon_time(std::time_t time)
 {
 	if(time) {
@@ -959,13 +928,7 @@ void addon_manager::on_addon_select()
 	find_widget<styled_widget>(parent, "translations", false).set_label(!languages.empty() ? languages : _("translations^None"));
 
 	const std::string& feedback_url = info->feedback_url;
-
-	if(!feedback_url.empty()) {
-		find_widget<stacked_widget>(parent, "feedback_stack", false).select_layer(1);
-		find_widget<text_box>(parent, "url", false).set_value(feedback_url);
-	} else {
-		find_widget<stacked_widget>(parent, "feedback_stack", false).select_layer(0);
-	}
+	find_widget<label>(parent, "url", false).set_label(!feedback_url.empty() ? feedback_url : _("url^None"));
 
 	bool installed = is_installed_addon_status(tracking_info_[info->id].state);
 	bool updatable = tracking_info_[info->id].state == ADDON_INSTALLED_UPGRADABLE;

--- a/src/gui/dialogs/addon/manager.hpp
+++ b/src/gui/dialogs/addon/manager.hpp
@@ -137,9 +137,6 @@ private:
 
 	void update_all_addons();
 
-	void browse_url_callback(text_box& url_box);
-	void copy_url_callback(text_box& url_box);
-
 	void apply_filters();
 	void order_addons();
 	void on_order_changed(unsigned int sort_column, preferences::SORT_ORDER order);


### PR DESCRIPTION
**N.B. This PR as it is exposes an unusual bug where the link's events (click, mouse motion) reflect the label's **previous** state whenever the selection changes. This results in situations where the label says "None" but it's actually still a clickable URL, or the URL displayed doesn't match the URL that will actually be opened when clicking on it. The PR post here is primarily intended as a test case for @Vultraz.**

The URL widgets (textbox + copy button + browse button) predate the implementation of link-awareness in labels and they sort of got carried over into the new design magically without there being a real need for that. Now that we have a visible cursor change when hovering links it's even less necessary to draw unnecessary attention to the link with a clunky and unintuitive (greyed out textbox...) interface.