### PR TITLE
Cleanup wmllint: display on/off

### DIFF
--- a/data/campaigns/Descent_Into_Darkness/scenarios/07b_A_Small_Favor2.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/07b_A_Small_Favor2.cfg
@@ -716,11 +716,9 @@
         [/filter]
         [message]
             speaker=narrator
-            #wmllint: display on
             message= _ "<i>Mirrors of shallow blue, cold and opaque, they stare,
 Piercing, unblinking, a pitiless reflection,
 Shattering our brittle, fancied reality.</i>"
-            #wmllint: display off
         [/message]
         [allow_undo][/allow_undo]
     [/event]
@@ -732,11 +730,9 @@ Shattering our brittle, fancied reality.</i>"
         [/filter]
         [message]
             speaker=narrator
-            #wmllint: display on
             message= _ "<i>Emerald, verdant green gives way,
 Touched by shadow, dark dye of black,
 An abhorrent stain of pestilence.</i>"
-            #wmllint: display off
         [/message]
         [allow_undo][/allow_undo]
     [/event]
@@ -748,11 +744,9 @@ An abhorrent stain of pestilence.</i>"
         [/filter]
         [message]
             speaker=narrator
-            #wmllint: display on
             message= _ "<i>Crimson pool, essence of life,
 Flesh and blood flow away to rot,
 Leaving only bones to remain.</i>"
-            #wmllint: display off
         [/message]
         [allow_undo][/allow_undo]
     [/event]

--- a/data/campaigns/Descent_Into_Darkness/scenarios/07c_A_Small_Favor3.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/07c_A_Small_Favor3.cfg
@@ -813,11 +813,9 @@
         [/filter]
         [message]
             speaker=narrator
-            #wmllint: display on
             message= _ "<i>Death is the twilight that follows the light of day.
 Life fades with the setting sun into darkness.
 Existence churns and the soul is reborn into endless night.</i>"
-            #wmllint: display off
         [/message]
         [allow_undo][/allow_undo]
     [/event]

--- a/data/campaigns/Descent_Into_Darkness/scenarios/09_Descent_into_Darkness.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/09_Descent_into_Darkness.cfg
@@ -1966,10 +1966,8 @@
         [message]
             speaker=narrator
             # wmllint: local spelling Zephryn
-            # wmllint: display on
             message= _ "<s><i>Welcome to Zephryn’s laboratory. Please be mindful of ongoing experiments during your visit.</i></s>
 <big><i><b>This territory is the domain of the mighty Xanthric. All unwelcome intruders shall die.</b></i></big>"
-            # wmllint: display off
             image=wesnoth-icon.png
         [/message]
 
@@ -2600,12 +2598,10 @@
 
         [message]
             speaker=narrator
-            # wmllint: display on
             message= _ "<i>Dark water beneath crystal ice,
 Unmasked by a lick of flame,
 Transmuted by the altar of darkness
 Into pitch black shadow.</i>"
-            # wmllint: display off
         [/message]
         [fire_event]
             name=potion text
@@ -2909,14 +2905,12 @@ Into pitch black shadow.</i>"
 
         [message]
             speaker=narrator
-            # wmllint: display on
             message= _ "<i>Bones, scattered carelessly onto the floor,
 Remains laid without rest,
 Reside outside their coffin, locked away,
 In eternal wakefulness.
 Then, the key is found and the lid opened,
 And the tongue of fire begets ashen repose.</i>"
-            # wmllint: display off
         [/message]
     [/event]
 

--- a/data/campaigns/Eastern_Invasion/scenarios/17a_The_Duel.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/17a_The_Duel.cfg
@@ -98,11 +98,9 @@
 
         [message]
             speaker=narrator
-            #wmllint: display on
             message= _ "The rules of the duel are these:
 You may recruit or recall up to 5 units.
 At the end of your first turn, your keep will disappear, and you must battle with whatever troops you have at that time."
-            #wmllint: display off
             image=wesnoth-icon.png
         [/message]
         [message]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/07_Crossroads.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/07_Crossroads.cfg
@@ -495,10 +495,8 @@
         [message]
             speaker=narrator
             image="scenery/signpost.png"
-            #wmllint: display on
             message= _ "NE — Dan’Tonk
 SE — Fort Tahn"
-            #wmllint: display off
         [/message]
         [message]
             speaker=Konrad

--- a/data/campaigns/Heir_To_The_Throne/scenarios/19c_Cliffs_of_Thoria.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/19c_Cliffs_of_Thoria.cfg
@@ -355,11 +355,9 @@
         [/message]
         [message]
             speaker=Keh Ohn
-            # wmllint: display on
             # wmllint: local spelling Soooo
             message= _ "(releasing a torrent of fire towards Konrad and Li’sar)
 Soooo... It is you who sent your subordinates to attack us. Now when we’ve destroyed them, you come to do the job yourselves."
-            # wmllint: display off
         [/message]
         [message]
             speaker=Konrad

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/03_A_Harrowing_Escape.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/03_A_Harrowing_Escape.cfg
@@ -235,10 +235,8 @@
             speaker=narrator
             image=scenery/signpost.png
             # wmllint: local spelling SE SW
-            #wmllint: display on
             message= _ "SE — The River Road.
 SW — The Midlands."
-            #wmllint: display off
             image=wesnoth-icon.png
         [/message]
         [allow_undo]

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/04a_The_Swamp_of_Esten.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/04a_The_Swamp_of_Esten.cfg
@@ -476,10 +476,8 @@
 
         [message]
             speaker=narrator
-            #wmllint: display on
             message= _ "East — The Oldwood Forest.
 Enter at Your Own Risk!"
-            #wmllint: display off
             image=scenery/signpost.png
         [/message]
         [allow_undo]

--- a/data/core/help.cfg
+++ b/data/core/help.cfg
@@ -662,7 +662,6 @@ It is not possible to remove add-ons for which there is publishing information (
     [topic]
         id=general_commands
         title= _ "General Commands"
-        # wmllint: display on
         text= _ "These commands can either be issued via the command line by prefixing them with ':' (as shown here) or via the chat by prefixing them with '/' (press 'm' first to open the chat line).
 
 " + "<header>text=':clear'</header>" + _ "
@@ -698,7 +697,6 @@ Save the game (without prompting).
 
 " + "<header>text=':wq'</header>" + _ "
 Save the game and quit the scenario (without prompting)."
-        # wmllint: display off
     [/topic]
     # wmllint: markcheck on
 

--- a/data/core/macros/ai_controller.cfg
+++ b/data/core/macros/ai_controller.cfg
@@ -760,13 +760,11 @@
                             [/else]
                         [/if]
 
-                        # wmllint: display on
                         {VARIABLE ai_controller_{AFFIX}.main_menu_message.message "$ai_controller_{AFFIX}.main_menu_message.message"+"
 <span color='black'>-</span>"+"
 "+_"Objective: $ai_controller.side_$ally_side|_current_settings.currently_doing_objective_description
 Behavior: $ai_controller.side_$ally_side|_current_settings.currently_doing_behavior_description"+"
 <span color='black'>-</span>"}
-                        # wmllint: display off
 
                         [set_variables]
                             name=header_message

--- a/data/multiplayer/scenarios/2p_Dark_Forecast.cfg
+++ b/data/multiplayer/scenarios/2p_Dark_Forecast.cfg
@@ -161,7 +161,6 @@ Note: You need to use the default map settings for the scenario to work right."
             speaker=narrator
             image=misc/time-schedules/default/schedule-dawn.png
             #wmllint: local spellings jb Rhuvaen
-            #wmllint: display on
             message= _ "Your aim is to survive the spawning waves of units and defeat the final archenemies.
 
 The spawning waves are randomly generated and will be different each time Dark Forecast is played.
@@ -178,7 +177,6 @@ The weather will also change randomly, affecting the layout of the map.
 
 <span color='green'>Rhuvaen:</span>
 • WML implementation"
-            #wmllint: display off
         [/message]
         [message]
             side=3

--- a/data/multiplayer/scenarios/ANL_utils/ANL_leader_options.cfg
+++ b/data/multiplayer/scenarios/ANL_utils/ANL_leader_options.cfg
@@ -309,9 +309,7 @@ Share knowledge of warfare"
                     [message]
                         caption= _ "Diplomatic Options"
                         speaker=unit
-                        # wmllint: display on
                         message= _ "What shall I do?"
-                        # wmllint: display off
 
                         # Nothing
 
@@ -558,9 +556,7 @@ Negotiation Progress: $player_$side_number|.leader_option_2.progress|/$player_$s
                         speaker=narrator
                         caption=_ "Negotiation Complete"
                         image=portraits/dwarves/lord.png
-                        # wmllint: display on
                         message= _ "Our talks are complete — the Dwarves will gladly fight by your side. Which of our brethren do you want to recruit?"
-                        # wmllint: display off
 
                         #textdomain wesnoth-units
                         {PICK_RECRUIT_OPTION ("units/dwarves/fighter.png~TC($side_number|,magenta)") "Dwarvish Fighter" _"Dwarvish Fighter" ally_1}
@@ -590,9 +586,7 @@ Negotiation Progress: $player_$side_number|.leader_option_2.progress|/$player_$s
                         speaker=narrator
                         caption=_ "Negotiation Complete"
                         image=portraits/elves/high-lord.png
-                        # wmllint: display on
                         message= _ "Our talks are complete — the Elves shall aid you in this battle. Which our of kin do you wish to recruit?"
-                        # wmllint: display off
 
                         #textdomain wesnoth-units
                         {PICK_RECRUIT_OPTION ("units/elves-wood/archer.png~TC($side_number|,magenta)") "Elvish Archer" _"Elvish Archer" ally_5}

--- a/data/multiplayer/scenarios/ANL_utils/ANL_research_options.cfg
+++ b/data/multiplayer/scenarios/ANL_utils/ANL_research_options.cfg
@@ -122,13 +122,11 @@
                     [message]
                         speaker=unit
                         caption=_ "Research"
-                        # wmllint: display on
                         message= _ "We are currently studying $player_$side_number|.research.target_language_name|. To which end would you have our scholars devote their minds?
 
 Our farms produce $player_$side_number|.farming.gold|g
 Our mines produce $player_$side_number|.mining.gold|g
 "
-                        # wmllint: display off
 
                         [option]
                             label= _ "Continue as before"


### PR DESCRIPTION
https://github.com/wesnoth/wesnoth/pull/5481 removed the check that made wmllint: display on and wmllint: display off necessary. This PR removes now redundant wmllint comments.
```sh
find ./data/ -name '*.cfg' -exec sed -ri '/^ *# *wmllint *:? *display *(on|off) *$/d; s/ *# *wmllint *:? *display *(on|off) *$//' '{}' ';'
```