### PR TITLE
Wesnothd: cleaned up usage of document smart pointers

### DIFF
--- a/src/server/common/server_base.cpp
+++ b/src/server/common/server_base.cpp
@@ -383,7 +383,7 @@ void server_base::coro_send_file(socket_ptr socket, const std::string& filename,
 
 #endif
 
-std::shared_ptr<simple_wml::document> server_base::coro_receive_doc(socket_ptr socket, boost::asio::yield_context yield)
+std::unique_ptr<simple_wml::document> server_base::coro_receive_doc(socket_ptr socket, boost::asio::yield_context yield)
 {
 	union DataSize
 	{
@@ -412,7 +412,7 @@ std::shared_ptr<simple_wml::document> server_base::coro_receive_doc(socket_ptr s
 
 	try {
 		simple_wml::string_span compressed_buf(buffer.get(), size);
-		return std::shared_ptr<simple_wml::document> { new simple_wml::document(compressed_buf) };
+		return std::make_unique<simple_wml::document>(compressed_buf);
 	}  catch (simple_wml::error& e) {
 		ERR_SERVER <<
 			client_address(socket) <<

--- a/src/server/common/server_base.hpp
+++ b/src/server/common/server_base.hpp
@@ -71,11 +71,11 @@ public:
 	 * @param socket
 	 * @param yield The function will suspend on read operation using this yield context
 	 */
-	std::shared_ptr<simple_wml::document> coro_receive_doc(socket_ptr socket, boost::asio::yield_context yield);
+	std::unique_ptr<simple_wml::document> coro_receive_doc(socket_ptr socket, boost::asio::yield_context yield);
 
 	/**
 	 * High level wrapper for sending a WML document
-	 * 
+	 *
 	 * This function returns before send is finished. This function can be called again on same socket before previous send was finished.
 	 * WML documents are kept in internal queue and sent in FIFO order.
 	 * @param socket

--- a/src/server/common/simple_wml.cpp
+++ b/src/server/common/simple_wml.cpp
@@ -1115,11 +1115,11 @@ void document::generate_root()
 	root_ = new node(*this, nullptr, &cbuf);
 }
 
-document* document::clone()
+std::unique_ptr<document> document::clone()
 {
 	char* buf = new char[strlen(output())+1];
 	strcpy(buf, output());
-	return new document(buf);
+	return std::make_unique<document>(buf);
 }
 
 void document::swap(document& o)

--- a/src/server/common/simple_wml.hpp
+++ b/src/server/common/simple_wml.hpp
@@ -19,6 +19,7 @@
 #include <cstddef>
 #include <iosfwd>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -247,7 +248,7 @@ public:
 
 	void compress();
 
-	document* clone();
+	std::unique_ptr<document> clone();
 
 	const string_span& operator[](const char* key) const {
 		return root()[key];

--- a/src/server/wesnothd/game.hpp
+++ b/src/server/wesnothd/game.hpp
@@ -20,8 +20,6 @@
 #include "server/common/simple_wml.hpp"
 #include "utils/make_enum.hpp"
 
-#include <boost/ptr_container/ptr_vector.hpp>
-
 #include <map>
 #include <vector>
 
@@ -270,7 +268,7 @@ public:
 	void send_data(simple_wml::document& data, const socket_ptr& exclude = socket_ptr(), std::string packet_type = "");
 
 	void clear_history();
-	void record_data(simple_wml::document* data);
+	void record_data(std::unique_ptr<simple_wml::document> data);
 	void save_replay();
 
 	/** The full scenario data. */
@@ -527,8 +525,7 @@ private:
 	simple_wml::document level_;
 
 	/** Replay data. */
-	typedef boost::ptr_vector<simple_wml::document> history;
-	mutable history history_;
+	mutable std::vector<std::unique_ptr<simple_wml::document>> history_;
 
 	/** Pointer to the game's description in the games_and_users_list_. */
 	simple_wml::node* description_;

--- a/src/server/wesnothd/server.hpp
+++ b/src/server/wesnothd/server.hpp
@@ -46,8 +46,8 @@ private:
 	bool accepting_connections() const { return !graceful_restart; }
 
 	void handle_player(boost::asio::yield_context yield, socket_ptr socket, const player& player);
-	void handle_player_in_lobby(socket_ptr socket, std::shared_ptr<simple_wml::document> doc);
-	void handle_player_in_game(socket_ptr socket, std::shared_ptr<simple_wml::document> doc);
+	void handle_player_in_lobby(socket_ptr socket, simple_wml::document& data);
+	void handle_player_in_game(socket_ptr socket, simple_wml::document& data);
 	void handle_whisper(socket_ptr socket, simple_wml::node& whisper);
 	void handle_query(socket_ptr socket, simple_wml::node& query);
 	void handle_nickserv(socket_ptr socket, simple_wml::node& nickserv);


### PR DESCRIPTION
This removes the use of boost::ptr_vector and replaces it with a vector of unique_ptr<document>. document::clone was also made to return a unique_ptr, which allows for the unification of doc pointer management. We don't have stray document pointers anymore, there's no manual deletion, and it's clear who owns what when (ptr_vector maintains ownership of the pointers it holds, but it's clearer to have everything using unique_ptr).

This also changes usecases of shared_ptr to unique_ptr and makes accommodations accordingly. `handle_player_in_game` and `handle_player_in_lobby` now take a document reference instead of shared_ptrs (they don't do anything with said pointers, and I don't think there are any async ops there that need them to extend the documents' lifetime). The doc send queue also uses `unique_ptrs` now, too.