### PR TITLE
Edit Scepter of Fire difficulty

### DIFF
--- a/data/campaigns/Sceptre_of_Fire/scenarios/4_Gathering_Materials.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/4_Gathering_Materials.cfg
@@ -206,13 +206,6 @@
         {FLAG_VARIANT knalgan}
         team_name=dwarves
         user_team_name= _ "Dwarves"
-        # When I first edited this scenario I didn't realize that
-        # the default gold when left unspecified is 100, so my specification
-        # of {GOLD 50 30 10} was actually an unwitting reduction...
-        # I am fixing that by just adding an extra hundreds digit, but that
-        # is untested...
-        {GOLD 150 130 110}
-        {INCOME 5 3 1}
     [/side]
     # these AI sides were set to not be on the same side. Assuming that is intentional, let's give them a little distinction and variety
     [side]
@@ -240,7 +233,7 @@
         recruit=Troll Whelp,Young Ogre,Troll Rocklobber
         team_name=trolls1
         user_team_name=_"Resident Trolls"
-        {GOLD 60 120 180}
+        {GOLD 75 125 175}
     [/side]
     [side]
 #ifdef HARD
@@ -267,7 +260,7 @@
         recruit=Troll Whelp,Young Ogre,Ogre
         team_name=trolls2
         user_team_name=_"Intruding Trolls"
-        {GOLD 60 120 180}
+        {GOLD 75 125 175}
     [/side]
     # Changing this leader to a rider goblin, because I don't know why a troll could recruit goblins...
     # If the troll does make sense, it can be changed back, but this way also brings some variety
@@ -296,10 +289,10 @@
         recruit=Goblin Spearman,Goblin Rouser,Goblin Impaler
         team_name=trolls3
         user_team_name=_"Goblin Explorers"
-        {GOLD 60 120 180}
+        {GOLD 75 125 175}
     [/side]
 
-    {TURNS 69 52 35}
+    {TURNS 40 37 34}
     victory_when_enemies_defeated=no
 
     {SCENARIO_MUSIC underground.ogg}

--- a/data/campaigns/Sceptre_of_Fire/scenarios/4_Gathering_Materials.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/4_Gathering_Materials.cfg
@@ -206,6 +206,13 @@
         {FLAG_VARIANT knalgan}
         team_name=dwarves
         user_team_name= _ "Dwarves"
+        # When I first edited this scenario I didn't realize that
+        # the default gold when left unspecified is 100, so my specification
+        # of {GOLD 50 30 10} was actually an unwitting reduction...
+        # I am fixing that by just adding an extra hundreds digit, but that
+        # is untested...
+        {GOLD 150 130 110}
+        {INCOME 5 3 1}
     [/side]
     # these AI sides were set to not be on the same side. Assuming that is intentional, let's give them a little distinction and variety
     [side]
@@ -233,7 +240,7 @@
         recruit=Troll Whelp,Young Ogre,Troll Rocklobber
         team_name=trolls1
         user_team_name=_"Resident Trolls"
-        {GOLD 75 125 175}
+        {GOLD 60 120 180}
     [/side]
     [side]
 #ifdef HARD
@@ -260,7 +267,7 @@
         recruit=Troll Whelp,Young Ogre,Ogre
         team_name=trolls2
         user_team_name=_"Intruding Trolls"
-        {GOLD 75 125 175}
+        {GOLD 60 120 180}
     [/side]
     # Changing this leader to a rider goblin, because I don't know why a troll could recruit goblins...
     # If the troll does make sense, it can be changed back, but this way also brings some variety
@@ -289,10 +296,10 @@
         recruit=Goblin Spearman,Goblin Rouser,Goblin Impaler
         team_name=trolls3
         user_team_name=_"Goblin Explorers"
-        {GOLD 75 125 175}
+        {GOLD 60 120 180}
     [/side]
 
-    {TURNS 40 37 34}
+    {TURNS 69 52 35}
     victory_when_enemies_defeated=no
 
     {SCENARIO_MUSIC underground.ogg}

--- a/data/campaigns/Sceptre_of_Fire/scenarios/6_Towards_the_Caves.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/6_Towards_the_Caves.cfg
@@ -2,7 +2,7 @@
 [scenario]
     name= _ "Towards the Caves"
     id=6_Towards_the_Caves
-    turns=12
+    {TURNS 20 16 12}
     map_file=6_Towards_the_Caves.map
     next_scenario=7_Outriding_the_Outriders
 
@@ -17,7 +17,7 @@
         canrecruit=yes
         controller=human
         recruit=Dwarvish Fighter,Dwarvish Thunderer,Dwarvish Guardsman,Dwarvish Scout,Gryphon Rider
-        gold=200
+        {GOLD 300 250 200}
         team_name=dwarves
         user_team_name= _ "Dwarves"
         {FLAG_VARIANT knalgan}
@@ -47,7 +47,7 @@
         [/modifications]
         canrecruit=yes
         recruit=Elvish Rider,Elvish Hero,Elvish Marksman,Elvish Ranger,Elvish Druid
-        {GOLD 300 350 400}
+        {GOLD 250 325 400}
         team_name=elves
         user_team_name= _ "Elves"
         [ai]
@@ -84,7 +84,7 @@
         {FLAG_VARIANT wood-elvish}
     [/side]
 
-    {STARTING_VILLAGES 2 12}
+    {STARTING_VILLAGES 2 {ON_DIFFICULTY 8 10 12}}
 
     [side]
         type=Elvish Marshal
@@ -94,7 +94,7 @@
         canrecruit=yes
         recruit=Elvish Rider,Elvish Hero,Elvish Marksman,Elvish Ranger,Elvish Druid
 
-        {GOLD 225 275 325}
+        {GOLD 200 260 320}
         team_name=elves
         user_team_name= _ "Elves"
         [ai]
@@ -103,15 +103,15 @@
                 [criteria]
                     x,y=36,3
                 [/criteria]
-                value=100
-                protect_radius=10
+                {QUANTITY value 60 80 100}
+                {QUANTITY protect_radius 8 9 10}
             [/goal]
             [goal]
                 name=target
                 [criteria]
                     race=dwarf
                 [/criteria]
-                value=10
+                {QUANTITY value 8 9 10}
             [/goal]
             [avoid]
                 x=1-18
@@ -121,8 +121,8 @@
         {FLAG_VARIANT wood-elvish}
     [/side]
 
-    {STARTING_VILLAGES 3 8}
-    {STARTING_VILLAGES_AREA 3 34 10 8}
+    {STARTING_VILLAGES 3 {ON_DIFFICULTY 6 7 8}}
+    {STARTING_VILLAGES_AREA 3 34 10 {ON_DIFFICULTY 6 7 8}}
 
     [side]
         type=Elvish Captain
@@ -131,7 +131,7 @@
         side=4
         canrecruit=yes
         recruit=Elvish Scout,Elvish Fighter,Elvish Archer,Elvish Shaman
-        {GOLD 100 150 200}
+        {GOLD 80 140 200}
         team_name=elves
         user_team_name= _ "Elves"
         [ai]
@@ -140,7 +140,7 @@
                 [criteria]
                     id=Alanin
                 [/criteria]
-                value=10
+                {QUANTITY value 6 8 10}
             [/goal]
             [goal]
                 name=target
@@ -153,7 +153,7 @@
         {FLAG_VARIANT wood-elvish}
     [/side]
 
-    {STARTING_VILLAGES 4 11}
+    {STARTING_VILLAGES 4 {ON_DIFFICULTY 9 10 11}}
 
     [story]
         [part]
@@ -483,6 +483,49 @@
             speaker=Thursagan
             message= _ "You going south has more of a chance of success for you than staying here or going back to the mines! And getting news to Haldric of what has happened is also the best way to get help to us."
         [/message]
+#ifdef EASY
+        [message]
+            speaker=Thursagan
+            message= _ "Here, if you are still having doubts, let me inscribe this rune for you to help you slip past their defenses."
+        [/message]
+        [modify_unit]
+            [filter]
+                id=Alanin
+            [/filter]
+            [object]
+                silent=yes
+                duration=forever
+                # (originally I gave him an additional movement point here, too,
+                # but that causes his dialogue in the beginning of the next scenario
+                # "Outriding the Outriders" to be false, so I am removing that now.)
+                [effect]
+                    apply_to=new_ability
+                    [abilities]
+                        {ABILITY_CONCEALMENT}
+                        {ABILITY_SKIRMISHER}
+                    [/abilities]
+                [/effect]
+            [/object]
+        [/modify_unit]
+        [sound]
+            name=mace.wav
+        [/sound]
+        [heal_unit]
+            [filter]
+                id=Alanin
+            [/filter]
+            moves=full
+            restore_attacks=yes
+        [/heal_unit]
+        [message]
+            speaker=Alanin
+            message= _ "Thanks!"
+        [/message]
+        [message]
+            speaker=narrator
+            message= _ "Alanin has gained new abilities!"
+        [/message]
+#endif
         [message]
             speaker=Alanin
             message= _ "I suppose..."
@@ -498,15 +541,15 @@
         name=turn 4
         [gold]
             side=2
-            amount=200
+            {QUANTITY amount 80 140 200}
         [/gold]
         [gold]
             side=3
-            amount=200
+            {QUANTITY amount 80 140 200}
         [/gold]
         [gold]
             side=4
-            amount=200
+            {QUANTITY amount 60 130 200}
         [/gold]
     [/event]
 


### PR DESCRIPTION
This is my attempt to apply patches from [my general mods collection](https://github.com/cooljeanius/wesnoth_mods/tree/master/campaigns/Sceptre_Of_Fire). Basically, I needed more turns in Gathering Materials, and I needed to make it easier for Alanin to escape in Towards the Caves. Tested on 1.14, not on 1.15 though.