### PR TITLE
Use wmllint: recognize instead of blanket wmllint: ignore in DiD

### DIFF
--- a/data/campaigns/Descent_Into_Darkness/scenarios/03_A_Haunting_in_Winter.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/03_A_Haunting_in_Winter.cfg
@@ -200,10 +200,11 @@
         [/unit]
 
         # Non-strong one:
+        # wmllint: recognize YOgre2
         [while]
             [not]
                 [have_unit]
-                    id=YOgre2  # wmllint: ignore - suppress unknown 'YOgre2' referred to by id
+                    id=YOgre2
                     [not]
                         trait=strong
                     [/not]


### PR DESCRIPTION
This is a follow-up for #5442. I have found a better way to suppress the wmllint error.