### PR TITLE
Support [terrain_defaults]'s original subtag names

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@
  ### WML Engine
    * Standard Location Filters now support gives_income=yes|no to make it simpler to match villages regardless of owner
  ### Miscellaneous and Bug Fixes
+   * Added support for 1.14’s tag names in `[terrain_defaults]` (issue #5308).
 
 ## Version 1.15.10
  ### Add-ons server


### PR DESCRIPTION
This is preparation for backporting 0ba433203e, with the idea that both sets
of names will be supported in both branches as part of fixing #5308.

No deprecation messages are added. While config::get_attribute_value() has a
config::get_old_attribute_value(), there isn't currently a similar utility for
config::child(); maybe I should add one now, but it feels too large a change
for a backport.