### PR TITLE
Editor help: make the named areas topic visible, make "to load ..." translatable

### DIFF
--- a/data/core/editor/help.cfg
+++ b/data/core/editor/help.cfg
@@ -18,7 +18,7 @@
 [section]
     id=editor_mode_scenario
     title= _ "Scenario Editor"
-    topics=..editor_mode_scenario, editor_tool_label, editor_tool_scenery, editor_tool_unit, editor_tool_village, editor_time_schedule, editor_playlist
+    topics=..editor_mode_scenario, editor_tool_label, editor_tool_scenery, editor_tool_unit, editor_tool_village, editor_named_area, editor_time_schedule, editor_playlist
     sort_topics=no
 [/section]
 
@@ -280,7 +280,7 @@ You can check which mode the editor is in by looking at the menu bar.
 
 To start a new map in scenario mode, choose “New Scenario” from the “File” menu.
 
-If you’re already editing a map in terrain mode, use “Save Scenario As” from the “File” menu; this will switch to scenario mode." + "
+If you’re already editing a map in terrain mode, use “Save Scenario As” from the “File” menu; this will switch to scenario mode.
 
 To load a map that was created in the scenario editor, use “Load Map” from the “File” menu, and select the .cfg file (not a .map file)." + "
 


### PR DESCRIPTION
This corrects a pair of editing errors, thanks to @celerini for reporting them.

This is targeting the 1.14 branch, I'll cherry-pick to master when it merges.