### PR TITLE
wmllint: cleanup two useless lines

### DIFF
--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -3473,7 +3473,6 @@ In your case, your system interprets your arguments as:
                 failed_any_dirs = True
                 print("wmllint: skipping non-existent path %s" % directory)
                 continue
-            ofp = None
             for fn in allcfgfiles(directory):
                 if verbose >= 2:
                     print(fn + ":")
@@ -3547,7 +3546,6 @@ In your case, your system interprets your arguments as:
                             failed_any_dirs = True
                             print("wmllint: skipping non-existent path %s" % directory)
                             continue
-                        ofp = None
                         for fn in allcfgfiles(directory):
                             if verbose >= 2:
                                 print(fn + ":")


### PR DESCRIPTION
As far as I can tell this lines do nothing.
1. `file_handle = None` is NOT how to close a file in python
2. The file handle is already closed due to `with open() as file_handle:`