### PR TITLE
Add #textdomain wesnoth to data/core/about_i18n.cfg

### DIFF
--- a/data/core/about_i18n.cfg
+++ b/data/core/about_i18n.cfg
@@ -1,3 +1,5 @@
+#textdomain wesnoth
+
 sort=yes
 
 [about]


### PR DESCRIPTION
wmllint complained:
"../../data/core/about_i18n.cfg", line 1: no textdomain string

Despite [data/core/about_i18n.cfg](https://github.com/wesnoth/wesnoth/blob/master/data/core/about_i18n.cfg) missing an explicit textdomain it appears to contain a number of strings marked for translation and I can see [translations](https://github.com/wesnoth/wesnoth/blob/master/po/wesnoth/af.po#L645) for those strings in the wesnoth textdomain folder.