### PR TITLE
wmllint(markcheck): Ignore values with macros

### DIFF
--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -2260,7 +2260,7 @@ to be called on their own".format(filename, num))
                     print('"%s", line %d: %s doesn`t need translation mark (translatable string is empty)' \
                           % (filename, i+1, key))
                     lines[i] = lines[i].replace("=_","=")
-                if markcheck and not value.startswith("$") and not value.startswith("{") and not re.match(" +", value) and not has_tr_mark and '""' not in lines[i] and not ("wmllint: ignore" in comment or "wmllint: noconvert" in comment):
+                if markcheck and not value.startswith("$") and "{" not in value and not re.match(" +", value) and not has_tr_mark and '""' not in lines[i] and not ("wmllint: ignore" in comment or "wmllint: noconvert" in comment):
                     print('"%s", line %d: %s needs translation mark' \
                           % (filename, i+1, key))
                     lines[i] = lines[i].replace('=', "=_ ", 1)


### PR DESCRIPTION
wmllint tried to add translation marks in several places where they are unnecessary.
Example:
description="-50% "+{STR_EXPERIENCE} ---> description=_ "-50% "+{STR_EXPERIENCE}

Full list:
"data/campaigns/World_Conquest/resources/data/artifacts.cfg", line 330: description needs translation mark
"data/campaigns/World_Conquest/resources/data/artifacts.cfg", line 520: description needs translation mark
"data/campaigns/World_Conquest/resources/data/artifacts.cfg", line 679: description needs translation mark
"data/campaigns/World_Conquest/resources/data/artifacts.cfg", line 690: description needs translation mark
"data/campaigns/World_Conquest/resources/data/artifacts.cfg", line 795: description needs translation mark