### PR TITLE
wmllint: Stop looking for wml tags inside [lua]

### DIFF
--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -1896,6 +1896,7 @@ to be called on their own".format(filename, num))
     in_map_generator = False
     in_name_generator = False
     in_candidate_action = False
+    in_lua = False
     storeid = None
     storevar = None
     ignoreable = False
@@ -1906,6 +1907,13 @@ to be called on their own".format(filename, num))
     translation_mark = re.compile(r'_ *"')
     name_generator_re = re.compile(r"name_generator\s*=\s*_\s*<<")
     for i in range(len(lines)):
+        if has_opening_tag(lines[i], "lua"):
+            in_lua = True
+        elif "[/lua]" in lines[i]:
+            in_lua = False
+        if in_lua:
+            # As far as I can tell none of the below tests make sense inside of a lua tag
+            continue
         if '[' in lines[i]:
             preamble_seen = True
         # This logic looks odd because a scenario can be conditionally


### PR DESCRIPTION
wmllint should not search for wml tags and keys inside [lua].
I caught it trying to add a translation mark in 23_Test_of_the_Clans inside a [lua] tag.