### PR TITLE
HTTT: add wmllint: recognize Simyr

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/13_The_Dwarven_Doors.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/13_The_Dwarven_Doors.cfg
@@ -372,6 +372,7 @@ end
         [/filter]
         [filter_second]
             side=1
+            # wmllint: recognize Simyr
             id=Haldiel,Simyr
             [or]
                 type=Paladin


### PR DESCRIPTION
wmllint tries to detect errors such as a scenario author forgetting to introduce a unit via [recall], [unit] etc and then referencing the unit by id.

Simyr is added to your recall list if you beat 02_Blackwater_Port on HARD by killing the orc leader.

In this instance the scenario author not automatically recalling Simyr is clearly intentional.