### PR TITLE
Remove strong trait from Elvish Lady trait pool.

### DIFF
--- a/data/core/units/elves/Lady.cfg
+++ b/data/core/units/elves/Lady.cfg
@@ -8,6 +8,11 @@
     small_profile="portraits/elves/lady.png~CROP(0,20,380,380)"
     profile="portraits/elves/lady.png"
     hitpoints=47
+    ignore_race_traits=yes
+    {TRAIT_QUICK}
+    {TRAIT_INTELLIGENT}
+    {TRAIT_RESILIENT}
+    {TRAIT_DEXTROUS}
     movement_type=woodland
     movement=6
     experience=150


### PR DESCRIPTION
She is a cutscene unit but has no melee attack. Inheriting the _strong_ trait would not benefit her in anyway.

This does not impact anything in particular but looks rather odd when you view the in-game help. Thus, I have fixed it.
![Screenshot 2021-03-11 044516](https://user-images.githubusercontent.com/5283677/110754972-9e616e00-8272-11eb-9b39-48362765b325.png)
