### PR TITLE
Fix comment parsing in wmllint

### DIFF
--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -1696,40 +1696,41 @@ def global_sanity_check(filename, lines):
         if line.startswith("#endif"):
             ifdef_stack.pop()
             continue
-        if "[generator]" in line:
+        precomment = line.split("#")[0]
+        if "[generator]" in precomment:
             in_generator = True
             continue
-        elif "[/generator]" in line:
+        elif "[/generator]" in precomment:
             in_generator = False
             continue
         # do not use has_opening_tag() here, otherwise a [+side] tag
         # will make the sidecount variable incorrect
-        elif "[side]" in line:
+        elif "[side]" in precomment:
             in_side = True
             sidecount += 1
             continue
-        elif "[/side]" in line:
+        elif "[/side]" in precomment:
             if recruit or recruitment_pattern:
                 sides.append((filename, recruit, recruitment_pattern))
             in_side = False
             recruit = {}
             recruitment_pattern = {}
             continue
-        elif in_side and has_opening_tag(line, "ai"):
+        elif in_side and has_opening_tag(precomment, "ai"):
             in_ai = True
             continue
-        elif in_side and has_opening_tag(line, "unit"):
+        elif in_side and has_opening_tag(precomment, "unit"):
             in_subunit = True
             continue
-        elif in_side and "[/ai]" in line:
+        elif in_side and "[/ai]" in precomment:
             in_ai = False
             continue
-        elif in_side and "[/unit]" in line:
+        elif in_side and "[/unit]" in precomment:
             in_subunit = False
             continue
         if "wmllint: skip-side" in line:
             sidecount += 1
-        if not in_side or in_subunit or '=' not in line:
+        if not in_side or in_subunit or '=' not in precomment:
             continue
         try:
             (key, prefix, value, comment) = parse_attribute(line)


### PR DESCRIPTION
wmllint saw [side] inside a comment and incorrectly assumed it is reading a side definition
This PR fixes the following wmllint errors:
```
"../../data/multiplayer/scenarios/4p_A_New_Land.cfg", line 484: side number 5 is out of sequence (11 expected)
"../../data/multiplayer/scenarios/4p_A_New_Land.cfg", line 488: side number 5 is out of sequence (11 expected)
"../../data/multiplayer/scenarios/4p_A_New_Land.cfg", line 512: side number 6 is out of sequence (11 expected)
"../../data/multiplayer/scenarios/4p_A_New_Land.cfg", line 516: side number 6 is out of sequence (11 expected)
"../../data/multiplayer/scenarios/4p_A_New_Land.cfg", line 540: side number 7 is out of sequence (11 expected)
"../../data/multiplayer/scenarios/4p_A_New_Land.cfg", line 544: side number 7 is out of sequence (11 expected)
"../../data/multiplayer/scenarios/4p_A_New_Land.cfg", line 568: side number 8 is out of sequence (11 expected)
"../../data/multiplayer/scenarios/4p_A_New_Land.cfg", line 572: side number 8 is out of sequence (11 expected)
"../../data/multiplayer/scenarios/4p_A_New_Land.cfg", line 805: side number 1 is out of sequence (11 expected)
"../../data/multiplayer/scenarios/4p_A_New_Land.cfg", line 818: side number 2 is out of sequence (11 expected)
"../../data/multiplayer/scenarios/4p_A_New_Land.cfg", line 831: side number 3 is out of sequence (11 expected)
"../../data/multiplayer/scenarios/4p_A_New_Land.cfg", line 844: side number 4 is out of sequence (11 expected)
```