### PR TITLE
Add #textdomain wesnoth to two files w/o explicit textdomain

### DIFF
--- a/data/core/macros/movetypes.cfg
+++ b/data/core/macros/movetypes.cfg
@@ -1,3 +1,5 @@
+#textdomain wesnoth
+
 #define LESS_NIMBLE_ELF
     # a special macro to define slightly less nimble elves such
     # as fighters, who don't do quite so well in forest

--- a/data/core/macros/optional_unit_advancements.cfg
+++ b/data/core/macros/optional_unit_advancements.cfg
@@ -1,3 +1,5 @@
+#textdomain wesnoth
+
 #define ENABLE_PARAGON
     # Place in a campaign or scenario definition to allow Dune Blademaster to advance to Dune Paragon.
     [modify_unit_type]


### PR DESCRIPTION
# Purpose of this PR
Fix wmllint errors:
```
"../../data/core/macros/movetypes.cfg", line 1: no textdomain string
"../../data/core/macros/optional_unit_advancements.cfg", line 1: no textdomain string
```

# Describe the solution
Add `#textdomain wesnoth` declaration to this two files. As far as I can tell this is just a formality: the files do not contain any strings that need a translation. I can see several other files in the same directory also defining `#textdomain wesnoth` as a formality. Example:
https://github.com/wesnoth/wesnoth/blob/d9ec9b9b55a5063a7709c52e6f28edaedad918a3/data/core/macros/event-utils.cfg#L1