### PR TITLE
Add [test] to list of tags with add-on id

### DIFF
--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -499,7 +499,8 @@ void game_config_manager::load_addons_cfg()
 				"resource",
 				"multiplayer",
 				"scenario",
-				"campaign"
+				"campaign",
+				"test"
 			};
 
 			// Annotate appropriate addon types with addon_id info.


### PR DESCRIPTION
As of PR #4963, the engine ignores all global tags defined by add-ons that are not active, that is, that are not used in the current game.  Whether an add-on counts as active is determined based on a list of possible tags with add-on ids.  The [test] tag is not included in this list, resulting in test scenarios in add-ons not working any more.