### PR TITLE
Add support for asynchronously querying a player's game history for display on the client.

### DIFF
--- a/source_lists/wesnothd
+++ b/source_lists/wesnothd
@@ -3,6 +3,7 @@ server/common/user_handler.cpp
 server/common/forum_user_handler.cpp
 server/common/resultsets/ban_check.cpp
 server/common/resultsets/tournaments.cpp
+server/common/resultsets/game_history.cpp
 server/common/server_base.cpp
 server/common/simple_wml.cpp
 server/wesnothd/ban.cpp

--- a/src/server/common/dbconn.hpp
+++ b/src/server/common/dbconn.hpp
@@ -16,6 +16,7 @@
 #include "config.hpp"
 #include "server/common/resultsets/rs_base.hpp"
 #include "server/common/resultsets/ban_check.hpp"
+#include "server/common/simple_wml.hpp"
 
 #include <mysql/mysql.h>
 #include "mariadb++/account.hpp"
@@ -56,6 +57,15 @@ class dbconn
 		 * @see forum_user_handler::get_tournaments().
 		 */
 		std::string get_tournaments();
+
+		/**
+		 * This is an asynchronous query that is executed on a separate connection to retrieve the game history for the provided player.
+		 * 
+		 * @param player_id The forum ID of the player to get the game history for.
+		 * @param offset The offset to provide to the database for where to start returning rows from.
+		 * @return The simple_wml document containing the query results, or simply the @a error attribute if an exception is thrown.
+		 */
+		std::unique_ptr<simple_wml::document> get_game_history(int player_id, int offset);
 
 		/**
 		 * @see forum_user_handler::user_exists().

--- a/src/server/common/forum_user_handler.cpp
+++ b/src/server/common/forum_user_handler.cpp
@@ -207,6 +207,14 @@ std::string fuh::get_tournaments(){
 	return conn_.get_tournaments();
 }
 
+void fuh::async_get_and_send_game_history(boost::asio::io_service& io_service, server_base& s_base, socket_ptr player_socket, int player_id, int offset) {
+	boost::asio::post([this, &s_base, player_socket, player_id, offset, &io_service] { 
+		boost::asio::post(io_service, [player_socket, &s_base, doc = conn_.get_game_history(player_id, offset)]{
+			s_base.async_send_doc_queued(player_socket, *doc);
+		});
+	 });
+}
+
 void fuh::db_insert_game_info(const std::string& uuid, int game_id, const std::string& version, const std::string& name, int reload, int observers, int is_public, int has_password){
 	conn_.insert_game_info(uuid, game_id, version, name, reload, observers, is_public, has_password);
 }

--- a/src/server/common/forum_user_handler.hpp
+++ b/src/server/common/forum_user_handler.hpp
@@ -121,6 +121,18 @@ public:
 	std::string get_tournaments();
 
 	/**
+	 * Runs an asynchronous query to fetch the user's game history data.
+	 * The result is then posted back to the main boost::asio thread to be sent to the requesting player.
+	 * 
+	 * @param io_service The boost io_service to use to post the query results back to the main boost::asio thread.
+	 * @param s_base The server instance the player is connected to.
+	 * @param player_socket The socket use to communicate with the player's client.
+	 * @param player_id The forum ID of the player to get the game history for.
+	 * @param offset Where to start returning rows to the client from the query results.
+	 */
+	void async_get_and_send_game_history(boost::asio::io_service& io_service, server_base& s_base, socket_ptr player_socket, int player_id, int offset);
+
+	/**
 	 * Inserts game related information.
 	 * 
 	 * @param uuid The value returned by @ref get_uuid().

--- a/src/server/common/resultsets/game_history.cpp
+++ b/src/server/common/resultsets/game_history.cpp
@@ -1,0 +1,87 @@
+/*
+   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#ifdef HAVE_MYSQLPP
+
+#include "server/common/resultsets/game_history.hpp"
+#include "serialization/string_utils.hpp"
+#include "log.hpp"
+
+static lg::log_domain log_sql_handler("sql_executor");
+#define ERR_SQL LOG_STREAM(err, log_sql_handler)
+
+void game_history::read(mariadb::result_set_ref rslt)
+{
+    while(rslt->next())
+    {
+        result r;
+        r.game_name = rslt->get_string("GAME_NAME");
+        r.reload = rslt->get_boolean("RELOAD");
+        r.game_start = rslt->get_date_time("START_TIME").str();
+        r.scenario_name = rslt->get_string("SCENARIO_NAME");
+        r.scenario_id = rslt->get_string("SCENARIO_ID");
+        r.era_name = rslt->get_string("ERA_NAME");
+        r.era_id = rslt->get_string("ERA_ID");
+        for(const auto& player_info : utils::split(rslt->get_string("PLAYERS")))
+        {
+            std::vector<std::string> info = utils::split(player_info, ':');
+            if(info.size() == 2)
+            {
+                r.players.emplace_back(player{ info[0], info[1] });
+            }
+            else
+            {
+                ERR_SQL << "Expected player information to split into two fields, instead found the value `" << player_info << "`." << std::endl;
+            }
+        }
+        r.modification_names = utils::split(rslt->get_string("MODIFICATION_NAMES"));
+        r.modification_ids = utils::split(rslt->get_string("MODIFICATION_IDS"));
+        r.replay_url = rslt->get_string("REPLAY_URL");
+        results.push_back(std::move(r));
+    }
+}
+
+std::unique_ptr<simple_wml::document> game_history::to_doc()
+{
+    auto doc = std::make_unique<simple_wml::document>();
+    for(const auto& result : results)
+    {
+        simple_wml::node& ghr = doc->root().add_child("game_history_result");
+        ghr.set_attr_dup("game_name", result.game_name.c_str());
+        ghr.set_attr_int("reload", result.reload);
+        ghr.set_attr_dup("game_start", result.game_start.c_str());
+        ghr.set_attr_dup("scenario_name", result.scenario_name.c_str());
+        ghr.set_attr_dup("scenario_id", result.scenario_id.c_str());
+        ghr.set_attr_dup("era_name", result.era_name.c_str());
+        ghr.set_attr_dup("era_id", result.era_id.c_str());
+        for(const auto& player : result.players)
+        {
+            simple_wml::node& p = ghr.add_child("player");
+            p.set_attr_dup("name", player.name.c_str());
+            p.set_attr_dup("faction", player.faction.c_str());
+        }
+        for(const auto& mod : result.modification_names)
+        {
+            simple_wml::node& m = ghr.add_child("modification");
+            m.set_attr_dup("name", mod.c_str());
+        }
+        for(const auto& mod : result.modification_ids)
+        {
+            simple_wml::node& m = ghr.add_child("modification");
+            m.set_attr_dup("id", mod.c_str());
+        }
+    }
+    return doc;
+}
+
+#endif //HAVE_MYSQLPP

--- a/src/server/common/resultsets/game_history.hpp
+++ b/src/server/common/resultsets/game_history.hpp
@@ -1,0 +1,52 @@
+/*
+   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#pragma once
+
+#include <vector>
+
+#include "mariadb++/result_set.hpp"
+
+#include "server/common/resultsets/rs_base.hpp"
+#include "server/common/simple_wml.hpp"
+
+class game_history : public rs_base
+{
+    struct player
+    {
+        std::string name;
+        std::string faction;
+    };
+
+    struct result
+    {
+        std::string game_name;
+        int reload;
+        std::string game_start;
+        std::string scenario_name;
+        std::string scenario_id;
+        std::string era_name;
+        std::string era_id;
+        std::vector<player> players;
+        std::vector<std::string> modification_names;
+        std::vector<std::string> modification_ids;
+        std::string replay_url;
+    };
+
+    public:
+        void read(mariadb::result_set_ref rslt);
+        std::unique_ptr<simple_wml::document> to_doc();
+    
+    private:
+        std::vector<result> results;
+};

--- a/src/server/common/user_handler.hpp
+++ b/src/server/common/user_handler.hpp
@@ -17,6 +17,7 @@
 class config;
 
 #include "exceptions.hpp"
+#include "server/common/server_base.hpp"
 
 #include <ctime>
 #include <string>
@@ -134,6 +135,7 @@ public:
 
 	virtual std::string get_uuid() = 0;
 	virtual std::string get_tournaments() = 0;
+	virtual void async_get_and_send_game_history(boost::asio::io_service& io_service, server_base& s_base, socket_ptr player_socket, int player_id, int offset) =0;
 	virtual void db_insert_game_info(const std::string& uuid, int game_id, const std::string& version, const std::string& name, int reload, int observers, int is_public, int has_password) = 0;
 	virtual void db_update_game_end(const std::string& uuid, int game_id, const std::string& replay_location) = 0;
 	virtual void db_insert_game_player_info(const std::string& uuid, int game_id, const std::string& username, int side_number, int is_host, const std::string& faction, const std::string& version, const std::string& source, const std::string& current_user) = 0;

--- a/utils/mp-server/table_definitions.sql
+++ b/utils/mp-server/table_definitions.sql
@@ -74,6 +74,7 @@ create table game_info
     PUBLIC           BIT(1) NOT NULL,
     PRIMARY KEY (INSTANCE_UUID, GAME_ID)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+CREATE INDEX START_TIME_IDX ON game_info(START_TIME);
 
 -- information about the players in a particular game present in game_info
 -- this is accurate at the start of the game, but is not currently updated if a side changes owners, someone disconnects, etc
@@ -96,6 +97,7 @@ create table game_player_info
     USER_NAME      VARCHAR(255) NOT NULL DEFAULT '',
     PRIMARY KEY (INSTANCE_UUID, GAME_ID, SIDE_NUMBER)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+CREATE INDEX USER_ID_IDX ON game_player_info(USER_ID);
 
 -- information about the scenario/era/modifications for the game
 -- TYPE: one of era/scenario/modification


### PR DESCRIPTION
---

The server expects a request of (`search_for` optional):
```
[game_history_request]
    offset=NN
    search_for="a_username"
[/game_history_request]
```
and will send a response with a [game_history_result] per game in the form of:
```
[game_history_result]
    game_name="game name"
    reload=yes|no
    game_start="some timestamp"
    scenario_name="some scenario name"
    scenario_id="some scenario id"
    era_name="some era name"
    era_id="some era id"
    [player]
        name="p1"
        faction="drakes"
    [/player]
    [player]
        name="p2"
        faction="loyalists"
    [/player]
    [modification]
        name="some mod name 1"
    [/modification]
    [modification]
        name="some mod name 2"
    [/modification]
    [modification]
        id="some_mod_id_1"
    [/modification]
    [modification]
        id="some_mod_id_2"
    [/modification]
[/game_history_result]
```

Also, I'm thinking it would make sense at this point to add an index to the game table's `START_TIME` (for the `order by` clause) and the player table's USER_ID (since it's used in the `exists` part of the statement)