### PR TITLE
Silence wmllint error about a missing campaign id

### DIFF
--- a/data/campaigns/Dead_Water/_main.cfg
+++ b/data/campaigns/Dead_Water/_main.cfg
@@ -71,9 +71,12 @@
     {campaigns/Dead_Water/units}
 [/units]
 
+# wmllint bug: wmllint is not smart enough to realise that the campaign already has an id
+# wmllint: validate-off
 [+campaign]
     {ENABLE_KRAKEN}
 [/campaign]
+# wmllint: validate-on
 
 {campaigns/Dead_Water/scenarios}
 


### PR DESCRIPTION
This PR fixes the following wmllint error:
```
"../../data/campaigns/Dead_Water/_main.cfg", line 76: campaign requires an ID attribute but has none
```

This wmllint error was caused by the fact that the campaign definition is split into two and wmllint is not smart enough to understand that.

https://github.com/wesnoth/wesnoth/blob/92fedf8f2aa7a4b83fe0e59e7e0e4f2c16e3c207/data/campaigns/Dead_Water/_main.cfg#L7-L8
https://github.com/wesnoth/wesnoth/blob/92fedf8f2aa7a4b83fe0e59e7e0e4f2c16e3c207/data/campaigns/Dead_Water/_main.cfg#L74-L76

