### PR TITLE
Adds optional database support to campaignd.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -88,7 +88,7 @@ opts.AddVariables(
     BoolVariable('prereqs','abort if prerequisites cannot be detected',True),
     ('program_suffix', 'suffix to append to names of installed programs',"$version_suffix"),
     ('version_suffix', 'suffix that will be added to default values of prefsdir, program_suffix and datadirname', ""),
-    BoolVariable('forum_user_handler', 'Enable forum user handler in wesnothd', False),
+    BoolVariable('forum_user_handler', 'Enable forum user handler in wesnothd and campaignd', False),
     ('server_gid', 'group id of the user who runs wesnothd', ""),
     ('server_uid', 'user id of the user who runs wesnothd', ""),
     BoolVariable('strict', 'Set to strict compilation', False),

--- a/source_lists/campaignd
+++ b/source_lists/campaignd
@@ -1,6 +1,12 @@
 addon/validation.cpp
+server/common/dbconn.cpp
+server/common/user_handler.cpp
+server/common/forum_user_handler.cpp
 server/common/server_base.cpp
 server/common/simple_wml.cpp
+server/common/resultsets/ban_check.cpp
+server/common/resultsets/tournaments.cpp
+server/common/resultsets/game_history.cpp
 server/campaignd/addon_utils.cpp
 server/campaignd/auth.cpp
 server/campaignd/blacklist.cpp

--- a/src/SConscript
+++ b/src/SConscript
@@ -191,7 +191,10 @@ else:
 
 #---campaignd---
 campaignd_sources = GetSources("campaignd")
-env.WesnothProgram("campaignd", campaignd_sources + libwesnoth_core, have_server_prereqs, OBJPREFIX = "campaignd_")
+if env["forum_user_handler"]:
+    env.WesnothProgram("campaignd", campaignd_sources + libwesnoth_core + libmariadbpp, have_server_prereqs, OBJPREFIX = "campaignd_")
+else:
+    env.WesnothProgram("campaignd", campaignd_sources + libwesnoth_core, have_server_prereqs, OBJPREFIX = "campaignd_")
 
 #---boost_unit_tests---
 test_sources = GetSources("boost_unit_tests")

--- a/src/addon/validation.cpp
+++ b/src/addon/validation.cpp
@@ -542,6 +542,14 @@ std::string addon_check_status_desc(unsigned int code)
 			N_("Version number not greater than the latest uploaded version.")
 		},
 		{
+			ADDON_CHECK_STATUS::BAD_FEEDBACK_TOPIC_ID,
+			N_("Feedback topic id is not a number.")
+		},
+		{
+			ADDON_CHECK_STATUS::FEEDBACK_TOPIC_ID_NOT_FOUND,
+			N_("Feedback topic does not exist.")
+		},
+		{
 			ADDON_CHECK_STATUS::INVALID_UTF8_ATTRIBUTE,
 			N_("The add-on publish information contains an invalid UTF-8 sequence.")
 		},

--- a/src/addon/validation.hpp
+++ b/src/addon/validation.hpp
@@ -60,6 +60,8 @@ enum class ADDON_CHECK_STATUS : unsigned int
 	BAD_TYPE					= 0x207,		/**< Bad add-on type */
 	VERSION_NOT_INCREMENTED		= 0x208,		/**< Version number is not an increment */
 	INVALID_UTF8_ATTRIBUTE		= 0x2FF,		/**< Invalid UTF-8 sequence in add-on metadata */
+	BAD_FEEDBACK_TOPIC_ID       = 0x209,        /**< The provided topic ID for the addon's feedback forum thread is invalid */
+	FEEDBACK_TOPIC_ID_NOT_FOUND = 0x2A0,        /**< The provided topic ID for the addon's feedback forum thread wasn't found in the forum database */
 	//
 	// Server errors
 	//

--- a/src/server/campaignd/server.cpp
+++ b/src/server/campaignd/server.cpp
@@ -1372,6 +1372,21 @@ ADDON_CHECK_STATUS server::validate_addon(const server::request& req, config*& e
 		return ADDON_CHECK_STATUS::UNEXPECTED_DELTA;
 	}
 
+	if(const config& url_params = upload.child("feedback")) {
+		try {
+			int topic_id = std::stoi(url_params["topic_id"].str("0"));
+			if(user_handler_ && topic_id != 0) {
+				if(!user_handler_->db_topic_id_exists(topic_id)) {
+					LOG_CS << "Validation error: feedback topic ID does not exist in forum database\n";
+					return ADDON_CHECK_STATUS::FEEDBACK_TOPIC_ID_NOT_FOUND;
+				}
+			}
+		} catch(...) {
+			LOG_CS << "Validation error: feedback topic ID is not a valid number\n";
+			return ADDON_CHECK_STATUS::BAD_FEEDBACK_TOPIC_ID;
+		}
+	}
+
 	return ADDON_CHECK_STATUS::SUCCESS;
 }
 

--- a/src/server/campaignd/server.cpp
+++ b/src/server/campaignd/server.cpp
@@ -42,6 +42,10 @@
 #include "hash.hpp"
 #include "utils/optimer.hpp"
 
+#ifdef HAVE_MYSQLPP
+#include "server/common/forum_user_handler.hpp"
+#endif
+
 #include <csignal>
 #include <ctime>
 #include <iomanip>
@@ -260,6 +264,7 @@ std::string simple_wml_escape(const std::string& text)
 
 server::server(const std::string& cfg_file, unsigned short port)
 	: server_base(default_campaignd_port, true)
+	, user_handler_(nullptr)
 	, capabilities_(cap_defaults)
 	, addons_()
 	, dirty_addons_()
@@ -451,6 +456,12 @@ void server::load_config()
 	}
 
 	LOG_CS << "Loaded addons metadata. " << addons_.size() << " addons found.\n";
+
+#ifdef HAVE_MYSQLPP
+	if(const config& user_handler = cfg_.child("user_handler")) {
+		user_handler_.reset(new fuh(user_handler));
+	}
+#endif
 }
 
 std::ostream& operator<<(std::ostream& o, const server::request& r)

--- a/src/server/campaignd/server.hpp
+++ b/src/server/campaignd/server.hpp
@@ -19,6 +19,7 @@
 #include "server/campaignd/blacklist.hpp"
 #include "server/common/server_base.hpp"
 #include "server/common/simple_wml.hpp"
+#include "server/common/user_handler.hpp"
 
 #include <boost/asio/basic_waitable_timer.hpp>
 
@@ -95,6 +96,7 @@ public:
 
 private:
 
+	std::unique_ptr<user_handler> user_handler_;
 	typedef std::function<void (server*, const request& req)> request_handler;
 	typedef std::map<std::string, request_handler> request_handlers_table;
 

--- a/src/server/common/dbconn.cpp
+++ b/src/server/common/dbconn.cpp
@@ -34,6 +34,7 @@ dbconn::dbconn(const config& c)
 	, db_game_content_info_table_(c["db_game_content_info_table"].str())
 	, db_user_group_table_(c["db_user_group_table"].str())
 	, db_tournament_query_(c["db_tournament_query"].str())
+	, db_topics_table_(c["db_topics_table"].str())
 {
 	try
 	{
@@ -341,6 +342,19 @@ void dbconn::set_oos_flag(const std::string& uuid, int game_id)
 	catch(const mariadb::exception::base& e)
 	{
 		log_sql_exception("Failed to set the OOS flag for UUID `"+uuid+"` and game ID `"+std::to_string(game_id)+"`", e);
+	}
+}
+
+bool dbconn::topic_id_exists(int topic_id) {
+	try
+	{
+		return exists(connection_, "SELECT 1 FROM `"+db_topics_table_+"` WHERE TOPIC_ID = ?",
+			topic_id);
+	}
+	catch(const mariadb::exception::base& e)
+	{
+		log_sql_exception("Unable to check whether `"+std::to_string(topic_id)+"` exists.", e);
+		return true;
 	}
 }
 

--- a/src/server/common/dbconn.hpp
+++ b/src/server/common/dbconn.hpp
@@ -143,6 +143,11 @@ class dbconn
 		 */
 		void set_oos_flag(const std::string& uuid, int game_id);
 
+		/**
+		 * @see forum_user_handler::db_topic_id_exists().
+		 */
+		bool topic_id_exists(int topic_id);
+
 	private:
 		/**
 		 * The account used to connect to the database.
@@ -169,6 +174,8 @@ class dbconn
 		std::string db_user_group_table_;
 		/** The text of the SQL query to use to retrieve any currently active tournaments. */
 		std::string db_tournament_query_;
+		/** The name of the table that contains phpbb forum thread information */
+		std::string db_topics_table_;
 
 		/**
 		 * This is used to write out error text when an SQL-related exception occurs.

--- a/src/server/common/dbconn.hpp
+++ b/src/server/common/dbconn.hpp
@@ -148,6 +148,11 @@ class dbconn
 		 */
 		bool topic_id_exists(int topic_id);
 
+		/**
+		 * @see forum_user_handler::db_insert_addon_info().
+		 */
+		void insert_addon_info(const std::string& instance_version, const std::string& id, const std::string& name, const std::string& type, const std::string& version, bool forum_auth, int topic_id);
+
 	private:
 		/**
 		 * The account used to connect to the database.
@@ -176,6 +181,8 @@ class dbconn
 		std::string db_tournament_query_;
 		/** The name of the table that contains phpbb forum thread information */
 		std::string db_topics_table_;
+		/** The name of the table that contains add-on information. */
+		std::string db_addon_info_table_;
 
 		/**
 		 * This is used to write out error text when an SQL-related exception occurs.

--- a/src/server/common/forum_user_handler.cpp
+++ b/src/server/common/forum_user_handler.cpp
@@ -247,4 +247,8 @@ bool fuh::db_topic_id_exists(int topic_id) {
 	return conn_.topic_id_exists(topic_id);
 }
 
+void fuh::db_insert_addon_info(const std::string& instance_version, const std::string& id, const std::string& name, const std::string& type, const std::string& version, bool forum_auth, int topic_id) {
+	conn_.insert_addon_info(instance_version, id, name, type, version, forum_auth, topic_id);
+}
+
 #endif //HAVE_MYSQLPP

--- a/src/server/common/forum_user_handler.cpp
+++ b/src/server/common/forum_user_handler.cpp
@@ -243,4 +243,8 @@ void fuh::async_test_query(boost::asio::io_service& io_service, int limit) {
 	 });
 }
 
+bool fuh::db_topic_id_exists(int topic_id) {
+	return conn_.topic_id_exists(topic_id);
+}
+
 #endif //HAVE_MYSQLPP

--- a/src/server/common/forum_user_handler.hpp
+++ b/src/server/common/forum_user_handler.hpp
@@ -200,6 +200,14 @@ public:
 	 */
 	void async_test_query(boost::asio::io_service& io_service, int limit);
 
+	/**
+	 * Checks whether a forum thread with @a topic_id exists.
+	 * 
+	 * @param topic_id The topic id to check for.
+	 * @return True if the thread exists or there was a database failure, false if the topic wasn't found.
+	 */
+	bool db_topic_id_exists(int topic_id);
+
 private:
 	/** An instance of the class responsible for executing the queries and handling the database connection. */
 	dbconn conn_;

--- a/src/server/common/forum_user_handler.hpp
+++ b/src/server/common/forum_user_handler.hpp
@@ -208,6 +208,19 @@ public:
 	 */
 	bool db_topic_id_exists(int topic_id);
 
+	/**
+	 * Inserts information about an uploaded add-on into the database.
+	 * 
+	 * @param instance_version The version of campaignd the add-on was uploaded to.
+	 * @param id The add-on's ID (aka directory name).
+	 * @param name The add-on's name from the pbl.
+	 * @param type The add-on's type from the pbl.
+	 * @param version The add-on's version from the pbl.
+	 * @param forum_auth Whether the provided author and password should be matched a forum account or not.
+	 * @param topic_id The forum topic ID of the add-on's feedback thread, 0 if not present.
+	 */
+	void db_insert_addon_info(const std::string& instance_version, const std::string& id, const std::string& name, const std::string& type, const std::string& version, bool forum_auth, int topic_id);
+
 private:
 	/** An instance of the class responsible for executing the queries and handling the database connection. */
 	dbconn conn_;

--- a/src/server/common/user_handler.hpp
+++ b/src/server/common/user_handler.hpp
@@ -143,4 +143,5 @@ public:
 	virtual void db_set_oos_flag(const std::string& uuid, int game_id) = 0;
 	virtual void async_test_query(boost::asio::io_service& io_service, int limit) = 0;
 	virtual bool db_topic_id_exists(int topic_id) = 0;
+	virtual void db_insert_addon_info(const std::string& instance_version, const std::string& id, const std::string& name, const std::string& type, const std::string& version, bool forum_auth, int topic_id) = 0;
 };

--- a/src/server/common/user_handler.hpp
+++ b/src/server/common/user_handler.hpp
@@ -142,4 +142,5 @@ public:
 	virtual void db_insert_game_content_info(const std::string& uuid, int game_id, const std::string& type, const std::string& name, const std::string& id, const std::string& source, const std::string& version) = 0;
 	virtual void db_set_oos_flag(const std::string& uuid, int game_id) = 0;
 	virtual void async_test_query(boost::asio::io_service& io_service, int limit) = 0;
+	virtual bool db_topic_id_exists(int topic_id) = 0;
 };

--- a/utils/mp-server/table_definitions.sql
+++ b/utils/mp-server/table_definitions.sql
@@ -123,3 +123,25 @@ create table game_content_info
     VERSION           VARCHAR(255) NOT NULL,
     PRIMARY KEY (INSTANCE_UUID, GAME_ID, TYPE, ID)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- information about an uploaded addon
+-- INSTANCE_VERSION: the version of the addons server instance
+-- ADDON_ID: the ID of the addon (folder name)
+-- ADDON_NAME: the name of the addon
+-- TYPE: the type of the addon
+-- VERSION: the version of the addon
+-- FORUM_AUTH: whether forum authentication is to be used when uploading
+-- UPLOADED_ON: when the addon was uploaded
+-- FEEDBACK_TOPIC: the forum topic ID where feedback for the addon can be posted, 0 if not set
+create table addon_info
+(
+    INSTANCE_VERSION VARCHAR(255) NOT NULL,
+    ADDON_ID         VARCHAR(255) NOT NULL,
+    ADDON_NAME       VARCHAR(255) NOT NULL,
+    TYPE             VARCHAR(255) NOT NULL,
+    VERSION          VARCHAR(255) NOT NULL,
+    FORUM_AUTH       BIT(1) NOT NULL,
+    UPLOADED_ON      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FEEDBACK_TOPIC   INT UNSIGNED NOT NULL,
+    PRIMARY KEY (INSTANCE_VERSION, ADDON_ID, VERSION)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/utils/mp-server/table_definitions.sql
+++ b/utils/mp-server/table_definitions.sql
@@ -18,6 +18,13 @@
 --     PRIMARY KEY (USER_ID, GROUP_ID)
 -- ) ENGINE=InnoDB;
 
+-- a minimal topics table, if not using a phpbb3 installation
+-- create table topics
+-- (
+--     TOPIC_ID MEDIUMINT(8) UNSIGNED NOT NULL AUTO_INCREMENT,
+--     PRIMARY KEY (TOPIC_ID)
+-- ) ENGINE=InnoDB;
+
 -- table which the forum inserts bans into, which wesnothd checks during login
 -- create table ban
 -- (


### PR DESCRIPTION
Also uses that support to insert data into the new "addon_info" table when an add-on is uploaded as well as adds validation of the topic_id to ensure it's a valid int before inserting.

One use case for this would be to be able to check how many people are using outdated add-ons when playing online multiplayer on the primary official server.  Others would be to let players know when they create/join a game with an outdated version of one or more add-ons that will be used as well as adding a way to open an add-on's feedback thread in their browser from the current game they are playing.

Addresses #5060
Addresses #5061

---

Implementing #5065 would be dependent on whenever #5567 is merged, since doesn't make sense to implement client-side hashing only to soon remove it when TLS support is added.