### PR TITLE
Fix wmllint confusing fake map border for fog

### DIFF
--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -2882,7 +2882,7 @@ def translator(filename, mapxforms, textxform):
                     else:
                         fields = [x for x in line]
                     outmap.append(fields)
-                    if not maskwarn and maptype == 'map' and ("_f" in line or "_s" in line):
+                    if not maskwarn and maptype == 'map' and re.search('_s|_f(?!me)', line):
                         print('"%s", line %d: warning, fog or shroud in map file' \
                               % (filename, lineno+1))
                         maskwarn = True


### PR DESCRIPTION
This PR fixes a wmllint bug that causes it to complain about fog in maps that contain a fake map border terrain code.

To quote https://wiki.wesnoth.org/TerrainCodeTableWML :

name | string
-|-
Fake Map Border | ^_fme
Fog | _f

This bug causes the following wmllint error:
```
"data/multiplayer/maps/2p_Hornshark_Island.map", line 2: warning, fog or shroud in map file
```