### PR TITLE
wc: markcheck off due to campaign-specific attrs

### DIFF
--- a/data/campaigns/World_Conquest/resources/data/training.cfg
+++ b/data/campaigns/World_Conquest/resources/data/training.cfg
@@ -1,4 +1,7 @@
 #textdomain wesnoth-wc
+
+#wmllint: markcheck off
+
 #define WORLD_CONQUEST_TEK_TRAINER_DEFINITIONS
     [trainer]
         type=Lich
@@ -792,3 +795,5 @@
         [/effect]
     [/chance]
 #enddef
+
+#wmllint: markcheck on


### PR DESCRIPTION
World_Conquest has a bunch of campaign-specific tags and attributes. This was causing wmllint to produce spurious errors (see below).

@soliton- suggested (https://github.com/wesnoth/wesnoth/pull/5484#issuecomment-763831678):
> support a wmllint directive to disable checks for a complete dir or so so we can exclude lua heavy stuff like WC

I think it would be easier to add `markcheck off`.

"data/campaigns/World_Conquest/resources/data/training.cfg", line 305: info should not have a translation mark
"data/campaigns/World_Conquest/resources/data/training.cfg", line 519: info should not have a translation mark
"data/campaigns/World_Conquest/resources/data/training.cfg", line 533: info should not have a translation mark
"data/campaigns/World_Conquest/resources/data/training.cfg", line 549: info should not have a translation mark
"data/campaigns/World_Conquest/resources/data/training.cfg", line 565: info should not have a translation mark
"data/campaigns/World_Conquest/resources/data/training.cfg", line 580: info should not have a translation mark
"data/campaigns/World_Conquest/resources/data/training.cfg", line 596: info should not have a translation mark
"data/campaigns/World_Conquest/resources/data/training.cfg", line 620: info should not have a translation mark
"data/campaigns/World_Conquest/resources/data/training.cfg", line 652: info should not have a translation mark
"data/campaigns/World_Conquest/resources/data/training.cfg", line 681: info should not have a translation mark
"data/campaigns/World_Conquest/resources/data/training.cfg", line 692: info should not have a translation mark
"data/campaigns/World_Conquest/resources/data/training.cfg", line 702: info should not have a translation mark
"data/campaigns/World_Conquest/resources/data/training.cfg", line 727: info should not have a translation mark