### PR TITLE
FS: removed use of Windows-specific error code

### DIFF
--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -35,7 +35,6 @@
 #include <boost/filesystem/fstream.hpp>
 #include <boost/iostreams/device/file_descriptor.hpp>
 #include <boost/iostreams/stream.hpp>
-#include <boost/system/windows_error.hpp>
 #include "game_config_view.hpp"
 
 #ifdef _WIN32
@@ -247,11 +246,7 @@ static void push_if_exists(std::vector<std::string>* vec, const bfs::path& file,
 
 static inline bool error_except_not_found(const error_code& ec)
 {
-	return (ec && ec.value() != boost::system::errc::no_such_file_or_directory
-#ifdef _WIN32
-		&& ec.value() != boost::system::windows_error::path_not_found
-#endif /*_WIN32*/
-	);
+	return ec != boost::system::errc::no_such_file_or_directory;
 }
 
 static bool is_directory_internal(const bfs::path& fpath)

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -246,7 +246,7 @@ static void push_if_exists(std::vector<std::string>* vec, const bfs::path& file,
 
 static inline bool error_except_not_found(const error_code& ec)
 {
-	return ec != boost::system::errc::no_such_file_or_directory;
+	return ec && ec != boost::system::errc::no_such_file_or_directory;
 }
 
 static bool is_directory_internal(const bfs::path& fpath)


### PR DESCRIPTION
The OS-specific error code headers were deprecated in Boost 1.75 (see #5359). This code was first added back in 2013
(see 037e1c12997fe92a2aed36c8b2a05ff31696e8de) but testing now on Windows 10 using Boost 1.73 at least shows that
`no_such_file_or_directory` is returned for both missing files and paths. Seems unnecessary to keep this case around
especially as the header is deprecated going forward.