### PR TITLE
Remove the unused completely_redrawn event

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -193,7 +193,6 @@ display::display(const display_context * dc, std::weak_ptr<wb::manager> wb, repo
 	map_labels_(new map_labels(nullptr)),
 	reports_object_(&reports_object),
 	scroll_event_("scrolled"),
-	complete_redraw_event_("completely_redrawn"),
 	frametimes_(50),
 	fps_counter_(),
 	fps_start_(),
@@ -2463,8 +2462,6 @@ void display::redraw_everything()
 	draw(true,true);
 	int ticks3 = SDL_GetTicks();
 	LOG_DP << "invalidate and draw: " << (ticks3 - ticks2) << " and " << (ticks2 - ticks1) << "\n";
-
-	complete_redraw_event_.notify_observers();
 }
 
 void display::add_redraw_observer(std::function<void(display&)> f)

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -562,8 +562,6 @@ public:
 	/** Expose the event, so observers can be notified about map scrolling. */
 	events::generic_event &scroll_event() const { return scroll_event_; }
 
-	events::generic_event& complete_redraw_event() { return complete_redraw_event_; }
-
 	/** Check if a tile is fully visible on screen. */
 	bool tile_fully_on_screen(const map_location& loc) const;
 
@@ -771,12 +769,6 @@ protected:
 
 	/** Event raised when the map is being scrolled */
 	mutable events::generic_event scroll_event_;
-
-	/**
-	 * notify observers that the screen has been redrawn completely
-	 * atm this is used for replay_controller to add replay controls to the standard theme
-	 */
-	events::generic_event complete_redraw_event_;
 
 	boost::circular_buffer<unsigned> frametimes_; // in milliseconds
 	unsigned int fps_counter_;


### PR DESCRIPTION
The main reason for opening the PR is to trigger a CI build; I'm expecting to merge this
within 24 hours unless it gets a negative review comment.

No observers attached themselves to this event. Commit ea257355 removed some
code that should have been triggered by the event, but which now (since
ea257355) uses the "theme_reset" event or update_enabled_buttons() instead.