### PR TITLE
Command history for in-game consoles

### DIFF
--- a/src/floating_textbox.cpp
+++ b/src/floating_textbox.cpp
@@ -33,7 +33,8 @@ namespace gui{
 		check_(nullptr),
 		mode_(TEXTBOX_NONE),
 		label_string_(),
-		label_(0)
+		label_(0),
+		command_history_()
 	{}
 
 	void floating_textbox::close(game_display& gui)
@@ -142,5 +143,19 @@ namespace gui{
 					events::chat_handler::MESSAGE_PRIVATE, false);
 		}
 		box_->set_text(text);
+	}
+
+	void floating_textbox::memorize_command(const std::string& command)
+	{
+		if(command.empty()) {
+			return;
+		}
+
+		auto prev = std::find(command_history_.begin(), command_history_.end(), command);
+
+		if(prev != command_history_.end()) {
+			command_history_.erase(prev);
+		}
+		command_history_.emplace_back(command);
 	}
 }

--- a/src/floating_textbox.hpp
+++ b/src/floating_textbox.hpp
@@ -37,12 +37,14 @@ namespace gui{
 		TEXTBOX_MODE mode() const { return mode_; }
 		const std::unique_ptr<gui::button>& check() const { return check_; }
 		const std::unique_ptr<gui::textbox>& box() const { return box_; }
+		const std::vector<std::string>& command_history() const { return command_history_; }
 
 		void close(game_display& gui);
 		void update_location(game_display& gui);
 		void show(gui::TEXTBOX_MODE mode, const std::string& label,
 			const std::string& check_label, bool checked, game_display& gui);
 		void tab(const std::set<std::string>& dictionary);
+		void memorize_command(const std::string& command);
 		bool active() const { return box_.get() != nullptr; }
 
 	private:
@@ -53,5 +55,7 @@ namespace gui{
 
 		std::string label_string_;
 		int label_;
+
+		std::vector<std::string> command_history_;
 	};
 }

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -645,6 +645,7 @@ void play_controller::enter_textbox()
 	switch(menu_handler_.get_textbox().mode()) {
 	case gui::TEXTBOX_SEARCH:
 		menu_handler_.do_search(str);
+		menu_handler_.get_textbox().memorize_command(str);
 		menu_handler_.get_textbox().close(*gui_);
 		break;
 	case gui::TEXTBOX_MESSAGE:
@@ -652,16 +653,58 @@ void play_controller::enter_textbox()
 		menu_handler_.get_textbox().close(*gui_); // need to close that one after executing do_speak() !
 		break;
 	case gui::TEXTBOX_COMMAND:
+		menu_handler_.get_textbox().memorize_command(str);
 		menu_handler_.get_textbox().close(*gui_);
 		menu_handler_.do_command(str);
 		break;
 	case gui::TEXTBOX_AI:
+		menu_handler_.get_textbox().memorize_command(str);
 		menu_handler_.get_textbox().close(*gui_);
 		menu_handler_.do_ai_formula(str, team_num, mousehandler);
 		break;
 	default:
 		menu_handler_.get_textbox().close(*gui_);
 		ERR_DP << "unknown textbox mode" << std::endl;
+	}
+}
+
+void play_controller::textbox_move_vertically(bool up)
+{
+	if(menu_handler_.get_textbox().active() == false) {
+		return;
+	}
+
+	if(menu_handler_.get_textbox().mode() == gui::TEXTBOX_MESSAGE
+		|| menu_handler_.get_textbox().mode() == gui::TEXTBOX_NONE) {
+		// Not handling messages to avoid spam
+		return;
+	}
+
+	const std::string str = menu_handler_.get_textbox().box()->text();
+	const std::vector<std::string>& command_history = menu_handler_.get_textbox().command_history();
+
+	auto prev = std::find(command_history.begin(), command_history.end(), str);
+
+	if (prev != command_history.end())
+	{
+		if(up) {
+			if(prev != command_history.begin()) {
+				menu_handler_.get_textbox().box()->set_text(*--prev);
+			}
+		} else {
+			if(++prev != command_history.end()) {
+				menu_handler_.get_textbox().box()->set_text(*prev);
+			} else {
+				menu_handler_.get_textbox().box()->set_text("");
+			}
+		}
+	} else if (up) {
+		if(command_history.size() > 0) {
+			menu_handler_.get_textbox().box()->set_text(*--prev);
+		}
+		if(!str.empty()) {
+			menu_handler_.get_textbox().memorize_command(str);
+		}
 	}
 }
 
@@ -803,6 +846,10 @@ void play_controller::process_focus_keydown_event(const SDL_Event& event)
 		menu_handler_.get_textbox().close(*gui_);
 	} else if(event.key.keysym.sym == SDLK_TAB) {
 		tab();
+	} else if(event.key.keysym.sym == SDLK_UP) {
+		textbox_move_vertically(true);
+	} else if(event.key.keysym.sym == SDLK_DOWN) {
+		textbox_move_vertically(false);
 	} else if(event.key.keysym.sym == SDLK_RETURN || event.key.keysym.sym == SDLK_KP_ENTER) {
 		enter_textbox();
 	}

--- a/src/play_controller.hpp
+++ b/src/play_controller.hpp
@@ -345,6 +345,7 @@ protected:
 	bool enemies_visible() const;
 
 	void enter_textbox();
+	void textbox_move_vertically(bool up);
 	void tab();
 
 


### PR DESCRIPTION
Now it's possible to browse the command history with up/down keys in in-game consoles such as used by debug mode, ai and search floating textboxes. It stores all the entered commands in chronological order, but already existing items will be moved to the end instead. If the player jumps to the previous command with some unenterred text in the textbox, it will also be stored. Chat messages are not stored like this to avoid spam.

I added a video with a little showcase below.

Closes #1542 .


https://user-images.githubusercontent.com/14872007/108371136-7e5c0300-720e-11eb-9039-bea0882c196d.mp4


(or this link if it doesn't show on github)
https://drive.google.com/file/d/18oYwpW3vEs2VP5OOh2iAXgyiS2Pjb-Er/view?usp=sharing