### PR TITLE
font: Work around chromatic aberration issue with Windows ClearType

### DIFF
--- a/src/font/text.cpp
+++ b/src/font/text.cpp
@@ -81,7 +81,9 @@ pango_text::pango_text()
 	cairo_font_options_t *fo = cairo_font_options_create();
 	cairo_font_options_set_hint_style(fo, CAIRO_HINT_STYLE_FULL);
 	cairo_font_options_set_hint_metrics(fo, CAIRO_HINT_METRICS_ON);
-	cairo_font_options_set_antialias(fo, CAIRO_ANTIALIAS_DEFAULT);
+	// Always use grayscale AA, particularly on Windows where ClearType subpixel hinting
+	// will result in colour fringing otherwise. See from_cairo_format() further below.
+	cairo_font_options_set_antialias(fo, CAIRO_ANTIALIAS_GRAY);
 
 	pango_cairo_context_set_font_options(context_.get(), fo);
 	cairo_font_options_destroy(fo);
@@ -633,6 +635,17 @@ static void from_cairo_format(uint32_t & c)
 	unpremultiply(r, div);
 	unpremultiply(g, div);
 	unpremultiply(b, div);
+
+#ifdef _WIN32
+	// Grayscale AA with ClearType results in wispy unreadable text because of gamma issues
+	// that would normally be solved by rendering directly onto the destination surface without
+	// alpha blending. However, since the current game engine design would never allow us to do
+	// that, we work around that by increasing alpha at the expense of AA accuracy (which is
+	// not particularly noticeable if you don't know what you're looking for anyway).
+	if(a < 255) {
+		a = std::clamp<unsigned>(unsigned(a) * 1.75, 0, 255);
+	}
+#endif
 
 	c = (static_cast<uint32_t>(a) << 24) | (static_cast<uint32_t>(r) << 16) | (static_cast<uint32_t>(g) << 8) | static_cast<uint32_t>(b);
 }


### PR DESCRIPTION
There's a long-standing issue with our usage of Cairo/ClearType on Windows that creates very noticeable chromatic aberration of rendered text (see the visual reference below) due to Wesnoth not respecting the industry recommendation of not using subpixel hinting when rendering text on transparent surfaces -- the latter being quite unfortunately something we always do because `pango_text` only generates transparent surfaces and most of the time has its output blitted onto more transparent surfaces.

This patch disables subpixel hinting, causing Cairo to render wispy text because of gamma issues when not rendering text directly onto an opaque surface. However, it also makes the implementation of pango_text overblend all transparent pixels to compensate like it was previously done before the revert in commit c91b200b7a10bf82fb13417a1267fcdf0fc4b2c1. This version uses alpha blending directly instead of forcing Pango to overdraw the entire text layout, however.

Overblending by 75% seems good enough for our purposes.

(Requesting @Vultraz's review since like all `pango_text`-related changes this is very much a UI related change and he's the current UI maintainer.)

## Visual reference

**Before:**

![pango-text-default-1](https://user-images.githubusercontent.com/489895/111112342-c38a0100-853e-11eb-98b6-a64f1300f832.png)
![pango-text-default-2](https://user-images.githubusercontent.com/489895/111112356-c97fe200-853e-11eb-9842-2dd95b8b873a.png)

**After (175% alpha):**

![pango-text-corrected-175-1](https://user-images.githubusercontent.com/489895/111216572-582e4680-85b3-11eb-8b80-4da38fa777c4.png)
![pango-text-corrected-175-2](https://user-images.githubusercontent.com/489895/111216604-62504500-85b3-11eb-9896-d795fe52ae66.png)

**After (300% alpha):**

![pango-text-corrected-1](https://user-images.githubusercontent.com/489895/111112570-2380a780-853f-11eb-8091-7c2fe837b76b.png)
![pango-text-corrected-2](https://user-images.githubusercontent.com/489895/111112745-72c6d800-853f-11eb-9805-1f53c0fed9ca.png)
