### PR TITLE
Some enhancements to the WML test runner

### DIFF
--- a/doc/man/wesnoth.6
+++ b/doc/man/wesnoth.6
@@ -226,6 +226,9 @@ or
 or
 .BR --plugin .
 .TP
+.B --nobanner
+suppress the startup banner.
+.TP
 .B --nomusic
 runs the game without music.
 .TP

--- a/run_wml_tests
+++ b/run_wml_tests
@@ -34,6 +34,30 @@ class TestCase:
     def __str__(self):
         return "TestCase<{status}, {name}>".format(status=self.status, name=self.name)
 
+class TestResultAccumulator:
+    passed = 0
+    skipped = 0
+    failed = 0
+    crashed = 0
+    
+    def __init__(self, total):
+        self.total = total
+    
+    def pass_test(self, n = 1):
+        self.passed = self.passed + n
+    
+    def skip_test(self, n = 1):
+        self.skipped = self.skipped + n
+    
+    def fail_test(self, n = 1):
+        self.failed = self.failed + n
+    
+    def crash_test(self, n = 1):
+        self.crashed = self.failed + n
+    
+    def __bool_(self):
+        return self.passed + self.skipped == self.total
+
 class TestListParser:
     """Each line in the list of tests should be formatted:
         <expected return code><space><name of unit test scenario>
@@ -63,7 +87,7 @@ class TestListParser:
             if self.verbose > 1:
                 print(t)
             test_list.append(t)
-        return batcher(test_list)
+        return batcher(test_list), TestResultAccumulator(len(test_list))
 
 def run_with_rerun_for_sdl_video(args, timeout):
     """A wrapper for subprocess.run with a workaround for the issue of travis+18.04
@@ -120,7 +144,7 @@ class WesnothRunner:
         if self.verbose > 1:
             print("Options that will be used for all Wesnoth instances:", repr(self.common_args))
 
-    def run_tests(self, test_list):
+    def run_tests(self, test_list, test_summary):
         """Run all of the tests in a single instance of Wesnoth"""
         if len(test_list) == 0:
             raise ValueError("Running an empty test list")
@@ -135,6 +159,7 @@ class WesnothRunner:
             args.append(test.name)
         if self.timeout == 0:
             if test.status == UnitTestResult.TIMEOUT:
+                test_summary.skip_test()
                 print('Skipping test', test_list[0].name, 'because timeout is disabled')
                 return
             timeout = None
@@ -159,6 +184,14 @@ class WesnothRunner:
             print(res.stdout.decode('utf-8'))
             if self.verbose > 1:
                 print("Result:", res.returncode)
+        returned_result = UnitTestResult(res.returncode)
+        num_passed = 0
+        if test_list[0].status == UnitTestResult.PASS:
+            num_passed = res.stdout.count(b"PASS TEST")
+            test_summary.pass_test(num_passed)
+        elif returned_result == expected_result:
+            num_passed = 1
+            test_summary.pass_test()
         if res.returncode < 0:
             print("Wesnoth exited because of signal", -res.returncode)
             if options.backtrace:
@@ -166,12 +199,15 @@ class WesnothRunner:
                 gdb_args = ["gdb", "-q", "-batch", "-ex", "start", "-ex", "continue", "-ex", "bt", "-ex", "quit", "--args"]
                 gdb_args.extend(args)
                 subprocess.run(gdb_args, timeout=240)
+            test_summary.crash_test()
+            test_summary.skip_test(len(test_list) - num_passed - 1)
             raise UnexpectedTestStatusException()
-        returned_result = UnitTestResult(res.returncode)
         if returned_result != expected_result:
             if self.verbose == 0:
                 print(res.stdout.decode('utf-8'))
             print("Failure, Wesnoth returned", returned_result, "but we expected", expected_result)
+            test_summary.fail_test()
+            test_summary.skip_test(len(test_list) - num_passed - 1)
             raise UnexpectedTestStatusException()
 
 def test_batcher(test_list):
@@ -248,15 +284,26 @@ if __name__ == '__main__':
         print(repr(options))
 
     batcher = test_nobatcher if options.batch_disable else test_batcher
-    test_list = TestListParser(options).get(batcher)
+    test_list, test_summary = TestListParser(options).get(batcher)
     runner = WesnothRunner(options)
 
-    a_test_failed = False
     for batch in test_list:
         try:
-            runner.run_tests(batch)
-        except UnexpectedTestStatusException:
-            a_test_failed = True
+            runner.run_tests(batch, test_summary)
+        except UnexpectedTestStatusException as e:
+            pass
 
-    if a_test_failed:
+    print("Result:", test_summary.passed, "of", test_summary.total, "tests passed")
+
+    if test_summary.passed != test_summary.total:
+        breakdown = ["{0} passed".format(test_summary.passed)]
+        if test_summary.failed > 0:
+            breakdown.append("{0} failed".format(test_summary.failed))
+        if test_summary.crashed > 0:
+            breakdown.append("{0} crashed".format(test_summary.crashed))
+        if test_summary.skipped > 0:
+            breakdown.append("{0} skipped".format(test_summary.skipped))
+        print("    ({0})".format(', '.join(breakdown)))
+
+    if not test_summary:
         sys.exit(1)

--- a/run_wml_tests
+++ b/run_wml_tests
@@ -156,7 +156,7 @@ class WesnothRunner:
             print(repr(args))
         try:
             res = run_with_rerun_for_sdl_video(args, timeout)
-        except subprocess.TimeoutExpired as e:
+        except subprocess.TimeoutExpired:
             print("Timed out (killed by Python timeout implementation)")
             res = subprocess.CompletedProcess(args, UnitTestResult.TIMEOUT.value)
         if self.verbose > 1:

--- a/run_wml_tests
+++ b/run_wml_tests
@@ -134,6 +134,9 @@ class WesnothRunner:
             args.append("-u")
             args.append(test.name)
         if self.timeout == 0:
+            if test.status == UnitTestResult.TIMEOUT:
+                print('Skipping test', test_list[0].name, 'because timeout is disabled')
+                return
             timeout = None
         else:
             if len(test_list) == 1:

--- a/run_wml_tests
+++ b/run_wml_tests
@@ -21,6 +21,9 @@ class UnitTestResult(enum.Enum):
     FAIL_WML_EXCEPTION = 6
     FAIL_BY_DEFEAT = 7
     PASS_BY_VICTORY = 8
+    
+    def __str__(self):
+        return str(self.value) + ' ' + self.name
 
 class TestCase:
     """Represents a single line of the wml_test_schedule."""
@@ -166,11 +169,12 @@ class WesnothRunner:
                 gdb_args.extend(args)
                 subprocess.run(gdb_args, timeout=240)
             raise UnexpectedTestStatusException()
-        if res.returncode != expected_result.value:
+        returned_result = UnitTestResult(res.returncode)
+        if returned_result != expected_result:
             with open(get_output_filename(args), "r") as output:
                 for line in output.readlines():
                 	print(line)
-            print("Failure, Wesnoth returned", res.returncode, "but we expected", expected_result.value)
+            print("Failure, Wesnoth returned", returned_result, "but we expected", expected_result)
             raise UnexpectedTestStatusException()
 
 def test_batcher(test_list):

--- a/run_wml_tests
+++ b/run_wml_tests
@@ -288,10 +288,15 @@ if __name__ == '__main__':
     runner = WesnothRunner(options)
 
     for batch in test_list:
-        try:
-            runner.run_tests(batch, test_summary)
-        except UnexpectedTestStatusException as e:
-            pass
+        while len(batch) > 0:
+            last_passed_count = test_summary.passed
+            try:
+                runner.run_tests(batch, test_summary)
+                batch = []
+            except UnexpectedTestStatusException as e:
+                just_passed = test_summary.passed - last_passed_count
+                batch = batch[just_passed + 1 :]
+                test_summary.skip_test(-len(batch))
 
     print("Result:", test_summary.passed, "of", test_summary.total, "tests passed")
 

--- a/run_wml_tests
+++ b/run_wml_tests
@@ -44,7 +44,7 @@ class TestListParser:
         self.verbose = options.verbose
         self.filename = options.list
 
-    def get(self):
+    def get(self, batcher):
         status_name_re = re.compile(r"^(\d+) ([\w-]+)$")
         test_list = []
         for line in open(self.filename, mode="rt"):
@@ -60,7 +60,7 @@ class TestListParser:
             if self.verbose > 1:
                 print(t)
             test_list.append(t)
-        return test_list
+        return batcher(test_list)
 
 def get_output_filename(args):
     for i,arg in enumerate(args):
@@ -186,6 +186,12 @@ def test_batcher(test_list):
     if len(expected_to_pass) > 0:
         yield expected_to_pass
 
+def test_nobatcher(test_list):
+    """A generator function that provides the same API as test_batcher but
+    emits the tests one at a time."""
+    for test in test_list:
+        yield [test]
+
 if __name__ == '__main__':
     ap = argparse.ArgumentParser()
     # The options that are mandatory to support (because they're used in the Travis script)
@@ -232,11 +238,12 @@ if __name__ == '__main__':
     if options.verbose > 1:
         print(repr(options))
 
-    test_list = TestListParser(options).get()
+    batcher = test_nobatcher if options.batch_disable else test_batcher
+    test_list = TestListParser(options).get(batcher)
     runner = WesnothRunner(options)
 
     a_test_failed = False
-    for batch in [test_list] if options.batch_disable else test_batcher(test_list):
+    for batch in test_list:
         try:
             runner.run_tests(batch)
         except UnexpectedTestStatusException:

--- a/run_wml_tests
+++ b/run_wml_tests
@@ -181,8 +181,14 @@ def test_batcher(test_list):
             expected_to_pass.append(test)
         else:
             yield [test]
-    if len(expected_to_pass) > 0:
+    if len(expected_to_pass) == 0:
+        return
+    if options.batch_max == 0:
         yield expected_to_pass
+        return
+    while len(expected_to_pass) > 0:
+        yield expected_to_pass[0:options.batch_max]
+        expected_to_pass = expected_to_pass[options.batch_max:]
 
 def test_nobatcher(test_list):
     """A generator function that provides the same API as test_batcher but
@@ -206,6 +212,8 @@ if __name__ == '__main__':
         help="New timer value to use for batched tests, instead of 300s as default.")
     ap.add_argument("-bd", "--batch-disable", action="store_true",
         help="Disable test batching, may be useful if debugging a small subset of tests.")
+    ap.add_argument("-bm", "--batch-max", type=int, default=0,
+        help="Maximum number of tests to do in a batch. Default no limit.")
     ap.add_argument("-s", "--no-strict", dest="strict_mode", action="store_false",
         help="Disable strict mode. By default, we run wesnoth with the option --log-strict=warning to ensure errors result in a failed test.")
     ap.add_argument("-d", "--debug_bin", action="store_true",

--- a/run_wml_tests
+++ b/run_wml_tests
@@ -65,12 +65,6 @@ class TestListParser:
             test_list.append(t)
         return batcher(test_list)
 
-def get_output_filename(args):
-    for i,arg in enumerate(args):
-        if arg == "-u":
-            return "test-output-"+args[i+1]
-    raise RuntimeError("No -u option found!")
-
 def run_with_rerun_for_sdl_video(args, timeout):
     """A wrapper for subprocess.run with a workaround for the issue of travis+18.04
     intermittently failing to initialise SDL.
@@ -79,14 +73,10 @@ def run_with_rerun_for_sdl_video(args, timeout):
     # be enough.
     sdl_retries = 0
     while sdl_retries < 10:
-        # For compatibility with Ubuntu 16.04 LTS, this has to run on Python3.5,
-        # so the capture_output argument is not available.
-        filename = get_output_filename(args)
-        res = subprocess.run(args, timeout=timeout, stdout=open(filename, "w"), stderr=subprocess.STDOUT)
+        res = subprocess.run(args, timeout=timeout, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         retry = False
-        with open(filename, "r") as output:
-            if "Could not initialize SDL_video" in output.read():
-                retry = True
+        if b"Could not initialize SDL_video" in res.stdout:
+            retry = True
         if not retry:
         	  return res
         sdl_retries += 1
@@ -115,7 +105,10 @@ class WesnothRunner:
         path += "/wesnoth"
         if options.debug_bin:
             path += "-debug"
-        self.common_args = [path]
+        self.common_args = [path, "--nobanner"]
+        if os.name == 'nt':
+            self.common_args.append("--wnoconsole")
+            self.common_args.append("--wnoredirect")
         if options.strict_mode:
             self.common_args.append("--log-strict=warning")
         if options.clean:
@@ -156,11 +149,13 @@ class WesnothRunner:
             print(repr(args))
         try:
             res = run_with_rerun_for_sdl_video(args, timeout)
-        except subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired as t:
             print("Timed out (killed by Python timeout implementation)")
-            res = subprocess.CompletedProcess(args, UnitTestResult.TIMEOUT.value)
-        if self.verbose > 1:
-            print("Result:", res.returncode)
+            res = subprocess.CompletedProcess(args, UnitTestResult.TIMEOUT.value, t.output)
+        if self.verbose > 0:
+            print(res.stdout.decode('utf-8'))
+            if self.verbose > 1:
+                print("Result:", res.returncode)
         if res.returncode < 0:
             print("Wesnoth exited because of signal", -res.returncode)
             if options.backtrace:
@@ -171,9 +166,8 @@ class WesnothRunner:
             raise UnexpectedTestStatusException()
         returned_result = UnitTestResult(res.returncode)
         if returned_result != expected_result:
-            with open(get_output_filename(args), "r") as output:
-                for line in output.readlines():
-                	print(line)
+            if self.verbose == 0:
+                print(res.stdout.decode('utf-8'))
             print("Failure, Wesnoth returned", returned_result, "but we expected", expected_result)
             raise UnexpectedTestStatusException()
 

--- a/run_wml_tests
+++ b/run_wml_tests
@@ -249,10 +249,10 @@ if __name__ == '__main__':
         help="New timer value to use, instead of 10s as default. The value 0 means no timer, and also skips tests that expect timeout.")
     ap.add_argument("-bt", "--batch-timeout", type=int, default=300,
         help="New timer value to use for batched tests, instead of 300s as default.")
-    ap.add_argument("-bd", "--batch-disable", action="store_true",
-        help="Disable test batching, may be useful if debugging a small subset of tests.")
     ap.add_argument("-bm", "--batch-max", type=int, default=0,
         help="Maximum number of tests to do in a batch. Default no limit.")
+    ap.add_argument("-bd", "--batch-disable", action="store_const", const=1, dest='batch_max',
+        help="Disable test batching, may be useful if debugging a small subset of tests. Equivalent to --batch-max=1")
     ap.add_argument("-s", "--no-strict", dest="strict_mode", action="store_false",
         help="Disable strict mode. By default, we run wesnoth with the option --log-strict=warning to ensure errors result in a failed test.")
     ap.add_argument("-d", "--debug_bin", action="store_true",
@@ -283,7 +283,7 @@ if __name__ == '__main__':
     if options.verbose > 1:
         print(repr(options))
 
-    batcher = test_nobatcher if options.batch_disable else test_batcher
+    batcher = test_nobatcher if options.batch_max == 1 else test_batcher
     test_list, test_summary = TestListParser(options).get(batcher)
     runner = WesnothRunner(options)
 

--- a/run_wml_tests
+++ b/run_wml_tests
@@ -109,15 +109,13 @@ def run_with_rerun_for_sdl_video(args, timeout):
 class WesnothRunner:
     def __init__(self, options):
         self.verbose = options.verbose
-        if options.path is None:
-            path = os.path.split(os.path.realpath(sys.argv[0]))[0]
-        elif options.path in ["XCode", "xcode", "Xcode"]:
+        if options.path in ["XCode", "xcode", "Xcode"]:
             import glob
             path_list = []
-            for build in ["Debug", "Release"]:
-                pattern = os.path.join("~/Library/Developer/XCode/DerivedData/Wesnoth*",
-                    build, "Build/Products/Release/Wesnoth.app/Contents/MacOS/")
-                path_list.extend(glob.glob(os.path.expanduser(pattern)))
+            build = "Debug" if options.debug_bin else "Release"
+            pattern = os.path.join("~/Library/Developer/XCode/DerivedData/The_Battle_for_Wesnoth*/Build/Products",
+                build, "The Battle for Wesnoth.app/Contents/MacOS/The Battle for Wesnoth")
+            path_list.extend(glob.glob(os.path.expanduser(pattern)))
             if len(path_list) == 0:
                 raise FileNotFoundError("Couldn't find your xcode build dir")
             if len(path_list) > 1:
@@ -125,10 +123,13 @@ class WesnothRunner:
                 raise RuntimeError("Found more than one xcode build dir")
             path = path_list[0]
         else:
-            path = options.path
-        path += "/wesnoth"
-        if options.debug_bin:
-            path += "-debug"
+            if options.path is None:
+                path = os.path.split(os.path.realpath(sys.argv[0]))[0]
+            else:
+                path = options.path
+            path += "/wesnoth"
+            if options.debug_bin:
+                path += "-debug"
         self.common_args = [path, "--nobanner"]
         if os.name == 'nt':
             self.common_args.append("--wnoconsole")
@@ -260,7 +261,8 @@ if __name__ == '__main__':
     ap.add_argument("-g", "--backtrace", action="store_true",
         help="If we encounter a crash, generate a backtrace using gdb. Must have gdb installed for this option.")
     ap.add_argument("-p", "--path", metavar="dir",
-        help="Path to wesnoth binary. By default assume it is with this script.")
+        help="Path to wesnoth binary. By default assume it is with this script."
+        + " If running on a Mac, passing 'xcode' as the path will attempt to locate the binary in Xcode derived data directories.")
     ap.add_argument("-l", "--list", metavar="filename",
         help="Loads list of tests from the given file.",
     default="wml_test_schedule")

--- a/run_wml_tests
+++ b/run_wml_tests
@@ -180,7 +180,7 @@ class WesnothRunner:
             res = run_with_rerun_for_sdl_video(args, timeout)
         except subprocess.TimeoutExpired as t:
             print("Timed out (killed by Python timeout implementation)")
-            res = subprocess.CompletedProcess(args, UnitTestResult.TIMEOUT.value, t.output)
+            res = subprocess.CompletedProcess(args, UnitTestResult.TIMEOUT.value, t.output or b'')
         if self.verbose > 0:
             print(res.stdout.decode('utf-8'))
             if self.verbose > 1:

--- a/src/commandline_options.cpp
+++ b/src/commandline_options.cpp
@@ -60,6 +60,14 @@ bad_commandline_tuple::bad_commandline_tuple(const std::string& str,
 {
 }
 
+
+#ifdef _WIN32
+#define IMPLY_WCONSOLE " Implies --wconsole."
+#else
+#define IMPLY_WCONSOLE
+#endif // _WIN32
+		 
+
 commandline_options::commandline_options(const std::vector<std::string>& args)
 	: bunzip2()
 	, bzip2()
@@ -173,7 +181,7 @@ commandline_options::commandline_options(const std::vector<std::string>& args)
 		("config-path", "prints the path of the userdata directory and exits. DEPRECATED: use userdata-path instead.")
 		("core", po::value<std::string>(), "overrides the loaded core with the one whose id is specified.")
 		("data-dir", po::value<std::string>(), "overrides the data directory with the one specified.")
-		("data-path", "prints the path of the data directory and exits.")
+		("data-path", "prints the path of the data directory and exits." IMPLY_WCONSOLE)
 		("debug,d", "enables additional command mode options in-game.")
 		("debug-lua", "enables some Lua debugging mechanisms")
 		("strict-lua", "disallow deprecated Lua API calls")
@@ -184,7 +192,7 @@ commandline_options::commandline_options(const std::vector<std::string>& args)
 		("editor,e", po::value<std::string>()->implicit_value(std::string()), "starts the in-game map editor directly. If file <arg> is specified, equivalent to -e --load <arg>.")
 		("gunzip", po::value<std::string>(), "decompresses a file (<arg>.gz) in gzip format and stores it without the .gz suffix. <arg>.gz will be removed.")
 		("gzip", po::value<std::string>(), "compresses a file (<arg>) in gzip format, stores it as <arg>.gz and removes <arg>.")
-		("help,h", "prints this message and exits.")
+		("help,h", "prints this message and exits." IMPLY_WCONSOLE)
 		("language,L", po::value<std::string>(), "uses language <arg> (symbol) this session. Example: --language ang_GB@latin")
 		("load,l", po::value<std::string>(), "loads the save <arg> from the standard save game directory. When launching the map editor via -e, the map <arg> is loaded, relative to the current directory. If it is a directory, the editor will start with a load map dialog opened there.")
 		("noaddons", "disables the loading of all add-ons.")
@@ -194,22 +202,10 @@ commandline_options::commandline_options(const std::vector<std::string>& args)
 		("nosound", "runs the game without sounds and music.")
 		("password", po::value<std::string>(), "uses <password> when connecting to a server, ignoring other preferences.")
 		("plugin", po::value<std::string>(), "(experimental) load a script which defines a wesnoth plugin. similar to --script below, but Lua file should return a function which will be run as a coroutine and periodically woken up with updates.")
-		("render-image", po::value<two_strings>()->multitoken(), "takes two arguments: <image> <output>. Like screenshot, but instead of a map, takes a valid Wesnoth 'image path string' with image path functions, and writes it to a .png file."
-#ifdef _WIN32
-		 " Implies --wconsole."
-#endif // _WIN32
-		 )
-		("report,R", "initializes game directories, prints build information suitable for use in bug reports, and exits."
-#ifdef _WIN32
-		 " Implies --wconsole."
-#endif // _WIN32
-		 )
+		("render-image", po::value<two_strings>()->multitoken(), "takes two arguments: <image> <output>. Like screenshot, but instead of a map, takes a valid Wesnoth 'image path string' with image path functions, and writes it to a .png file." IMPLY_WCONSOLE)
+		("report,R", "initializes game directories, prints build information suitable for use in bug reports, and exits." IMPLY_WCONSOLE)
 		("rng-seed", po::value<unsigned int>(), "seeds the random number generator with number <arg>. Example: --rng-seed 0")
-		("screenshot", po::value<two_strings>()->multitoken(), "takes two arguments: <map> <output>. Saves a screenshot of <map> to <output> without initializing a screen. Editor must be compiled in for this to work."
-#ifdef _WIN32
-		 " Implies --wconsole."
-#endif // _WIN32
-		 )
+		("screenshot", po::value<two_strings>()->multitoken(), "takes two arguments: <map> <output>. Saves a screenshot of <map> to <output> without initializing a screen. Editor must be compiled in for this to work." IMPLY_WCONSOLE)
 		("script", po::value<std::string>(), "(experimental) file containing a Lua script to control the client")
 		("server,s", po::value<std::string>()->implicit_value(std::string()), "connects to the host <arg> if specified or to the first host in your preferences.")
 		("strict-validation", "makes validation errors fatal")
@@ -218,13 +214,15 @@ commandline_options::commandline_options(const std::vector<std::string>& args)
 		("userconfig-dir", po::value<std::string>(), "sets the path of the user config directory to $HOME/<arg> or My Documents\\My Games\\<arg> for Windows. You can specify also an absolute path outside the $HOME or My Documents\\My Games directory. Defaults to $HOME/.config/wesnoth on X11 and to the userdata-dir on other systems.")
 		("userconfig-path", "prints the path of the user config directory and exits.")
 		("userdata-dir", po::value<std::string>(), "sets the path of the userdata directory to $HOME/<arg> or My Documents\\My Games\\<arg> for Windows. You can specify also an absolute path outside the $HOME or My Documents\\My Games directory.")
-		("userdata-path", "prints the path of the userdata directory and exits.")
+		("userdata-path", "prints the path of the userdata directory and exits." IMPLY_WCONSOLE)
 		("username", po::value<std::string>(), "uses <username> when connecting to a server, ignoring other preferences.")
 		("validcache", "assumes that the cache is valid. (dangerous)")
 		("version,v", "prints the game's version number and exits.")
 		("with-replay", "replays the file loaded with the --load option.")
 #ifdef _WIN32
 		("wconsole", "attaches a console window on startup (Windows only). Implied by any option that prints something and exits.")
+		("wnoconsole", "don't attach a console window on startup (Windows only). Overrides options that imply --wconsole.")
+		("wnoredirect", "disables standard redirection of logging to a file (Windows only), allowing the output to be piped to another command")
 #endif // _WIN32
 		;
 
@@ -248,7 +246,7 @@ commandline_options::commandline_options(const std::vector<std::string>& args)
 
 	po::options_description logging_opts("Logging options");
 	logging_opts.add_options()
-		("logdomains", po::value<std::string>()->implicit_value(std::string()), "lists defined log domains (only the ones containing <arg> filter if such is provided) and exits.")
+		("logdomains", po::value<std::string>()->implicit_value(std::string()), "lists defined log domains (only the ones containing <arg> filter if such is provided) and exits." IMPLY_WCONSOLE)
 		("log-error", po::value<std::string>(), "sets the severity level of the specified log domain(s) to 'error'. <arg> should be given as a comma-separated list of domains, wildcards are allowed. Example: --log-error=network,gui/*,engine/enemies")
 		("log-warning", po::value<std::string>(), "sets the severity level of the specified log domain(s) to 'warning'. Similar to --log-error.")
 		("log-info", po::value<std::string>(), "sets the severity level of the specified log domain(s) to 'info'. Similar to --log-error.")
@@ -289,14 +287,14 @@ commandline_options::commandline_options(const std::vector<std::string>& args)
 	po::options_description parsing_opts("WML parsing options");
 	parsing_opts.add_options()
 		("use-schema,S", po::value<std::string>(), "specify a schema to validate WML against (defaults to the core schema)")
-		("validate,V", po::value<std::string>(), "validate a specified WML file against a schema")
+		("validate,V", po::value<std::string>(), "validate a specified WML file against a schema" IMPLY_WCONSOLE)
 		("validate-addon", po::value<std::string>(), "validate the specified addon's WML against the schema. Requires the user to play the campaign (in the GUI) to trigger the validation.")
 		("validate-core", "validate the core WML against the schema")
-		("validate-schema", po::value<std::string>(), "validate a specified WML schema")
-		("diff,D", po::value<two_strings>()->multitoken(), "diff two preprocessed WML documents")
+		("validate-schema", po::value<std::string>(), "validate a specified WML schema" IMPLY_WCONSOLE)
+		("diff,D", po::value<two_strings>()->multitoken(), "diff two preprocessed WML documents" IMPLY_WCONSOLE)
 		("output,o", po::value<std::string>(), "output to specified file")
-		("patch,P", po::value<two_strings>()->multitoken(), "apply a patch to a preprocessed WML document")
-		("preprocess,p", po::value<two_strings>()->multitoken(), "requires two arguments: <file/folder> <target directory>. Preprocesses a specified file/folder. The preprocessed file(s) will be written in the specified target directory: a plain cfg file and a processed cfg file.")
+		("patch,P", po::value<two_strings>()->multitoken(), "apply a patch to a preprocessed WML document" IMPLY_WCONSOLE)
+		("preprocess,p", po::value<two_strings>()->multitoken(), "requires two arguments: <file/folder> <target directory>. Preprocesses a specified file/folder. The preprocessed file(s) will be written in the specified target directory: a plain cfg file and a processed cfg file." IMPLY_WCONSOLE)
 		("preprocess-defines", po::value<std::string>(), "comma separated list of defines to be used by '--preprocess' command. If 'SKIP_CORE' is in the define list the data/core won't be preprocessed. Example: --preprocess-defines=FOO,BAR")
 		("preprocess-input-macros", po::value<std::string>(), "used only by the '--preprocess' command. Specifies source file <arg> that contains [preproc_define]s to be included before preprocessing.")
 		("preprocess-output-macros", po::value<std::string>()->implicit_value(std::string()), "used only by the '--preprocess' command. Will output all preprocessed macros in the target file <arg>. If the file is not specified the output will be file '_MACROS_.cfg' in the target directory of preprocess's command.")

--- a/src/commandline_options.cpp
+++ b/src/commandline_options.cpp
@@ -107,6 +107,7 @@ commandline_options::commandline_options(const std::vector<std::string>& args)
 	, nocache(false)
 	, nodelay(false)
 	, nogui(false)
+	, nobanner(false)
 	, nomusic(false)
 	, nosound(false)
 	, new_widgets(false)
@@ -280,6 +281,7 @@ commandline_options::commandline_options(const std::vector<std::string>& args)
 		("unit,u", po::value<std::vector<std::string>>(), "runs a unit test scenario. The GUI is not shown and the exit code of the program reflects the victory / defeat conditions of the scenario.\n\t0 - PASS\n\t1 - FAIL\n\t3 - FAIL (INVALID REPLAY)\n\t4 - FAIL (ERRORED REPLAY)\n\t5 - FAIL (BROKE STRICT)\n\t6 - FAIL (WML EXCEPTION)\n\tMultiple tests can be run by giving this option multiple times, in this case the test run will stop immediately after any test which doesn't PASS and the return code will be the status of the test that caused the stop.")
 		("showgui", "don't run headlessly (for debugging a failing test)")
 		("log-strict", po::value<std::string>(), "sets the strict level of the logger. any messages sent to log domains of this level or more severe will cause the unit test to fail regardless of the victory result.")
+		("nobanner", "suppress startup banner.")
 		("noreplaycheck", "don't try to validate replay of unit test.")
 		("mp-test", "load the test mp scenarios.")
 		;
@@ -422,6 +424,8 @@ commandline_options::commandline_options(const std::vector<std::string>& args)
 		nosound = true;
 	if (vm.count("nogui"))
 		nogui = true;
+	if (vm.count("nobanner"))
+		nobanner = true;
 	if (vm.count("parm"))
 		multiplayer_parm = parse_to_uint_string_string_tuples_(vm["parm"].as<std::vector<std::string>>());
 	if (vm.count("preprocess"))

--- a/src/commandline_options.hpp
+++ b/src/commandline_options.hpp
@@ -145,6 +145,8 @@ public:
 	bool nodelay;
 	/** True if --nogui was given on the command line. Disables GUI. */
 	bool nogui;
+	/** True if --nobanner was given on the command line. Disables startup banner. */
+	bool nobanner;
 	/** True if --nomusic was given on the command line. Disables music. */
 	bool nomusic;
 	/** True if --nosound was given on the command line. Disables sound. */

--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -261,13 +261,15 @@ game_launcher::game_launcher(const commandline_options& cmdline_opts)
 	if(cmdline_opts_.translation_percent)
 		set_min_translation_percent(*cmdline_opts_.translation_percent);
 
-	std::cerr
-		<< "\nData directory:               " << filesystem::sanitize_path(game_config::path)
-		<< "\nUser configuration directory: " << filesystem::sanitize_path(filesystem::get_user_config_dir())
-		<< "\nUser data directory:          " << filesystem::sanitize_path(filesystem::get_user_data_dir())
-		<< "\nCache directory:              " << filesystem::sanitize_path(filesystem::get_cache_dir())
-		<< '\n';
-	std::cerr << '\n';
+	if(!cmdline_opts.nobanner) {
+		std::cerr
+			<< "\nData directory:               " << filesystem::sanitize_path(game_config::path)
+			<< "\nUser configuration directory: " << filesystem::sanitize_path(filesystem::get_user_config_dir())
+			<< "\nUser data directory:          " << filesystem::sanitize_path(filesystem::get_user_data_dir())
+			<< "\nCache directory:              " << filesystem::sanitize_path(filesystem::get_cache_dir())
+			<< '\n';
+		std::cerr << '\n';
+	}
 
 	// disable sound in nosound mode, or when sound engine failed to initialize
 	if(no_sound || ((preferences::sound_on() || preferences::music_on() ||
@@ -341,7 +343,7 @@ bool game_launcher::init_lua_script()
 {
 	bool error = false;
 
-	std::cerr << "Checking lua scripts... ";
+	if(!cmdline_opts_.nobanner) std::cerr << "Checking lua scripts... ";
 
 	if(cmdline_opts_.script_unsafe_mode) {
 		// load the "package" package, so that scripts can get what packages they want
@@ -421,7 +423,7 @@ bool game_launcher::init_lua_script()
 		}
 	}
 
-	if(!error) {
+	if(!error && !cmdline_opts_.nobanner) {
 		std::cerr << "ok\n";
 	}
 

--- a/src/log_windows.cpp
+++ b/src/log_windows.cpp
@@ -465,12 +465,19 @@ std::string log_file_path()
 	return "";
 }
 
-void early_log_file_setup()
+static bool disable_redirect;
+
+void early_log_file_setup(bool disable)
 {
 	if(lfm) {
 		return;
 	}
 
+	if(disable) {
+		disable_redirect = true;
+		return;
+	}
+	
 	lfm.reset(new log_file_manager());
 }
 
@@ -491,8 +498,9 @@ bool using_own_console()
 
 void finish_log_file_setup()
 {
+	if(disable_redirect) return;
 	// Make sure the LFM is actually set up just in case.
-	early_log_file_setup();
+	early_log_file_setup(false);
 
 	if(lfm->console_enabled()) {
 		// Nothing to do if running in console mode.

--- a/src/log_windows.hpp
+++ b/src/log_windows.hpp
@@ -57,7 +57,7 @@ std::string log_file_path();
  * horribly wrong as soon as we try to use the logging facilities internally
  * for debug messages.
  */
-void early_log_file_setup();
+void early_log_file_setup(bool disable);
 
 /**
  * Relocates the stdout+stderr log file to the user data directory.

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -406,7 +406,7 @@ static int process_command_args(const commandline_options& cmdline_opts)
 		}
 
 		game_config::path = filesystem::normalize_path(game_config::path, true, true);
-		std::cerr << "Overriding data directory with " << game_config::path << std::endl;
+		if(!cmdline_opts.nobanner) std::cerr << "Overriding data directory with " << game_config::path << std::endl;
 
 		if(!filesystem::is_directory(game_config::path)) {
 			std::cerr << "Could not find directory '" << game_config::path << "'\n";
@@ -962,6 +962,15 @@ int main(int argc, char** argv)
 {
 	auto args = read_argv(argc, argv);
 	assert(!args.empty());
+	
+	// --nobanner needs to be detected before the main command-line parsing happens
+	bool nobanner = false;
+	for(const auto& arg : args) {
+		if(arg == "--nobanner") {
+			nobanner = true;
+			break;
+		}
+	}
 
 #ifdef _WIN32
 	// Some switches force a Windows console to be attached to the process even
@@ -1032,9 +1041,11 @@ int main(int argc, char** argv)
 	SDL_StartTextInput();
 
 	try {
-		std::cerr << "Battle for Wesnoth v" << game_config::revision  << " " << game_config::build_arch() << '\n';
-		const std::time_t t = std::time(nullptr);
-		std::cerr << "Started on " << ctime(&t) << "\n";
+		if(!nobanner) {
+			std::cerr << "Battle for Wesnoth v" << game_config::revision  << " " << game_config::build_arch() << '\n';
+			const std::time_t t = std::time(nullptr);
+			std::cerr << "Started on " << ctime(&t) << "\n";
+		}
 
 		const std::string& exe_dir = filesystem::get_exe_dir();
 		if(!exe_dir.empty()) {
@@ -1060,7 +1071,7 @@ int main(int argc, char** argv)
 			}
 
 			if(!auto_dir.empty()) {
-				std::cerr << "Automatically found a possible data directory at " << filesystem::sanitize_path(auto_dir) << '\n';
+				if(!nobanner) std::cerr << "Automatically found a possible data directory at " << filesystem::sanitize_path(auto_dir) << '\n';
 				game_config::path = auto_dir;
 			}
 		}


### PR DESCRIPTION
This is a bunch of updates to the WML test runner that I did while trying to figure out the test failures in #4580. The general motivation is that I was unable to get the output from the test that failed or even identify _which_ test that failed when running on Windows.

The main purpose of this PR is to verify that the runner still works on POSIX systems, but I'm also open to review comments.

* The first commit just fixes the new command-line argument I recently added on master - apparently I forgot to test it and it didn't work, just crashed the runner.
* In order to reduce clutter when displaying test output, I've added a `--nobanner` flag to Wesnoth. This could be probably achieved with `tail` or similar tools on POSIX systems, but that won't work on Wesnoth. The flag suppresses all or most output up to the "Checking lua scripts..." line.
* Showing the numeric test return code is kind of silly, especially when you're using Python enums that know their own name, so now a failed test shows the actual meaning of the return codes (in addition to the number)
* The test runner now uses a pipe instead of a temporary file to capture the output. If you pass `-v` (which previously did nothing), you can see the full output from every test. This avoids cluttering the repository root directory with all the test result files. It doesn't use the `capture_output` parameter that the code comment mentioned because that captures stdout and stderr separately whereas I wanted to capture them merged together.
* The test runner was unable to capture the output from the test on Windows, due to the log redirection, so I've added `--wnoredirect` to Windows builds to disable it. I've also added `--wnoconsole` to disable the automatic console attachment if you're using a flag that normally implies it; I suspect that wasn't actually needed for my purpose but I figure it can't hurt to leave it in.
* The test runner can now limit the size of a test batch. If we ever run into a problem where we have so many tests that the batch times out, we can use this. At the moment, I don't think we have enough tests for it to matter.
* The test runner claimed to skip tests that expect timeout when timeout is disabled, but it didn't actually do so. This is fixed.
* The test runner now prints a summary of tests passed and failed at the end. It also includes a count of tests that crashed (due to a signal) or were skipped (due to expecting timeout when timeout is disabled).
* When told to run multiple tests, the Wesnoth executable exits on the first failure. The test runner now determines which test fails and starts a new batch to continue where it left off.