### PR TITLE
LOW: Don't forget to undefine local macros

### DIFF
--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg
@@ -292,6 +292,7 @@ Chapter Three"
 #ifdef MULTIPLAYER
             {LEAVE_BEHIND_L3 landar 2}
 #endif
+#undef LEAVE_BEHIND_L3
             {RECALL_LOYALS}
 
             [objectives]

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter4/13_News_from_the_Front.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter4/13_News_from_the_Front.cfg
@@ -143,6 +143,8 @@
         {LEAVE_BEHIND_L3 landar 2}
 #endif
 
+#undef LEAVE_BEHIND_L3
+
         #TODO recall or create if not recallable
 
         {RECALL_LOYALS}


### PR DESCRIPTION
Fix preprocessor warning:
warning preprocessor: Redefining macro LEAVE_BEHIND_L3 without explicit #undef at campaigns/Legend_of_Wesmere/scenarios/chapter4/13_News_from_the_Front.cfg:105
    included from campaigns/Legend_of_Wesmere/_main.cfg:18
    included from _main.cfg:38
previously defined at campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg:240
    included from campaigns/Legend_of_Wesmere/_main.cfg:17
    included from _main.cfg:38