### PR TITLE
Handle empty children in patch_movetype

### DIFF
--- a/src/units/types.cpp
+++ b/src/units/types.cpp
@@ -885,12 +885,8 @@ void patch_movetype(movetype& mt,
 	config mt_cfg;
 	mt.write(mt_cfg);
 
-	// original_cfg can be blank, if a movetype similar to "none" exists.
-	// "none" is a real movetype defined in units.cfg for units that shouldn't
-	// be able to move.
-	const auto& original_cfg = mt_cfg.child(type_to_patch);
-	if(!replace && original_cfg.has_attribute(new_key)) {
-		// Don't replace if the key already exists in the config (even if empty).
+	if(!replace && mt_cfg.child_or_empty(type_to_patch).has_attribute(new_key)) {
+		// Don't replace if this type already exists in the config
 		return;
 	}
 


### PR DESCRIPTION
In movetype::write, the children might not be created if that child has an
empty config; there might be no child at all for movetypes such as "none". The
movetype "none" is a real movetype defined in units.cfg for units that
shouldn't be able to move.

The original_cfg local variable was only used once anyway, removing it and the
comment made the code clearer.

This wasn't caught in the 1.15 testing, but with 1.14 it resulted in a
"mandatory WML child missing" warning.