### PR TITLE
EI S7a S10 S11: Minor fixes

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/07a_The_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/07a_The_Crossing.cfg
@@ -136,9 +136,13 @@
             id=Owaec
         [/recall]
 
-        [hide_unit]
-            id=Garnad
-        [/hide_unit]
+        [store_unit]
+            [filter]
+                id=Garnad
+            [/filter]
+            kill=yes
+            variable=saved_Garnad
+        [/store_unit]
 
         [message]
             speaker=Gweddry
@@ -180,9 +184,11 @@
             type=Bone Knight
         [/move_unit_fake]
 
-        [unhide_unit]
-            id=Garnad
-        [/unhide_unit]
+        [unstore_unit]
+            variable=saved_Garnad
+            x,y=36,29
+        [/unstore_unit]
+        {CLEAR_VARIABLE saved_Garnad}
 
         [terrain]
             x,y=36,29

--- a/data/campaigns/Eastern_Invasion/scenarios/10_Lake_Vrug.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/10_Lake_Vrug.cfg
@@ -168,6 +168,7 @@
         [fire_event]
             name=movement_warning
         [/fire_event]
+        [allow_undo][/allow_undo]
     [/event]
 
     [event]

--- a/data/campaigns/Eastern_Invasion/scenarios/10_Lake_Vrug.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/10_Lake_Vrug.cfg
@@ -29,7 +29,8 @@
         controller=human
         team_name=good
         user_team_name=_"Wesnothians"
-        shroud=yes
+        shroud=no
+        fog=yes
         {GOLD 300 260 220}
         {FLAG_VARIANT loyalist}
     [/side]
@@ -157,6 +158,11 @@
             speaker=Gweddry
             message= _ "Very well, we will take care of the trolls and gryphons. Search the library and may you find us an answer. Onward!"
         [/message]
+        {HIGHLIGHT_IMAGE 12 4 items/gohere.png ()}
+        [label]
+            x,y=12,4
+            text = _ "The stronghold"
+        [/label]
     [/event]
 
     #give the player a hint about mountainous terrain

--- a/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
@@ -1110,12 +1110,13 @@
         [objectives]
             side=1
             [objective]
-                description= _ "Gweddry reaches the western exit"
+                description= _ "Move Gweddry to the western exit"
                 condition=win
             [/objective]
             [objective]
                 description= _ "Retrieve the stolen gold"
                 condition=win
+                {BONUS_OBJECTIVE_CAPTION}
                 [show_if]
                     [variable]
                         name=stored_player_gold
@@ -1126,6 +1127,7 @@
             [objective]
                 description= _ "Release the remaining prisoners"
                 condition=win
+                {BONUS_OBJECTIVE_CAPTION}
                 [show_if]
                     [have_unit]
                         side=3


### PR DESCRIPTION
S7a: Improve how side 2 makes its entrance. Don't use [hide_unit], that's not what it's for.

EI S10: Make recall undoable: this event shows a warning about recalled units having low / no movement through mountainous terrain.

EI S10: Switch shroud to fog. The scenario was otherwise generally unwinnable on the first attempt. Although the extra turns in added in ab900b0093503809d91fc9c48ead19e388b63fe7 help with that, it's still worth changing to fog instead of shroud.

EI S11: Annotate bonus objectives as such.

Part of #4145.