### PR TITLE
cave_map_generator.lua: limit find_path dimensions to inner board.

### DIFF
--- a/data/lua/cave_map_generator.lua
+++ b/data/lua/cave_map_generator.lua
@@ -132,7 +132,7 @@ function callbacks.generate_map(params)
 				return res
 			end
 			local path = wesnoth.find_path(
-				v.start_x, v.start_y, v.dest_x, v.dest_y, calc, params.map_width, params.map_height)
+				v.start_x, v.start_y, v.dest_x, v.dest_y, calc, map.w - 2, map.h - 2)
 			for i, loc in ipairs(path) do
 				local locs_set = LS.create()
 				build_chamber(loc[1], loc[2], locs_set, width, jagged)


### PR DESCRIPTION
find_path last 2 arguments are the dimensions of the map.
If you create 2 chambers and a passage at the bottom edge of the map, the generated path will be impassable because it goes into the border.
This PR makes find_path consider the inner board only for its path calculation.
