### PR TITLE
Add wmllint: display on/off where needed

### DIFF
--- a/data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg
+++ b/data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg
@@ -363,9 +363,11 @@
         [/message]
         [message]
             speaker=Harper
+            #wmllint: display on
             message= _ "...
 ...
 ..."
+            #wmllint: display off
         [/message]
         [message]
             speaker=Harper

--- a/data/campaigns/Sceptre_of_Fire/scenarios/3_Searching_for_the_Runecrafter.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/3_Searching_for_the_Runecrafter.cfg
@@ -370,8 +370,10 @@
         [/message]
         [message]
             speaker=Krawg
+            #wmllint: display on
             message= _ "Screech!
 <i>(Makes eye contact, bobs and cocks head.)</i>"
+            #wmllint: display off
         [/message]
         [message]
             speaker=Rugnur
@@ -379,8 +381,10 @@
         [/message]
         [message]
             speaker=Krawg
+            #wmllint: display on
             message= _ "Krawg!
 <i>(Looks out over the icy taiga, turns gaze back toward the dwarves.)</i>"
+            #wmllint: display off
         [/message]
         [message]
             speaker=Krawg
@@ -392,8 +396,10 @@
         [/message]
         [message]
             speaker=Krawg
+            #wmllint: display on
             message= _ "Yes...
 <i>(Quickly shifts gaze to nearby woods, adopts a hostile stance, then glances back to the dwarves.)</i>"
+            #wmllint: display off
         [/message]
         [message]
             speaker=Baglur
@@ -438,8 +444,10 @@
             [then]
                 [message]
                     speaker=Krawg
+                    #wmllint: display on
                     message= _ "Screech!
 <i>(Nods at the middle distance.)</i>"
+                    #wmllint: display off
                 [/message]
             [/then]
             [else]


### PR DESCRIPTION
Wrap wmllint display on/wmllint display off around several messages where manual line breaks are clearly inserted intentionally.