### PR TITLE
NEAREST_HEX: variable location_found is no longer used.

### DIFF
--- a/data/campaigns/Secrets_of_the_Ancients/utils/sota-utils.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/utils/sota-utils.cfg
@@ -564,10 +564,6 @@
         name=distance
         value=0
     [/set_variable]
-    [set_variable]
-        name=location_found
-        value=no
-    [/set_variable]
     [clear_variable]
         name={VAR_NAME}
     [/clear_variable]
@@ -598,19 +594,6 @@
                 variable={VAR_NAME}
             [/store_locations]
 
-            [if]
-                [variable]
-                    name={VAR_NAME}.length
-                    greater_than=0
-                [/variable]
-                [then]
-                    [set_variable]
-                        name=location_found
-                        value=yes
-                    [/set_variable]
-                [/then]
-            [/if]
-
             [set_variable]
                 name=distance
                 add=1
@@ -619,7 +602,7 @@
     [/while]
 
     [clear_variable]
-        name=location_found, distance
+        name=distance
     [/clear_variable]
 #enddef
 


### PR DESCRIPTION
The while loop no longer checks for location_found to stop.
location_found gets set inside the while loop and then gets cleared outside of it.
The variable itself can be safely removed, it serves no purpose.