### PR TITLE
Convert relevant cases of lexical_cast to std::to_string().

### DIFF
--- a/src/config_attribute_value.cpp
+++ b/src/config_attribute_value.cpp
@@ -316,8 +316,8 @@ public:
 	std::string operator()(const boost::blank &) const { return default_; }
 	std::string operator()(const yes_no & b)     const { return b.str(); }
 	std::string operator()(const true_false & b) const { return b.str(); }
-	std::string operator()(int i)                const { return lexical_cast<std::string>(i); }
-	std::string operator()(unsigned long long u) const { return lexical_cast<std::string>(u); }
+	std::string operator()(int i)                const { return std::to_string(i); }
+	std::string operator()(unsigned long long u) const { return std::to_string(u); }
 	std::string operator()(double d)             const { return lexical_cast<std::string>(d); }
 	std::string operator()(const std::string& s) const { return s; }
 	std::string operator()(const t_string& s)    const { return s.str(); }

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2734,7 +2734,7 @@ void display::draw_hex(const map_location& loc) {
 		if (draw_num_of_bitmaps_) {
 			int off_x = xpos + hex_size()/2;
 			int off_y = ypos + hex_size()/2;
-			surface text = font::get_rendered_text(lexical_cast<std::string>(num_images_bg + num_images_fg), font::SIZE_SMALL, font::NORMAL_COLOR);
+			surface text = font::get_rendered_text(std::to_string(num_images_bg + num_images_fg), font::SIZE_SMALL, font::NORMAL_COLOR);
 			surface bg(text->w, text->h);
 			SDL_Rect bg_rect {0, 0, text->w, text->h};
 			sdl::fill_surface_rect(bg, &bg_rect, 0xaa000000);

--- a/src/gui/dialogs/lua_interpreter.cpp
+++ b/src/gui/dialogs/lua_interpreter.cpp
@@ -37,7 +37,6 @@
 #include "scripting/lua_kernel_base.hpp"
 #include "serialization/string_utils.hpp"
 #include "serialization/unicode.hpp"
-#include "lexical_cast.hpp"
 #include "log.hpp"
 #include "font/pango/escape.hpp"
 
@@ -314,7 +313,7 @@ public:
 
 			std::string result;
 			for (int i = 0; the_list[i]; i++) {
-				result += lexical_cast<std::string, int>(i+history_base);
+				result += std::to_string(i+history_base);
 				result += ": ";
 				result += the_list[i]->line;
 				result += "\n";

--- a/src/server/common/server_base.cpp
+++ b/src/server/common/server_base.cpp
@@ -14,7 +14,6 @@
 
 #include "server/common/server_base.hpp"
 
-#include "lexical_cast.hpp"
 #include "log.hpp"
 #include "filesystem.hpp"
 
@@ -177,7 +176,7 @@ void server_base::handle_termination(const boost::system::error_code& error, int
 	std::string signame;
 	if(signal_number == SIGINT) signame = "SIGINT";
 	else if(signal_number == SIGTERM) signame = "SIGTERM";
-	else signame = lexical_cast<std::string>(signal_number);
+	else signame = std::to_string(signal_number);
 	LOG_SERVER << signame << " caught, exiting without cleanup immediately.\n";
 	exit(128 + signal_number);
 }

--- a/src/server/wesnothd/player.cpp
+++ b/src/server/wesnothd/player.cpp
@@ -13,7 +13,6 @@
 */
 
 #include "server/wesnothd/player.hpp"
-#include "lexical_cast.hpp"
 
 wesnothd::player::player(const std::string& n, simple_wml::node& cfg, int id,
                          bool registered, const std::string& version, const std::string& source, const std::size_t max_messages,
@@ -67,7 +66,7 @@ void wesnothd::player::mark_available(const int game_id,
 	} else {
 		cfg_.set_attr("available", "no");
 	}
-	cfg_.set_attr_dup("game_id", lexical_cast<std::string>(game_id).c_str());
+	cfg_.set_attr_dup("game_id", std::to_string(game_id).c_str());
 	cfg_.set_attr_dup("location", location.c_str());
 }
 

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -22,7 +22,6 @@
 #include "config.hpp"
 #include "filesystem.hpp"
 #include "game_config.hpp"
-#include "lexical_cast.hpp"
 #include "log.hpp"
 #include "multiplayer_error_codes.hpp"
 #include "serialization/parser.hpp"
@@ -1464,7 +1463,7 @@ void server::handle_player_in_game(socket_ptr socket, simple_wml::document& data
 			}
 
 			g.set_description(&desc);
-			desc.set_attr_dup("id", lexical_cast<std::string>(g.id()).c_str());
+			desc.set_attr_dup("id", std::to_string(g.id()).c_str());
 		} else {
 			WRN_SERVER << client_address(socket) << "\t" << player.name() << "\tsent scenario data in game:\t\""
 					   << g.name() << "\" (" << g.id() << ", " << g.db_id() << ") although it's already initialized.\n";


### PR DESCRIPTION
In general I think it's best to use std implementations unless there's a functional or performance reason not to, but also in a few cases this also allows removing the include of lexical_cast.hpp.