### PR TITLE
EI: minor fixes for S1 and S2

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/01_The_Outpost.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/01_The_Outpost.cfg
@@ -212,6 +212,7 @@
                 description= _ "Defend the outpost"
                 condition=win
             [/objective]
+            {ALTERNATIVE_OBJECTIVE_BONUS ( _ "Defeat all enemy leaders")}
             [objective]
                 description= _ "Death of Gweddry"
                 condition=lose
@@ -221,7 +222,6 @@
                 condition=lose
             [/objective]
             [gold_carryover]
-                bonus=yes
                 carryover_percentage=40
             [/gold_carryover]
         [/objectives]

--- a/data/campaigns/Eastern_Invasion/scenarios/01_The_Outpost.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/01_The_Outpost.cfg
@@ -37,7 +37,7 @@
             # The River Guard posts had been built in 470 YW. They were
             # abandoned in 544 YW; the wave of colonization had begun around
             # 530 YW.
-            story= _ "In the days of the king Garard I, two strong-points had been built along the near bank of the Weldyn, south of Soradoc, to stop bandits and orcish raiders out of the Estmarks from entering Wesnoth. But in later years the River Guard posts had been abandoned, as colonists spread into the Estmarks and the orcs were driven in retreat north of the Great River."
+            story= _ "In the days of King Garard I, two strong-points had been built along the near bank of the Weldyn, south of Soradoc, to stop bandits and orcish raiders out of the Estmarks from entering Wesnoth. But in later years the River Guard posts had been abandoned, as colonists spread into the Estmarks and the orcs were driven in retreat north of the Great River."
             {EI_BIGMAP}
         [/part]
         [part]

--- a/data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg
@@ -311,7 +311,7 @@
 
         [message]
             speaker=Gweddry
-            message= _ "We are soldiers of the king of Wesnoth. Will you help us fight these trolls?"
+            message= _ "We are soldiers of the King of Wesnoth. Will you help us fight these trolls?"
         [/message]
 
         [message]

--- a/data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg
@@ -197,6 +197,20 @@
             message= _ "This is an old escape route for the outpost. Unfortunately these caves are currently inhabited by trolls, who are blocking our path through the tunnel."
         [/message]
 
+        # Lift shroud around the amulet
+        [scroll_to]
+            x,y=12,2
+        [/scroll_to]
+        [remove_shroud]
+            side=1
+            x,y=12,2
+            radius=1
+        [/remove_shroud]
+        [delay]
+            time=750
+        [/delay]
+
+        # Path leading through the troll cave
         [scroll_to]
             x,y=15,7
         [/scroll_to]


### PR DESCRIPTION
EI S1: Update objectives to reflect when an early finish bonus is given.

EI S1, S2: Fix typos

EI S2: Lift shroud (but not fog) around the amulet. Gives the player a hint to
explore around the amulet, despite the objectives saying "Get moving quickly",
which discourages that in the first playthrough. This might also prevent
players interpreting the revealed path directly through the trolls as the
suggested path through the level. By putting one of the dots in an obvious
dead-end, it's less of a surprise that the path shown by the other dots leads
to getting trapped between trolls and undead.

Part of #4145