### PR TITLE
Fixed unstore_unit lua code (issue #5519)

### DIFF
--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -839,7 +839,8 @@ wml_actions.unstore_unit = function(cfg)
 	local x = cfg.x or unit.x or -1
 	local y = cfg.y or unit.y or -1
 	if cfg.location_id then
-		x, y = wesnoth.special_locations[cfg.location_id]
+		local loc = wesnoth.special_locations[cfg.location_id]
+		x,y = loc[1], loc[2]
 	end
 	wesnoth.add_known_unit(unit.type)
 	if on_board(x, y) then

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -839,8 +839,7 @@ wml_actions.unstore_unit = function(cfg)
 	local x = cfg.x or unit.x or -1
 	local y = cfg.y or unit.y or -1
 	if cfg.location_id then
-		local loc = wesnoth.special_locations[cfg.location_id]
-		x,y = loc[1], loc[2]
+		x,y = table.unpack(wesnoth.special_locations[cfg.location_id])
 	end
 	wesnoth.add_known_unit(unit.type)
 	if on_board(x, y) then
@@ -878,10 +877,10 @@ wml_actions.teleport = function(cfg)
 		return
 	end
 	local x,y = cfg.x, cfg.y
-	if not x or not y then
-		x,y = wesnoth.special_locations[cfg.location_id]
+	if cfg.location_id then
+		x,y = table.unpack(wesnoth.special_locations[cfg.location_id])
 	end
-	wesnoth.teleport(unit, cfg.x, cfg.y, cfg.check_passability == false, cfg.clear_shroud ~= false, cfg.animate)
+	wesnoth.teleport(unit, x, y, cfg.check_passability == false, cfg.clear_shroud ~= false, cfg.animate)
 end
 
 function wml_actions.remove_sound_source(cfg)


### PR DESCRIPTION
x,y were both binding to whole table instead of their expected values
#5519 should now be solved, although there still might be problem with location_id in teleport code