### PR TITLE
Include architecture info into wesnoth's informations

### DIFF
--- a/src/desktop/apple_version.mm
+++ b/src/desktop/apple_version.mm
@@ -55,6 +55,12 @@ namespace apple {
 		version_string += [[version_array objectAtIndex:1] UTF8String];
 		version_string += " (";
 		version_string += [[version_array objectAtIndex:3] UTF8String];
+		
+#if defined(__aarch64__)
+		version_string += " arm64";
+#elif defined(__x86_64__)
+		version_string += " x86_64";
+#endif
 
 		return version_string;
 	}


### PR DESCRIPTION
## Description
Because of universal wesnoth 1.15.8 package I wanted to have easy way to determine which arch user use. So I added this exact patch from commit cbe72f5 into official 1.15.8 package. Now it is good time to discuss it and maybe change it for all platforms.

## Ping
@shikadiqueen
@Pentarctagon 