### PR TITLE
wmllint: fix textdomain errors

### DIFF
--- a/data/campaigns/Sceptre_of_Fire/utils/bigmap.cfg
+++ b/data/campaigns/Sceptre_of_Fire/utils/bigmap.cfg
@@ -1,3 +1,5 @@
+#textdomain wesnoth-sof
+
 #define SOF_BIGMAP
     [background_layer]
         image=maps/background.jpg

--- a/data/campaigns/Secrets_of_the_Ancients/utils/terrain_graphics.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/utils/terrain_graphics.cfg
@@ -1,3 +1,4 @@
+#textdomain wesnoth-sota
 #ifdef EDITOR
 [terrain_graphics]
     [tile]

--- a/data/campaigns/The_Rise_Of_Wesnoth/units/Kalian.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/units/Kalian.cfg
@@ -1,4 +1,4 @@
-
+#textdomain wesnoth-trow
 # Cutscene-only unit, has no need of fancy animations
 [unit_type]
     id=Elvish Champion Kalian

--- a/data/campaigns/World_Conquest/_main.cfg
+++ b/data/campaigns/World_Conquest/_main.cfg
@@ -1,6 +1,5 @@
-## MP Campaign (Scenarios in Multiplayer >> Random Maps)
-
 #textdomain wesnoth-wc
+## MP Campaign (Scenarios in Multiplayer >> Random Maps)
 
 [textdomain]
     name="wesnoth-wc"

--- a/data/campaigns/World_Conquest/config.cfg
+++ b/data/campaigns/World_Conquest/config.cfg
@@ -1,3 +1,5 @@
+#textdomain wesnoth-wc
+
 #ifdef EDITOR
 #ifndef LOAD_WC2
 #define LOAD_WC2

--- a/data/campaigns/World_Conquest/era/campaign/heroes.cfg
+++ b/data/campaigns/World_Conquest/era/campaign/heroes.cfg
@@ -1,4 +1,4 @@
-##############################################################
+#textdomain wesnoth-wc
 
 #define WORLD_CONQUEST_II_ERA_HEROES_TRAITS
     [trait_extra]

--- a/data/campaigns/World_Conquest/era/era.cfg
+++ b/data/campaigns/World_Conquest/era/era.cfg
@@ -1,3 +1,4 @@
+#textdomain wesnoth-wc
 ## add subfolders
 {./factions}
 {./campaign}

--- a/data/campaigns/World_Conquest/resources/data/artifacts.cfg
+++ b/data/campaigns/World_Conquest/resources/data/artifacts.cfg
@@ -1,4 +1,4 @@
-
+#textdomain wesnoth-wc
 #define WORLD_CONQUEST_TEK_ARTIFACT_DEFINITIONS
     ## in alphabetic order by name
     ## uses some macros from training

--- a/data/campaigns/World_Conquest/resources/data/training.cfg
+++ b/data/campaigns/World_Conquest/resources/data/training.cfg
@@ -1,4 +1,4 @@
-
+#textdomain wesnoth-wc
 #define WORLD_CONQUEST_TEK_TRAINER_DEFINITIONS
     [trainer]
         type=Lich

--- a/data/campaigns/World_Conquest/resources/resources.cfg
+++ b/data/campaigns/World_Conquest/resources/resources.cfg
@@ -1,3 +1,4 @@
+#textdomain wesnoth-wc
 ## add subfolders
 {./data}
 {./strings}

--- a/data/campaigns/World_Conquest/scenarios/WC_II_scenario.cfg
+++ b/data/campaigns/World_Conquest/scenarios/WC_II_scenario.cfg
@@ -1,3 +1,4 @@
+#textdomain wesnoth-wc
 ## macros may not be used inside translatable strings.
 
 #define WC_II_CAMPAIGN_NAME_1P


### PR DESCRIPTION
Ibanovic wants all #textdomain declrations in line 1: c10cf2b68b6

Several files were missing an explicit textdomain declaration.
Three of them actually have translated strings that defaulted to "wesnoth" textdomain:
- data/campaigns/World_Conquest/resources/data/training.cfg
- data/campaigns/World_Conquest/era/campaign/heroes.cfg
- data/campaigns/World_Conquest/scenarios/WC_II_scenario.cfg