### PR TITLE
Make the preferences window big enough for HDPI fonts

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@
    * Added a "disengaged" orb, shown instead of the partially-moved orb for units that can move but can't attack.
    * Added information about the build's (not runtime) target CPU architecture to the game version info dialog and --report.
    * Added terminal-style command history browsing with up-down keys for in-game consoles used by debug mode, ai and search floating textboxes.
+   * Made the preferences dialog larger on HDPI screens; this fixes a usability issue with HDPI font sizes (issue #5185).
  ### WML Engine
    * Extent 'special_id_active' and 'special_type_active' to abilities used like weapon and to [leadership] abilities.
    * abilities used like weapon can call [leading_anim] now.

--- a/data/gui/window/preferences.cfg
+++ b/data/gui/window/preferences.cfg
@@ -129,7 +129,8 @@
 	[resolution]
 		definition = "default"
 
-		{GUI_WINDOW_FIXED_SIZE_CENTERED 800 600}
+		# The hotkey list will always want to be as tall as possible, which causes a lot of blank space on the other tabs. Limit the height so that the "General" tab fits the content tightly with non-HDPI fonts, and looks reasonable with HDPI fonts.
+		maximum_height = "({GUI_SCALE_RESOLUTION 600})"
 
 		[linked_group]
 			id = "page_icon"

--- a/data/gui/window/preferences/01_general.cfg
+++ b/data/gui/window/preferences/01_general.cfg
@@ -225,6 +225,8 @@
 [layer]
 
 	[row]
+		grow_factor = 0
+
 		[column]
 			horizontal_grow = true
 			vertical_alignment = "top"
@@ -234,10 +236,14 @@
 		[/column]
 	[/row]
 
+	{_GUI_PREFERENCES_SPACER_ROW}
+
 	[row]
+		grow_factor = 1
+
 		[column]
 			horizontal_alignment = "left"
-			vertical_alignment = "bottom"
+			vertical_alignment = "top"
 
 			[grid]
 				{_GUI_PREFERENCES_GENERAL_GRID_2}

--- a/data/gui/window/preferences/03_display.cfg
+++ b/data/gui/window/preferences/03_display.cfg
@@ -297,6 +297,8 @@
 [layer]
 
 	[row]
+		grow_factor = 0
+
 		[column]
 			horizontal_grow = true
 			vertical_alignment = "top"
@@ -307,10 +309,14 @@
 		[/column]
 	[/row]
 
+	{_GUI_PREFERENCES_SPACER_ROW}
+
 	[row]
+		grow_factor = 1
+
 		[column]
 			horizontal_alignment = "left"
-			vertical_alignment = "bottom"
+			vertical_alignment = "top"
 
 			[grid]
 				{_GUI_PREFERENCES_DISPLAY_GRID_2}

--- a/data/gui/window/preferences/05_multiplayer.cfg
+++ b/data/gui/window/preferences/05_multiplayer.cfg
@@ -142,7 +142,7 @@
 			border = "all"
 			border_size = 5
 			horizontal_alignment = "left"
-			vertical_alignment = "bottom"
+			vertical_alignment = "top"
 
 			[button]
 				id = mp_alerts
@@ -155,7 +155,7 @@
 			border = "all"
 			border_size = 5
 			horizontal_alignment = "left"
-			vertical_alignment = "bottom"
+			vertical_alignment = "top"
 
 			[button]
 				id = mp_wesnothd
@@ -425,14 +425,28 @@
 
 [layer]
 	[row]
+		[column]
+			horizontal_alignment = "left"
+			vertical_alignment = "top"
+
+			[grid]
+				{_GUI_PREFERENCES_MP_SWITCH_ROW}
+			[/grid]
+		[/column]
+	[/row]
+
+	{_GUI_PREFERENCES_SPACER_ROW}
+
+	[row]
 		grow_factor = 1
 		[column]
 			horizontal_grow = true
-			vertical_grow = true
+			vertical_alignment = "top"
 
 			{_GUI_PREFS_TAB_PAGER (
 				[layer]
 					[row]
+						grow_factor = 0
 						[column]
 							horizontal_grow = true
 							vertical_alignment = "top"
@@ -443,10 +457,13 @@
 						[/column]
 					[/row]
 
+					{_GUI_PREFERENCES_SPACER_ROW}
+
 					[row]
+						grow_factor = 1
 						[column]
 							horizontal_alignment = "left"
-							vertical_alignment = "bottom"
+							vertical_alignment = "top"
 
 							[grid]
 								{_GUI_PREFERENCES_MP_PAGE_1_GRID_2}
@@ -469,17 +486,6 @@
 				[/layer]
 			)}
 
-		[/column]
-	[/row]
-
-	[row]
-		[column]
-			horizontal_alignment = "left"
-			vertical_alignment = "bottom"
-
-			[grid]
-				{_GUI_PREFERENCES_MP_SWITCH_ROW}
-			[/grid]
 		[/column]
 	[/row]
 [/layer]


### PR DESCRIPTION
The hardcoded size of the window was too small for the large fonts on HDPI
displays, this changes to almost-automatic sizing. It leaves an upper limit for
the height of 80% of the main window size, so that there's a border at top and
bottom. Fixes #5185

Buttons that were placed at the bottom of pages move up so that they aren't
too far from the other controls. The sub-tab-selector buttons on the
multiplayer tab move above the sub-tabs themselves.

With HDPI text, the checkboxes are placed a little too high to align with
the font, but that's a cosmetic detail; this commit fixes the usability issue.

![wesnoth_preferences_4k_comparison](https://user-images.githubusercontent.com/101462/107511492-d909b500-6ba5-11eb-8134-340f75edb917.png)