### PR TITLE
Improve the Load dialog's UX when there are no save files or corrupted files

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,8 @@
  ### Translations
  ### Units
  ### User interface
+   * Improved the Load dialog when there are no saved games for the current version, and also when there are corrupted files.
+   * Re-added the pop-up when there are no saved games at all (issue #5517).
  ### WML Engine
    * Standard Location Filters now support gives_income=yes|no to make it simpler to match villages regardless of owner
  ### Miscellaneous and Bug Fixes

--- a/src/gui/dialogs/game_load.hpp
+++ b/src/gui/dialogs/game_load.hpp
@@ -50,10 +50,7 @@ class game_load : public modal_dialog
 public:
 	game_load(const game_config_view& cache_config, savegame::load_game_metadata& data);
 
-	static bool execute(const game_config_view& cache_config, savegame::load_game_metadata& data)
-	{
-		return game_load(cache_config, data).show();
-	}
+	static bool execute(const game_config_view& cache_config, savegame::load_game_metadata& data);
 
 private:
 	/** Inherited from modal_dialog. */
@@ -72,7 +69,8 @@ private:
 	void delete_button_callback();
 	void handle_dir_select();
 
-	void display_savegame_internal();
+	/** Part of display_savegame that might throw a config::error if the savegame data is corrupt. */
+	void display_savegame_internal(const savegame::save_info& game);
 	void display_savegame();
 	void evaluate_summary_string(std::stringstream& str, const config& cfg_summary);
 


### PR DESCRIPTION
Re-add the popup that appears when "Load" is pressed on the title screen if
there are no files, but now check for files from previous versions too.

Improve handling of switching from a version with files to a version without
files, disabling buttons on the load dialog when there are no files in the
current directory.

This adds a \todo about the error path at the start of evaluate_summary_string,
this path is reached by creating empty files in the save dir. The dialog's state
is reasonable, so it seemed a low priority and I don't want to introduce new
bugs by refactoring this path now.

Fixes #5517 