### PR TITLE
Rendering only the visible area in text_shape

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
  ### WML Engine
    * Modify implementation of overwrite_specials attribute for replace yes/no parameter by none/one_side/both_sides and select abilities used like weapons and specials who must be overwrited(owned by fighter where special applied or both)
  ### Miscellaneous and Bug Fixes
+   * More optimizations in the UI drawing code, these shouldn't have visible effects (PR #5681).
    * Made GUI.pyw compatible with Python 3.9 (issue #5719).
    * Removed workarounds for bugs affecting older SDL 2.0 versions, including an extra copy of the game screen made during gamemap scrolling (PR #5736).
 

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@
    * Modify implementation of overwrite_specials attribute for replace yes/no parameter by none/one_side/both_sides and select abilities used like weapons and specials who must be overwrited(owned by fighter where special applied or both)
  ### Miscellaneous and Bug Fixes
    * More optimizations in the UI drawing code, these shouldn't have visible effects (PR #5681).
+   * Further optimised rendering text, fixes the crash displaying the full credits (issue #5043).
    * Made GUI.pyw compatible with Python 3.9 (issue #5719).
    * Removed workarounds for bugs affecting older SDL 2.0 versions, including an extra copy of the game screen made during gamemap scrolling (PR #5736).
 

--- a/src/font/text.hpp
+++ b/src/font/text.hpp
@@ -83,8 +83,20 @@ public:
 	/**
 	 * Returns the rendered text.
 	 *
-	 * Before rendering it tests whether a redraw is needed and if so it first
-	 * redraws the surface before returning it.
+	 * @param viewport Only this area needs to be drawn - the returned
+	 * surface's origin will correspond to viewport.x and viewport.y, the
+	 * width and height will be at least viewport.w and viewport.h (although
+	 * they may be larger).
+	 */
+	surface& render(const SDL_Rect& viewport);
+
+	/**
+	 * Equivalent to render(viewport), where the viewport's top-left is at
+	 * (0,0) and the area is large enough to contain the full text.
+	 *
+	 * The top-left of the viewport will be at (0,0), regardless of the values
+	 * of x and y.  If the x or y co-ordinates are non-zero, then x columns and
+	 * y rows of blank space are included in the amount of memory allocated.
 	 */
 	surface& render();
 
@@ -362,15 +374,17 @@ private:
 	/** The dirty state of the surface. */
 	mutable bool surface_dirty_;
 
+	/** The area that's cached in surface_, which is the area that was rendered when surface_dirty_ was last set to false. */
+	SDL_Rect rendered_viewport_;
+
 	/**
 	 * Renders the text.
 	 *
 	 * It will do a recalculation first so no need to call both.
 	 */
-	void rerender();
+	void rerender(const SDL_Rect& viewport);
 
-	void render(PangoLayout& layout, const PangoRectangle& rect,
-		const std::size_t surface_buffer_offset, const unsigned stride);
+	void render(PangoLayout& layout, const SDL_Rect& viewport, const unsigned stride);
 
 	/**
 	 * Buffer to store the image on.

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -738,20 +738,16 @@ void text_shape::draw(surface& canvas,
 		return;
 	}
 
-	// TODO: This creates a surface that's the full text_width x text_height, and then discards most of it by
-	// calling blit_surface(... , &rects.clip_in_shape, ..., ...). Should be improved with a change to pango_text,
-	// so that we can call text_renderer.render(rects.clip_in_shape) and get a smaller surface instead.
-	surface& surf = text_renderer.render();
+	surface& surf = text_renderer.render(rects.clip_in_shape);
 	if(surf->w == 0) {
 		DBG_GUI_D << "Text: Rendering '" << text
 				  << "' resulted in an empty canvas, leave.\n";
 		return;
 	}
 
-	// Blit the clipped region - this needs non-const copies of the rects
-	auto clip_in_shape = rects.clip_in_shape;
+	// Blit the clipped region - this needs a non-const copy of the rect
 	auto dst_in_viewport = rects.dst_in_viewport;
-	blit_surface(surf, &clip_in_shape, canvas, &dst_in_viewport);
+	blit_surface(surf, nullptr, canvas, &dst_in_viewport);
 }
 
 /***** ***** ***** ***** ***** CANVAS ***** ***** ***** ***** *****/


### PR DESCRIPTION
Merge #5681's canvas viewport support with #5682's pango_text viewport support. Both of those seemed large enough to split into their own PRs, this is the small change that needs both together; if the canvas PR merges first then I could roll this into the pango_text PR.

Fixes #5043.