### PR TITLE
change User to Custom to unify the help with the game

### DIFF
--- a/data/core/editor/help.cfg
+++ b/data/core/editor/help.cfg
@@ -259,7 +259,7 @@ The editor can load most maps from older versions of Wesnoth, but not all. Maps 
 
 The right-hand sidebar contains, from top to bottom, the mini-map, the toolkit (see the pages for each tool), tool options, and <ref>dst='editor_palette' text='Palette'</ref>.
 
-When saved using “Save Map As” and saving to the default directory, the resulting map can be found in the “User Maps” game type of the multiplayer “Create Game” dialog."
+When saved using “Save Map As” and saving to the default directory, the resulting map can be found in the “Custom Maps” game type of the multiplayer “Create Game” dialog."
 [/topic]
 # wmllint: markcheck on
 


### PR DESCRIPTION
I see no "User Maps" under the list box when loading previously saved map, but the "Custom Maps" appears here.