### PR TITLE
Quote an attribute value

### DIFF
--- a/data/campaigns/Descent_Into_Darkness/scenarios/02_Peaceful_Valley.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/02_Peaceful_Valley.cfg
@@ -514,7 +514,7 @@
     [event]
         name=die
         [filter]
-            id=T'shar Lggi
+            id="T'shar Lggi"
         [/filter]
 
         [message]


### PR DESCRIPTION
~~1. According to this https://github.com/wesnoth/wesnoth/commit/6405507b2408fc79511c0210a7a39689d56a4b6f  `[message]` with `speaker=narrator` is supposed to have `image=wesnoth-icon.png`~~

2. https://github.com/wesnoth/wesnoth/blob/75271a824657b0be63369ed4fc55cf0cb3579429/data/tools/wmllint#L2583
