### PR TITLE
DiD: add wmllint: recognize Jaime

### DIFF
--- a/data/campaigns/Descent_Into_Darkness/scenarios/08_Alone_at_Last.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/08_Alone_at_Last.cfg
@@ -565,6 +565,12 @@
         [/message]
     [/event]
 
+    # wmllint checks that every unit referred to in [event], [message] etc is first introduced by [unit], [recall] etc.
+    # It does this to catch errors where a scenario author forgets to recall a unit.
+    # Jaime is spawned by an easter egg in 07a_A_Small_Favor.
+    # Jaime may be on the recall list for this scenario if the egg was triggered and if Jaime survives 07a, 07b and 07c.
+    # I assume that in this case the scenario author intentionally counts on the player manually recalling Jaime instead of using [recall].
+    # wmllint: recognize Jaime
     [event]
         name=moveto
         [filter]


### PR DESCRIPTION
This PR silences a wmllint error (unknown 'Jaime' referred to by id) in DiD caused by an intentional scenario design choice.

wmllint checks that every unit referred to in [event], [message] etc is first introduced by [unit], [recall] etc. It does this to catch errors where a scenario author forgets to recall a unit. Jaime is spawned by an easter egg in 07a_A_Small_Favor. Jaime may be on the recall list for this scenario if the egg was triggered and if Jaime survives 07a, 07b and 07c. I assume that in this case the scenario author intentionally counts on the player manually recalling Jaime instead of using [recall].