### PR TITLE
HTTT: add wmllint: recognize Kalenz Delfador Konrad Li'sar

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/22_Return_to_Wesnoth.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/22_Return_to_Wesnoth.cfg
@@ -70,6 +70,10 @@
                     [scroll_to]
                         x,y=1,1
                     [/scroll_to]
+                    # wmllint: recognize Kalenz
+                    # wmllint: recognize Delfador
+                    # wmllint: recognize Konrad
+                    # wmllint: recognize Li'sar
                     [message]
                         speaker=Kalenz
                         scroll=no


### PR DESCRIPTION
wmllint tries to detect errors such as a scenario referencing the unit by id before it is introduced by via [recall], [unit] etc. The definition of "before" wmllint wants to check is chronological: "does an event that introduces a unit happen before an event that references it?", but the current implementation cheats by simply checking if the definition textually precedes the reference.

22_Return_to_Wesnoth contains two prestart events. The first prestart event defines an event that triggers on turn 4. The second prestart event introduces Kalenz, Delfador and Li'sar.
I could merge the prestart events and reorder the code to avoid the wmllint error, but since it does not actually make the code easier to read I chose a less disruptive option of simply adding "wmllint: recognize".