### PR TITLE
Avoid [var] inside lua code

### DIFF
--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg
@@ -270,12 +270,11 @@ Chapter Three"
             local args = (...)
             local units = wml.child_array(args, "units")
             local empty_str = args.empty
-            local var = args.variable
 
             for i = 1, #units do
                 units[i] = units[i].name
             end
-            wml.variables[var] = stringx.format_conjunct_list(empty_str, units)
+            wml.variables[args.variable] = stringx.format_conjunct_list(empty_str, units)
         >>
         [args]
             empty= _ "some experienced warriors" # wmllint: ignore


### PR DESCRIPTION
wmllint confuses [var] in an expression wml.variables[var] for an opening tag.
The easiest solution is to rewrite the lua code to not contain stuff that confuses wmllint.

Fixes:
"data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg", line 289: unbalanced [var] closed with [/lua].
"data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg", line 387: unbalanced [var] closed with [/command].
"data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg", line 388: unbalanced [var] closed with [/event].
"data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg", line 542: unbalanced [var] closed with [/scenario].
"data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg", line 544: tag stack nonempty ([('scenario', {'name': '_ "Bounty Hunters"', 'id': '09_Bounty_Hunters', 'next_scenario': '10_Cliffs_of_Thoria', 'random_start_time': 'no', 'allow_new_game': 'yes', 'new_game_title': '_ "Chapter Three: The Book of Crelanu"', 'force_lock_settings': 'yes', 'experience_modifier': '100', 'victory_when_enemies_defeated': 'no', 'save_id': 'Cleodil', 'disallow_shuffle': 'yes', 'no_leader': 'yes'}, ['story', 'side', 'unit', 'unit', 'unit', 'side', 'side', 'side']), ('event', {'name': 'start'}, []), ('command', {}, ['persistent_carryover_unstore', 'store_unit']), ('lua', {'code': '<<', 'args': '(...)', 'units': 'wml.child_array(args, "units")', 'empty_str': 'args.empty', 'var': 'args.variable'}, []), ('var', {}, ['args', 'objectives', 'message', 'message', 'message', 'message', 'message', 'message', 'message', 'message', 'message', 'message', 'message', 'message', 'event', 'event'])]) at end of file.