### PR TITLE
Tweak Eastern Invasion difficulty

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/01_The_Outpost.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/01_The_Outpost.cfg
@@ -339,7 +339,7 @@
 
         [gold]
             side=2,3,4
-            amount=20
+            amount={ON_DIFFICULTY 20 22 24}
         [/gold]
 
         {REPLACE_SCENARIO_MUSIC the_dangerous_symphony.ogg}
@@ -411,11 +411,7 @@
 
         [gold]
             side=2,3,4
-#ifdef EASY
-            amount=50
-#else
-            amount=100
-#endif
+            amount={ON_DIFFICULTY 50 75 100}
         [/gold]
 
         [modify_side]

--- a/data/campaigns/Eastern_Invasion/scenarios/01_The_Outpost.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/01_The_Outpost.cfg
@@ -62,7 +62,7 @@
         side=1
         controller=human
         recruit=Spearman,Cavalryman,Mage,Heavy Infantryman
-        {GOLD 180 150 120}
+        {GOLD 190 155 120}
         team_name=wesnothians
         user_team_name= _ "Wesnothians"
         {FLAG_VARIANT loyalist}
@@ -339,7 +339,7 @@
 
         [gold]
             side=2,3,4
-            amount=25
+            amount=20
         [/gold]
 
         {REPLACE_SCENARIO_MUSIC the_dangerous_symphony.ogg}
@@ -411,7 +411,11 @@
 
         [gold]
             side=2,3,4
+#ifdef EASY
+            amount=50
+#else
             amount=100
+#endif
         [/gold]
 
         [modify_side]

--- a/data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg
@@ -107,7 +107,11 @@
         no_leader=yes
         hidden=yes
 
+#ifdef EASY
         village_gold=2
+#else
+        village_gold=3
+#endif
         village_support=2
 
         [ai]
@@ -393,7 +397,11 @@
 
     # Mal-Bakral arrives
     [event]
+#ifdef EASY
         name=turn 7
+#else
+        name=turn 6
+#endif
 
         {VARIABLE undead yes}
 

--- a/data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg
@@ -4,7 +4,7 @@
     id=02_The_Escape_Tunnel
     name= _ "The Escape Tunnel"
     map_file=02_The_Escape_Tunnel.map
-    {TURNS 26 24 22}
+    {TURNS 28 25 22}
     next_scenario=03_An_Unexpected_Appearance
     victory_when_enemies_defeated=no
 
@@ -20,7 +20,7 @@
     [side]
         side=1
         controller=human
-        {GOLD 180 150 120}
+        {GOLD 190 155 120}
         {INCOME 5 4 3}
         team_name=wesnothians
         user_team_name= _ "Wesnothians"
@@ -59,8 +59,8 @@
         side=3
         controller=ai
         recruit=Dwarvish Fighter,Dwarvish Thunderer,Dwarvish Scout
-        {GOLD 70 60 50}
-        {INCOME 6 5 4}
+        {GOLD 90 70 50}
+        {INCOME 8 6 4}
         team_name=wesnothians
         user_team_name= _ "Wesnothians"
         {FLAG_VARIANT knalgan}
@@ -99,7 +99,7 @@
         recruit=Vampire Bat,Ghost,Skeleton,Ghoul
 #endif
         {GOLD 120 150 180}
-        {INCOME 9 12 15}
+        {INCOME 7 11 15}
         team_name=undead
         user_team_name= _ "Undead"
         {FLAG_VARIANT undead}
@@ -107,7 +107,7 @@
         no_leader=yes
         hidden=yes
 
-        village_gold=3
+        village_gold=2
         village_support=2
 
         [ai]
@@ -393,7 +393,7 @@
 
     # Mal-Bakral arrives
     [event]
-        name=turn 6
+        name=turn 7
 
         {VARIABLE undead yes}
 

--- a/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
@@ -191,15 +191,8 @@
             [modifications]
                 {TRAIT_LOYAL}
 #ifdef EASY
-                [object]
-                    silent=yes
-                    duration=forever
-                    [effect]
-                        apply_to=hitpoints
-                        increase_total=10
-                        heal_full=yes
-                    [/effect]
-                [/object]
+                {TRAIT_RESILIENT}
+                {TRAIT_HEALTHY}
 #endif
             [/modifications]
         [/unit]

--- a/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
@@ -44,7 +44,7 @@
         controller=ai
         recruit=Orcish Warrior,Goblin Knight
         {GOLD 100 150 200}
-        {INCOME 10 20 30}
+        {INCOME 16 24 30}
         team_name=bad
         user_team_name=_"Evil"
         [ai]
@@ -55,7 +55,7 @@
 
     {LIMIT_CONTEMPORANEOUS_RECRUITS 2 "Direwolf Rider" {ON_DIFFICULTY 1 2 3}}
 
-    {STARTING_VILLAGES 2 {ON_DIFFICULTY 4 6 8}}
+    {STARTING_VILLAGES 2 {ON_DIFFICULTY 6 7 8}}
 
     [side]
         type=Troll Warrior
@@ -66,7 +66,7 @@
         controller=ai
         recruit=Troll,Troll Rocklobber,Goblin Pillager
         {GOLD 100 150 200}
-        {INCOME 10 20 30}
+        {INCOME 16 24 30}
         team_name=bad
         user_team_name=_"Evil"
         [ai]
@@ -76,7 +76,7 @@
 
     {LIMIT_CONTEMPORANEOUS_RECRUITS 3 "Troll Warrior" {ON_DIFFICULTY 1 2 3}}
 
-    {STARTING_VILLAGES 3 {ON_DIFFICULTY 4 6 8}}
+    {STARTING_VILLAGES 3 {ON_DIFFICULTY 6 7 8}}
 
     [side]
         type=Orcish Warlord
@@ -92,7 +92,7 @@
         recruit=Orcish Crossbowman,Orcish Slayer,Orcish Warrior
 #endif
         {GOLD 100 150 200}
-        {INCOME 10 20 30}
+        {INCOME 16 24 30}
         team_name=bad
         user_team_name=_"Evil"
         [ai]
@@ -101,7 +101,7 @@
         {FLAG_VARIANT6 ragged}
     [/side]
 
-    {STARTING_VILLAGES 4 {ON_DIFFICULTY 4 6 8}}
+    {STARTING_VILLAGES 4 {ON_DIFFICULTY 6 7 8}}
 
     [event]
         name=prestart
@@ -184,7 +184,7 @@
             id=Engineer
             name= _ "Engineer"
             unrenamable=yes
-            type={ON_DIFFICULTY "Arch Mage" "Silver Mage" "Red Mage"}
+            type="Red Mage"
             x,y=18,5
             side=1
             random_traits=no
@@ -209,7 +209,8 @@
         [/message]
         [message]
             speaker=Engineer
-            #po: This is thickly accented English
+            #po: This is thickly accented English. In unaccented English, it would read:
+            #po: "I'm an engineer. I expect you'll have a need of my services. I bet you're going to want me to blow up that bridge over there."
             message= _ "I’m an enginea’. I s’pect you’ll have a need of me services. I bet you’re gonna want me to blow up that bridge ov’r theah." # wmllint: no spellcheck
         [/message]
         [message]
@@ -226,6 +227,7 @@
         [/message]
         [message]
             speaker=Engineer
+            #po: "I'm not charging gold — I want protection! Everywhere I go, I see orcs, undead. It isn't safe around here!"
             message= _ "I ain’t charging gold — I wants protecshun! Everywhere I go, I see orcs, undead. ’T’ain’t safe ’round ’ere!"  # wmllint: no spellcheck
         [/message]
         [message]
@@ -234,6 +236,7 @@
         [/message]
         [message]
             speaker=Engineer
+            #po: "Deal. I can blow her [it] up once I get to that signpost over there. That's where my equipment is. But everyone not over there on that side when it blows will be killed by the orcs for sure!"
             message= _ "Deal. I c’n blow’er up once I get to that signpost ov’r dere. That’s where my eq’pment is. But ev’ryone not ov’r theah on that side when it blows w’ll be killed by the orcs fa’ sure!"   # wmllint: no spellcheck
         [/message]
         [item]
@@ -251,6 +254,7 @@
         [/filter]
         [message]
             speaker=Engineer
+            #po: "So, do you want me to blow up the bridge yet, Captain?"
             message= _ "So, d’ya want me to blow up der bridge yet, Cap’n?" # wmllint: no spellcheck
         [/message]
         [message]
@@ -261,6 +265,7 @@
                 [command]
                     [message]
                         speaker=Engineer
+                        #po: "All right! Blasting time!"
                         message= _ "All right! Blast’n time!" # wmllint: no spellcheck
                     [/message]
                     [sound]
@@ -329,6 +334,7 @@
                 [command]
                     [message]
                         speaker=Engineer
+                        #po: "No? All right then, we'll wait for later, eh?"
                         message= _ "Neh? A’right then, we’ll wait fa’ later, eh?"   # wmllint: no spellcheck
                     [/message]
 
@@ -377,6 +383,7 @@
         [/message]
         [message]
             speaker=Engineer
+            #po: "I'll be following you from now on. I hope you can get to Weldyn and all so I can stop running..."
             message= _ "I’ll be followin’ yah from now on. Hope yah can get to Weld’n an’ all so I c’n stop runnin’..." # wmllint: no spellcheck
         [/message]
     [/event]

--- a/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
@@ -3,7 +3,7 @@
     id=12_Evacuation
     name= _ "Evacuation"
     map_file=12_Evacuation.map
-    turns=14
+    {TURNS 16 15 14}
     next_scenario=13_The_Drowned_Plains
 
     {DEFAULT_SCHEDULE}
@@ -30,7 +30,7 @@
         controller=human
         team_name=wesnothians
         user_team_name=_"Wesnothians"
-        {GOLD 280 250 220}
+        {GOLD 290 255 220}
         {FLAG_VARIANT loyalist}
     [/side]
 
@@ -44,7 +44,7 @@
         controller=ai
         recruit=Orcish Warrior,Goblin Knight
         {GOLD 100 150 200}
-        {INCOME 20 25 30}
+        {INCOME 10 20 30}
         team_name=bad
         user_team_name=_"Evil"
         [ai]
@@ -53,9 +53,9 @@
         {FLAG_VARIANT6 ragged}
     [/side]
 
-    {LIMIT_CONTEMPORANEOUS_RECRUITS 2 "Direwolf Rider" 3}
+    {LIMIT_CONTEMPORANEOUS_RECRUITS 2 "Direwolf Rider" {ON_DIFFICULTY 1 2 3}}
 
-    {STARTING_VILLAGES 2 8}
+    {STARTING_VILLAGES 2 {ON_DIFFICULTY 4 6 8}}
 
     [side]
         type=Troll Warrior
@@ -66,7 +66,7 @@
         controller=ai
         recruit=Troll,Troll Rocklobber,Goblin Pillager
         {GOLD 100 150 200}
-        {INCOME 20 25 30}
+        {INCOME 10 20 30}
         team_name=bad
         user_team_name=_"Evil"
         [ai]
@@ -74,9 +74,9 @@
         [/ai]
     [/side]
 
-    {LIMIT_CONTEMPORANEOUS_RECRUITS 4 "Troll Warrior" 3}
+    {LIMIT_CONTEMPORANEOUS_RECRUITS 3 "Troll Warrior" {ON_DIFFICULTY 1 2 3}}
 
-    {STARTING_VILLAGES 3 8}
+    {STARTING_VILLAGES 3 {ON_DIFFICULTY 4 6 8}}
 
     [side]
         type=Orcish Warlord
@@ -86,9 +86,13 @@
         canrecruit=yes
         facing=sw
         controller=ai
+#ifdef EASY
+        recruit=Orcish Crossbowman,Orcish Assassin,Orcish Warrior
+#else
         recruit=Orcish Crossbowman,Orcish Slayer,Orcish Warrior
+#endif
         {GOLD 100 150 200}
-        {INCOME 20 25 30}
+        {INCOME 10 20 30}
         team_name=bad
         user_team_name=_"Evil"
         [ai]
@@ -97,7 +101,7 @@
         {FLAG_VARIANT6 ragged}
     [/side]
 
-    {STARTING_VILLAGES 4 8}
+    {STARTING_VILLAGES 4 {ON_DIFFICULTY 4 6 8}}
 
     [event]
         name=prestart
@@ -121,11 +125,7 @@
 #define TROLL_GUARD SIDE X Y WML
     [unit]
         side={SIDE}
-#ifdef EASY
-        type=Troll
-#else
-        type=Troll Warrior
-#endif
+        type={ON_DIFFICULTY "Troll Whelp" "Troll" "Troll Warrior"}
         generate_name=yes
         x,y={X},{Y}
         ai_special=guardian
@@ -184,12 +184,23 @@
             id=Engineer
             name= _ "Engineer"
             unrenamable=yes
-            type=Red Mage
+            type={ON_DIFFICULTY "Arch Mage" "Silver Mage" "Red Mage"}
             x,y=18,5
             side=1
             random_traits=no
             [modifications]
                 {TRAIT_LOYAL}
+#ifdef EASY
+                [object]
+                    silent=yes
+                    duration=forever
+                    [effect]
+                        apply_to=hitpoints
+                        increase_total=10
+                        heal_full=yes
+                    [/effect]
+                [/object]
+#endif
             [/modifications]
         [/unit]
         [message]

--- a/data/campaigns/Eastern_Invasion/scenarios/17b_Weldyn_Besieged.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/17b_Weldyn_Besieged.cfg
@@ -349,7 +349,7 @@
             id=Mal-Ravanal
             name= _ "Mal-Ravanal"
             profile=portraits/mal-ravanal.png
-            hitpoints=80 # Full amount; I considered having him start with less but it doesn't make sense for him to start injured
+            hitpoints=80
             [variables]
                 random_lich=no
             [/variables]

--- a/data/campaigns/Eastern_Invasion/scenarios/17b_Weldyn_Besieged.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/17b_Weldyn_Besieged.cfg
@@ -36,7 +36,9 @@
 
     # Gweddry gets the villages within the moat.
     # The ones outside he'll actually have to take.
-    {STARTING_VILLAGES 1 3}
+    # (On Hard at least; on easier difficulties we can be nicer)
+    {STARTING_VILLAGES 1 {ON_DIFFICULTY 7 5 3}}
+    # (I had changed this to "9 6 3" originally, but that turned out to be too much. If testing reveals that "7 5 3" is still too much, too, maybe drop the value even further down to "5 4 3".)
 
     [side]
         type=Lich
@@ -347,7 +349,7 @@
             id=Mal-Ravanal
             name= _ "Mal-Ravanal"
             profile=portraits/mal-ravanal.png
-            hitpoints=80
+            hitpoints=80 # Full amount; I considered having him start with less but it doesn't make sense for him to start injured
             [variables]
                 random_lich=no
             [/variables]
@@ -374,7 +376,7 @@
         [/allow_recruit]
 
         [gold]
-            amount=100
+            {QUANTITY amount 80 90 100}
             side=$unit.side
         [/gold]
 


### PR DESCRIPTION
These are mostly just changes to gold/income/turns values, so they should be pretty safe to merge. Note that I originally developed these changes against 1.14, and @nemaara has already made some of her own changes to Eastern Invasion as part of 1.15, so I just dropped the parts that didn't apply anymore, or that didn't make sense anymore. This means I haven't actually tested these changes in this form, just in the form that appears in [https://github.com/cooljeanius/wesnoth_mods/tree/master/campaigns/Eastern_Invasion](https://github.com/cooljeanius/wesnoth_mods/tree/master/campaigns/Eastern_Invasion). They should be similar enough that that shouldn't make much of a difference, though.