### PR TITLE
Use gcc-9 in the Scout runtime instead of gcc-5.

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -169,8 +169,8 @@ jobs:
           export IMAGE=steamrt
           export NLS=false
           export TOOL=scons
-          export CC=gcc-5
-          export CXX=g++-5
+          export CC=gcc-9
+          export CXX=g++-9
           export CXX_STD=14
           export CFG=release
           export LTO=false

--- a/utils/dockerbuilds/CI/Dockerfile-base-steamrt
+++ b/utils/dockerbuilds/CI/Dockerfile-base-steamrt
@@ -4,10 +4,10 @@ ARG BOOST_VERSION=1.66.0
 ARG BOOST_VERSION_=1_66_0
 
 RUN apt-get update
-RUN apt-get install -y scons libsdl2-dev libsdl2 g++-5 libicu-dev libreadline-dev expect-dev
+RUN apt-get install -y scons libsdl2-dev libicu-dev libreadline-dev expect-dev
 
 RUN wget --max-redirect 3 https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_}.tar.gz
 RUN mkdir -p /src/boost && tar zxf boost_${BOOST_VERSION_}.tar.gz -C /src/boost --strip-components=1
-RUN cd /src/boost && ./bootstrap.sh --with-libraries=iostreams,regex,system,filesystem,program_options,random,locale,context,coroutine && ./b2 toolset=gcc-5 --layout=system link=static variant=release cxxflags='-fPIE -fstack-protector-strong' define=_FORTIFY_SOURCE=2 install
+RUN cd /src/boost && ./bootstrap.sh --with-libraries=iostreams,regex,system,filesystem,program_options,random,locale,context,coroutine && ./b2 toolset=gcc-9 --layout=system link=static variant=release cxxflags='-fPIE -fstack-protector-strong' define=_FORTIFY_SOURCE=2 install
 
-RUN mkdir -p /staging/lib64 && cp /usr/lib/libicu*.so.* /lib/x86_64-linux-gnu/libhistory.so.6 /staging/lib64/
+RUN mkdir -p /staging/lib64 && cp /usr/lib/libicu*.so.* /lib/x86_64-linux-gnu/libhistory.so.6 /lib/x86_64-linux-gnu/libcrypto.so.1.0.0 /staging/lib64/

--- a/utils/dockerbuilds/make_steam_image
+++ b/utils/dockerbuilds/make_steam_image
@@ -2,7 +2,7 @@
 
 VALVEFILE=com.valvesoftware.SteamRuntime.Sdk-amd64,i386-scout-sysroot.Dockerfile
 VALVETAR=com.valvesoftware.SteamRuntime.Sdk-amd64,i386-scout-sysroot.tar.gz
-VALVE_SNAPSHOT=0.20201007.1
+VALVE_SNAPSHOT=0.20210114.2
 
 DOCKERBASEIMAGE=steamrt_scout_amd64
 DOCKERLOCALIMAGE=wesnoth/wesnoth:steamrt-master

--- a/utils/dockerbuilds/steamrt/Dockerfile
+++ b/utils/dockerbuilds/steamrt/Dockerfile
@@ -3,4 +3,4 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 COPY start.sh /staging/start.sh
 
-ENTRYPOINT mkdir -p /build && cd /build && scons -j `nproc` ctool=gcc-5 cxxtool=g++-5 boostdir=/usr/local/include boostlibdir=/usr/local/lib extra_flags_config=-lrt -Y /wesnoth && cp /build/wesnoth /output/ && cp /build/wesnothd /output/ && cp -r /staging/* /output/
+ENTRYPOINT mkdir -p /build && cd /build && scons -j `nproc` ctool=gcc-9 cxxtool=g++-9 boostdir=/usr/local/include boostlibdir=/usr/local/lib extra_flags_config=-lrt -Y /wesnoth && cp /build/wesnoth /output/ && cp /build/wesnothd /output/ && cp -r /staging/* /output/


### PR DESCRIPTION
The gcc-9 shipped with the Scout runtime forces the use of -static-libstdc++ which is what allows this to work. However, LTO is not yet able to be enabled since as of right now it simply crashes immediately with `free(): invalid pointer`.

---

Note 1: Information about the Scout-provided `gcc-9` comes from https://github.com/ValveSoftware/steam-for-linux/issues/7430#issuecomment-761068435
Note 2: The updated docker image has not yet been uploaded for this PR.