### PR TITLE
HTTT: don't change unit id

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/05b_Isle_of_the_Damned.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/05b_Isle_of_the_Damned.cfg
@@ -38,7 +38,7 @@
     # the same as the initial Advisor we would appoint if we took the path through Muff Malal's Peninsula, and
     # will be the initial Advisor recalled at the start of The Siege of Elensefar.
     #
-    # We store a copy of this Advisor, giving it a new id. This is done in prestart because the recall list will
+    # We store a copy of this Advisor. This is done in prestart because the recall list will
     # not be available at the point the ship returns to collect Konrad. When the ship comes to collect Konrad,
     # we will unstore this copy and hide it before it speaks its line. This way the ship appears to be selected,
     # but the unit's name, profile image and details are displayed; just as if the unit were inside the ship.
@@ -78,11 +78,6 @@
                 role=Advisor
             [/filter]
         [/store_unit]
-
-        [set_variable]
-            name=hidden_advisor.id
-            value=hidden_advisor
-        [/set_variable]
     [/event]
 
     [story]
@@ -479,16 +474,16 @@
     [/unstore_unit]
 
     [hide_unit]
-        id=hidden_advisor
+        role=Advisor
     [/hide_unit]
 
     [message]
-        speaker=hidden_advisor
+        role=Advisor
         message= _ "Thank goodness we have found you, sir! Come aboard quickly, we shall take you away from this horrible island!"
     [/message]
 
     [kill]
-        id=hidden_advisor
+        role=Advisor
     [/kill]
 #enddef
 


### PR DESCRIPTION
05b_Isle_of_the_Damned was using black magic: [store_unit] plus [set_variable] to change a unit's id. This confused wmllint. This is also just unnecessarily complicated since there are two more conventional ways to refer to the same unit: role=Advisor and id=$hidden_advisor.id. I chose the first option.

# Testing
- [x] Old save
  Before applying this PR:
  1. Start HTTT
  2. Create an easily identifiable unit that matches the role selector (eg Elvish Sylph)
  3. Optional: rename the unit
  2. :choose_level 05b_Isle_of_the_Damned
  3. Save & quit to desktop
  4. Apply the PR
  5. Load
  6. debug kill the liches
  7. See that the message works correctly
- [x] New save
  After applying the PR
  1. Start HTTT
  2. Create an easily identifiable unit that matches the role selector (eg Elvish Sylph)
  3. Optional: rename the unit
  2. :choose_level 05b_Isle_of_the_Damned
  6. debug kill the liches
  7. See that the message works correctly