### PR TITLE
Take display zoom into account when rendering unit animation frames

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
    * Added information about the build's (not runtime) target CPU architecture to the game version info dialog and --report.
  ### WML Engine
  ### Miscellaneous and Bug Fixes
+   * Fixed display zoom not being taken into account when using the `x`, `y`, `directional_x` and `directional_y` attributes in unit animations.
 
 ## Version 1.15.9
  ### Add-ons server

--- a/src/units/frame.cpp
+++ b/src/units/frame.cpp
@@ -522,6 +522,7 @@ void unit_frame::redraw(const int frame_time, bool on_start_time, bool in_scope_
 
 	const int x = static_cast<int>(tmp_offset * xdst + (1.0 - tmp_offset) * xsrc) + d2;
 	const int y = static_cast<int>(tmp_offset * ydst + (1.0 - tmp_offset) * ysrc) + d2;
+	const double disp_zoom = display::get_singleton()->get_zoom_factor();
 
 	if(image != nullptr) {
 		bool facing_west = (
@@ -536,19 +537,19 @@ void unit_frame::redraw(const int frame_time, bool on_start_time, bool in_scope_
 		if(!current_data.auto_hflip) { facing_west = false; }
 		if(!current_data.auto_vflip) { facing_north = true; }
 
-		int my_x = x + current_data.x - image->w / 2;
-		int my_y = y + current_data.y - image->h / 2;
+		int my_x = x + current_data.x * disp_zoom - image->w / 2;
+		int my_y = y + current_data.y * disp_zoom - image->h / 2;
 
 		if(facing_west) {
-			my_x -= current_data.directional_x;
+			my_x -= current_data.directional_x * disp_zoom;
 		} else {
-			my_x += current_data.directional_x;
+			my_x += current_data.directional_x * disp_zoom;
 		}
 
 		if(facing_north) {
-			my_y += current_data.directional_y;
+			my_y += current_data.directional_y * disp_zoom;
 		} else {
-			my_y -= current_data.directional_y;
+			my_y -= current_data.directional_y * disp_zoom;
 		}
 
 		display::get_singleton()->render_image(my_x, my_y,
@@ -602,16 +603,16 @@ void unit_frame::redraw(const int frame_time, bool on_start_time, bool in_scope_
 
 	if(direction != map_location::SOUTH_WEST && direction != map_location::NORTH_WEST) {
 		halo_id = halo_man.add(
-			static_cast<int>(x + current_data.halo_x * display::get_singleton()->get_zoom_factor()),
-			static_cast<int>(y + current_data.halo_y * display::get_singleton()->get_zoom_factor()),
+			static_cast<int>(x + current_data.halo_x * disp_zoom),
+			static_cast<int>(y + current_data.halo_y * disp_zoom),
 			current_data.halo  + current_data.halo_mod,
 			map_location(-1, -1),
 			orientation
 		);
 	} else {
 		halo_id = halo_man.add(
-			static_cast<int>(x - current_data.halo_x * display::get_singleton()->get_zoom_factor()),
-			static_cast<int>(y + current_data.halo_y * display::get_singleton()->get_zoom_factor()),
+			static_cast<int>(x - current_data.halo_x * disp_zoom),
+			static_cast<int>(y + current_data.halo_y * disp_zoom),
 			current_data.halo  + current_data.halo_mod,
 			map_location(-1, -1),
 			orientation


### PR DESCRIPTION
**Note:** I have tested the patch against the bug's test case, but I need to go over my own files to see if I can find a more elaborate test case involving progressive parameters.

It was already considered for registering halos, just not for rendering regular frames. This commit touches the halo code a little so we don't need to call get_zoom_factor() multiple times per frame.

Closes #5508.