### PR TITLE
UtBS - new terrain-graphics rules for flood water

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
@@ -4181,7 +4181,7 @@
         [/store_locations]
 
         [terrain]
-            terrain=Wwg
+            terrain=Wwgz
 
             [filter_adjacent_location]
                 find_in=shallow_to_deep_locs

--- a/data/campaigns/Under_the_Burning_Suns/utils/terrain.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/utils/terrain.cfg
@@ -15,6 +15,20 @@
     hide_help=yes
 [/terrain_type]
 
+# custom water for flood terrain-graphics transitions
+
+[terrain_type]
+    symbol_image=water/coast-grey-tile
+    id=gray_utbs_water
+    name= _ "Shallow Water"
+    editor_name= _ "Flood Water"
+    string=Wwgz
+    aliasof=Wst
+    submerge=0.4
+    editor_group=utbs
+    hide_help=yes
+[/terrain_type]
+
 # human ship terrain (alias of village so it can be captured); note that the
 # ship images are placed as an [item]
 

--- a/data/campaigns/Under_the_Burning_Suns/utils/terrain_graphics.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/utils/terrain_graphics.cfg
@@ -17,15 +17,26 @@
 
 {DISABLE_WALL_TRANSITIONS Kyd}
 
-#ifndef EDITOR
-# This makes gray shallow water transition on top of the wooden floor, which
+############################################################################
+# This makes gray shallow water transition on top of the floor terrains, which
 # otherwise would have a hard edge.
-#
-# This is #ifdef'd away for the editor because otherwise the transition would
-# always work in the editor and give the false impression of working outside
-# UtBS.
+# It uses custom terrain Wwgz code in place of standard gray Wwg
+############################################################################
 
-{NEW:WATER_342_180_TRANSITION Wwg Iwr -553 "~CS(10,-5,-10)" water/water 17}
+# these are the terrains that look more 'flooded' without their usual banked transitions
+#define UTBS_WOOD_FLOOR
+Iwr,Ior,Icn,R*,Ias*,Uu* #enddef
+
+{NEW:WATER_342_180         Wwgz water/water 17 DURATION=125 RANDOM_START=125}
+{NEW:DISABLE_GENERIC_CORNER_TRANSITION ({UTBS_WOOD_FLOOR},Xo*) Wwgz}
+{NEW:DISABLE_TRANSITION Wwgz {UTBS_WOOD_FLOOR}  FLAG=non_submerged}
+{NEW:WATER_342_180_OVERLAY Wwgz                       water/overlay-gray     -280}
+{NEW:WATER_342_180_OVERLAY_TRANSITION     Wwgz (!,Wog,Wwg,Wwrg,Wwgz,!,W*,Sm) -281 water/overlay-gray     0.20}
+
+# the wood-water transitions still have a faint hex-tooth edge, but this isn't enough to fix that without modifying the other side
+# {NEW:TRANSITION            Iwr,Ior,Icn              Wwgz        -501               interior/wood-regular FLAG=transition2 IPF="~O(0.1)"}
+
+{NEW:WATER_342_180_TRANSITION Wwgz ({UTBS_WOOD_FLOOR}) -282 "~CS(10,-5,-10)" water/water 17}
 
 # Disables the generic land-water transition from floor to water
 [terrain_graphics]
@@ -35,12 +46,12 @@
 1"
     [tile]
         pos=1
-        type=Wwg
+        type=Wwgz
         set_no_flag=beach-@R0-@R5,beach-@R0-@R1
     [/tile]
     [tile]
         pos=2
-        type=Iwr
+        type={UTBS_WOOD_FLOOR}
         set_no_flag=beach-@R2-@R3,beach-@R3-@R2
     [/tile]
 
@@ -55,17 +66,22 @@
 1"
     [tile]
         pos=1
-        type=Iwr
+        type={UTBS_WOOD_FLOOR}
         set_flag=transition-@R0
     [/tile]
     [tile]
         pos=2
-        type=Wwg
+        type=Wwgz
     [/tile]
 
     rotations=n,ne,se,s,sw,nw
 [/terrain_graphics]
+############################################################################
+############################################################################
 
+#undef UTBS_WOOD_FLOOR
+
+#ifndef EDITOR
 # The ruined desert castles in this campaign were ravaged by meteors
 {OVERLAY_RANDOM      Cdr                           embellishments/stones-small}
 #endif

--- a/data/core/terrain-graphics.cfg
+++ b/data/core/terrain-graphics.cfg
@@ -1024,8 +1024,8 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 {NEW:WATER_342_180_TRANSITION             Wo*           (!,Wo*,!,W*,Sm)          -550 "~O(50%)" water/ocean 21 DURATION=125 RANDOM_START=no}
 {NEW:WATER_342_180_TRANSITION             Ww*           (!,Ww*,!,W*,Sm)          -551 "~O(50%)" water/water 17 DURATION=125 RANDOM_START=no}
 
-{NEW:WATER_342_180_OVERLAY_TRANSITION     Wog,Wwg,Wwrg  (!,Wog,Wwg,Wwrg,!,W*,Sm) -503 water/overlay-gray     0.20}
-{NEW:WATER_342_180_OVERLAY_TRANSITION     Wot,Wwt,Wwrt  (!,Wot,Wwt,Wwrt,!,W*,Sm) -505 water/overlay-tropical 0.16}
+{NEW:WATER_342_180_OVERLAY_TRANSITION     Wog,Wwg,Wwrg  (!,Wog*,Wwg*,Wwrg,!,W*,Sm) -503 water/overlay-gray     0.20}
+{NEW:WATER_342_180_OVERLAY_TRANSITION     Wot,Wwt,Wwrt  (!,Wot*,Wwt*,Wwrt,!,W*,Sm) -505 water/overlay-tropical 0.16}
 
 # We currently can't afford these extra rules to make the water transition nicely onto void and off-map, so
 # instead we make void and off-map transition over water.

--- a/data/core/terrain-graphics/new-macros.cfg
+++ b/data/core/terrain-graphics/new-macros.cfg
@@ -842,6 +842,9 @@ transition_inverted#endarg
 #arg FLAG
 transition#endarg
 
+#arg IPF
+~NOP()#endarg
+
     [terrain_graphics]
         map="
 , 2
@@ -854,7 +857,7 @@ transition#endarg
             type={ADJACENT}
             set_no_flag={FLAG}-@R0,{FLAG}-@R1,{FLAG}-@R2,{FLAG}-@R3,{FLAG}-@R4,{FLAG}-@R5
             [image]
-                name={IMAGESTEM}-@R0-@R1-@R2-@R3-@R4-@R5.png
+                name={IMAGESTEM}-@R0-@R1-@R2-@R3-@R4-@R5.png{IPF}
                 layer={LAYER}
             [/image]
         [/tile]
@@ -903,7 +906,7 @@ transition#endarg
             type={ADJACENT}
             set_no_flag={FLAG}-@R0,{FLAG}-@R1,{FLAG}-@R2,{FLAG}-@R3,{FLAG}-@R4
             [image]
-                name={IMAGESTEM}-@R0-@R1-@R2-@R3-@R4.png
+                name={IMAGESTEM}-@R0-@R1-@R2-@R3-@R4.png{IPF}
                 layer={LAYER}
             [/image]
         [/tile]
@@ -947,7 +950,7 @@ transition#endarg
             type={ADJACENT}
             set_no_flag={FLAG}-@R0,{FLAG}-@R1,{FLAG}-@R2,{FLAG}-@R3
             [image]
-                name={IMAGESTEM}-@R0-@R1-@R2-@R3.png
+                name={IMAGESTEM}-@R0-@R1-@R2-@R3.png{IPF}
                 layer={LAYER}
             [/image]
         [/tile]
@@ -986,7 +989,7 @@ transition#endarg
             type={ADJACENT}
             set_no_flag={FLAG}-@R0,{FLAG}-@R1,{FLAG}-@R2
             [image]
-                name={IMAGESTEM}-@R0-@R1-@R2.png
+                name={IMAGESTEM}-@R0-@R1-@R2.png{IPF}
                 layer={LAYER}
             [/image]
         [/tile]
@@ -1020,7 +1023,7 @@ transition#endarg
             type={ADJACENT}
             set_no_flag={FLAG}-@R0,{FLAG}-@R1
             [image]
-                name={IMAGESTEM}-@R0-@R1.png
+                name={IMAGESTEM}-@R0-@R1.png{IPF}
                 layer={LAYER}
             [/image]
         [/tile]
@@ -1049,7 +1052,7 @@ transition#endarg
             type={ADJACENT}
             set_no_flag={FLAG}-@R0
             [image]
-                name={IMAGESTEM}-@R0.png
+                name={IMAGESTEM}-@R0.png{IPF}
                 layer={LAYER}
             [/image]
         [/tile]
@@ -1514,6 +1517,177 @@ corner#endarg
                 name={IMAGESTEM}.png~MASK(terrain/{MASKSTEM}-convex-@R0-@R1.png{MASKIPF})
                 layer={LAYER}
             [/image]
+        [/tile]
+
+        rotations=tr,r,br,bl,l,tl
+    [/terrain_graphics]
+#enddef
+
+#define NEW:DISABLE_GENERIC_CORNER_TRANSITION TERRAINLIST ADJACENT
+
+#arg FLAG
+corner#endarg
+
+    [terrain_graphics]
+        map="
+,  2
+2,   2
+,  1
+2,   2
+,  2"
+        [tile]
+            pos=1
+            type={ADJACENT}
+            set_no_flag={FLAG}-concave-@R0,{FLAG}-concave-@R1,{FLAG}-concave-@R2,{FLAG}-concave-@R3,{FLAG}-concave-@R4,{FLAG}-concave-@R5
+        [/tile]
+        [tile]
+            pos=2
+            type={TERRAINLIST}
+        [/tile]
+
+        rotations=tr,r,br,bl,l,tl
+    [/terrain_graphics]
+    [terrain_graphics]
+        map="
+,  2
+.,   2
+,  1
+2,   2
+,  2"
+        [tile]
+            pos=1
+            type={ADJACENT}
+            set_no_flag={FLAG}-concave-@R0,{FLAG}-concave-@R1,{FLAG}-concave-@R2,{FLAG}-concave-@R3
+        [/tile]
+        [tile]
+            pos=2
+            type={TERRAINLIST}
+        [/tile]
+
+        rotations=tr,r,br,bl,l,tl
+    [/terrain_graphics]
+    [terrain_graphics]
+        map="
+,  2
+.,   2
+,  1
+.,   2
+,  2"
+        [tile]
+            pos=1
+            type={ADJACENT}
+            set_no_flag={FLAG}-concave-@R0,{FLAG}-concave-@R1,{FLAG}-concave-@R2
+        [/tile]
+        [tile]
+            pos=2
+            type={TERRAINLIST}
+        [/tile]
+
+        rotations=tr,r,br,bl,l,tl
+    [/terrain_graphics]
+    [terrain_graphics]
+        map="
+,  2
+.,   2
+,  1
+.,   2
+,  ."
+        [tile]
+            pos=1
+            type={ADJACENT}
+            set_no_flag={FLAG}-concave-@R0,{FLAG}-concave-@R1
+        [/tile]
+        [tile]
+            pos=2
+            type={TERRAINLIST}
+        [/tile]
+
+        rotations=tr,r,br,bl,l,tl
+    [/terrain_graphics]
+    [terrain_graphics]
+        map="
+,  2
+.,   2
+,  1
+.,   .
+,  ."
+        [tile]
+            pos=1
+            type={ADJACENT}
+            set_no_flag={FLAG}-concave-@R0
+        [/tile]
+        [tile]
+            pos=2
+            type={TERRAINLIST}
+        [/tile]
+
+        rotations=tr,r,br,bl,l,tl
+    [/terrain_graphics]
+    [terrain_graphics]
+        map="
+,  2
+3,   3
+,  1
+.,   .
+,  ."
+        [tile]
+            pos=1
+            type={TERRAINLIST}
+        [/tile]
+        [tile]
+            pos=2
+            type={ADJACENT}
+            set_no_flag={FLAG}-convex-@R0-@R5,{FLAG}-convex-@R5-@R0
+        [/tile]
+        [tile]
+            pos=3
+            type=!,{TERRAINLIST}
+        [/tile]
+
+        rotations=tr,r,br,bl,l,tl
+    [/terrain_graphics]
+    [terrain_graphics]
+        map="
+,  2
+.,   3
+,  1
+.,   .
+,  ."
+        [tile]
+            pos=1
+            type={TERRAINLIST}
+        [/tile]
+        [tile]
+            pos=2
+            type={ADJACENT}
+            set_no_flag={FLAG}-convex-@R0-@R5
+        [/tile]
+        [tile]
+            pos=3
+            type=!,{TERRAINLIST}
+        [/tile]
+
+        rotations=tr,r,br,bl,l,tl
+    [/terrain_graphics]
+    [terrain_graphics]
+        map="
+,  2
+.,   3
+,  1
+.,   .
+,  ."
+        [tile]
+            pos=1
+            type={TERRAINLIST}
+        [/tile]
+        [tile]
+            pos=2
+            type=!,{TERRAINLIST}
+        [/tile]
+        [tile]
+            pos=3
+            type={ADJACENT}
+            set_no_flag={FLAG}-convex-@R0-@R1
         [/tile]
 
         rotations=tr,r,br,bl,l,tl
@@ -4194,6 +4368,9 @@ no#endarg
 
 #define NEW:WATER_342_180 TERRAINLIST IMAGESTEM FRAMES
 
+#arg LAYER
+-999#endarg
+
 #arg DURATION
 100#endarg
 
@@ -4206,7 +4383,7 @@ no#endarg
             type={TERRAINLIST}
             set_no_flag=base
 
-            {WATER_342_180_TILE_VARIANTS "" -1000 "" {IMAGESTEM} {FRAMES} DURATION={DURATION} RANDOM_START={RANDOM_START}}
+            {WATER_342_180_TILE_VARIANTS "" {LAYER} "" {IMAGESTEM} {FRAMES} DURATION={DURATION} RANDOM_START={RANDOM_START}}
         [/tile]
     [/terrain_graphics]
 #enddef


### PR DESCRIPTION
Fixes #5539
Makes the flood water in Sc8 have a fading overlap on floor terrains, instead of the usual banks and edges.
I think it works based on what I see in the editor, but still need to test in scenario.

I'm not sure if this should be back-ported to BfW 1.14, or maybe it's better to just remove the custom rules and live with the default transitions.