### PR TITLE
Add missing NOTE_MARKSMAN to Dune Sky Hunter

### DIFF
--- a/data/core/units/dunefolk/Sky_Hunter.cfg
+++ b/data/core/units/dunefolk/Sky_Hunter.cfg
@@ -38,6 +38,7 @@ units/dunefolk/skirmisher/#enddef
     description= _ "Often mistaken for young Rocs, desert eagles are large, majestic birds of prey who are notoriously aggressive and nearly impossible to tame. In the wild, the eagles feed on larger prey such as wolves, small horses, and, it is said, naughty young children. The power of these creatures makes them tremendously difficult to engage, with only the most skilled of falconers even daring to approach them. In the event that the bird tamer is actually successful, the relationship between bird and hunter becomes less of master and pet, and more a mutual bond between two equals. Serving not only as tools for combat, the eagles can live for up to a few decades and are often precious companions to their dunefolk partners."
     {NOTE_SKIRMISHER}
     {NOTE_DIVERSION}
+    {NOTE_MARKSMAN}
     die_sound={SOUND_LIST:HUMAN_FEMALE_DIE}
     {DEFENSE_ANIM_FILTERED "{PATH_TEMP}sky_hunter-eagle-defend2.png" "{PATH_TEMP}sky_hunter-eagle-defend1.png" {SOUND_LIST:HUMAN_FEMALE_HIT} (
     )}


### PR DESCRIPTION
Dune Sky Hunter has a {WEAPON_SPECIAL_MARKSMAN} but is missing {NOTE_MARKSMAN}
https://github.com/wesnoth/wesnoth/blob/cd833206b19bc2982e0d914b42fa2e785c7f4608/data/core/units/dunefolk/Sky_Hunter.cfg#L150-L161

This PR adds the missing {NOTE_MARKSMAN}