### PR TITLE
wmllint: recognize a WC-specific translatable attribute

### DIFF
--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -1157,7 +1157,7 @@ def is_translatable(key):
         "currently_doing_description", "description", "description_inactive",
         "editor_name", "end_text", "difficulty_descriptions", "female_message",
         "female_name_inactive", "female_names", "female_text", "help_text",
-        "help_topic_text", "label", "male_message", "male_names", "male_text",
+        "help_topic_text", "info", "label", "male_message", "male_names", "male_text",
         "message", "name", "name_inactive", "new_game_title", "note",
         "option_description", "option_name", "order", "plural_name", "prefix",
         "reason", "set_description", "source", "story", "summary", "victory_string",


### PR DESCRIPTION
World_Conquest has a bunch of campaign-specific tags and attributes. This was causing wmllint to produce spurious errors (see below).
I marked the "info" attribute as translatable.

"data/campaigns/World_Conquest/resources/data/training.cfg", line 305: info should not have a translation mark
"data/campaigns/World_Conquest/resources/data/training.cfg", line 519: info should not have a translation mark
"data/campaigns/World_Conquest/resources/data/training.cfg", line 533: info should not have a translation mark
"data/campaigns/World_Conquest/resources/data/training.cfg", line 549: info should not have a translation mark
"data/campaigns/World_Conquest/resources/data/training.cfg", line 565: info should not have a translation mark
"data/campaigns/World_Conquest/resources/data/training.cfg", line 580: info should not have a translation mark
"data/campaigns/World_Conquest/resources/data/training.cfg", line 596: info should not have a translation mark
"data/campaigns/World_Conquest/resources/data/training.cfg", line 620: info should not have a translation mark
"data/campaigns/World_Conquest/resources/data/training.cfg", line 652: info should not have a translation mark
"data/campaigns/World_Conquest/resources/data/training.cfg", line 681: info should not have a translation mark
"data/campaigns/World_Conquest/resources/data/training.cfg", line 692: info should not have a translation mark
"data/campaigns/World_Conquest/resources/data/training.cfg", line 702: info should not have a translation mark
"data/campaigns/World_Conquest/resources/data/training.cfg", line 727: info should not have a translation mark