### PR TITLE
wmllint: Ignore location_id when checking for shroud and fog

### DIFF
--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -2884,8 +2884,8 @@ def translator(filename, mapxforms, textxform):
                     else:
                         fields = [x for x in line]
                     outmap.append(fields)
-                    terrain_strings = (f.split()[-1] for f in fields)
                     if not maskwarn and maptype == 'map':
+                        terrain_strings = (f.split()[-1] for f in fields)
                         if any(re.search('_s|_f(?!me)', t) for t in terrain_strings):
                             print('"%s", line %d: warning, fog or shroud in map file' \
                                   % (filename, lineno+1))

--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -2884,10 +2884,12 @@ def translator(filename, mapxforms, textxform):
                     else:
                         fields = [x for x in line]
                     outmap.append(fields)
-                    if not maskwarn and maptype == 'map' and re.search('_s|_f(?!me)', line):
-                        print('"%s", line %d: warning, fog or shroud in map file' \
-                              % (filename, lineno+1))
-                        maskwarn = True
+                    terrain_strings = (f.split()[-1] for f in fields)
+                    if not maskwarn and maptype == 'map':
+                        if any(re.search('_s|_f(?!me)', t) for t in terrain_strings):
+                            print('"%s", line %d: warning, fog or shroud in map file' \
+                                  % (filename, lineno+1))
+                            maskwarn = True
             # Deduce the map type
             if not map_only:
                 if maptype == "map":


### PR DESCRIPTION
The following line was causing a wmllint error because it contains _s:
```
Irs, book_start Icr^Ii, Irs
```
```
"../../data/campaigns/Descent_Into_Darkness/maps/07c_A_Small_Favor3.map", line 10: warning, fog or shroud in map file
```