### PR TITLE
Add side=1 in httt_utils.cfg to appease wmllint

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
@@ -686,6 +686,7 @@ fire:  +10%"
     [unit]
         id=Delfador
         name= _ "Delfador"
+        side=1
         profile=portraits/delfador-elvish.png~RIGHT()
         unrenamable=yes
         type=Elder Mage
@@ -701,6 +702,7 @@ fire:  +10%"
     [unit]
         id=Kalenz
         name= _ "Kalenz"
+        side=1
         profile=portraits/kalenz.png
         unrenamable=yes
         type=Elvish Lord
@@ -716,6 +718,7 @@ fire:  +10%"
     [unit]
         id="Li'sar"
         name= _ "Li’sar"
+        side=1
         profile=portraits/lisar.png
         unrenamable=yes
         type=Princess


### PR DESCRIPTION
This PR fixes the following wmllint errors:
"data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg", line 697: unit declaration without side attribute
"data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg", line 712: unit declaration without side attribute
"data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg", line 727: unit declaration without side attribute

As far as I understand this should be safe - side defaults to 1 anyway.