### PR TITLE
Unsubtly warn about subtle problems loading saved games from old versions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
    * Improved the Load dialog when there are no saved games for the current version, and also when there are corrupted files.
    * Re-added the pop-up when there are no saved games at all (issue #5517).
    * Fixed resource leak in the Pango text rendering pipeline when using the characters_per_line constraint.
+   * Make the warning about loading saves from old versions much clearer.
  ### WML Engine
    * Standard Location Filters now support gives_income=yes|no to make it simpler to match villages regardless of owner
  ### Miscellaneous and Bug Fixes

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -257,11 +257,22 @@ bool loadgame::check_version_compatibility(const version_info& save_version)
 
 	if(preferences::confirm_load_save_from_different_version()) {
 		const std::string message
-			= _("This save is from a different version of the game ($version_number|). Do you wish to try to load it?");
+			= _("This save is from a different version of the game ($version_number|), and might not work with this "
+				"version.\n"
+				"\n"
+				"<b>Warning:</b> saves in the middle of campaigns are especially likely to fail, and you should either "
+				"use the old version or restart the campaign. Even when a saved game seems to load successfully, "
+				"subtler aspects like gameplay balance and story progression could be impacted. The difficulty, the "
+				"challenge, the <i>fun</i> may be missing.\n"
+				"\n"
+				"For example, the campaign may have been rebalanced with fewer enemies in the early scenarios, but "
+				"expecting your recall list to have correspondingly less experience in the late scenarios.\n"
+				"\n"
+				"Do you wish to continue?");
 		utils::string_map symbols;
 		symbols["version_number"] = save_version.str();
 		const int res = gui2::show_message(_("Load Game"), utils::interpolate_variables_into_string(message, &symbols),
-			gui2::dialogs::message::yes_no_buttons);
+			gui2::dialogs::message::yes_no_buttons, true);
 		return res == gui2::retval::OK;
 	}
 


### PR DESCRIPTION
This connects to issue #2710, although the main reasoning about it is in #5517.
The difficulty balance isn't the only problem with loading old saved games, but
it's a simple example to explain.

This warning is intended for the change between 1.14 and 1.16, but will be shown
to anyone loading 1.15.x saves into 1.15.y - that's something that they should
expect in a dev branch.