### PR TITLE
Make wesnothd use iterators instead of socket_ptrs to keep track of players

### DIFF
--- a/src/server/wesnothd/game.cpp
+++ b/src/server/wesnothd/game.cpp
@@ -74,12 +74,6 @@ namespace wesnothd
 int game::id_num = 1;
 int game::db_id_num = 1;
 
-void game::missing_user(player_iterator /*socket*/, const std::string& func) const
-{
-	WRN_GAME << func << "(): Could not find user (socket:\t<some C++ pointer>"
-			 << ") in player_info_ in game:\t\"" << name_ << "\" (" << id_ << ", " << db_id_ << ")\n";
-}
-
 game::game(wesnothd::server& server, player_connections& player_connections,
 		player_iterator host,
 		const std::string& name,

--- a/src/server/wesnothd/game.cpp
+++ b/src/server/wesnothd/game.cpp
@@ -1927,10 +1927,11 @@ std::string game::debug_sides_info() const
 utils::optional<player_iterator> game::find_user(const simple_wml::string_span& name)
 {
 	auto player { player_connections_.get<name_t>().find(name.to_string()) };
-	if(player != player_connections_.get<name_t>().end())
+	if(player != player_connections_.get<name_t>().end()) {
 		return player_connections_.project<0>(player);
-	else
+	} else {
 		return {};
+	}
 }
 
 void game::send_and_record_server_message(const char* message, utils::optional<player_iterator> exclude)

--- a/src/server/wesnothd/game.cpp
+++ b/src/server/wesnothd/game.cpp
@@ -74,14 +74,14 @@ namespace wesnothd
 int game::id_num = 1;
 int game::db_id_num = 1;
 
-void game::missing_user(socket_ptr /*socket*/, const std::string& func) const
+void game::missing_user(player_iterator /*socket*/, const std::string& func) const
 {
 	WRN_GAME << func << "(): Could not find user (socket:\t<some C++ pointer>"
 			 << ") in player_info_ in game:\t\"" << name_ << "\" (" << id_ << ", " << db_id_ << ")\n";
 }
 
 game::game(wesnothd::server& server, player_connections& player_connections,
-		const socket_ptr& host,
+		player_iterator host,
 		const std::string& name,
 		bool save_replays,
 		const std::string& replay_save_path)
@@ -115,18 +115,11 @@ game::game(wesnothd::server& server, player_connections& player_connections,
 	, rng_()
 	, last_choice_request_id_(-1) /* or maybe 0 ? it shouldn't matter*/
 {
-	assert(owner_);
 	players_.push_back(owner_);
 
-	const auto iter = player_connections_.find(owner_);
-	if(iter == player_connections_.end()) {
-		missing_user(owner_, __func__);
-		return;
-	}
-
 	// Mark the host as unavailable in the lobby.
-	iter->info().mark_available(id_, name_);
-	iter->info().set_status(player::PLAYING);
+	owner_->info().mark_available(id_, name_);
+	owner_->info().set_status(player::PLAYING);
 }
 
 game::~game()
@@ -134,7 +127,7 @@ game::~game()
 	try {
 		save_replay();
 
-		for(const socket_ptr& user_ptr : all_game_users()) {
+		for(player_iterator user_ptr : all_game_users()) {
 			remove_player(user_ptr, false, true);
 		}
 
@@ -159,12 +152,12 @@ bool game::allow_observers() const
 	return get_multiplayer(level_.root())["observer"].to_bool(true);
 }
 
-bool game::is_observer(const socket_ptr& player) const
+bool game::is_observer(player_iterator player) const
 {
 	return std::find(observers_.begin(), observers_.end(), player) != observers_.end();
 }
 
-bool game::is_muted_observer(const socket_ptr& player) const
+bool game::is_muted_observer(player_iterator player) const
 {
 	if(!is_observer(player)) {
 		return false;
@@ -177,37 +170,26 @@ bool game::is_muted_observer(const socket_ptr& player) const
 	return std::find(muted_observers_.begin(), muted_observers_.end(), player) != muted_observers_.end();
 }
 
-bool game::is_player(const socket_ptr& player) const
+bool game::is_player(player_iterator player) const
 {
 	return std::find(players_.begin(), players_.end(), player) != players_.end();
 }
 
-std::string game::username(const socket_ptr& player) const
+std::string game::username(player_iterator iter) const
 {
-	const auto iter = player_connections_.find(player);
-	if(iter != player_connections_.end()) {
-		return iter->info().name();
-	}
-
-	return "(unknown)";
+	return iter->info().name();
 }
 
-std::string game::list_users(user_vector users, const std::string& func) const
+std::string game::list_users(user_vector users, const std::string& /*func*/) const
 {
 	std::string list;
 
-	for(const user_vector::value_type& user : users) {
-		const auto iter = player_connections_.find(user);
-
-		if(iter != player_connections_.end()) {
-			if(!list.empty()) {
-				list += ", ";
-			}
-
-			list += iter->info().name();
-		} else {
-			missing_user(user, func);
+	for(auto user : users) {
+		if(!list.empty()) {
+			list += ", ";
 		}
+
+		list += user->info().name();
 	}
 
 	return list;
@@ -227,7 +209,7 @@ void game::perform_controller_tweaks()
 		simple_wml::node& side = *sides[side_index];
 
 		if(side["controller"] != "null") {
-			if(sides_[side_index] == 0) {
+			if(!sides_[side_index]) {
 				sides_[side_index] = owner_;
 				std::stringstream msg;
 				msg << "Side " << side_index + 1
@@ -237,13 +219,7 @@ void game::perform_controller_tweaks()
 				send_and_record_server_message(msg.str());
 			}
 
-			const auto user = player_connections_.find(sides_[side_index]);
-			std::string user_name = "null (server missing user)";
-			if(user == player_connections_.end()) {
-				missing_user(user->socket(), __func__);
-			} else {
-				user_name = username(user->socket());
-			}
+			std::string user_name = username(sides_[side_index].value());
 
 			// Issue change_controller command, transferring this side to its owner with proper name and controller.
 			// Ensures that what the server now thinks is true is effected on all of the clients.
@@ -255,13 +231,13 @@ void game::perform_controller_tweaks()
 			// In the server controller tweaks, we want to avoid sending controller change messages to the host.
 			// Doing this has the negative consequence that all of the AI side names are given the owners name.
 			// Therefore, if the side belongs to the host, we pass player_left = true, otherwise player_left = false.
-			change_controller(side_index, sides_[side_index], user_name, sides_[side_index] == owner_);
+			change_controller(side_index, sides_[side_index].value(), user_name, sides_[side_index] == owner_);
 
 			// next line change controller types found in level_ to be what is appropriate for an observer at game
 			// start.
 			side.set_attr("is_local", "no");
 
-			if(sides_[side_index] == 0) {
+			if(!sides_[side_index]) {
 				std::stringstream msg;
 				msg << "Side " << side_index + 1 << " had no controller AFTER controller tweaks! Ruh Roh!";
 				LOG_GAME << msg.str() << " (game id: " << id_ << ", " << db_id_ << ")\n";
@@ -278,7 +254,7 @@ void game::perform_controller_tweaks()
 	// not to send them at all, although not if it complicates the server code.
 }
 
-void game::start_game(const socket_ptr& starter)
+void game::start_game(player_iterator starter)
 {
 	const simple_wml::node::child_list& sides = get_sides_list();
 	DBG_GAME << "****\n Starting game. sides = " << std::endl;
@@ -293,7 +269,7 @@ void game::start_game(const socket_ptr& starter)
 
 	const bool save = multiplayer["savegame"].to_bool();
 	LOG_GAME
-		<< client_address(starter) << "\t" << player_connections_.find(starter)->name() << "\t"
+		<< starter->client_ip() << "\t" << starter->name() << "\t"
 		<< (advance ? "advanced" : "started") << (save ? " reloaded" : "") << " game:\t\"" << name_ << "\" (" << id_
 		<< ", " << db_id_ << ") with: " << list_users(players_, __func__)
 		<< ". Settings: map: " << multiplayer["mp_scenario"]
@@ -322,7 +298,7 @@ void game::start_game(const socket_ptr& starter)
 				continue;
 			}
 
-			if(sides_[side_index] == 0) {
+			if(!sides_[side_index]) {
 				std::stringstream msg;
 				msg << "Side " << side_index + 1
 				    << " has no controller but should! The host needs to assign control for the game to proceed past "
@@ -372,7 +348,7 @@ bool game::send_taken_side(simple_wml::document& cfg, const simple_wml::node* si
 		return false;
 	}
 
-	if(sides_[side_index] != 0) {
+	if(sides_[side_index]) {
 		return false;
 	}
 
@@ -380,11 +356,11 @@ bool game::send_taken_side(simple_wml::document& cfg, const simple_wml::node* si
 	cfg.root().set_attr_dup("side", (*side)["side"]);
 
 	// Tell the host which side the new player should take.
-	server.async_send_doc_queued(owner_, cfg);
+	server.async_send_doc_queued(owner_->socket(), cfg);
 	return true;
 }
 
-bool game::take_side(const socket_ptr& user)
+bool game::take_side(player_iterator user)
 {
 	DBG_GAME << "take_side...\n";
 
@@ -393,7 +369,7 @@ bool game::take_side(const socket_ptr& user)
 	}
 
 	simple_wml::document cfg;
-	cfg.root().set_attr_dup("name", player_connections_.find(user)->name().c_str());
+	cfg.root().set_attr_dup("name", user->name().c_str());
 
 	// FIXME: The client code (multiplayer.wait.cpp) the host code (connect_engine.cpp) and the server code
 	// (this file) has this code to figure out a fitting side for new players, this is clearly too much.
@@ -402,7 +378,7 @@ bool game::take_side(const socket_ptr& user)
 
 	for(const simple_wml::node* side : sides) {
 		if(((*side)["controller"] == "human" || (*side)["controller"] == "reserved")
-				&& (*side)["current_player"] == player_connections_.find(user)->name().c_str()) {
+				&& (*side)["current_player"] == user->name().c_str()) {
 
 			if(send_taken_side(cfg, side)) {
 				return true;
@@ -462,18 +438,13 @@ void game::update_side_data()
 	// For each user:
 	// * Find the username.
 	// * Find the side this username corresponds to.
-	for(const socket_ptr& user : users) {
-		auto iter = player_connections_.find(user);
-		if(iter == player_connections_.end()) {
-			missing_user(user, __func__);
-			continue;
-		}
+	for(auto iter : users) {
 
 		bool side_found = false;
 		for(unsigned side_index = 0; side_index < level_sides.size(); ++side_index) {
 			const simple_wml::node* side = level_sides[side_index];
 
-			if(side_index >= sides_.size() || sides_[side_index] != 0) {
+			if(side_index >= sides_.size() || sides_[side_index]) {
 				continue;
 			}
 
@@ -487,9 +458,9 @@ void game::update_side_data()
 				}
 
 				side_controllers_[side_index].parse(controller);
-				sides_[side_index] = user;
+				sides_[side_index] = iter;
 				side_found = true;
-			} else if(user == owner_ && (controller == "null")) {
+			} else if(iter == owner_ && (controller == "null")) {
 				// the *user == owner_ check has no effect,
 				// it's just an optimisation so that we only do this once.
 				side_controllers_[side_index].parse(controller);
@@ -497,10 +468,10 @@ void game::update_side_data()
 		}
 
 		if(side_found) {
-			players_.push_back(user);
+			players_.push_back(iter);
 			iter->info().set_status(player::PLAYING);
 		} else {
-			observers_.push_back(user);
+			observers_.push_back(iter);
 			iter->info().set_status(player::OBSERVING);
 		}
 	}
@@ -508,12 +479,12 @@ void game::update_side_data()
 	DBG_GAME << debug_player_info();
 }
 
-void game::transfer_side_control(const socket_ptr& sock, const simple_wml::node& cfg)
+void game::transfer_side_control(player_iterator player, const simple_wml::node& cfg)
 {
 	DBG_GAME << "transfer_side_control...\n";
 
-	if(!is_player(sock) && sock != owner_) {
-		send_server_message("You cannot change controllers: not a player.", sock);
+	if(!is_player(player) && player != owner_) {
+		send_server_message("You cannot change controllers: not a player.", player);
 		return;
 	}
 
@@ -522,49 +493,45 @@ void game::transfer_side_control(const socket_ptr& sock, const simple_wml::node&
 	if(side_num < 1 || side_num > sides_.size()) {
 		std::ostringstream msg;
 		msg << "The side number has to be between 1 and " << sides_.size() << ".";
-		send_server_message(msg.str(), sock);
+		send_server_message(msg.str(), player);
 		return;
 	}
 
 	if(side_num > get_sides_list().size()) {
-		send_server_message("Invalid side number.", sock);
+		send_server_message("Invalid side number.", player);
 		return;
 	}
 
 	const simple_wml::string_span& newplayer_name = cfg["player"];
-	const socket_ptr old_player = sides_[side_num - 1];
-	const auto oldplayer = player_connections_.find(old_player);
+	auto old_player = sides_[side_num - 1];
 	const std::string& controller_type = cfg["to"].to_string();
-	if(oldplayer == player_connections_.end()) {
-		missing_user(old_player, __func__);
-	}
 
-	const std::string old_player_name = username(old_player);
+	const std::string old_player_name = old_player ? username(old_player.value()) : "null";
 
 	// Not supported anymore.
 	if(newplayer_name.empty()) {
 		std::stringstream msg;
 		msg << "Received invalid [change_controller] with no player= attribute specified";
 		DBG_GAME << msg.str() << "\n";
-		send_server_message(msg.str(), sock);
+		send_server_message(msg.str(), player);
 		return;
 	}
 
 	// Check if the sender actually owns the side he gives away or is the host.
-	if(!(sock == old_player || sock == owner_)) {
+	if(!(player == old_player || player == owner_)) {
 		std::stringstream msg;
 		msg << "You can't give away side " << side_num << ". It's controlled by '" << old_player_name << "' not you.";
 		DBG_GAME << msg.str() << "\n";
-		send_server_message(msg.str(), sock);
+		send_server_message(msg.str(), player);
 		return;
 	}
 
 	// find the player that is passed control
-	socket_ptr newplayer = find_user(newplayer_name);
+	auto newplayer { find_user(newplayer_name) };
 
 	// Is he in this game?
-	if(player_connections_.find(newplayer) == player_connections_.end() || !is_member(newplayer)) {
-		send_server_message(newplayer_name.to_string() + " is not in this game", sock);
+	if(!newplayer || !is_member(newplayer.value())) {
+		send_server_message(newplayer_name.to_string() + " is not in this game", player);
 		return;
 	}
 
@@ -574,11 +541,11 @@ void game::transfer_side_control(const socket_ptr& sock, const simple_wml::node&
 		if(CONTROLLER::string_to_enum(controller_type) == side_controllers_[side_num - 1]) {
 			std::stringstream msg;
 			msg << "Side " << side_num << " is already controlled by " << newplayer_name << ".";
-			send_server_message(msg.str(), sock);
+			send_server_message(msg.str(), player);
 			return;
 		} else {
 			side_controllers_[side_num - 1] = CONTROLLER::string_to_enum(controller_type);
-			change_controller_type(side_num - 1, newplayer, player_connections_.find(newplayer)->info().name());
+			change_controller_type(side_num - 1, newplayer.value(), newplayer.value()->info().name());
 			return;
 		}
 	}
@@ -586,10 +553,10 @@ void game::transfer_side_control(const socket_ptr& sock, const simple_wml::node&
 	sides_[side_num - 1].reset();
 
 	// If the old player lost his last side, make him an observer.
-	if(std::find(sides_.begin(), sides_.end(), old_player) == sides_.end() && is_player(old_player)) {
-		observers_.push_back(old_player);
+	if(old_player && std::find(sides_.begin(), sides_.end(), old_player) == sides_.end() && is_player(old_player.value())) {
+		observers_.push_back(old_player.value());
 
-		player_connections_.find(old_player)->info().set_status(player::OBSERVING);
+		old_player.value()->info().set_status(player::OBSERVING);
 		players_.erase(std::remove(players_.begin(), players_.end(), old_player), players_.end());
 
 		// Tell others that the player becomes an observer.
@@ -598,28 +565,28 @@ void game::transfer_side_control(const socket_ptr& sock, const simple_wml::node&
 		// Update the client side observer list for everyone except old player.
 		simple_wml::document observer_join;
 		observer_join.root().add_child("observer").set_attr_dup("name", old_player_name.c_str());
-		send_data(observer_join, old_player);
+		send_data(observer_join, old_player.value());
 	}
 
-	change_controller(side_num - 1, newplayer, player_connections_.find(newplayer)->info().name(), false);
+	change_controller(side_num - 1, newplayer.value(), newplayer.value()->info().name(), false);
 
 	// If we gave the new side to an observer add him to players_.
-	if(is_observer(newplayer)) {
-		players_.push_back(newplayer);
-		player_connections_.find(newplayer)->info().set_status(player::PLAYING);
+	if(is_observer(newplayer.value())) {
+		players_.push_back(newplayer.value());
+		newplayer.value()->info().set_status(player::PLAYING);
 		observers_.erase(std::remove(observers_.begin(), observers_.end(), newplayer), observers_.end());
 		// Send everyone but the new player the observer_quit message.
-		send_observerquit(newplayer);
+		send_observerquit(newplayer.value());
 	}
 }
 
 void game::change_controller(
-		const std::size_t side_index, const socket_ptr& sock, const std::string& player_name, const bool player_left)
+		const std::size_t side_index, player_iterator player, const std::string& player_name, const bool player_left)
 {
 	DBG_GAME << __func__ << "...\n";
 
 	const std::string& side = lexical_cast_default<std::string, std::size_t>(side_index + 1);
-	sides_[side_index] = sock;
+	sides_[side_index] = player;
 
 	if(player_left && side_controllers_[side_index] == CONTROLLER::AI) {
 		// Automatic AI side transfer.
@@ -629,7 +596,7 @@ void game::change_controller(
 		}
 	}
 
-	auto response = change_controller_type(side_index, sock, player_name);
+	auto response = change_controller_type(side_index, player, player_name);
 
 	if(started_) {
 		// the purpose of these records is so that observers, replay viewers, get controller updates correctly
@@ -641,11 +608,11 @@ void game::change_controller(
 	// side_drop already.)
 	if(!player_left) {
 		response->root().child("change_controller")->set_attr("is_local", "yes");
-		server.async_send_doc_queued(sock, *response.get());
+		server.async_send_doc_queued(player->socket(), *response.get());
 	}
 }
 
-std::unique_ptr<simple_wml::document> game::change_controller_type(const std::size_t side_index, const socket_ptr& sock, const std::string& player_name)
+std::unique_ptr<simple_wml::document> game::change_controller_type(const std::size_t side_index, player_iterator player, const std::string& player_name)
 {
 	const std::string& side = std::to_string(side_index + 1);
 	simple_wml::document response;
@@ -658,7 +625,7 @@ std::unique_ptr<simple_wml::document> game::change_controller_type(const std::si
 	change.set_attr_dup("controller", side_controllers_[side_index].to_cstring());
 	change.set_attr("is_local", "no");
 
-	send_data(response, sock);
+	send_data(response, player);
 	return response.clone();
 }
 
@@ -669,7 +636,7 @@ void game::notify_new_host()
 	cfg.root().add_child("host_transfer");
 
 	std::string message = owner_name + " has been chosen as the new host.";
-	server.async_send_doc_queued(owner_, cfg);
+	server.async_send_doc_queued(owner_->socket(), cfg);
 	send_and_record_server_message(message);
 }
 
@@ -686,7 +653,7 @@ bool game::describe_slots()
 	for(const simple_wml::node* side : get_sides_list()) {
 		if(((*side)["allow_player"].to_bool(true) == false) || (*side)["controller"] == "null") {
 			num_sides--;
-		} else if(sides_[i] == 0) {
+		} else if(!sides_[i]) {
 			++available_slots;
 		}
 
@@ -704,9 +671,9 @@ bool game::describe_slots()
 	return true;
 }
 
-bool game::player_is_banned(const socket_ptr& sock, const std::string& name) const
+bool game::player_is_banned(player_iterator player, const std::string& name) const
 {
-	auto ban = std::find(bans_.begin(), bans_.end(), client_address(sock));
+	auto ban = std::find(bans_.begin(), bans_.end(), player->client_ip());
 	auto name_ban = std::find(name_bans_.begin(), name_bans_.end(), name);
 
 	return ban != bans_.end() || name_ban != name_bans_.end();
@@ -722,7 +689,7 @@ void game::mute_all_observers()
 	}
 }
 
-void game::send_muted_observers(const socket_ptr& user) const
+void game::send_muted_observers(player_iterator user) const
 {
 	if(all_observers_muted_) {
 		send_server_message("All observers are muted.", user);
@@ -734,7 +701,7 @@ void game::send_muted_observers(const socket_ptr& user) const
 	send_server_message("Muted observers: " + muted_nicks, user);
 }
 
-void game::mute_observer(const simple_wml::node& mute, const socket_ptr& muter)
+void game::mute_observer(const simple_wml::node& mute, player_iterator muter)
 {
 	if(muter != owner_) {
 		send_server_message("You cannot mute: not the game host.", muter);
@@ -747,13 +714,13 @@ void game::mute_observer(const simple_wml::node& mute, const socket_ptr& muter)
 		return;
 	}
 
-	const socket_ptr& user = find_user(username);
+	auto user { find_user(username) };
 
 	/**
 	 * @todo FIXME: Maybe rather save muted nicks as a set of strings and
 	 * also allow muting of usernames not in the game.
 	 */
-	if(!user || !is_observer(user)) {
+	if(!user || !is_observer(user.value())) {
 		send_server_message("Observer '" + username.to_string() + "' not found.", muter);
 		return;
 	}
@@ -764,19 +731,19 @@ void game::mute_observer(const simple_wml::node& mute, const socket_ptr& muter)
 		return;
 	}
 
-	if(is_muted_observer(user)) {
+	if(is_muted_observer(user.value())) {
 		send_server_message(username.to_string() + " is already muted.", muter);
 		return;
 	}
 
-	LOG_GAME << client_address(muter) << "\t" << game::username(muter) << " muted: " << username << " ("
-	         << client_address(user) << ")\tin game:\t\"" << name_ << "\" (" << id_ << ", " << db_id_ << ")\n";
+	LOG_GAME << muter->client_ip() << "\t" << game::username(muter) << " muted: " << username << " ("
+	         << user.value()->client_ip() << ")\tin game:\t\"" << name_ << "\" (" << id_ << ", " << db_id_ << ")\n";
 
-	muted_observers_.push_back(user);
+	muted_observers_.push_back(user.value());
 	send_and_record_server_message(username.to_string() + " has been muted.");
 }
 
-void game::unmute_observer(const simple_wml::node& unmute, const socket_ptr& unmuter)
+void game::unmute_observer(const simple_wml::node& unmute, player_iterator unmuter)
 {
 	if(unmuter != owner_) {
 		send_server_message("You cannot unmute: not the game host.", unmuter);
@@ -790,105 +757,105 @@ void game::unmute_observer(const simple_wml::node& unmute, const socket_ptr& unm
 		return;
 	}
 
-	const socket_ptr& user = find_user(username);
-	if(!user || !is_observer(user)) {
+	auto user { find_user(username) };
+	if(!user || !is_observer(user.value())) {
 		send_server_message("Observer '" + username.to_string() + "' not found.", unmuter);
 		return;
 	}
 
-	if(!is_muted_observer(user)) {
+	if(!is_muted_observer(user.value())) {
 		send_server_message(username.to_string() + " is not muted.", unmuter);
 		return;
 	}
 
-	LOG_GAME << client_address(unmuter) << "\t" << game::username(unmuter) << " unmuted: " << username << " ("
-	         << client_address(user) << ")\tin game:\t\"" << name_ << "\" (" << id_ << ", " << db_id_ << ")\n";
+	LOG_GAME << unmuter->client_ip() << "\t" << game::username(unmuter) << " unmuted: " << username << " ("
+	         << user.value()->client_ip() << ")\tin game:\t\"" << name_ << "\" (" << id_ << ", " << db_id_ << ")\n";
 
 	muted_observers_.erase(std::remove(muted_observers_.begin(), muted_observers_.end(), user), muted_observers_.end());
 	send_and_record_server_message(username.to_string() + " has been unmuted.");
 }
 
-void game::send_leave_game(const socket_ptr& user) const
+void game::send_leave_game(player_iterator user) const
 {
 	static simple_wml::document leave_game("[leave_game]\n[/leave_game]\n", simple_wml::INIT_COMPRESSED);
-	server.async_send_doc_queued(user, leave_game);
+	server.async_send_doc_queued(user->socket(), leave_game);
 }
 
-socket_ptr game::kick_member(const simple_wml::node& kick, const socket_ptr& kicker)
+utils::optional<player_iterator> game::kick_member(const simple_wml::node& kick, player_iterator kicker)
 {
 	if(kicker != owner_) {
 		send_server_message("You cannot kick: not the game host", kicker);
-		return socket_ptr();
+		return {};
 	}
 
 	const simple_wml::string_span& username = kick["username"];
-	const socket_ptr& user = find_user(username);
+	auto user { find_user(username) };
 
-	if(!user || !is_member(user)) {
+	if(!user || !is_member(user.value())) {
 		send_server_message("'" + username.to_string() + "' is not a member of this game.", kicker);
-		return socket_ptr();
+		return {};
 	} else if(user == kicker) {
 		send_server_message("Don't kick yourself, silly.", kicker);
-		return socket_ptr();
-	} else if(player_connections_.find(user)->info().is_moderator()) {
+		return {};
+	} else if(user.value()->info().is_moderator()) {
 		send_server_message("You're not allowed to kick a moderator.", kicker);
-		return socket_ptr();
+		return {};
 	}
 
-	LOG_GAME << client_address(kicker) << "\t" << game::username(kicker) << "\tkicked: " << username << " ("
-	         << client_address(user) << ")\tfrom game:\t\"" << name_ << "\" (" << id_ << ", " << db_id_ << ")\n";
+	LOG_GAME << kicker->client_ip() << "\t" << game::username(kicker) << "\tkicked: " << username << " ("
+	         << user.value()->client_ip() << ")\tfrom game:\t\"" << name_ << "\" (" << id_ << ", " << db_id_ << ")\n";
 
 	send_and_record_server_message(username.to_string() + " has been kicked.");
 
 	// Tell the user to leave the game.
-	send_leave_game(user);
-	remove_player(user);
+	send_leave_game(user.value());
+	remove_player(user.value());
 	return user;
 }
 
-socket_ptr game::ban_user(const simple_wml::node& ban, const socket_ptr& banner)
+utils::optional<player_iterator> game::ban_user(const simple_wml::node& ban, player_iterator banner)
 {
 	if(banner != owner_) {
 		send_server_message("You cannot ban: not the game host", banner);
-		return socket_ptr();
+		return {};
 	}
 
 	const simple_wml::string_span& username = ban["username"];
-	const socket_ptr& user = find_user(username);
+	auto user { find_user(username) };
 
 	if(!user) {
 		send_server_message("User '" + username.to_string() + "' not found.", banner);
-		return socket_ptr();
+		return {};
 	} else if(user == banner) {
 		send_server_message("Don't ban yourself, silly.", banner);
-		return socket_ptr();
-	} else if(player_is_banned(user, username.to_string())) {
+		return {};
+	} else if(player_is_banned(user.value(), username.to_string())) {
 		send_server_message("'" + username.to_string() + "' is already banned.", banner);
-		return socket_ptr();
-	} else if(player_connections_.find(user)->info().is_moderator()) {
+		return {};
+	} else if(user.value()->info().is_moderator()) {
 		send_server_message("You're not allowed to ban a moderator.", banner);
-		return socket_ptr();
+		return {};
 	}
 
-	LOG_GAME << client_address(banner) << "\t" << game::username(banner) << "\tbanned: " << username << " ("
-	         << client_address(user) << ")\tfrom game:\t\"" << name_ << "\" (" << id_ << ", " << db_id_ << ")\n";
+	LOG_GAME << banner->client_ip() << "\t" << game::username(banner) << "\tbanned: " << username << " ("
+	         << user.value()->client_ip() << ")\tfrom game:\t\"" << name_ << "\" (" << id_ << ", " << db_id_ << ")\n";
 
-	bans_.push_back(client_address(user));
+	bans_.push_back(user.value()->client_ip());
 	name_bans_.push_back(username.to_string());
 	send_and_record_server_message(username.to_string() + " has been banned.");
 
-	if(is_member(user)) {
+	if(is_member(user.value())) {
 		// tell the user to leave the game.
-		send_leave_game(user);
-		remove_player(user);
+		send_leave_game(user.value());
+		remove_player(user.value());
 		return user;
 	}
 
 	// Don't return the user if he wasn't in this game.
-	return socket_ptr();
+	return {};
 }
 
-void game::unban_user(const simple_wml::node& unban, const socket_ptr& unbanner)
+void game::unban_user(const simple_wml::node& unban, player_iterator unbanner)
 {
 	if(unbanner != owner_) {
 		send_server_message("You cannot unban: not the game host.", unbanner);
@@ -896,37 +863,33 @@ void game::unban_user(const simple_wml::node& unban, const socket_ptr& unbanner)
 	}
 
 	const simple_wml::string_span& username = unban["username"];
-	const socket_ptr& user = find_user(username);
+	auto user { find_user(username) };
 
 	if(!user) {
 		send_server_message("User '" + username.to_string() + "' not found.", unbanner);
 		return;
 	}
 
-	if(!player_is_banned(user, username.to_string())) {
+	if(!player_is_banned(user.value(), username.to_string())) {
 		send_server_message("'" + username.to_string() + "' is not banned.", unbanner);
 		return;
 	}
 
 	LOG_GAME
-		<< client_address(unbanner) << "\t" << player_connections_.find(unbanner)->info().name()
-		<< "\tunbanned: " << username << " (" << client_address(user) << ")\tfrom game:\t\"" << name_ << "\" ("
+		<< unbanner->client_ip() << "\t" << unbanner->info().name()
+		<< "\tunbanned: " << username << " (" << user.value()->client_ip() << ")\tfrom game:\t\"" << name_ << "\" ("
 		<< id_ << ", " << db_id_ << ")\n";
 
-	bans_.erase(std::remove(bans_.begin(), bans_.end(), client_address(user)), bans_.end());
+	bans_.erase(std::remove(bans_.begin(), bans_.end(), user.value()->client_ip()), bans_.end());
 	name_bans_.erase(std::remove(name_bans_.begin(), name_bans_.end(), username.to_string()), name_bans_.end());
 	send_and_record_server_message(username.to_string() + " has been unbanned.");
 }
 
-void game::process_message(simple_wml::document& data, const socket_ptr& user)
+void game::process_message(simple_wml::document& data, player_iterator user)
 {
-	if(!owner_) {
-		ERR_GAME << "No owner in game::process_message" << std::endl;
-	}
-
 	simple_wml::node* const message = data.root().child("message");
 	assert(message);
-	message->set_attr_dup("sender", player_connections_.find(user)->info().name().c_str());
+	message->set_attr_dup("sender", user->info().name().c_str());
 
 	const simple_wml::string_span& msg = (*message)["message"];
 	chat_message::truncate_message(msg, *message);
@@ -934,7 +897,7 @@ void game::process_message(simple_wml::document& data, const socket_ptr& user)
 	send_data(data, user, "game message");
 }
 
-bool game::is_legal_command(const simple_wml::node& command, const socket_ptr& user)
+bool game::is_legal_command(const simple_wml::node& command, player_iterator user)
 {
 	const bool is_player = this->is_player(user);
 	const bool is_host = user == owner_;
@@ -999,7 +962,7 @@ bool game::is_legal_command(const simple_wml::node& command, const socket_ptr& u
 	return false;
 }
 
-bool game::process_turn(simple_wml::document& data, const socket_ptr& user)
+bool game::process_turn(simple_wml::document& data, player_iterator user)
 {
 	// DBG_GAME << "processing commands: '" << cfg << "'\n";
 	if(!started_) {
@@ -1020,16 +983,16 @@ bool game::process_turn(simple_wml::document& data, const socket_ptr& user)
 
 	for(simple_wml::node* command : commands) {
 		DBG_GAME << "game " << id_ << ", " << db_id_ << " received [" << (*command).first_child() << "] from player '" << username(user)
-				 << "'(" << user << ") during turn " << current_side_index_ + 1 << "," << current_turn_ << "\n";
+				 << "'(" << ") during turn " << current_side_index_ + 1 << "," << current_turn_ << "\n";
 		if(!is_legal_command(*command, user)) {
 			LOG_GAME << "ILLEGAL COMMAND in game: " << id_ << ", " << db_id_ << " (((" << simple_wml::node_to_string(*command)
 					 << ")))\n";
 
 			std::stringstream msg;
 			msg << "Removing illegal command '" << (*command).first_child().to_string() << "' from: " << username(user)
-				<< ". Current player is: " << username(current_player()) << " (" << current_side_index_ + 1 << "/" << nsides_
+				<< ". Current player is: " << username(current_player().value()) << " (" << current_side_index_ + 1 << "/" << nsides_
 				<< ").";
-			LOG_GAME << msg.str() << " (socket: " << current_player() << ") (game id: " << id_ << ", " << db_id_ << ")\n";
+			LOG_GAME << msg.str() << " (socket: " << current_player().value()->socket() << ") (game id: " << id_ << ", " << db_id_ << ")\n";
 			send_and_record_server_message(msg.str());
 
 			marked.push_back(index - marked.size());
@@ -1045,7 +1008,7 @@ bool game::process_turn(simple_wml::document& data, const socket_ptr& user)
 
 			// Force the description to be correct,
 			// to prevent spoofing of messages.
-			speak.set_attr_dup("id", player_connections_.find(user)->info().name().c_str());
+			speak.set_attr_dup("id", user->info().name().c_str());
 
 			// Also check the side for players.
 			if(is_player(user)) {
@@ -1077,7 +1040,7 @@ bool game::process_turn(simple_wml::document& data, const socket_ptr& user)
 
 				// figure out who gets the surrendered side
 				if(owner_ == user) {
-					playername = username(sides_[(side_index + 1) % sides_.size()]);
+					playername = username(sides_[(side_index + 1) % sides_.size()].value());
 				} else {
 					playername = username(owner_);
 				}
@@ -1164,7 +1127,7 @@ void game::handle_random_choice(const simple_wml::node&)
 	command.set_attr("from_side", "server");
 	command.set_attr("dependent", "yes");
 
-	send_data(*mdata, socket_ptr(), "game replay");
+	send_data(*mdata, {}, "game replay");
 	record_data(std::move(mdata));
 }
 
@@ -1208,7 +1171,7 @@ void game::handle_controller_choice(const simple_wml::node& req)
 	const bool becomes_null = new_controller == CONTROLLER::EMPTY;
 
 	if(was_null) {
-		assert(sides_[side_index] == 0);
+		assert(!sides_[side_index]);
 		sides_[side_index] = current_player();
 	}
 
@@ -1229,9 +1192,8 @@ void game::handle_controller_choice(const simple_wml::node& req)
 	command.set_attr("from_side", "server");
 	command.set_attr("dependent", "yes");
 
-	// Calling send_to_one to 0 connect causes the package to be sent to all clients.
-	if(sides_[side_index] != 0) {
-		server.async_send_doc_queued(sides_[side_index], *mdata);
+	if(sides_[side_index]) {
+		server.async_send_doc_queued(sides_[side_index].value()->socket(), *mdata);
 	}
 
 	change_controller_wml.set_attr("is_local", "no");
@@ -1240,7 +1202,7 @@ void game::handle_controller_choice(const simple_wml::node& req)
 	record_data(std::move(mdata));
 }
 
-void game::handle_choice(const simple_wml::node& data, const socket_ptr& user)
+void game::handle_choice(const simple_wml::node& data, player_iterator user)
 {
 
 	if(!started_) {
@@ -1259,7 +1221,7 @@ void game::handle_choice(const simple_wml::node& data, const socket_ptr& user)
 	// since we reset the last_choice_request_id_ when a new scenario is loaded,
 	// the code would otherwise wrongly accept these requests from client in old
 	// scenarios. which would result on oos.
-	if(players_not_advanced_.find(user) != players_not_advanced_.end()) {
+	if(players_not_advanced_.find(&*user) != players_not_advanced_.end()) {
 		return;
 	}
 
@@ -1270,7 +1232,7 @@ void game::handle_choice(const simple_wml::node& data, const socket_ptr& user)
 	}
 
 	DBG_GAME << "answering seed request " << request_id << " by player "
-			 << player_connections_.find(user)->info().name() << "(" << user << ")" << std::endl;
+			 << user->info().name() << "(" << user->socket() << ")" << std::endl;
 	last_choice_request_id_ = request_id;
 
 	if(const simple_wml::node* rand = data.child("random_seed")) {
@@ -1284,7 +1246,7 @@ void game::handle_choice(const simple_wml::node& data, const socket_ptr& user)
 	}
 }
 
-void game::process_whiteboard(simple_wml::document& data, const socket_ptr& user)
+void game::process_whiteboard(simple_wml::document& data, player_iterator user)
 {
 	if(!started_ || !is_player(user)) {
 		return;
@@ -1298,7 +1260,7 @@ void game::process_whiteboard(simple_wml::document& data, const socket_ptr& user
 
 	if(side_index >= sides_.size() || sides_[side_index] != user) {
 		std::ostringstream msg;
-		msg << "Ignoring illegal whiteboard data, sent from user '" << player_connections_.find(user)->info().name()
+		msg << "Ignoring illegal whiteboard data, sent from user '" << user->info().name()
 		    << "' which had an invalid side '" << side_index + 1 << "' specified" << std::endl;
 
 		const std::string& msg_str = msg.str();
@@ -1311,7 +1273,7 @@ void game::process_whiteboard(simple_wml::document& data, const socket_ptr& user
 	send_data_sides(data, to_sides, user);
 }
 
-void game::process_change_turns_wml(simple_wml::document& data, const socket_ptr& user)
+void game::process_change_turns_wml(simple_wml::document& data, player_iterator user)
 {
 	if(!started_ || !is_player(user)) {
 		return;
@@ -1392,14 +1354,14 @@ void game::update_turn_data()
  * @todo differentiate between "observers not allowed" and "player already in the game" errors.
  * maybe return a string with an error message.
  */
-bool game::add_player(const socket_ptr& player, bool observer)
+bool game::add_player(player_iterator player, bool observer)
 {
 	if(is_member(player)) {
-		ERR_GAME << "ERROR: Player is already in this game. (socket: " << player << ")\n";
+		ERR_GAME << "ERROR: Player is already in this game. (socket: " << player->socket() << ")\n";
 		return false;
 	}
 
-	socket_ptr user = player;
+	auto user = player;
 
 	DBG_GAME << debug_player_info();
 
@@ -1408,10 +1370,10 @@ bool game::add_player(const socket_ptr& player, bool observer)
 		DBG_GAME << "adding player...\n";
 		players_.push_back(player);
 
-		player_connections_.find(user)->info().set_status(player::PLAYING);
+		user->info().set_status(player::PLAYING);
 
-		send_and_record_server_message(player_connections_.find(user)->info().name() + " has joined the game.", player);
-	} else if(!allow_observers() && !player_connections_.find(user)->info().is_moderator()) {
+		send_and_record_server_message(user->info().name() + " has joined the game.", player);
+	} else if(!allow_observers() && !user->info().is_moderator()) {
 		return false;
 	} else {
 		if(!observer) {
@@ -1423,34 +1385,34 @@ bool game::add_player(const socket_ptr& player, bool observer)
 		observers_.push_back(player);
 		if(!allow_observers()) {
 			send_and_record_server_message(
-				player_connections_.find(user)->info().name() + " is now observing the game.", player);
+				user->info().name() + " is now observing the game.", player);
 		}
 
 		simple_wml::document observer_join;
 		observer_join.root()
 			.add_child("observer")
-			.set_attr_dup("name", player_connections_.find(user)->info().name().c_str());
+			.set_attr_dup("name", user->info().name().c_str());
 
 		// Send observer join to everyone except the new observer.
 		send_data(observer_join, player);
 	}
 
 	LOG_GAME
-		<< client_address(player) << "\t" << player_connections_.find(user)->info().name() << "\tjoined game:\t\""
-		<< name_ << "\" (" << id_ << ", " << db_id_ << ")" << (observer ? " as an observer" : "") << ". (socket: " << player
+		<< player->client_ip() << "\t" << user->info().name() << "\tjoined game:\t\""
+		<< name_ << "\" (" << id_ << ", " << db_id_ << ")" << (observer ? " as an observer" : "") << ". (socket: " << player->socket()
 		<< ")\n";
 
-	player_connections_.find(user)->info().mark_available(id_, name_);
-	player_connections_.find(user)->info().set_status((observer) ? player::OBSERVING : player::PLAYING);
+	user->info().mark_available(id_, name_);
+	user->info().set_status((observer) ? player::OBSERVING : player::PLAYING);
 	DBG_GAME << debug_player_info();
 
 	// Send the user the game data.
-	server.async_send_doc_queued(player, level_);
+	server.async_send_doc_queued(player->socket(), level_);
 
 	if(started_) {
 		// Tell this player that the game has started
 		static simple_wml::document start_game_doc("[start_game]\n[/start_game]\n", simple_wml::INIT_COMPRESSED);
-		server.async_send_doc_queued(player, start_game_doc);
+		server.async_send_doc_queued(player->socket(), start_game_doc);
 
 		// Send observer join of all the observers in the game to the new player
 		// only once the game started. The client forgets about it anyway otherwise.
@@ -1465,7 +1427,7 @@ bool game::add_player(const socket_ptr& player, bool observer)
 	const std::string clones = has_same_ip(player);
 	if(!clones.empty()) {
 		send_and_record_server_message(
-			player_connections_.find(user)->info().name() + " has the same IP as: " + clones);
+			user->info().name() + " has the same IP as: " + clones);
 	}
 
 	if(became_observer) {
@@ -1476,10 +1438,10 @@ bool game::add_player(const socket_ptr& player, bool observer)
 	return true;
 }
 
-bool game::remove_player(const socket_ptr& player, const bool disconnect, const bool destruct)
+bool game::remove_player(player_iterator player, const bool disconnect, const bool destruct)
 {
 	if(!is_member(player)) {
-		ERR_GAME << "ERROR: User is not in this game. (socket: " << player << ")\n";
+		ERR_GAME << "ERROR: User is not in this game. (socket: " << player->socket() << ")\n";
 		return false;
 	}
 
@@ -1491,26 +1453,26 @@ bool game::remove_player(const socket_ptr& player, const bool disconnect, const 
 
 	players_.erase(std::remove(players_.begin(), players_.end(), player), players_.end());
 	observers_.erase(std::remove(observers_.begin(), observers_.end(), player), observers_.end());
-	players_not_advanced_.erase(player);
+	players_not_advanced_.erase(&*player);
 
 	const bool game_ended = players_.empty() || (host && !started_);
 
-	socket_ptr user = player;
+	auto user = player;
 
 	LOG_GAME
-		<< client_address(user)
-		<< "\t" << player_connections_.find(user)->info().name()
+		<< user->client_ip()
+		<< "\t" << user->info().name()
 		<< ((game_ended && !(observer && destruct)) ? (started_ ? "\tended" : "\taborted") : "\thas left")
 		<< " game:\t\"" << name_ << "\" (" << id_ << ", " << db_id_ << ")"
 		<< (game_ended && started_ && !(observer && destruct)
 			? " at turn: " + lexical_cast_default<std::string, std::size_t>(current_turn())
 				+ " with reason: '" + termination_reason() + "'"
 			: "")
-		<< (observer ? " as an observer" : "") << (disconnect ? " and disconnected" : "") << ". (socket: " << user
+		<< (observer ? " as an observer" : "") << (disconnect ? " and disconnected" : "") << ". (socket: " << user->socket()
 		<< ")\n";
 
 	if(game_ended && started_ && !(observer && destruct)) {
-		send_server_message_to_all(player_connections_.find(user)->info().name() + " ended the game.", player);
+		send_server_message_to_all(user->info().name() + " ended the game.", player);
 	}
 
 	if(game_ended || destruct) {
@@ -1520,13 +1482,13 @@ bool game::remove_player(const socket_ptr& player, const bool disconnect, const 
 	// Don't mark_available() since the player got already removed from the
 	// games_and_users_list_.
 	if(!disconnect) {
-		player_connections_.find(user)->info().mark_available();
+		user->info().mark_available();
 	}
 
 	if(observer) {
 		send_observerquit(user);
 	} else {
-		send_and_record_server_message(player_connections_.find(user)->info().name()
+		send_and_record_server_message(user->info().name()
 			+ (disconnect ? " has disconnected." : " has left the game."), player);
 	}
 
@@ -1541,7 +1503,7 @@ bool game::remove_player(const socket_ptr& player, const bool disconnect, const 
 	// Look for all sides the player controlled and drop them.
 	// (Give them to the host.
 	for(unsigned side_index = 0; side_index < sides_.size(); ++side_index) {
-		const socket_ptr& side = sides_[side_index];
+		auto side = sides_[side_index];
 
 		if(side != player) {
 			continue;
@@ -1556,15 +1518,10 @@ bool game::remove_player(const socket_ptr& player, const bool disconnect, const 
 		// Check whether the host is actually a player and make him one if not.
 		if(!is_player(owner_)) {
 			DBG_GAME << "making the owner a player...\n";
-			auto owner_iter = player_connections_.find(owner_);
-			if(owner_iter == player_connections_.end())
-				ERR_GAME << "game owner " << client_address(owner_) << "is not in player_connections_\n";
-			else {
-				owner_iter->info().set_status(player::PLAYING);
-				observers_.erase(std::remove(observers_.begin(), observers_.end(), owner_), observers_.end());
-				players_.push_back(owner_);
-				send_observerquit(owner_);
-			}
+			owner_->info().set_status(player::PLAYING);
+			observers_.erase(std::remove(observers_.begin(), observers_.end(), owner_), observers_.end());
+			players_.push_back(owner_);
+			send_observerquit(owner_);
 		}
 
 		// send the host a notification of removal of this side
@@ -1578,7 +1535,7 @@ bool game::remove_player(const socket_ptr& player, const bool disconnect, const 
 
 		DBG_GAME << "*** sending side drop: \n" << drop.output() << std::endl;
 
-		server.async_send_doc_queued(owner_, drop);
+		server.async_send_doc_queued(owner_->socket(), drop);
 	}
 
 	if(ai_transfer) {
@@ -1591,7 +1548,7 @@ bool game::remove_player(const socket_ptr& player, const bool disconnect, const 
 	return false;
 }
 
-void game::send_user_list(const socket_ptr& exclude)
+void game::send_user_list(utils::optional<player_iterator> exclude)
 {
 	// If the game hasn't started yet, then send all players a list of the users in the game.
 	if(started_ /*|| description_ == nullptr*/) {
@@ -1601,38 +1558,34 @@ void game::send_user_list(const socket_ptr& exclude)
 	simple_wml::document cfg;
 	simple_wml::node& list = cfg.root();
 
-	for(const socket_ptr& user_ptr : all_game_users()) {
-		const auto pl = player_connections_.find(user_ptr);
+	for(auto pl : all_game_users()) {
+		simple_wml::node& user = list.add_child("user");
 
-		if(pl != player_connections_.end()) {
-			simple_wml::node& user = list.add_child("user");
-
-			// Don't need to duplicate pl->info().name().c_str() because the
-			// document will be destroyed by the end of the function
-			user.set_attr_dup("name", pl->info().name().c_str());
-			user.set_attr("host", is_owner(user_ptr) ? "yes" : "no");
-			user.set_attr("observer", is_observer(user_ptr) ? "yes" : "no");
-		}
+		// Don't need to duplicate pl->info().name().c_str() because the
+		// document will be destroyed by the end of the function
+		user.set_attr_dup("name", pl->info().name().c_str());
+		user.set_attr("host", is_owner(pl) ? "yes" : "no");
+		user.set_attr("observer", is_observer(pl) ? "yes" : "no");
 	}
 
 	send_data(cfg, exclude);
 }
 
-void game::new_scenario(const socket_ptr& sender)
+void game::new_scenario(player_iterator sender)
 {
 	assert(sender == owner_);
 	players_not_advanced_.clear();
-	for(const socket_ptr& user_ptr : all_game_users()) {
+	for(auto user_ptr : all_game_users()) {
 		if(user_ptr != sender) {
-			players_not_advanced_.insert(user_ptr);
+			players_not_advanced_.insert(&*user_ptr);
 		}
 	}
 	started_ = false;
 }
 
-void game::load_next_scenario(const socket_ptr& user)
+void game::load_next_scenario(player_iterator user)
 {
-	send_server_message_to_all(player_connections_.find(user)->info().name() + " advances to the next scenario", user);
+	send_server_message_to_all(user->info().name() + " advances to the next scenario", user);
 
 	simple_wml::document cfg_scenario;
 	simple_wml::node& next_scen = cfg_scenario.root().add_child("next_scenario");
@@ -1670,10 +1623,10 @@ void game::load_next_scenario(const socket_ptr& user)
 		cfg_controller.set_attr("is_local", side_user == user ? "yes" : "no");
 	}
 
-	server.async_send_doc_queued(user, cfg_scenario);
-	server.async_send_doc_queued(user, doc_controllers);
+	server.async_send_doc_queued(user->socket(), cfg_scenario);
+	server.async_send_doc_queued(user->socket(), doc_controllers);
 
-	players_not_advanced_.erase(user);
+	players_not_advanced_.erase(&*user);
 
 	// Send the player the history of the game to-date.
 	send_history(user);
@@ -1683,23 +1636,23 @@ void game::load_next_scenario(const socket_ptr& user)
 }
 
 template<typename Container>
-void game::send_to_players(simple_wml::document& data, const Container& players, socket_ptr exclude)
+void game::send_to_players(simple_wml::document& data, const Container& players, utils::optional<player_iterator> exclude)
 {
 	for(const auto& player : players) {
 		if(player != exclude) {
-			server.async_send_doc_queued(player, data);
+			server.async_send_doc_queued(player->socket(), data);
 		}
 	}
 }
 
-void game::send_data(simple_wml::document& data, const socket_ptr& exclude, std::string /*packet_type*/)
+void game::send_data(simple_wml::document& data, utils::optional<player_iterator> exclude, std::string /*packet_type*/)
 {
 	send_to_players(data, all_game_users(), exclude);
 }
 
 void game::send_data_sides(simple_wml::document& data,
 		const simple_wml::string_span& sides,
-		const socket_ptr& exclude)
+		utils::optional<player_iterator> exclude)
 {
 	std::vector<int> sides_vec = ::split<int>(sides, ::split_conv_impl);
 
@@ -1708,12 +1661,12 @@ void game::send_data_sides(simple_wml::document& data,
 	decltype(players_) filtered_players;
 
 	std::copy_if(players_.begin(), players_.end(), std::back_inserter(filtered_players),
-		[this, &sides_vec](socket_ptr user) { return controls_side(sides_vec, user); });
+		[this, &sides_vec](player_iterator user) { return controls_side(sides_vec, user); });
 
 	send_to_players(data, filtered_players, exclude);
 }
 
-bool game::controls_side(const std::vector<int>& sides, const socket_ptr& player) const
+bool game::controls_side(const std::vector<int>& sides, player_iterator player) const
 {
 	for(int side : sides) {
 		std::size_t side_index = side - 1;
@@ -1726,58 +1679,54 @@ bool game::controls_side(const std::vector<int>& sides, const socket_ptr& player
 	return false;
 }
 
-std::string game::has_same_ip(const socket_ptr& user) const
+std::string game::has_same_ip(player_iterator user) const
 {
 	const user_vector users = all_game_users();
-	const std::string ip = client_address(user);
+	const std::string ip = user->client_ip();
 
 	std::string clones;
-	for(const socket_ptr& u : users) {
-		if(ip == client_address(u) && user != u) {
-			const auto pl = player_connections_.find(u);
-
-			if(pl != player_connections_.end()) {
-				clones += (clones.empty() ? "" : ", ") + pl->info().name();
-			}
+	for(auto u : users) {
+		if(ip == u->client_ip() && user != u) {
+			clones += (clones.empty() ? "" : ", ") + u->info().name();
 		}
 	}
 
 	return clones;
 }
 
-void game::send_observerjoins(const socket_ptr& sock)
+void game::send_observerjoins(utils::optional<player_iterator> player)
 {
-	for(const socket_ptr& ob : observers_) {
-		if(ob == sock) {
+	for(auto ob : observers_) {
+		if(ob == player) {
 			continue;
 		}
 
 		simple_wml::document cfg;
-		cfg.root().add_child("observer").set_attr_dup("name", player_connections_.find(ob)->info().name().c_str());
+		cfg.root().add_child("observer").set_attr_dup("name", ob->info().name().c_str());
 
-		if(sock == socket_ptr()) {
+		if(!player) {
 			// Send to everyone except the observer in question.
 			send_data(cfg, ob);
 		} else {
 			// Send to the (new) user.
-			server.async_send_doc_queued(sock, cfg);
+			server.async_send_doc_queued(player.value()->socket(), cfg);
 		}
 	}
 }
 
-void game::send_observerquit(const socket_ptr& observer)
+void game::send_observerquit(player_iterator observer)
 {
 	simple_wml::document observer_quit;
 
 	// Don't need to dup the attribute because this document is short-lived.
 	observer_quit.root()
 		.add_child("observer_quit")
-		.set_attr_dup("name", player_connections_.find(observer)->info().name().c_str());
+		.set_attr_dup("name", observer->info().name().c_str());
 
 	send_data(observer_quit, observer);
 }
 
-void game::send_history(const socket_ptr& socket) const
+void game::send_history(player_iterator player) const
 {
 	if(history_.empty()) {
 		return;
@@ -1795,7 +1744,7 @@ void game::send_history(const socket_ptr& socket) const
 		auto doc = std::make_unique<simple_wml::document>(buf.c_str(), simple_wml::INIT_STATIC);
 		doc->compress();
 
-		server.async_send_doc_queued(socket, *doc);
+		server.async_send_doc_queued(player->socket(), *doc);
 
 		history_.clear();
 		history_.push_back(std::move(doc));
@@ -1939,25 +1888,13 @@ std::string game::debug_player_info() const
 	result << "game id: " << id_ << ", " << db_id_ << "\n";
 
 	//	result << "players_.size: " << players_.size() << "\n";
-	for(const socket_ptr& p : players_) {
-		const auto user = player_connections_.find(p);
-
-		if(user != player_connections_.end()) {
-			result << "player: " << user->info().name().c_str() << "\n";
-		} else {
-			result << "player: '" << p << "' not found\n";
-		}
+	for(auto user : players_) {
+		result << "player: " << user->info().name().c_str() << "\n";
 	}
 
 	//	result << "observers_.size: " << observers_.size() << "\n";
-	for(const socket_ptr& o : observers_) {
-		const auto user = player_connections_.find(o);
-
-		if(user != player_connections_.end()) {
-			result << "observer: " << user->info().name().c_str() << "\n";
-		} else {
-			result << "observer: '" << o << "' not found\n";
-		}
+	for(auto user : observers_) {
+		result << "observer: " << user->info().name().c_str() << "\n";
 	}
 	/*	result << "player_info_: begin\n";
 		for (player_map::const_iterator info = player_info_->begin(); info != player_info_->end(); info++){
@@ -1980,27 +1917,26 @@ std::string game::debug_sides_info() const
 			<< "side " << (*s)["side"].to_int()
 			<< " :\t" << (*s)["controller"].to_string()
 			<< "\t, " << side_controllers_[(*s)["side"].to_int() - 1].to_cstring()
-			<< "\t( " << sides_[(*s)["side"].to_int() - 1]
+			<< "\t( " << sides_[(*s)["side"].to_int() - 1].value()->socket()
 			<< ",\t" << (*s)["current_player"].to_string() << " )\n";
 	}
 
 	return result.str();
 }
 
-socket_ptr game::find_user(const simple_wml::string_span& name)
+utils::optional<player_iterator> game::find_user(const simple_wml::string_span& name)
 {
-	const auto iter = player_connections_.get<name_t>().find(name.to_string());
-	if(iter != player_connections_.get<name_t>().end()) {
-		return iter->socket();
-	} else {
-		return socket_ptr();
-	}
+	auto player { player_connections_.get<name_t>().find(name.to_string()) };
+	if(player != player_connections_.get<name_t>().end())
+		return player_connections_.project<0>(player);
+	else
+		return {};
 }
 
-void game::send_and_record_server_message(const char* message, const socket_ptr& exclude)
+void game::send_and_record_server_message(const char* message, utils::optional<player_iterator> exclude)
 {
 	auto doc = std::make_unique<simple_wml::document>();
-	send_server_message(message, socket_ptr(), doc.get());
+	send_server_message(message, {}, doc.get());
 	send_data(*doc, exclude, "message");
 
 	if(started_) {
@@ -2008,14 +1944,14 @@ void game::send_and_record_server_message(const char* message, const socket_ptr&
 	}
 }
 
-void game::send_server_message_to_all(const char* message, const socket_ptr& exclude)
+void game::send_server_message_to_all(const char* message, utils::optional<player_iterator> exclude)
 {
 	simple_wml::document doc;
-	send_server_message(message, socket_ptr(), &doc);
+	send_server_message(message, {}, &doc);
 	send_data(doc, exclude, "message");
 }
 
-void game::send_server_message(const char* message, const socket_ptr& sock, simple_wml::document* docptr) const
+void game::send_server_message(const char* message, utils::optional<player_iterator> player, simple_wml::document* docptr) const
 {
 	simple_wml::document docbuf;
 	if(docptr == nullptr) {
@@ -2039,8 +1975,8 @@ void game::send_server_message(const char* message, const socket_ptr& sock, simp
 		msg.set_attr_dup("message", message);
 	}
 
-	if(sock) {
-		server.async_send_doc_queued(sock, doc);
+	if(player) {
+		server.async_send_doc_queued(player.value()->socket(), doc);
 	}
 }
 

--- a/src/server/wesnothd/game.cpp
+++ b/src/server/wesnothd/game.cpp
@@ -174,7 +174,7 @@ std::string game::username(player_iterator iter) const
 	return iter->info().name();
 }
 
-std::string game::list_users(user_vector users, const std::string& /*func*/) const
+std::string game::list_users(user_vector users) const
 {
 	std::string list;
 
@@ -265,7 +265,7 @@ void game::start_game(player_iterator starter)
 	LOG_GAME
 		<< starter->client_ip() << "\t" << starter->name() << "\t"
 		<< (advance ? "advanced" : "started") << (save ? " reloaded" : "") << " game:\t\"" << name_ << "\" (" << id_
-		<< ", " << db_id_ << ") with: " << list_users(players_, __func__)
+		<< ", " << db_id_ << ") with: " << list_users(players_)
 		<< ". Settings: map: " << multiplayer["mp_scenario"]
 		<< "\tera: "       << multiplayer["mp_era"]
 		<< "\tXP: "        << multiplayer["experience_modifier"]
@@ -690,7 +690,7 @@ void game::send_muted_observers(player_iterator user) const
 		return;
 	}
 
-	std::string muted_nicks = list_users(muted_observers_, __func__);
+	std::string muted_nicks = list_users(muted_observers_);
 
 	send_server_message("Muted observers: " + muted_nicks, user);
 }

--- a/src/server/wesnothd/game.hpp
+++ b/src/server/wesnothd/game.hpp
@@ -459,7 +459,7 @@ private:
 	std::string username(player_iterator pl) const;
 
 	/** Returns a comma separated list of user names. */
-	std::string list_users(user_vector users, const std::string& func) const;
+	std::string list_users(user_vector users) const;
 
 	/** calculates the initial value for sides_, side_controllerds_, nsides_*/
 	void reset_sides();

--- a/src/server/wesnothd/game.hpp
+++ b/src/server/wesnothd/game.hpp
@@ -461,9 +461,6 @@ private:
 	/** Returns a comma separated list of user names. */
 	std::string list_users(user_vector users, const std::string& func) const;
 
-	/** Function to log when we don't find a connection in player_info_. */
-	void missing_user(player_iterator socket, const std::string& func) const;
-
 	/** calculates the initial value for sides_, side_controllerds_, nsides_*/
 	void reset_sides();
 

--- a/src/server/wesnothd/game.hpp
+++ b/src/server/wesnothd/game.hpp
@@ -20,7 +20,7 @@
 #include "server/common/simple_wml.hpp"
 #include "utils/make_enum.hpp"
 
-#include <utils/optional_fwd.hpp>
+#include "utils/optional_fwd.hpp"
 
 #include <map>
 #include <vector>

--- a/src/server/wesnothd/game.hpp
+++ b/src/server/wesnothd/game.hpp
@@ -20,6 +20,8 @@
 #include "server/common/simple_wml.hpp"
 #include "utils/make_enum.hpp"
 
+#include <utils/optional_fwd.hpp>
+
 #include <map>
 #include <vector>
 
@@ -27,8 +29,8 @@
 
 namespace wesnothd
 {
-typedef std::vector<socket_ptr> user_vector;
-typedef std::vector<socket_ptr> side_vector;
+typedef std::vector<player_iterator> user_vector;
+typedef std::vector<utils::optional<player_iterator>> side_vector;
 class server;
 
 class game
@@ -41,7 +43,7 @@ public:
 	);
 
 	game(wesnothd::server& server, player_connections& player_connections,
-			const socket_ptr& host,
+			player_iterator host,
 			const std::string& name = "",
 			bool save_replays = false,
 			const std::string& replay_save_path = "");
@@ -68,25 +70,25 @@ public:
 		return name_;
 	}
 
-	bool is_owner(const socket_ptr& player) const
+	bool is_owner(player_iterator player) const
 	{
 		return (player == owner_);
 	}
 
-	bool is_member(const socket_ptr& player) const
+	bool is_member(player_iterator player) const
 	{
 		return is_player(player) || is_observer(player);
 	}
 
 	bool allow_observers() const;
-	bool is_observer(const socket_ptr& player) const;
-	bool is_player(const socket_ptr& player) const;
+	bool is_observer(player_iterator player) const;
+	bool is_player(player_iterator player) const;
 
 	/** Checks whether the connection's ip address or username is banned. */
-	bool player_is_banned(const socket_ptr& player, const std::string& name) const;
+	bool player_is_banned(player_iterator player, const std::string& name) const;
 
 	/** when the host sends the new scenario of a mp campaign */
-	void new_scenario(const socket_ptr& player);
+	void new_scenario(player_iterator player);
 
 	bool level_init() const
 	{
@@ -153,36 +155,36 @@ public:
 	 * Mute an observer or give a message of all currently muted observers if no
 	 * name is given.
 	 */
-	void mute_observer(const simple_wml::node& mute, const socket_ptr& muter);
+	void mute_observer(const simple_wml::node& mute, player_iterator muter);
 
-	void unmute_observer(const simple_wml::node& unmute, const socket_ptr& unmuter);
+	void unmute_observer(const simple_wml::node& unmute, player_iterator unmuter);
 
 	/**
 	 * Kick a member by name.
 	 *
-	 * @return                    The network handle of the removed member if
-	 *                            successful, null pointer otherwise.
+	 * @return                    The iterator to the removed member if
+	 *                            successful, empty optional otherwise.
 	 */
-	socket_ptr kick_member(const simple_wml::node& kick, const socket_ptr& kicker);
+	utils::optional<player_iterator> kick_member(const simple_wml::node& kick, player_iterator kicker);
 
 	/**
 	 * Ban and kick a user by name.
 	 *
 	 * The user does not need to be in this game but logged in.
 	 *
-	 * @return                    The network handle of the banned player if he
-	 *                            was in this game, null pointer otherwise.
+	 * @return                    The iterator to the banned player if he
+	 *                            was in this game, empty optional otherwise.
 	 */
-	socket_ptr ban_user(const simple_wml::node& ban, const socket_ptr& banner);
+	utils::optional<player_iterator> ban_user(const simple_wml::node& ban, player_iterator banner);
 
-	void unban_user(const simple_wml::node& unban, const socket_ptr& unbanner);
+	void unban_user(const simple_wml::node& unban, player_iterator unbanner);
 
 	/**
 	 * Add a user to the game.
 	 *
 	 * @return                    True iff the user successfully joined the game.
 	 */
-	bool add_player(const socket_ptr& player, bool observer = false);
+	bool add_player(player_iterator player, bool observer = false);
 
 	/**
 	 * Removes a user from the game.
@@ -191,12 +193,12 @@ public:
 	 *                            no more players or the host left on a not yet
 	 *                            started game.
 	 */
-	bool remove_player(const socket_ptr& player, const bool disconnect = false, const bool destruct = false);
+	bool remove_player(player_iterator player, const bool disconnect = false, const bool destruct = false);
 
 	/** Adds players and observers into one vector and returns that. */
 	const user_vector all_game_users() const;
 
-	void start_game(const socket_ptr& starter);
+	void start_game(player_iterator starter);
 
 	// this is performed just before starting and before [start_game] signal
 	// send scenario_diff's specific to each client so that they locally
@@ -206,7 +208,7 @@ public:
 	void update_game();
 
 	/** A user (player only?) asks for the next scenario to advance to. */
-	void load_next_scenario(const socket_ptr& user); // const
+	void load_next_scenario(player_iterator user); // const
 
 	// iceiceice: I unmarked this const because I want to send and record server messages when I fail to tweak sides
 	// properly
@@ -215,9 +217,9 @@ public:
 	void update_side_data();
 
 	/** Let's a player owning a side give it to another player or observer. */
-	void transfer_side_control(const socket_ptr& sock, const simple_wml::node& cfg);
+	void transfer_side_control(player_iterator player, const simple_wml::node& cfg);
 
-	void process_message(simple_wml::document& data, const socket_ptr& user);
+	void process_message(simple_wml::document& data, player_iterator);
 
 	/**
 	 * Handles [end_turn], repackages [commands] with private [speak]s in them
@@ -228,12 +230,12 @@ public:
 	 *
 	 * @returns                   True if the turn ended.
 	 */
-	bool process_turn(simple_wml::document& data, const socket_ptr& user);
+	bool process_turn(simple_wml::document& data, player_iterator user);
 
 	/** Handles incoming [whiteboard] data. */
-	void process_whiteboard(simple_wml::document& data, const socket_ptr& user);
+	void process_whiteboard(simple_wml::document& data, player_iterator user);
 	/** Handles incoming [change_turns_wml] data. */
-	void process_change_turns_wml(simple_wml::document& data, const socket_ptr& user);
+	void process_change_turns_wml(simple_wml::document& data, player_iterator user);
 
 	/**
 	 * Set the description to the number of available slots.
@@ -242,30 +244,30 @@ public:
 	 */
 	bool describe_slots();
 
-	void send_server_message_to_all(const char* message, const socket_ptr& exclude = socket_ptr());
-	void send_server_message_to_all(const std::string& message, const socket_ptr& exclude = socket_ptr())
+	void send_server_message_to_all(const char* message, utils::optional<player_iterator> exclude = {});
+	void send_server_message_to_all(const std::string& message, utils::optional<player_iterator> exclude = {})
 	{
 		send_server_message_to_all(message.c_str(), exclude);
 	}
 
 	void send_server_message(
-			const char* message, const socket_ptr& sock = socket_ptr(), simple_wml::document* doc = nullptr) const;
+			const char* message, utils::optional<player_iterator> player = {}, simple_wml::document* doc = nullptr) const;
 	void send_server_message(
-			const std::string& message, const socket_ptr& sock = socket_ptr(), simple_wml::document* doc = nullptr) const
+			const std::string& message, utils::optional<player_iterator> player = {}, simple_wml::document* doc = nullptr) const
 	{
-		send_server_message(message.c_str(), sock, doc);
+		send_server_message(message.c_str(), player, doc);
 	}
 
 	/** Send data to all players in this game except 'exclude'. */
-	void send_and_record_server_message(const char* message, const socket_ptr& exclude = socket_ptr());
-	void send_and_record_server_message(const std::string& message, const socket_ptr& exclude = socket_ptr())
+	void send_and_record_server_message(const char* message, utils::optional<player_iterator> exclude = {});
+	void send_and_record_server_message(const std::string& message, utils::optional<player_iterator> exclude = {})
 	{
 		send_and_record_server_message(message.c_str(), exclude);
 	}
 
 	template<typename Container>
-	void send_to_players(simple_wml::document& data, const Container& players, socket_ptr exclude = socket_ptr());
-	void send_data(simple_wml::document& data, const socket_ptr& exclude = socket_ptr(), std::string packet_type = "");
+	void send_to_players(simple_wml::document& data, const Container& players, utils::optional<player_iterator> exclude = {});
+	void send_data(simple_wml::document& data, utils::optional<player_iterator> exclude = {}, std::string packet_type = "");
 
 	void clear_history();
 	void record_data(std::unique_ptr<simple_wml::document> data);
@@ -318,7 +320,7 @@ public:
 
 	void set_termination_reason(const std::string& reason);
 
-	void handle_choice(const simple_wml::node& data, const socket_ptr& user);
+	void handle_choice(const simple_wml::node& data, player_iterator user);
 
 	void handle_random_choice(const simple_wml::node& data);
 
@@ -334,7 +336,7 @@ public:
 	/**
 	 * Function which returns true iff 'player' controls any of the sides spcified in 'sides'.
 	 */
-	bool controls_side(const std::vector<int>& sides, const socket_ptr& player) const;
+	bool controls_side(const std::vector<int>& sides, player_iterator player) const;
 
 	bool is_reload() const;
 
@@ -348,23 +350,23 @@ private:
 		return nsides_ ? (current_side_index_ % nsides_) : 0;
 	}
 
-	const socket_ptr current_player() const
+	utils::optional<player_iterator> current_player() const
 	{
-		return (nsides_ ? sides_[current_side()] : socket_ptr());
+		return sides_[current_side()];
 	}
 
-	bool is_current_player(const socket_ptr& player) const
+	bool is_current_player(player_iterator player) const
 	{
 		return (current_player() == player);
 	}
 
-	bool is_muted_observer(const socket_ptr& player) const;
+	bool is_muted_observer(player_iterator player) const;
 	bool all_observers_muted() const
 	{
 		return all_observers_muted_;
 	}
 
-	void send_muted_observers(const socket_ptr& user) const;
+	void send_muted_observers(player_iterator user) const;
 
 	bool send_taken_side(simple_wml::document& cfg, const simple_wml::node* side) const;
 
@@ -377,21 +379,21 @@ private:
 	 * First we look for a side where save_id= or current_player= matches the
 	 * new user's name then we search for the first controller="network" side.
 	 */
-	bool take_side(const socket_ptr& user);
+	bool take_side(player_iterator user);
 
 	/**
 	 * Send [change_controller] message to tell all clients the new controller's name
 	 * or controller type (human or ai).
 	 */
 	void change_controller(const std::size_t side_num,
-			const socket_ptr& sock,
+			player_iterator sock,
 			const std::string& player_name,
 			const bool player_left = true);
 	std::unique_ptr<simple_wml::document> change_controller_type(const std::size_t side_num,
-			const socket_ptr& sock,
+			player_iterator player,
 			const std::string& player_name);
-	void transfer_ai_sides(const socket_ptr& player);
-	void send_leave_game(const socket_ptr& user) const;
+	void transfer_ai_sides(player_iterator player);
+	void send_leave_game(player_iterator user) const;
 
 	/**
 	 * @param data the data to be sent to the sides.
@@ -400,24 +402,24 @@ private:
 	 */
 	void send_data_sides(simple_wml::document& data,
 			const simple_wml::string_span& sides,
-			const socket_ptr& exclude = socket_ptr());
+			utils::optional<player_iterator> exclude = {});
 
 	void send_data_observers(
-			simple_wml::document& data, const socket_ptr& exclude = socket_ptr(), std::string packet_type = "") const;
+			simple_wml::document& data, utils::optional<player_iterator> exclude = {}, std::string packet_type = "") const;
 
 	/**
 	 * Send [observer] tags of all the observers in the game to the user or
 	 * everyone if none given.
 	 */
-	void send_observerjoins(const socket_ptr& sock = socket_ptr());
-	void send_observerquit(const socket_ptr& observer);
-	void send_history(const socket_ptr& sock) const;
+	void send_observerjoins(utils::optional<player_iterator> player = {});
+	void send_observerquit(player_iterator observer);
+	void send_history(player_iterator sock) const;
 
 	/** In case of a host transfer, notify the new host about its status. */
 	void notify_new_host();
 
 	/** Shortcut to a convenience function for finding a user by name. */
-	socket_ptr find_user(const simple_wml::string_span& name);
+	utils::optional<player_iterator> find_user(const simple_wml::string_span& name);
 
 	bool observers_can_label() const
 	{
@@ -429,13 +431,13 @@ private:
 		return true;
 	}
 
-	bool is_legal_command(const simple_wml::node& command, const socket_ptr& user);
+	bool is_legal_command(const simple_wml::node& command, player_iterator user);
 
 	/**
 	 * Checks whether a user has the same IP as any other members of this game.
 	 * @return  A comma separated string of members with matching IPs.
 	 */
-	std::string has_same_ip(const socket_ptr& user) const;
+	std::string has_same_ip(player_iterator user) const;
 
 	/**
 	 * Function which should be called every time a player ends their turn
@@ -451,16 +453,16 @@ private:
 	 *
 	 * Only sends data if the game is initialized but not yet started.
 	 */
-	void send_user_list(const socket_ptr& exclude = socket_ptr());
+	void send_user_list(utils::optional<player_iterator> exclude = {});
 
 	/** Returns the name of the user or "(unfound)". */
-	std::string username(const socket_ptr& pl) const;
+	std::string username(player_iterator pl) const;
 
 	/** Returns a comma separated list of user names. */
 	std::string list_users(user_vector users, const std::string& func) const;
 
 	/** Function to log when we don't find a connection in player_info_. */
-	void missing_user(socket_ptr socket, const std::string& func) const;
+	void missing_user(player_iterator socket, const std::string& func) const;
 
 	/** calculates the initial value for sides_, side_controllerds_, nsides_*/
 	void reset_sides();
@@ -489,7 +491,7 @@ private:
 	std::string password_;
 
 	/** The game host or later owner (if the host left). */
-	socket_ptr owner_;
+	player_iterator owner_;
 
 	/** A vector of players (members owning a side). */
 	user_vector players_;
@@ -544,7 +546,7 @@ private:
 	 * keep track of those players because processing certain
 	 * input from those side wil lead to error (oos)
 	 */
-	std::set<socket_ptr> players_not_advanced_;
+	std::set<const player_record*> players_not_advanced_;
 
 	std::string termination_;
 

--- a/src/server/wesnothd/player_connection.hpp
+++ b/src/server/wesnothd/player_connection.hpp
@@ -44,7 +44,7 @@ public:
 		return socket_;
 	}
 
-	std::string saved_client_ip() const
+	std::string client_ip() const
 	{
 		return ip_address;
 	}
@@ -90,5 +90,7 @@ using player_connections = bmi::multi_index_container<player_record, bmi::indexe
 	bmi::ordered_non_unique<bmi::tag<game_t>,
 		bmi::const_mem_fun<player_record, int, &player_record::game_id>>
 >>;
+
+typedef player_connections::const_iterator player_iterator;
 
 } // namespace wesnothd

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -190,7 +190,7 @@ static bool make_change_diff(const simple_wml::node& src,
 static std::string player_status(const wesnothd::player_record& player)
 {
 	std::ostringstream out;
-	out << "'" << player.name() << "' @ " << client_address(player.socket());
+	out << "'" << player.name() << "' @ " << player.client_ip();
 	return out.str();
 }
 
@@ -997,37 +997,38 @@ void server::send_password_request(socket_ptr socket,
 	async_send_doc_queued(socket, doc);
 }
 
-void server::handle_player(boost::asio::yield_context yield, socket_ptr socket, const player& player)
+void server::handle_player(boost::asio::yield_context yield, socket_ptr socket, const player& player_data)
 {
 	if(lan_server_)
 		abort_lan_server_timer();
 
 	bool inserted;
-	std::tie(std::ignore, inserted) = player_connections_.insert(player_connections::value_type(socket, player));
+	player_iterator player;
+	std::tie(player, inserted) = player_connections_.insert(player_connections::value_type(socket, player_data));
 	assert(inserted);
 
-	BOOST_SCOPE_EXIT_ALL(this, &socket) {
-		remove_player(socket);
+	BOOST_SCOPE_EXIT_ALL(this, &player) {
+		remove_player(player);
 	};
 
 	async_send_doc_queued(socket, games_and_users_list_);
 
 	if(!motd_.empty()) {
-		send_server_message(socket, motd_+'\n'+announcements_+tournaments_, "motd");
+		send_server_message(player, motd_+'\n'+announcements_+tournaments_, "motd");
 	}
-	send_server_message(socket, information_, "server_info");
-	send_server_message(socket, announcements_+tournaments_, "announcements");
-	if(version_info(player.version()) < secure_version ){
-		send_server_message(socket, "You are using version " + player.version() + " which has known security issues that can be used to compromise your computer. We strongly recommend updating to a Wesnoth version " + secure_version.str() + " or newer!", "alert");
+	send_server_message(player, information_, "server_info");
+	send_server_message(player, announcements_+tournaments_, "announcements");
+	if(version_info(player_data.version()) < secure_version ){
+		send_server_message(player, "You are using version " + player_data.version() + " which has known security issues that can be used to compromise your computer. We strongly recommend updating to a Wesnoth version " + secure_version.str() + " or newer!", "alert");
 	}
-	if(version_info(player.version()) < version_info(recommended_version_)) {
-		send_server_message(socket, "A newer Wesnoth version, " + recommended_version_ + ", is out!", "alert");
+	if(version_info(player_data.version()) < version_info(recommended_version_)) {
+		send_server_message(player, "A newer Wesnoth version, " + recommended_version_ + ", is out!", "alert");
 	}
 
 	// Send other players in the lobby the update that the player has joined
 	simple_wml::document diff;
 	make_add_diff(games_and_users_list_.root(), nullptr, "user", diff);
-	send_to_lobby(diff, socket);
+	send_to_lobby(diff, player);
 
 	while(true) {
 		boost::system::error_code ec;
@@ -1040,44 +1041,44 @@ void server::handle_player(boost::asio::yield_context yield, socket_ptr socket, 
 		}
 
 		if(simple_wml::node* whisper = doc->child("whisper")) {
-			handle_whisper(socket, *whisper);
+			handle_whisper(player, *whisper);
 		}
 
 		if(simple_wml::node* query = doc->child("query")) {
-			handle_query(socket, *query);
+			handle_query(player, *query);
 		}
 
 		if(simple_wml::node* nickserv = doc->child("nickserv")) {
-			handle_nickserv(socket, *nickserv);
+			handle_nickserv(player, *nickserv);
 		}
 
-		if(!player_is_in_game(socket)) {
-			handle_player_in_lobby(socket, *doc);
+		if(!player_is_in_game(player)) {
+			handle_player_in_lobby(player, *doc);
 		} else {
-			handle_player_in_game(socket, *doc);
+			handle_player_in_game(player, *doc);
 		}
 	}
 }
 
-void server::handle_player_in_lobby(socket_ptr socket, simple_wml::document& data)
+void server::handle_player_in_lobby(player_iterator player, simple_wml::document& data)
 {
 	if(simple_wml::node* message = data.child("message")) {
-		handle_message(socket, *message);
+		handle_message(player, *message);
 		return;
 	}
 
 	if(simple_wml::node* create_game = data.child("create_game")) {
-		handle_create_game(socket, *create_game);
+		handle_create_game(player, *create_game);
 		return;
 	}
 
 	if(simple_wml::node* join = data.child("join")) {
-		handle_join_game(socket, *join);
+		handle_join_game(player, *join);
 		return;
 	}
 }
 
-void server::handle_whisper(socket_ptr socket, simple_wml::node& whisper)
+void server::handle_whisper(player_iterator player, simple_wml::node& whisper)
 {
 	if((whisper["receiver"].empty()) || (whisper["message"].empty())) {
 		static simple_wml::document data(
@@ -1088,21 +1089,21 @@ void server::handle_whisper(socket_ptr socket, simple_wml::node& whisper)
 			simple_wml::INIT_COMPRESSED
 		);
 
-		async_send_doc_queued(socket, data);
+		async_send_doc_queued(player->socket(), data);
 		return;
 	}
 
-	whisper.set_attr_dup("sender", player_connections_.find(socket)->name().c_str());
+	whisper.set_attr_dup("sender", player->name().c_str());
 
 	auto receiver_iter = player_connections_.get<name_t>().find(whisper["receiver"].to_string());
 	if(receiver_iter == player_connections_.get<name_t>().end()) {
-		send_server_message(socket, "Can't find '" + whisper["receiver"].to_string() + "'.", "error");
+		send_server_message(player, "Can't find '" + whisper["receiver"].to_string() + "'.", "error");
 		return;
 	}
 
-	auto g = player_connections_.find(socket)->get_game();
-	if(g && g->started() && g->is_player(receiver_iter->socket())) {
-		send_server_message(socket, "You cannot send private messages to players in a running game you observe.", "error");
+	auto g = player->get_game();
+	if(g && g->started() && g->is_player(player_connections_.project<0>(receiver_iter))) {
+		send_server_message(player, "You cannot send private messages to players in a running game you observe.", "error");
 		return;
 	}
 
@@ -1117,13 +1118,8 @@ void server::handle_whisper(socket_ptr socket, simple_wml::node& whisper)
 	async_send_doc_queued(receiver_iter->socket(), cwhisper);
 }
 
-void server::handle_query(socket_ptr socket, simple_wml::node& query)
+void server::handle_query(player_iterator iter, simple_wml::node& query)
 {
-	auto iter = player_connections_.find(socket);
-	if(iter == player_connections_.end()) {
-		return;
-	}
-
 	wesnothd::player& player = iter->info();
 
 	const std::string command(query["type"].to_string());
@@ -1153,7 +1149,7 @@ void server::handle_query(socket_ptr socket, simple_wml::node& query)
 		response << process_command(command, player.name());
 	} else if(player.is_moderator()) {
 		if(command == "signout") {
-			LOG_SERVER << "Admin signed out: IP: " << client_address(socket) << "\tnick: " << player.name()
+			LOG_SERVER << "Admin signed out: IP: " << iter->client_ip() << "\tnick: " << player.name()
 					   << std::endl;
 			player.set_moderator(false);
 			// This string is parsed by the client!
@@ -1162,7 +1158,7 @@ void server::handle_query(socket_ptr socket, simple_wml::node& query)
 				user_handler_->set_is_moderator(player.name(), false);
 			}
 		} else {
-			LOG_SERVER << "Admin Command: type: " << command << "\tIP: " << client_address(socket)
+			LOG_SERVER << "Admin Command: type: " << command << "\tIP: " << iter->client_ip()
 					   << "\tnick: " << player.name() << std::endl;
 			response << process_command(command, player.name());
 			LOG_SERVER << response.str() << std::endl;
@@ -1171,7 +1167,7 @@ void server::handle_query(socket_ptr socket, simple_wml::node& query)
 		response << query_help_msg;
 	} else if(command == "admin" || command.compare(0, 6, "admin ") == 0) {
 		if(admin_passwd_.empty()) {
-			send_server_message(socket, "No password set.", "error");
+			send_server_message(iter, "No password set.", "error");
 			return;
 		}
 
@@ -1181,7 +1177,7 @@ void server::handle_query(socket_ptr socket, simple_wml::node& query)
 		}
 
 		if(passwd == admin_passwd_) {
-			LOG_SERVER << "New Admin recognized: IP: " << client_address(socket) << "\tnick: " << player.name()
+			LOG_SERVER << "New Admin recognized: IP: " << iter->client_ip() << "\tnick: " << player.name()
 					   << std::endl;
 			player.set_moderator(true);
 			// This string is parsed by the client!
@@ -1191,7 +1187,7 @@ void server::handle_query(socket_ptr socket, simple_wml::node& query)
 				user_handler_->set_is_moderator(player.name(), true);
 			}
 		} else {
-			WRN_SERVER << "FAILED Admin attempt with password: '" << passwd << "'\tIP: " << client_address(socket)
+			WRN_SERVER << "FAILED Admin attempt with password: '" << passwd << "'\tIP: " << iter->client_ip()
 					   << "\tnick: " << player.name() << std::endl;
 			response << "Error: wrong password";
 		}
@@ -1199,14 +1195,14 @@ void server::handle_query(socket_ptr socket, simple_wml::node& query)
 		response << "Error: unrecognized query: '" << command << "'\n" << query_help_msg;
 	}
 
-	send_server_message(socket, response.str(), "info");
+	send_server_message(iter, response.str(), "info");
 }
 
-void server::handle_nickserv(socket_ptr socket, simple_wml::node& nickserv)
+void server::handle_nickserv(player_iterator player, simple_wml::node& nickserv)
 {
 	// Check if this server allows nick registration at all
 	if(!user_handler_) {
-		send_server_message(socket, "This server does not allow username registration.", "error");
+		send_server_message(player, "This server does not allow username registration.", "error");
 		return;
 	}
 
@@ -1214,9 +1210,9 @@ void server::handle_nickserv(socket_ptr socket, simple_wml::node& nickserv)
 	if(nickserv.child("info")) {
 		try {
 			std::string res = user_handler_->user_info((*nickserv.child("info"))["name"].to_string());
-			send_server_message(socket, res, "info");
+			send_server_message(player, res, "info");
 		} catch(const user_handler::error& e) {
-			send_server_message(socket,
+			send_server_message(player,
 				"There was an error looking up the details of the user '"
 				+ (*nickserv.child("info"))["name"].to_string() + "'. "
 				+ " The error message was: " + e.message, "error"
@@ -1227,11 +1223,10 @@ void server::handle_nickserv(socket_ptr socket, simple_wml::node& nickserv)
 	}
 }
 
-void server::handle_message(socket_ptr socket, simple_wml::node& message)
+void server::handle_message(player_iterator user, simple_wml::node& message)
 {
-	auto user = player_connections_.find(socket);
 	if(user->info().is_message_flooding()) {
-		send_server_message(socket,
+		send_server_message(user,
 			"Warning: you are sending too many messages too fast. Your message has not been relayed.", "error");
 		return;
 	}
@@ -1246,52 +1241,46 @@ void server::handle_message(socket_ptr socket, simple_wml::node& message)
 	chat_message::truncate_message(msg, trunc_message);
 
 	if(msg.size() >= 3 && simple_wml::string_span(msg.begin(), 4) == "/me ") {
-		LOG_SERVER << client_address(socket) << "\t<" << user->name()
+		LOG_SERVER << user->client_ip() << "\t<" << user->name()
 				   << simple_wml::string_span(msg.begin() + 3, msg.size() - 3) << ">\n";
 	} else {
-		LOG_SERVER << client_address(socket) << "\t<" << user->name() << "> " << msg << "\n";
+		LOG_SERVER << user->client_ip() << "\t<" << user->name() << "> " << msg << "\n";
 	}
 
-	send_to_lobby(relay_message, socket);
+	send_to_lobby(relay_message, user);
 }
 
-void server::handle_create_game(socket_ptr socket, simple_wml::node& create_game)
+void server::handle_create_game(player_iterator player, simple_wml::node& create_game)
 {
 	if(graceful_restart) {
 		static simple_wml::document leave_game_doc("[leave_game]\n[/leave_game]\n", simple_wml::INIT_COMPRESSED);
-		async_send_doc_queued(socket, leave_game_doc);
+		async_send_doc_queued(player->socket(), leave_game_doc);
 
-		send_server_message(socket,
+		send_server_message(player,
 			"This server is shutting down. You aren't allowed to make new games. Please "
 			"reconnect to the new server.", "error");
 
-		async_send_doc_queued(socket, games_and_users_list_);
+		async_send_doc_queued(player->socket(), games_and_users_list_);
 		return;
 	}
 
-	player_connections_.modify(
-		player_connections_.find(socket), std::bind(&server::create_game, this, std::placeholders::_1, std::ref(create_game)));
-
-	return;
-}
-
-void server::create_game(player_record& host_record, simple_wml::node& create_game)
-{
 	const std::string game_name = create_game["name"].to_string();
 	const std::string game_password = create_game["password"].to_string();
 	const std::string initial_bans = create_game["ignored"].to_string();
 
-	DBG_SERVER << client_address(host_record.socket()) << "\t" << host_record.info().name()
+	DBG_SERVER << player->client_ip() << "\t" << player->info().name()
 			   << "\tcreates a new game: \"" << game_name << "\".\n";
 
 	// Create the new game, remove the player from the lobby
 	// and set the player as the host/owner.
-	host_record.get_game().reset(
-		new wesnothd::game(*this, player_connections_, host_record.socket(), game_name, save_replays_, replay_save_path_),
-		std::bind(&server::cleanup_game, this, std::placeholders::_1)
-	);
+	player_connections_.modify(player, [this, player, &game_name](player_record& host_record) {
+		host_record.get_game().reset(
+			new wesnothd::game(*this, player_connections_, player, game_name, save_replays_, replay_save_path_),
+			std::bind(&server::cleanup_game, this, std::placeholders::_1)
+		);
+	});
 
-	wesnothd::game& g = *host_record.get_game();
+	wesnothd::game& g = *player->get_game();
 
 	DBG_SERVER << "initial bans: " << initial_bans << "\n";
 	if(initial_bans != "") {
@@ -1337,7 +1326,7 @@ void server::cleanup_game(game* game_ptr)
 	delete game_ptr;
 }
 
-void server::handle_join_game(socket_ptr socket, simple_wml::node& join)
+void server::handle_join_game(player_iterator player, simple_wml::node& join)
 {
 	const bool observer = join.attr("observe").to_bool();
 	const std::string& password = join["password"].to_string();
@@ -1352,55 +1341,55 @@ void server::handle_join_game(socket_ptr socket, simple_wml::node& join)
 
 	static simple_wml::document leave_game_doc("[leave_game]\n[/leave_game]\n", simple_wml::INIT_COMPRESSED);
 	if(!g) {
-		WRN_SERVER << client_address(socket) << "\t" << player_connections_.find(socket)->info().name()
+		WRN_SERVER << player->client_ip() << "\t" << player->info().name()
 				   << "\tattempted to join unknown game:\t" << game_id << ".\n";
-		async_send_doc_queued(socket, leave_game_doc);
-		send_server_message(socket, "Attempt to join unknown game.", "error");
-		async_send_doc_queued(socket, games_and_users_list_);
+		async_send_doc_queued(player->socket(), leave_game_doc);
+		send_server_message(player, "Attempt to join unknown game.", "error");
+		async_send_doc_queued(player->socket(), games_and_users_list_);
 		return;
 	} else if(!g->level_init()) {
-		WRN_SERVER << client_address(socket) << "\t" << player_connections_.find(socket)->info().name()
+		WRN_SERVER << player->client_ip() << "\t" << player->info().name()
 				   << "\tattempted to join uninitialized game:\t\"" << g->name() << "\" (" << game_id << ").\n";
-		async_send_doc_queued(socket, leave_game_doc);
-		send_server_message(socket, "Attempt to join an uninitialized game.", "error");
-		async_send_doc_queued(socket, games_and_users_list_);
+		async_send_doc_queued(player->socket(), leave_game_doc);
+		send_server_message(player, "Attempt to join an uninitialized game.", "error");
+		async_send_doc_queued(player->socket(), games_and_users_list_);
 		return;
-	} else if(player_connections_.find(socket)->info().is_moderator()) {
+	} else if(player->info().is_moderator()) {
 		// Admins are always allowed to join.
-	} else if(g->player_is_banned(socket, player_connections_.find(socket)->info().name())) {
-		DBG_SERVER << client_address(socket)
-				   << "\tReject banned player: " << player_connections_.find(socket)->info().name()
+	} else if(g->player_is_banned(player, player->info().name())) {
+		DBG_SERVER << player->client_ip()
+				   << "\tReject banned player: " << player->info().name()
 				   << "\tfrom game:\t\"" << g->name() << "\" (" << game_id << ").\n";
-		async_send_doc_queued(socket, leave_game_doc);
-		send_server_message(socket, "You are banned from this game.", "error");
-		async_send_doc_queued(socket, games_and_users_list_);
+		async_send_doc_queued(player->socket(), leave_game_doc);
+		send_server_message(player, "You are banned from this game.", "error");
+		async_send_doc_queued(player->socket(), games_and_users_list_);
 		return;
 	} else if(!g->password_matches(password)) {
-		WRN_SERVER << client_address(socket) << "\t" << player_connections_.find(socket)->info().name()
+		WRN_SERVER << player->client_ip() << "\t" << player->info().name()
 				   << "\tattempted to join game:\t\"" << g->name() << "\" (" << game_id << ") with bad password\n";
-		async_send_doc_queued(socket, leave_game_doc);
-		send_server_message(socket, "Incorrect password.", "error");
-		async_send_doc_queued(socket, games_and_users_list_);
+		async_send_doc_queued(player->socket(), leave_game_doc);
+		send_server_message(player, "Incorrect password.", "error");
+		async_send_doc_queued(player->socket(), games_and_users_list_);
 		return;
 	}
 
-	bool joined = g->add_player(socket, observer);
+	bool joined = g->add_player(player, observer);
 	if(!joined) {
-		WRN_SERVER << client_address(socket) << "\t" << player_connections_.find(socket)->info().name()
+		WRN_SERVER << player->client_ip() << "\t" << player->info().name()
 				   << "\tattempted to observe game:\t\"" << g->name() << "\" (" << game_id
 				   << ") which doesn't allow observers.\n";
-		async_send_doc_queued(socket, leave_game_doc);
+		async_send_doc_queued(player->socket(), leave_game_doc);
 
-		send_server_message(socket,
+		send_server_message(player,
 			"Attempt to observe a game that doesn't allow observers. (You probably joined the "
 			"game shortly after it filled up.)", "error");
 
-		async_send_doc_queued(socket, games_and_users_list_);
+		async_send_doc_queued(player->socket(), games_and_users_list_);
 		return;
 	}
 
-	player_connections_.modify(player_connections_.find(socket),
-		std::bind(&player_record::set_game, std::placeholders::_1, player_connections_.get<game_t>().find(game_id)->get_game()));
+	player_connections_.modify(player,
+		std::bind(&player_record::set_game, std::placeholders::_1, g));
 
 	g->describe_slots();
 
@@ -1408,26 +1397,25 @@ void server::handle_join_game(socket_ptr socket, simple_wml::node& join)
 	simple_wml::document diff;
 	bool diff1 = make_change_diff(*games_and_users_list_.child("gamelist"), "gamelist", "game", g->description(), diff);
 	bool diff2 = make_change_diff(games_and_users_list_.root(), nullptr, "user",
-		player_connections_.find(socket)->info().config_address(), diff);
+		player->info().config_address(), diff);
 
 	if(diff1 || diff2) {
 		send_to_lobby(diff);
 	}
 }
 
-void server::handle_player_in_game(socket_ptr socket, simple_wml::document& data)
+void server::handle_player_in_game(player_iterator p, simple_wml::document& data)
 {
 	DBG_SERVER << "in process_data_game...\n";
 
-	auto p = player_connections_.find(socket);
-	wesnothd::player& player = p->info();
+	wesnothd::player& player { p->info() };
 
 	game& g = *(p->get_game());
 	std::weak_ptr<game> g_ptr{p->get_game()};
 
 	// If this is data describing the level for a game.
 	if(data.child("snapshot") || data.child("scenario")) {
-		if(!g.is_owner(socket)) {
+		if(!g.is_owner(p)) {
 			return;
 		}
 
@@ -1438,7 +1426,7 @@ void server::handle_player_in_game(socket_ptr socket, simple_wml::document& data
 		// place a pointer to that summary in the game's description.
 		// g.level() should then receive the full data for the game.
 		if(!g.level_init()) {
-			LOG_SERVER << client_address(socket) << "\t" << player.name() << "\tcreated game:\t\"" << g.name() << "\" ("
+			LOG_SERVER << p->client_ip() << "\t" << player.name() << "\tcreated game:\t\"" << g.name() << "\" ("
 					   << g.id() << ", " << g.db_id() << ").\n";
 			// Update our config object which describes the open games,
 			// and save a pointer to the description in the new game.
@@ -1451,13 +1439,13 @@ void server::handle_player_in_game(socket_ptr socket, simple_wml::document& data
 			if(const simple_wml::node* m = data.child("multiplayer")) {
 				m->copy_into(desc);
 			} else {
-				WRN_SERVER << client_address(socket) << "\t" << player.name() << "\tsent scenario data in game:\t\""
+				WRN_SERVER << p->client_ip() << "\t" << player.name() << "\tsent scenario data in game:\t\""
 						   << g.name() << "\" (" << g.id() << ", " << g.db_id() << ") without a 'multiplayer' child.\n";
 				// Set the description so it can be removed in delete_game().
 				g.set_description(&desc);
 				delete_game(g.id());
 
-				send_server_message(socket,
+				send_server_message(p,
 					"The scenario data is missing the [multiplayer] tag which contains the "
 					"game settings. Game aborted.", "error");
 				return;
@@ -1466,7 +1454,7 @@ void server::handle_player_in_game(socket_ptr socket, simple_wml::document& data
 			g.set_description(&desc);
 			desc.set_attr_dup("id", lexical_cast<std::string>(g.id()).c_str());
 		} else {
-			WRN_SERVER << client_address(socket) << "\t" << player.name() << "\tsent scenario data in game:\t\""
+			WRN_SERVER << p->client_ip() << "\t" << player.name() << "\tsent scenario data in game:\t\""
 					   << g.name() << "\" (" << g.id() << ", " << g.db_id() << ") although it's already initialized.\n";
 			return;
 		}
@@ -1519,7 +1507,7 @@ void server::handle_player_in_game(socket_ptr socket, simple_wml::document& data
 		// Send the update of the game description to the lobby.
 		simple_wml::document diff;
 		make_add_diff(*games_and_users_list_.child("gamelist"), "gamelist", "game", diff);
-		make_change_diff(games_and_users_list_.root(), nullptr, "user", player_connections_.find(socket)->info().config_address(), diff);
+		make_change_diff(games_and_users_list_.root(), nullptr, "user", p->info().config_address(), diff);
 
 		send_to_lobby(diff);
 
@@ -1527,18 +1515,18 @@ void server::handle_player_in_game(socket_ptr socket, simple_wml::document& data
 		return;
 		// Everything below should only be processed if the game is already initialized.
 	} else if(!g.level_init()) {
-		WRN_SERVER << client_address(socket) << "\tReceived unknown data from: " << player.name()
-				   << " (socket:" << socket << ") while the scenario wasn't yet initialized.\n"
+		WRN_SERVER << p->client_ip() << "\tReceived unknown data from: " << player.name()
+				   << " (socket:" << p->socket() << ") while the scenario wasn't yet initialized.\n"
 				   << data.output();
 		return;
 		// If the host is sending the next scenario data.
 	} else if(const simple_wml::node* scenario = data.child("store_next_scenario")) {
-		if(!g.is_owner(socket)) {
+		if(!g.is_owner(p)) {
 			return;
 		}
 
 		if(!g.level_init()) {
-			WRN_SERVER << client_address(socket) << "\tWarning: " << player.name()
+			WRN_SERVER << p->client_ip() << "\tWarning: " << player.name()
 					   << "\tsent [store_next_scenario] in game:\t\"" << g.name() << "\" (" << g.id()
 					   << ", " << g.db_id() << ") while the scenario is not yet initialized.";
 			return;
@@ -1549,7 +1537,7 @@ void server::handle_player_in_game(socket_ptr socket, simple_wml::document& data
 			user_handler_->db_update_game_end(uuid_, g.db_id(), g.get_replay_filename());
 		}
 
-		g.new_scenario(socket);
+		g.new_scenario(p);
 		g.reset_last_synced_context_id();
 
 		// Record the full scenario in g.level()
@@ -1558,7 +1546,7 @@ void server::handle_player_in_game(socket_ptr socket, simple_wml::document& data
 		g.next_db_id();
 
 		if(g.description() == nullptr) {
-			ERR_SERVER << client_address(socket) << "\tERROR: \"" << g.name() << "\" (" << g.id()
+			ERR_SERVER << p->client_ip() << "\tERROR: \"" << g.name() << "\" (" << g.id()
 					   << ", " << g.db_id() << ") is initialized but has no description_.\n";
 			return;
 		}
@@ -1569,12 +1557,12 @@ void server::handle_player_in_game(socket_ptr socket, simple_wml::document& data
 		if(const simple_wml::node* m = scenario->child("multiplayer")) {
 			m->copy_into(desc);
 		} else {
-			WRN_SERVER << client_address(socket) << "\t" << player.name() << "\tsent scenario data in game:\t\""
+			WRN_SERVER << p->client_ip() << "\t" << player.name() << "\tsent scenario data in game:\t\""
 					   << g.name() << "\" (" << g.id() << ", " << g.db_id() << ") without a 'multiplayer' child.\n";
 
 			delete_game(g.id());
 
-			send_server_message(socket,
+			send_server_message(p,
 				"The scenario data is missing the [multiplayer] tag which contains the game "
 				"settings. Game aborted.", "error");
 			return;
@@ -1598,17 +1586,17 @@ void server::handle_player_in_game(socket_ptr socket, simple_wml::document& data
 		// Tell everyone that the next scenario data is available.
 		static simple_wml::document notify_next_scenario(
 			"[notify_next_scenario]\n[/notify_next_scenario]\n", simple_wml::INIT_COMPRESSED);
-		g.send_data(notify_next_scenario, socket);
+		g.send_data(notify_next_scenario, p);
 
 		// Send the update of the game description to the lobby.
 		update_game_in_lobby(g);
 		return;
 		// A mp client sends a request for the next scenario of a mp campaign.
 	} else if(data.child("load_next_scenario")) {
-		g.load_next_scenario(socket);
+		g.load_next_scenario(p);
 		return;
 	} else if(data.child("start_game")) {
-		if(!g.is_owner(socket)) {
+		if(!g.is_owner(p)) {
 			return;
 		}
 
@@ -1618,8 +1606,8 @@ void server::handle_player_in_game(socket_ptr socket, simple_wml::document& data
 		// Send notification of the game starting immediately.
 		// g.start_game() will send data that assumes
 		// the [start_game] message has been sent
-		g.send_data(data, socket);
-		g.start_game(socket);
+		g.send_data(data, p);
+		g.start_game(p);
 
 		if(user_handler_) {
 			const simple_wml::node& m = *g.level().root().child("multiplayer");
@@ -1660,13 +1648,13 @@ void server::handle_player_in_game(socket_ptr socket, simple_wml::document& data
 		update_game_in_lobby(g);
 		return;
 	} else if(data.child("leave_game")) {
-		if(g.remove_player(socket)) {
+		if(g.remove_player(p)) {
 			delete_game(g.id());
 		} else {
 			auto description = g.description();
 
 			// After this line, the game object may be destroyed. Don't use `g`!
-			player_connections_.modify(player_connections_.find(socket), std::bind(&player_record::enter_lobby, std::placeholders::_1));
+			player_connections_.modify(p, std::bind(&player_record::enter_lobby, std::placeholders::_1));
 
 			// Only run this if the game object is still valid
 			if(auto gStrong = g_ptr.lock()) {
@@ -1679,17 +1667,17 @@ void server::handle_player_in_game(socket_ptr socket, simple_wml::document& data
 			bool diff2 = make_change_diff(games_and_users_list_.root(), nullptr, "user", player.config_address(), diff);
 
 			if(diff1 || diff2) {
-				send_to_lobby(diff, socket);
+				send_to_lobby(diff, p);
 			}
 
 			// Send the player who has quit the gamelist.
-			async_send_doc_queued(socket, games_and_users_list_);
+			async_send_doc_queued(p->socket(), games_and_users_list_);
 		}
 
 		return;
 		// If this is data describing side changes by the host.
 	} else if(const simple_wml::node* scenario_diff = data.child("scenario_diff")) {
-		if(!g.is_owner(socket)) {
+		if(!g.is_owner(p)) {
 			return;
 		}
 
@@ -1706,15 +1694,15 @@ void server::handle_player_in_game(socket_ptr socket, simple_wml::document& data
 			update_game_in_lobby(g);
 		}
 
-		g.send_data(data, socket);
+		g.send_data(data, p);
 		return;
 		// If a player changes his faction.
 	} else if(data.child("change_faction")) {
-		g.send_data(data, socket);
+		g.send_data(data, p);
 		return;
 		// If the owner of a side is changing the controller.
 	} else if(const simple_wml::node* change = data.child("change_controller")) {
-		g.transfer_side_control(socket, *change);
+		g.transfer_side_control(p, *change);
 		if(g.describe_slots()) {
 			update_game_in_lobby(g);
 		}
@@ -1722,8 +1710,8 @@ void server::handle_player_in_game(socket_ptr socket, simple_wml::document& data
 		return;
 		// If all observers should be muted. (toggles)
 	} else if(data.child("muteall")) {
-		if(!g.is_owner(socket)) {
-			g.send_server_message("You cannot mute: not the game host.", socket);
+		if(!g.is_owner(p)) {
+			g.send_server_message("You cannot mute: not the game host.", p);
 			return;
 		}
 
@@ -1731,21 +1719,21 @@ void server::handle_player_in_game(socket_ptr socket, simple_wml::document& data
 		return;
 		// If an observer should be muted.
 	} else if(const simple_wml::node* mute = data.child("mute")) {
-		g.mute_observer(*mute, socket);
+		g.mute_observer(*mute, p);
 		return;
 		// If an observer should be unmuted.
 	} else if(const simple_wml::node* unmute = data.child("unmute")) {
-		g.unmute_observer(*unmute, socket);
+		g.unmute_observer(*unmute, p);
 		return;
 		// The owner is kicking/banning someone from the game.
 	} else if(data.child("kick") || data.child("ban")) {
 		bool ban = (data.child("ban") != nullptr);
-		const socket_ptr user = (ban
-			? g.ban_user(*data.child("ban"), socket)
-			: g.kick_member(*data.child("kick"), socket));
+		auto user { ban
+			? g.ban_user(*data.child("ban"), p)
+			: g.kick_member(*data.child("kick"), p)};
 
 		if(user) {
-			player_connections_.modify(player_connections_.find(user), std::bind(&player_record::enter_lobby, std::placeholders::_1));
+			player_connections_.modify(user.value(), std::bind(&player_record::enter_lobby, std::placeholders::_1));
 			if(g.describe_slots()) {
 				update_game_in_lobby(g, user);
 			}
@@ -1753,21 +1741,21 @@ void server::handle_player_in_game(socket_ptr socket, simple_wml::document& data
 			// Send all other players in the lobby the update to the gamelist.
 			simple_wml::document gamelist_diff;
 			make_change_diff(*games_and_users_list_.child("gamelist"), "gamelist", "game", g.description(), gamelist_diff);
-			make_change_diff(games_and_users_list_.root(), nullptr, "user", player_connections_.find(user)->info().config_address(), gamelist_diff);
+			make_change_diff(games_and_users_list_.root(), nullptr, "user", user.value()->info().config_address(), gamelist_diff);
 
-			send_to_lobby(gamelist_diff, socket);
+			send_to_lobby(gamelist_diff, p);
 
 			// Send the removed user the lobby game list.
-			async_send_doc_queued(user, games_and_users_list_);
+			async_send_doc_queued(user.value()->socket(), games_and_users_list_);
 		}
 
 		return;
 	} else if(const simple_wml::node* unban = data.child("unban")) {
-		g.unban_user(*unban, socket);
+		g.unban_user(*unban, p);
 		return;
 		// If info is being provided about the game state.
 	} else if(const simple_wml::node* info = data.child("info")) {
-		if(!g.is_player(socket)) {
+		if(!g.is_player(p)) {
 			return;
 		}
 
@@ -1786,26 +1774,26 @@ void server::handle_player_in_game(socket_ptr socket, simple_wml::document& data
 		// Notify the game of the commands, and if it changes
 		// the description, then sync the new description
 		// to players in the lobby.
-		if(g.process_turn(data, socket)) {
+		if(g.process_turn(data, p)) {
 			update_game_in_lobby(g);
 		}
 
 		return;
 	} else if(data.child("whiteboard")) {
-		g.process_whiteboard(data, socket);
+		g.process_whiteboard(data, p);
 		return;
 	} else if(data.child("change_turns_wml")) {
-		g.process_change_turns_wml(data, socket);
+		g.process_change_turns_wml(data, p);
 		update_game_in_lobby(g);
 		return;
 	} else if(simple_wml::node* sch = data.child("request_choice")) {
-		g.handle_choice(*sch, socket);
+		g.handle_choice(*sch, p);
 		return;
 	} else if(data.child("message")) {
-		g.process_message(data, socket);
+		g.process_message(data, p);
 		return;
 	} else if(data.child("stop_updates")) {
-		g.send_data(data, socket);
+		g.send_data(data, p);
 		return;
 		// Data to ignore.
 	} else if(
@@ -1817,7 +1805,7 @@ void server::handle_player_in_game(socket_ptr socket, simple_wml::document& data
 		return;
 	}
 
-	WRN_SERVER << client_address(socket) << "\tReceived unknown data from: " << player.name() << " (socket:" << socket
+	WRN_SERVER << p->client_ip() << "\tReceived unknown data from: " << player.name() << " (socket:" << p->socket()
 			   << ") in game: \"" << g.name() << "\" (" << g.id() << ", " << g.db_id() << ")\n"
 			   << data.output();
 }
@@ -1833,23 +1821,19 @@ void server::send_server_message(socket_ptr socket, const std::string& message, 
 	async_send_doc_queued(socket, server_message);
 }
 
-void server::remove_player(socket_ptr socket)
+void server::disconnect_player(player_iterator player)
 {
-	std::string ip;
+	player->socket()->shutdown(boost::asio::ip::tcp::socket::shutdown_receive);
+}
 
-	auto iter = player_connections_.find(socket);
-	if(iter == player_connections_.end()) {
-		return;
-	} else {
-		// client_address() is very likely to return <unknown address> at this point
-		// so we remember ip in player_connections_
-		ip = iter->saved_client_ip();
-	}
+void server::remove_player(player_iterator iter)
+{
+	std::string ip = iter->client_ip();
 
 	const std::shared_ptr<game> g = iter->get_game();
 	bool game_ended = false;
 	if(g) {
-		game_ended = g->remove_player(socket, true, false);
+		game_ended = g->remove_player(iter, true, false);
 	}
 
 	const simple_wml::node::child_list& users = games_and_users_list_.root().children("user");
@@ -1859,7 +1843,7 @@ void server::remove_player(socket_ptr socket)
 	// Notify other players in lobby
 	simple_wml::document diff;
 	if(make_delete_diff(games_and_users_list_.root(), nullptr, "user", iter->info().config_address(), diff)) {
-		send_to_lobby(diff, socket);
+		send_to_lobby(diff, iter);
 	}
 
 	games_and_users_list_.root().remove_child("user", index);
@@ -1877,39 +1861,37 @@ void server::remove_player(socket_ptr socket)
 
 	player_connections_.erase(iter);
 
-	if(socket->is_open()) {
-		socket->close();
-	}
-
 	if(lan_server_ && player_connections_.size() == 0)
 		start_lan_server_timer();
 
 	if(game_ended) delete_game(g->id());
 }
 
-void server::send_to_lobby(simple_wml::document& data, socket_ptr exclude)
+void server::send_to_lobby(simple_wml::document& data, utils::optional<player_iterator> exclude)
 {
-	for(const auto& player : player_connections_.get<game_t>().equal_range(0)) {
-		if(player.socket() != exclude) {
-			async_send_doc_queued(player.socket(), data);
+	for(const auto& p : player_connections_.get<game_t>().equal_range(0)) {
+		auto player { player_connections_.iterator_to(p) };
+		if(player != exclude) {
+			async_send_doc_queued(player->socket(), data);
 		}
 	}
 }
 
-void server::send_server_message_to_lobby(const std::string& message, socket_ptr exclude)
+void server::send_server_message_to_lobby(const std::string& message, utils::optional<player_iterator> exclude)
 {
-	for(const auto& player : player_connections_.get<game_t>().equal_range(0)) {
-		if(player.socket() != exclude) {
-			send_server_message(player.socket(), message, "alert");
+	for(const auto& p : player_connections_.get<game_t>().equal_range(0)) {
+		auto player { player_connections_.iterator_to(p) };
+		if(player != exclude) {
+			send_server_message(player, message, "alert");
 		}
 	}
 }
 
-void server::send_server_message_to_all(const std::string& message, socket_ptr exclude)
+void server::send_server_message_to_all(const std::string& message, utils::optional<player_iterator> exclude)
 {
-	for(const auto& player : player_connections_) {
-		if(player.socket() != exclude) {
-			send_server_message(player.socket(), message, "alert");
+	for(auto player = player_connections_.begin(); player != player_connections_.end(); ++player) {
+		if(player != exclude) {
+			send_server_message(player, message, "alert");
 		}
 	}
 }
@@ -2147,7 +2129,7 @@ void server::roll_handler(const std::string& issuer_name,
 
 	auto g_ptr = player_ptr->get_game();
 	if(g_ptr) {
-		g_ptr->send_server_message_to_all(issuer_name + " rolled a die [1 - " + parameters + "] and got a " + value + ".", player_ptr->socket());
+		g_ptr->send_server_message_to_all(issuer_name + " rolled a die [1 - " + parameters + "] and got a " + value + ".", player_connections_.project<0>(player_ptr));
 	} else {
 		*out << " (The result is shown to others only in a game.)";
 	}
@@ -2336,7 +2318,7 @@ void server::status_handler(
 	if(utils::isvalid_username(parameters)) {
 		for(const auto& player : player_connections_) {
 			if(utf8::lowercase(parameters) == utf8::lowercase(player.info().name())) {
-				parameters = client_address(player.socket());
+				parameters = player.client_ip();
 				found_something = true;
 				break;
 			}
@@ -2353,7 +2335,7 @@ void server::status_handler(
 	const bool match_ip = (std::count(parameters.begin(), parameters.end(), '.') >= 1);
 	for(const auto& player : player_connections_) {
 		if(parameters.empty() || parameters == "*" ||
-			(match_ip  && utils::wildcard_string_match(client_address(player.socket()), parameters)) ||
+			(match_ip  && utils::wildcard_string_match(player.client_ip(), parameters)) ||
 			(!match_ip && utils::wildcard_string_match(utf8::lowercase(player.info().name()), utf8::lowercase(parameters)))
 		) {
 			found_something = true;
@@ -2377,16 +2359,16 @@ void server::clones_handler(const std::string& /*issuer_name*/,
 	std::set<std::string> clones;
 
 	for(auto it = player_connections_.begin(); it != player_connections_.end(); ++it) {
-		if(clones.find(client_address(it->socket())) != clones.end()) {
+		if(clones.find(it->client_ip()) != clones.end()) {
 			continue;
 		}
 
 		bool found = false;
 		for(auto clone = std::next(it); clone != player_connections_.end(); ++clone) {
-			if(client_address(it->socket()) == client_address(clone->socket())) {
+			if(it->client_ip() == clone->client_ip()) {
 				if(!found) {
 					found = true;
-					clones.insert(client_address(it->socket()));
+					clones.insert(it->client_ip());
 					*out << std::endl << player_status(*it);
 				}
 
@@ -2477,7 +2459,7 @@ void server::ban_handler(
 					banned = true;
 				}
 
-				const std::string ip = client_address(player.socket());
+				const std::string ip = player.client_ip();
 				*out << ban_manager_.ban(ip, parsed_time, reason, issuer_name, dummy_group, target);
 			}
 		}
@@ -2539,7 +2521,7 @@ void server::kickban_handler(
 	}
 
 	std::string dummy_group;
-	std::vector<socket_ptr> users_to_kick;
+	std::vector<player_iterator> users_to_kick;
 
 	// if we find a '.' consider it an ip mask
 	/** @todo  FIXME: make a proper check for valid IPs. */
@@ -2548,23 +2530,23 @@ void server::kickban_handler(
 
 		*out << ban_manager_.ban(target, parsed_time, reason, issuer_name, dummy_group);
 
-		for(const auto& player : player_connections_) {
-			if(utils::wildcard_string_match(client_address(player.socket()), target)) {
-				users_to_kick.push_back(player.socket());
+		for(player_iterator player = player_connections_.begin(); player != player_connections_.end(); ++player) {
+			if(utils::wildcard_string_match(player->client_ip(), target)) {
+				users_to_kick.push_back(player);
 			}
 		}
 	} else {
-		for(const auto& player : player_connections_) {
-			if(utils::wildcard_string_match(player.info().name(), target)) {
+		for(player_iterator player = player_connections_.begin(); player != player_connections_.end(); ++player) {
+			if(utils::wildcard_string_match(player->info().name(), target)) {
 				if(banned) {
 					*out << "\n";
 				} else {
 					banned = true;
 				}
 
-				const std::string ip = client_address(player.socket());
+				const std::string ip = player->client_ip();
 				*out << ban_manager_.ban(ip, parsed_time, reason, issuer_name, dummy_group, target);
-				users_to_kick.push_back(player.socket());
+				users_to_kick.push_back(player);
 			}
 		}
 
@@ -2588,10 +2570,10 @@ void server::kickban_handler(
 		}
 	}
 
-	for(const auto& user : users_to_kick) {
-		*out << "\nKicked " << player_connections_.find(user)->info().name() << " (" << client_address(user) << ").";
-		async_send_error(user, "You have been banned. Reason: " + reason);
-		remove_player(user);
+	for(auto user : users_to_kick) {
+		*out << "\nKicked " << user->info().name() << " (" << user->client_ip() << ").";
+		async_send_error(user->socket(), "You have been banned. Reason: " + reason);
+		disconnect_player(user);
 	}
 }
 
@@ -2649,7 +2631,7 @@ void server::gban_handler(
 					banned = true;
 				}
 
-				const std::string ip = client_address(player.socket());
+				const std::string ip = player.client_ip();
 				*out << ban_manager_.ban(ip, parsed_time, reason, issuer_name, group, target);
 			}
 		}
@@ -2728,27 +2710,27 @@ void server::kick_handler(const std::string& /*issuer_name*/,
 	// if we find a '.' consider it an ip mask
 	const bool match_ip = (std::count(kick_mask.begin(), kick_mask.end(), '.') >= 1);
 
-	std::vector<socket_ptr> users_to_kick;
-	for(const auto& player : player_connections_) {
-		if((match_ip && utils::wildcard_string_match(client_address(player.socket()), kick_mask)) ||
-		  (!match_ip && utils::wildcard_string_match(player.info().name(), kick_mask))
+	std::vector<player_iterator> users_to_kick;
+	for(player_iterator player = player_connections_.begin(); player != player_connections_.end(); ++player) {
+		if((match_ip && utils::wildcard_string_match(player->client_ip(), kick_mask)) ||
+		  (!match_ip && utils::wildcard_string_match(player->info().name(), kick_mask))
 		) {
-			users_to_kick.push_back(player.socket());
+			users_to_kick.push_back(player);
 		}
 	}
 
-	for(const auto& socket : users_to_kick) {
+	for(const auto& player : users_to_kick) {
 		if(kicked) {
 			*out << "\n";
 		} else {
 			kicked = true;
 		}
 
-		*out << "Kicked " << player_connections_.find(socket)->name() << " (" << client_address(socket) << "). '"
+		*out << "Kicked " << player->name() << " (" << player->client_ip() << "). '"
 			 << kick_message << "'";
 
-		async_send_error(socket, kick_message);
-		remove_player(socket);
+		async_send_error(player->socket(), kick_message);
+		disconnect_player(player);
 	}
 
 	if(!kicked) {
@@ -2807,7 +2789,7 @@ void server::searchlog_handler(const std::string& /*issuer_name*/,
 			found_something = true;
 			auto player = player_connections_.get<name_t>().find(username);
 
-			if(player != player_connections_.get<name_t>().end() && client_address(player->socket()) == ip) {
+			if(player != player_connections_.get<name_t>().end() && player->client_ip() == ip) {
 				*out << std::endl << player_status(*player);
 			} else {
 				*out << "\n'" << username << "' @ " << ip
@@ -2907,7 +2889,7 @@ void server::delete_game(int gameid, const std::string& reason)
 	}
 }
 
-void server::update_game_in_lobby(const wesnothd::game& g, const socket_ptr& exclude)
+void server::update_game_in_lobby(const wesnothd::game& g, utils::optional<player_iterator> exclude)
 {
 	simple_wml::document diff;
 	if(make_change_diff(*games_and_users_list_.child("gamelist"), "gamelist", "game", g.description(), diff)) {

--- a/src/server/wesnothd/server.hpp
+++ b/src/server/wesnothd/server.hpp
@@ -24,6 +24,7 @@
 #include "server/wesnothd/player_connection.hpp"
 
 #include <boost/asio/steady_timer.hpp>
+#include <utils/optional_fwd.hpp>
 
 #include <random>
 
@@ -46,26 +47,28 @@ private:
 	bool accepting_connections() const { return !graceful_restart; }
 
 	void handle_player(boost::asio::yield_context yield, socket_ptr socket, const player& player);
-	void handle_player_in_lobby(socket_ptr socket, simple_wml::document& data);
-	void handle_player_in_game(socket_ptr socket, simple_wml::document& data);
-	void handle_whisper(socket_ptr socket, simple_wml::node& whisper);
-	void handle_query(socket_ptr socket, simple_wml::node& query);
-	void handle_nickserv(socket_ptr socket, simple_wml::node& nickserv);
-	void handle_message(socket_ptr socket, simple_wml::node& message);
-	void handle_create_game(socket_ptr socket, simple_wml::node& create_game);
-	void create_game(player_record& host, simple_wml::node& create_game);
+	void handle_player_in_lobby(player_iterator player, simple_wml::document& doc);
+	void handle_player_in_game(player_iterator player, simple_wml::document& doc);
+	void handle_whisper(player_iterator player, simple_wml::node& whisper);
+	void handle_query(player_iterator player, simple_wml::node& query);
+	void handle_nickserv(player_iterator player, simple_wml::node& nickserv);
+	void handle_message(player_iterator player, simple_wml::node& message);
+	void handle_create_game(player_iterator player, simple_wml::node& create_game);
 	void cleanup_game(game*); // deleter for shared_ptr
-	void handle_join_game(socket_ptr socket, simple_wml::node& join);
-	void remove_player(socket_ptr socket);
+	void handle_join_game(player_iterator player, simple_wml::node& join);
+	void disconnect_player(player_iterator player);
+	void remove_player(player_iterator player);
 
 	void send_server_message(socket_ptr socket, const std::string& message, const std::string& type);
-	void send_to_lobby(simple_wml::document& data, socket_ptr exclude = socket_ptr());
-	void send_server_message_to_lobby(const std::string& message, socket_ptr exclude = socket_ptr());
-	void send_server_message_to_all(const std::string& message, socket_ptr exclude = socket_ptr());
+	void send_server_message(player_iterator player, const std::string& message, const std::string& type) {
+		send_server_message(player->socket(), message, type);
+	}
+	void send_to_lobby(simple_wml::document& data, utils::optional<player_iterator> exclude = {});
+	void send_server_message_to_lobby(const std::string& message, utils::optional<player_iterator> exclude = {});
+	void send_server_message_to_all(const std::string& message, utils::optional<player_iterator> exclude = {});
 
-	bool player_is_in_game(socket_ptr socket) const
-	{
-		return player_connections_.find(socket)->get_game() != nullptr;
+	bool player_is_in_game(player_iterator player) const {
+		return player->get_game() != nullptr;
 	}
 
 	wesnothd::ban_manager ban_manager_;
@@ -190,7 +193,7 @@ private:
 
 	void delete_game(int, const std::string& reason="");
 
-	void update_game_in_lobby(const wesnothd::game& g, const socket_ptr& exclude=socket_ptr());
+	void update_game_in_lobby(const game& g, utils::optional< wesnothd::player_iterator > exclude = {});
 
 	void start_new_server();
 

--- a/src/server/wesnothd/server.hpp
+++ b/src/server/wesnothd/server.hpp
@@ -23,8 +23,9 @@
 #include "server/common/server_base.hpp"
 #include "server/wesnothd/player_connection.hpp"
 
+#include "utils/optional_fwd.hpp"
+
 #include <boost/asio/steady_timer.hpp>
-#include <utils/optional_fwd.hpp>
 
 #include <random>
 

--- a/src/server/wesnothd/server.hpp
+++ b/src/server/wesnothd/server.hpp
@@ -194,7 +194,7 @@ private:
 
 	void delete_game(int, const std::string& reason="");
 
-	void update_game_in_lobby(const game& g, utils::optional< wesnothd::player_iterator > exclude = {});
+	void update_game_in_lobby(const game& g, utils::optional<player_iterator> exclude = {});
 
 	void start_new_server();
 


### PR DESCRIPTION
Use `player_iterator` typedef instead of `socket_ptr` to refer to players once they're logged in. `player_iterator` points directly to player's record in `player_connections_` container allowing for access to any stats associated with player without searching by socket. Also this paves way to potentially remembering disconnected players for purpose of implementing player reconnect feature.

Interface conventions:
- `player_iterator` arguments should always refer to player existing in `player_connections_`. Potential past-the-end iterators should be checked for before passing the `player_iterator` to other functions.
- `utils::optional<player_iterator>` should be used in cases where actual player may not exist.