### PR TITLE
DiD: fix some wmllint errors

### DIFF
--- a/data/campaigns/Descent_Into_Darkness/scenarios/03_A_Haunting_in_Winter.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/03_A_Haunting_in_Winter.cfg
@@ -203,7 +203,7 @@
         [while]
             [not]
                 [have_unit]
-                    id=YOgre2
+                    id=YOgre2  # wmllint: ignore - suppress unknown 'YOgre2' referred to by id
                     [not]
                         trait=strong
                     [/not]

--- a/data/campaigns/Descent_Into_Darkness/scenarios/07b_A_Small_Favor2.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/07b_A_Small_Favor2.cfg
@@ -716,9 +716,11 @@
         [/filter]
         [message]
             speaker=narrator
+#wmllint: display on
             message= _ "<i>Mirrors of shallow blue, cold and opaque, they stare,
 Piercing, unblinking, a pitiless reflection,
 Shattering our brittle, fancied reality.</i>"
+#wmllint: display off
         [/message]
         [allow_undo][/allow_undo]
     [/event]
@@ -730,9 +732,11 @@ Shattering our brittle, fancied reality.</i>"
         [/filter]
         [message]
             speaker=narrator
+#wmllint: display on
             message= _ "<i>Emerald, verdant green gives way,
 Touched by shadow, dark dye of black,
 An abhorrent stain of pestilence.</i>"
+#wmllint: display off
         [/message]
         [allow_undo][/allow_undo]
     [/event]
@@ -744,9 +748,11 @@ An abhorrent stain of pestilence.</i>"
         [/filter]
         [message]
             speaker=narrator
+#wmllint: display on
             message= _ "<i>Crimson pool, essence of life,
 Flesh and blood flow away to rot,
 Leaving only bones to remain.</i>"
+#wmllint: display off
         [/message]
         [allow_undo][/allow_undo]
     [/event]

--- a/data/campaigns/Descent_Into_Darkness/scenarios/07c_A_Small_Favor3.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/07c_A_Small_Favor3.cfg
@@ -813,9 +813,11 @@
         [/filter]
         [message]
             speaker=narrator
+#wmllint: display on
             message= _ "<i>Death is the twilight that follows the light of day.
 Life fades with the setting sun into darkness.
 Existence churns and the soul is reborn into endless night.</i>"
+#wmllint: display off
         [/message]
         [allow_undo][/allow_undo]
     [/event]

--- a/data/campaigns/Descent_Into_Darkness/scenarios/09_Descent_into_Darkness.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/09_Descent_into_Darkness.cfg
@@ -1966,8 +1966,10 @@
         [message]
             speaker=narrator
             # wmllint: local spelling Zephryn
+            # wmllint: display on
             message= _ "<s><i>Welcome to Zephryn’s laboratory. Please be mindful of ongoing experiments during your visit.</i></s>
 <big><i><b>This territory is the domain of the mighty Xanthric. All unwelcome intruders shall die.</b></i></big>"
+            # wmllint: display off
             image=wesnoth-icon.png
         [/message]
 
@@ -2598,10 +2600,12 @@
 
         [message]
             speaker=narrator
+            # wmllint: display on
             message= _ "<i>Dark water beneath crystal ice,
 Unmasked by a lick of flame,
 Transmuted by the altar of darkness
 Into pitch black shadow.</i>"
+            # wmllint: display off
         [/message]
         [fire_event]
             name=potion text
@@ -2905,12 +2909,14 @@ Into pitch black shadow.</i>"
 
         [message]
             speaker=narrator
+            # wmllint: display on
             message= _ "<i>Bones, scattered carelessly onto the floor,
 Remains laid without rest,
 Reside outside their coffin, locked away,
 In eternal wakefulness.
 Then, the key is found and the lid opened,
 And the tongue of fire begets ashen repose.</i>"
+            # wmllint: display off
         [/message]
     [/event]
 


### PR DESCRIPTION
This PR:
1. adds `#wmllint: display on/off` in several places where line breaks inside messages are clearly intentional
2. Suppresses a wmllint false positive: `unknown 'YOgre2' referred to by id`