### PR TITLE
Fix wrong comment handling in wmllint

### DIFF
--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -1804,13 +1804,14 @@ def global_sanity_check(filename, lines):
     # Because we can't be sure about what the UMC author wants to do, just warn
     in_campaign = False
     for num, line in enumerate(lines, start=1):
-        if "[campaign]" in line:
+        precomment = line.split("#")[0]
+        if "[campaign]" in precomment:
             in_campaign = True
             continue
-        if "[/campaign]" in line:
+        if "[/campaign]" in precomment:
             in_campaign = False
             continue
-        if has_opening_tag(line, "advancefrom"):
+        if has_opening_tag(precomment, "advancefrom"):
             print("{}, line {}: [advancefrom] needs to be manually updated to \
 [modify_unit_type] and moved into the _main.cfg file".format(filename, num))
         if in_campaign:


### PR DESCRIPTION
This PR fixes the following wmllint error:
```
../../data/campaigns/Dead_Water/scenarios/06_Uncharted_Islands.cfg, line 22: [advancefrom] needs to be manually updated to [modify_unit_type] and moved into the _main.cfg file
```

A comment containing a string [advancefrom] was causing wmllint to get confused

https://github.com/wesnoth/wesnoth/blob/92fedf8f2aa7a4b83fe0e59e7e0e4f2c16e3c207/data/campaigns/Dead_Water/scenarios/06_Uncharted_Islands.cfg#L22