### PR TITLE
Fix several wmllint errors in data/core/units

### DIFF
--- a/data/core/units/monsters/Frost_Stoat.cfg
+++ b/data/core/units/monsters/Frost_Stoat.cfg
@@ -32,7 +32,7 @@
     {AMLA_DEFAULT}
     cost=12
     usage=fighter
-    description= _ "Frost Stoats are a devious rodent predominantly found in the frozen parts of the Northlands, although they can survive anywhere.  Their most distinctive feature is their icy-cold front claws, which is unlike anything found in other wild animals.  These stoats generally scavenge refuse or hunt smaller animals, but are quite territorial and the young adults have been known to attack larger intruders, including humans and orcs."
+    description= _ "Frost Stoats are a devious rodent predominantly found in the frozen parts of the Northlands, although they can survive anywhere. Their most distinctive feature is their icy-cold front claws, which is unlike anything found in other wild animals. These stoats generally scavenge refuse or hunt smaller animals, but are quite territorial and the young adults have been known to attack larger intruders, including humans and orcs."
     {NOTE_SKIRMISHER}
     die_sound=hiss-die.wav
     undead_variation=rat

--- a/data/core/units/monsters/Scarab.cfg
+++ b/data/core/units/monsters/Scarab.cfg
@@ -22,7 +22,7 @@
     [/special_note]
     cost=12
     usage=fighter
-    description= _ "Horned Scarabs are large, rugged insects that can grow to be quite large, making them a threat when they decide to be aggressive.  Their primary means of attack is the large, sharp horn growing from their head.  Because of their large size, armor, and horn, they cannot fly."
+    description= _ "Horned Scarabs are large, rugged insects that can grow to be quite large, making them a threat when they decide to be aggressive. Their primary means of attack is the large, sharp horn growing from their head. Because of their large size, armor, and horn, they cannot fly."
     die_sound=hiss-die.wav
     undead_variation=spider # not perfect, but better than a bald man
     [movement_costs]

--- a/data/core/units/monsters/Wild_Wyvern.cfg
+++ b/data/core/units/monsters/Wild_Wyvern.cfg
@@ -41,7 +41,7 @@
     {AMLA_DEFAULT}
     cost=75
     usage=scout
-    description="Wyverns are large reptiles that resemble dragons, but are not the intelligent, magical creatures.  However, the fact that they are just wild beasts should not cause any traveler who encounters one to dismiss the threat, for they are fast and fierce when threatened or hungry.
+    description= _ "Wyverns are large reptiles that resemble dragons, but are not the intelligent, magical creatures. However, the fact that they are just wild beasts should not cause any traveler who encounters one to dismiss the threat, for they are fast and fierce when threatened or hungry.
 
 Wyverns are social creatures, usually traveling in pairs or small groups.  Their hunting patterns and diet are difficult to discern, for they often work with smaller animals that would appear to be potential prey.  That odd behavior may be an adaptation to the harsh desert environments they often inhabit."
     die_sound=drake-die.ogg

--- a/data/core/units/nagas/Dirkfang.cfg
+++ b/data/core/units/nagas/Dirkfang.cfg
@@ -15,7 +15,7 @@
     advances_to=Naga Ophidian,Naga Ringcaster
     cost=15
     usage=mixed fighter
-    description= _ "In contrast to the heavily melee-focused style of their northern brethren, young Naga of the southern waters prefer to soften their prey from afar before closing in. The small chakri they throw can be carried on the wrist or on a belt without causing hindrance.  While any final kill under water must usually be done at close range, the mixed combat style often allows them to live long enough to learn and improve. Sometimes viewed as cowardly by the northern Naga warriors, these fighters are nonetheless effective when it comes time to engage in warfare."
+    description= _ "In contrast to the heavily melee-focused style of their northern brethren, young Naga of the southern waters prefer to soften their prey from afar before closing in. The small chakri they throw can be carried on the wrist or on a belt without causing hindrance. While any final kill under water must usually be done at close range, the mixed combat style often allows them to live long enough to learn and improve. Sometimes viewed as cowardly by the northern Naga warriors, these fighters are nonetheless effective when it comes time to engage in warfare."
     die_sound=naga-die.ogg
     {DEFENSE_ANIM_FILTERED "units/nagas/dirkfang-range-defend2.png" "units/nagas/dirkfang-range-defend1.png" {SOUND_LIST:NAGA_HIT} (
         [filter_attack]

--- a/data/core/units/nagas/Ophidian.cfg
+++ b/data/core/units/nagas/Ophidian.cfg
@@ -15,7 +15,7 @@
     advances_to=Naga Sicarius
     cost=24
     usage=fighter
-    description= _ "Experienced warriors of the Southern Naga often find work as mercenaries, usually hired by neighboring Dunefolk to control key waterways near the coastline.  Due to their constant confrontations with enemy horsemen, Ophidians have retired the ringed blades of their youth and picked up the piercing bow.  Though generally amicable with their wealthy employers, this friendliness should not be mistaken for loyalty, for the Ophidian are known for readily switching between rival city-state factions at the start of each shipping season, when demand for water-based protection is the highest.  As a group, these nagas encourage a healthy amount of competition among the surface factions, ensuring their services are valued by one tribe or another."
+    description= _ "Experienced warriors of the Southern Naga often find work as mercenaries, usually hired by neighboring Dunefolk to control key waterways near the coastline. Due to their constant confrontations with enemy horsemen, Ophidians have retired the ringed blades of their youth and picked up the piercing bow. Though generally amicable with their wealthy employers, this friendliness should not be mistaken for loyalty, for the Ophidian are known for readily switching between rival city-state factions at the start of each shipping season, when demand for water-based protection is the highest. As a group, these nagas encourage a healthy amount of competition among the surface factions, ensuring their services are valued by one tribe or another."
     die_sound=naga-die.ogg
     {DEFENSE_ANIM "units/nagas/ophidian.png" "units/nagas/ophidian.png" {SOUND_LIST:NAGA_HIT} }
     [defense]

--- a/data/core/units/nagas/Ringcaster.cfg
+++ b/data/core/units/nagas/Ringcaster.cfg
@@ -14,7 +14,7 @@
     advances_to=Naga Zephyr
     cost=24
     usage=mixed fighter
-    description= _ "The chakram, a greater blade ring than the chakri, is the signature weapon of the southern Naga and their renowned Ringcasters.  Well balanced chakrams are useful for throwing, but the rejected blades make a good fist-load weapon, similar to a sharp-bladed tekko or knuckleduster."
+    description= _ "The chakram, a greater blade ring than the chakri, is the signature weapon of the southern Naga and their renowned Ringcasters. Well balanced chakrams are useful for throwing, but the rejected blades make a good fist-load weapon, similar to a sharp-bladed tekko or knuckleduster."
     die_sound=naga-die.ogg
     {DEFENSE_ANIM "units/nagas/ringcaster.png" "units/nagas/ringcaster.png" {SOUND_LIST:NAGA_HIT} }
 


### PR DESCRIPTION
This PR fixes the following wmllint errors:
```
"../../data/core/units/monsters/Frost_Stoat.cfg", line 35: double space after sentence end
wmllint: converting ../../data/core/units/monsters/Frost_Stoat.cfg
"../../data/core/units/monsters/Scarab.cfg", line 25: double space after sentence end
wmllint: converting ../../data/core/units/monsters/Scarab.cfg
"../../data/core/units/monsters/Wild_Wyvern.cfg", line 44: description needs translation mark
"../../data/core/units/monsters/Wild_Wyvern.cfg", line 44: double space after sentence end
wmllint: converting ../../data/core/units/monsters/Wild_Wyvern.cfg
"../../data/core/units/nagas/Dirkfang.cfg", line 18: double space after sentence end
wmllint: converting ../../data/core/units/nagas/Dirkfang.cfg
"../../data/core/units/nagas/Ophidian.cfg", line 18: double space after sentence end
wmllint: converting ../../data/core/units/nagas/Ophidian.cfg
"../../data/core/units/nagas/Ringcaster.cfg", line 17: double space after sentence end
wmllint: converting ../../data/core/units/nagas/Ringcaster.cfg
```