### PR TITLE
wmlxgettext: support double quotes in raw strings (fixes #4484)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,8 @@
  ### Translations
    * Updated translations: Catalan, Chinese (Traditional), French, Portuguese (Brazil),
      Spanish
+ ### Miscellaneous and Bug Fixes
+   * Added support to wmlxgettext for double-quote characters in translatable raw strings
 
 ## Version 1.14.15
  ### Add-ons client

--- a/data/core/editor/help.cfg
+++ b/data/core/editor/help.cfg
@@ -327,7 +327,7 @@ If your add-on will only be used on 1.16 and later, there are new features to lo
 • maps/map_from_01.cfg
   ◦ this is the file created by the scenario editor
 • scenarios/01_Forest.cfg
-  ◦ inside the [scenario] element, use “map_file=""map_from_01.cfg""” to load that file>>
+  ◦ inside the [scenario] element, use “map_file="map_from_01.cfg"” to load that file>>
 [/topic]
 # wmllint: unbalanced-off
 # wmllint: markcheck on
@@ -388,7 +388,7 @@ These files can be used directly for multiplayer games, the number of players is
 These files can be used in a scenario’s .cfg file, with the scenario’s WML providing additional information such as teams, custom events, and complex side setups. The .cfg file loads the map file with either of:
 
 • map_file=maps/01_First_Map.map <italic>text='— supported since Wesnoth 1.14'</italic>
-• map_data=""{maps/01_First_Map.map}"" <italic>text='— a WML preprocessor include'</italic>
+• map_data="{maps/01_First_Map.map}" <italic>text='— a WML preprocessor include'</italic>
 
 The <italic>text='map_file'</italic> method is preferred over using a preprocessor include.>> + "
 

--- a/data/tools/pywmlx/state/machine.py
+++ b/data/tools/pywmlx/state/machine.py
@@ -248,11 +248,13 @@ class PendingLuaString:
 
 
 class PendingWmlString:
-    def __init__(self, lineno, wmlstring, ismultiline, istranslatable):
+    def __init__(self, lineno, wmlstring, ismultiline, istranslatable, israw):
+        """The israw argument indicates a << >> delimited string"""
         self.lineno = lineno
         self.wmlstring = wmlstring.replace('\\', r'\\')
         self.ismultiline = ismultiline
         self.istranslatable = istranslatable
+        self.israw = israw
 
     def addline(self, value):
         self.wmlstring = self.wmlstring + '\n' + value.replace('\\', r'\\')
@@ -275,7 +277,10 @@ class PendingWmlString:
                 # so, using "if errcode != 1"
                 # we will add the translatable string ONLY if it is NOT empty
                 _linenosub += 1
-                self.wmlstring = re.sub('""', r'\"', self.wmlstring)
+                if self.israw:
+                    self.wmlstring = re.sub('"', r'\"', self.wmlstring)
+                else:
+                    self.wmlstring = re.sub('""', r'\"', self.wmlstring)
                 pywmlx.nodemanip.addNodeSentence(self.wmlstring,
                                              ismultiline=self.ismultiline,
                                              lineno=self.lineno,

--- a/data/tools/pywmlx/state/wml_states.py
+++ b/data/tools/pywmlx/state/wml_states.py
@@ -169,7 +169,7 @@ class WmlStr02:
                    'please report a bug if you encounter this error message')
         pywmlx.state.machine._pending_wmlstring = (
             pywmlx.state.machine.PendingWmlString(
-                lineno, loc_string, loc_multiline, loc_translatable
+                lineno, loc_string, loc_multiline, loc_translatable, israw=True
             )
         )
         return (xline, _nextstate)
@@ -249,7 +249,7 @@ class WmlStr01:
             xline = xline [ match.end(): ]
         pywmlx.state.machine._pending_wmlstring = (
             pywmlx.state.machine.PendingWmlString(
-                lineno, match.group(2), loc_multiline, loc_translatable
+                lineno, match.group(2), loc_multiline, loc_translatable, israw=False
             )
         )
         return (xline, _nextstate)


### PR DESCRIPTION
This adds support for _<<map="{maps/01_First_Map.map}">>, as used in the
editor file format documentation.

This doesn't require another .pot update, because both the workaround in
3d77d36 and this fix generate the same string in the .pot file. However, it
does change the string that the Wesnoth executable looks for so that it matches
the .pot file's contents.

Cherry picked from commit c30c30acfc3b8ba85742a449e2e65beec3dedfcd, and
additionally reverted commit 3d77d36bb0dc4db1afb3e3c1c0d2dbf7f4c6c77d.