### PR TITLE
DiD: suppress: Inky speaks in his/her "die" event rather than "last breath"

### DIFF
--- a/data/campaigns/Descent_Into_Darkness/scenarios/10_Endless_Night.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/10_Endless_Night.cfg
@@ -1389,7 +1389,9 @@
             [/not]
             [then]
                 [message]
+                    # wmllint: deathcheck off
                     speaker=Inky
+                    # wmllint: deathcheck on
                     message= _ "Bloub°°°"
                 [/message]
             [/then]

--- a/data/campaigns/Descent_Into_Darkness/scenarios/10_Endless_Night.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/10_Endless_Night.cfg
@@ -1405,6 +1405,7 @@
                 [/then]
             [/elseif]
             [else]
+                # This scenario (Endless_Night) repeats itself. To trigger this branch the player has to kill Inky two times.
                 [message]
                     speaker=Mal Keshar
                     message= _ "It appears that she has evaded me once again."


### PR DESCRIPTION
It is a common mistake to have a unit speak in his/her "die" event (after the death animation is played). Wmllint tries to catch that. In this case, however, Inky does not actually die (as far as the plot is concerned) so it is a perfectly valid stylistic choice for her to make a "Bloub" sound as she dives into the water.