### PR TITLE
Add a prompt to allow entering an add-on's password at upload time.

### DIFF
--- a/data/gui/window/addon_auth.cfg
+++ b/data/gui/window/addon_auth.cfg
@@ -1,0 +1,150 @@
+#textdomain wesnoth-lib
+###
+### Definition of the window to provide authentication information when uploading an add-on
+###
+
+[window]
+	id = "addon_auth"
+	description =_  "Add-on upload authentication dialog"
+
+	[resolution]
+		definition = "default"
+
+		automatic_placement = true
+		vertical_placement = "center"
+		horizontal_placement = "center"
+
+		maximum_width = 800
+
+		[tooltip]
+			id = "tooltip"
+		[/tooltip]
+
+		[helptip]
+			id = "tooltip"
+		[/helptip]
+
+		[grid]
+
+			[row]
+				grow_factor = 0
+
+				[column]
+					grow_factor = 1
+
+					border = "all"
+					border_size = 5
+					horizontal_alignment = "left"
+					[label]
+						definition = "title"
+
+						label = _ "Authenticate"
+					[/label]
+
+				[/column]
+
+			[/row]
+
+			[row]
+				grow_factor = 1
+
+				[column]
+					grow_factor = 1
+
+					horizontal_grow = true
+
+					[grid]
+
+						[row]
+							grow_factor = 1
+
+							[column]
+								grow_factor = 0
+
+								border = "all"
+								border_size = 5
+								horizontal_alignment = "left"
+
+								[label]
+									definition = "default"
+
+									label = _ "Password:"
+								[/label]
+
+							[/column]
+
+							[column]
+								grow_factor = 1
+
+								border = "all"
+								border_size = 5
+								horizontal_alignment = "right"
+
+								[password_box]
+									id = "password"
+									definition = "default"
+								[/password_box]
+
+							[/column]
+
+						[/row]
+
+					[/grid]
+
+				[/column]
+
+			[/row]
+
+			[row]
+				grow_factor = 0
+
+				[column]
+					grow_factor = 0
+					horizontal_alignment = "right"
+
+					[grid]
+
+						[row]
+							grow_factor = 0
+
+							[column]
+								border = "all"
+								border_size = 5
+								horizontal_alignment = "right"
+
+								[button]
+									id = "ok"
+									definition = "default"
+
+									label = _ "OK"
+								[/button]
+
+							[/column]
+
+							[column]
+								border = "all"
+								border_size = 5
+								horizontal_alignment = "right"
+
+								[button]
+									id = "cancel"
+									definition = "default"
+
+									label = _ "Cancel"
+								[/button]
+
+							[/column]
+
+						[/row]
+
+					[/grid]
+
+				[/column]
+
+			[/row]
+
+		[/grid]
+
+	[/resolution]
+
+[/window]

--- a/projectfiles/VC16/wesnoth.vcxproj
+++ b/projectfiles/VC16/wesnoth.vcxproj
@@ -1442,6 +1442,13 @@
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Debug|x64'">$(IntDir)Gui\Core\Window_Builder\</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Release|x64'">$(IntDir)Gui\Core\Window_Builder\</ObjectFileName>
     </ClCompile>
+    <ClCompile Include="..\..\src\gui\dialogs\addon\addon_auth.cpp">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)Gui\Dialogs\Addon\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='ReleaseDEBUG|x64'">$(IntDir)Gui\Dialogs\Addon\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)Gui\Dialogs\Addon\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Debug|x64'">$(IntDir)Gui\Dialogs\Addon\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Test_Release|x64'">$(IntDir)Gui\Dialogs\Addon\</ObjectFileName>
+    </ClCompile>
     <ClCompile Include="..\..\src\gui\dialogs\addon\connect.cpp">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)Gui\Dialogs\Addon\</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='ReleaseDEBUG|x64'">$(IntDir)Gui\Dialogs\Addon\</ObjectFileName>
@@ -3783,6 +3790,7 @@
     <ClInclude Include="..\..\src\gui\core\window_builder.hpp" />
     <ClInclude Include="..\..\src\gui\core\window_builder\helper.hpp" />
     <ClInclude Include="..\..\src\gui\core\window_builder\instance.hpp" />
+    <ClInclude Include="..\..\src\gui\dialogs\addon\addon_auth.hpp" />
     <ClInclude Include="..\..\src\gui\dialogs\addon\connect.hpp" />
     <ClInclude Include="..\..\src\gui\dialogs\addon\install_dependencies.hpp" />
     <ClInclude Include="..\..\src\gui\dialogs\addon\license_prompt.hpp" />

--- a/projectfiles/VC16/wesnoth.vcxproj.filters
+++ b/projectfiles/VC16/wesnoth.vcxproj.filters
@@ -698,6 +698,9 @@
     <ClCompile Include="..\..\src\gui\dialogs\wml_message.cpp">
       <Filter>Gui\Dialogs</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\gui\dialogs\addon\addon_auth.cpp">
+      <Filter>Gui\Dialogs\Addon</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\gui\dialogs\addon\connect.cpp">
       <Filter>Gui\Dialogs\Addon</Filter>
     </ClCompile>
@@ -2141,6 +2144,9 @@
     <ClInclude Include="..\..\src\gui\dialogs\wml_message.hpp">
       <Filter>Gui\Dialogs</Filter>
     </ClInclude>
+    <ClCompile Include="..\..\gui\dialogs\addon\addon_auth.hpp">
+      <Filter>Gui\Dialogs\Addon</Filter>
+    </ClCompile>
     <ClInclude Include="..\..\src\gui\dialogs\addon\connect.hpp">
       <Filter>Gui\Dialogs\Addon</Filter>
     </ClInclude>

--- a/source_lists/wesnoth
+++ b/source_lists/wesnoth
@@ -162,6 +162,7 @@ gui/core/widget_definition.cpp
 gui/core/window_builder.cpp
 gui/core/window_builder/helper.cpp
 gui/core/window_builder/instance.cpp
+gui/dialogs/addon/addon_auth.cpp
 gui/dialogs/addon/connect.cpp
 gui/dialogs/addon/install_dependencies.cpp
 gui/dialogs/addon/license_prompt.cpp

--- a/src/gui/dialogs/addon/addon_auth.cpp
+++ b/src/gui/dialogs/addon/addon_auth.cpp
@@ -1,0 +1,48 @@
+/*
+	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY.
+
+	See the COPYING file for more details.
+*/
+
+#define GETTEXT_DOMAIN "wesnoth-lib"
+
+#include <functional>
+
+#include "gui/dialogs/addon/addon_auth.hpp"
+
+#include "gui/auxiliary/find_widget.hpp"
+#include "gui/widgets/password_box.hpp"
+#include "gui/widgets/window.hpp"
+
+namespace gui2::dialogs
+{
+
+REGISTER_DIALOG(addon_auth)
+
+addon_auth::addon_auth(config& cfg)
+	: cfg_(cfg)
+{
+	
+}
+
+void addon_auth::pre_show(window& win)
+{
+	win.add_to_tab_order(find_widget<password_box>(&win, "password", false, true));
+}
+
+void addon_auth::post_show(window& win)
+{
+	if(get_retval() == gui2::retval::OK)
+	{
+		cfg_["passphrase"] = find_widget<password_box>(&win, "password", false).get_real_value();
+	}
+}
+
+} // namespace dialogs

--- a/src/gui/dialogs/addon/addon_auth.hpp
+++ b/src/gui/dialogs/addon/addon_auth.hpp
@@ -1,0 +1,50 @@
+/*
+	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY.
+
+	See the COPYING file for more details.
+*/
+
+#pragma once
+
+#include "gui/dialogs/modal_dialog.hpp"
+
+namespace gui2::dialogs
+{
+
+/**
+ * @ingroup GUIWindowDefinitionWML
+ *
+ * This shows the dialog to provide a password when uploading an add-on.
+ * 
+ * Key               |Type           |Mandatory|Description
+ * ------------------|---------------|---------|-----------
+ * password          | text_box      |yes      |The password used to verify the uploader.
+ */
+class addon_auth : public modal_dialog
+{
+public:
+	addon_auth(config& cfg_);
+
+	DEFINE_SIMPLE_EXECUTE_WRAPPER(addon_auth)
+
+private:
+	/** Inherited from modal_dialog, implemented by REGISTER_DIALOG. */
+	virtual const std::string& window_id() const override;
+
+	/** Inherited from modal_dialog. */
+	virtual void pre_show(window& window) override;
+
+	/** Inherited from modal_dialog. */
+	virtual void post_show(window& window) override;
+
+	config& cfg_;
+};
+
+} // namespace gui2::dialogs

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -28,6 +28,7 @@
 #include "gui/auxiliary/filter.hpp"
 #include "gui/auxiliary/find_widget.hpp"
 #include "gui/dialogs/addon/license_prompt.hpp"
+#include "gui/dialogs/addon/addon_auth.hpp"
 #include "gui/dialogs/message.hpp"
 #include "gui/dialogs/transient_message.hpp"
 #include "gui/widgets/button.hpp"
@@ -734,6 +735,13 @@ void addon_manager::publish_addon(const addon_info& addon)
 			gui2::dialogs::message::yes_no_buttons);
 
 		if(res != gui2::retval::OK) {
+			return;
+		}
+	}
+
+	// the passphrase isn't provided, prompt for it
+	if(cfg["passphrase"].empty()) {
+		if(!gui2::dialogs::addon_auth::execute(cfg)) {
 			return;
 		}
 	}

--- a/src/tests/gui/test_gui2.cpp
+++ b/src/tests/gui/test_gui2.cpp
@@ -31,6 +31,7 @@
 #include "generators/map_create.hpp"
 #include "gettext.hpp"
 #include "gui/core/layout_exception.hpp"
+#include "gui/dialogs/addon/addon_auth.hpp"
 #include "gui/dialogs/addon/connect.hpp"
 #include "gui/dialogs/addon/install_dependencies.hpp"
 #include "gui/dialogs/addon/license_prompt.hpp"
@@ -413,6 +414,7 @@ BOOST_AUTO_TEST_CASE(test_gui2)
 	/**** Run the tests. *****/
 
 	/* The modal_dialog classes. */
+	test<addon_auth>();
 	test<addon_connect>();
 	test<addon_license_prompt>();
 	//test<addon_manager>();
@@ -568,6 +570,16 @@ BOOST_AUTO_TEST_CASE(test_make_test_fake)
 }
 
 namespace {
+
+template<>
+struct dialog_tester<addon_auth>
+{
+	config cfg;
+	addon_auth* create()
+	{
+		return new addon_auth(cfg);
+	}
+};
 
 template<>
 struct dialog_tester<addon_connect>


### PR DESCRIPTION
This is an alternative to needing to store the plaintext password in the _server.pbl.