### PR TITLE
Rename functions managing special weapons to improve readability for engine devellopper

### DIFF
--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -143,14 +143,14 @@ battle_context_unit_stats::battle_context_unit_stats(nonempty_unit_const_ptr up,
 		opp_ctx.emplace(opp_weapon->specials_context(oppp, up, opp_loc, u_loc, !attacking, weapon));
 	}
 
-	slows = weapon->has_special_and_abilities("slow");
-	drains = !opp.get_state("undrainable") && weapon->has_special_and_abilities("drains");
-	petrifies = weapon->has_special_and_abilities("petrifies");
-	poisons = !opp.get_state("unpoisonable") && weapon->has_special_and_abilities("poison") && !opp.get_state(unit::STATE_POISONED);
+	slows = weapon->has_special_or_abilities("slow");
+	drains = !opp.get_state("undrainable") && weapon->has_special_or_abilities("drains");
+	petrifies = weapon->has_special_or_abilities("petrifies");
+	poisons = !opp.get_state("unpoisonable") && weapon->has_special_or_abilities("poison") && !opp.get_state(unit::STATE_POISONED);
 	backstab_pos = is_attacker && backstab_check(u_loc, opp_loc, units, resources::gameboard->teams());
 	rounds = weapon->get_specials_and_abilities("berserk").highest("value", 1).first;
 
-	firststrike = weapon->has_special_and_abilities("firststrike");
+	firststrike = weapon->has_special_or_abilities("firststrike");
 
 	{
 		const int distance = distance_between(u_loc, opp_loc);

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -155,11 +155,11 @@ battle_context_unit_stats::battle_context_unit_stats(nonempty_unit_const_ptr up,
 	{
 		const int distance = distance_between(u_loc, opp_loc);
 		const bool out_of_range = distance > weapon->max_range() || distance < weapon->min_range();
-		disable = weapon->get_special_bool_old("disable") || out_of_range;
+		disable = weapon->get_special_bool_without_abilities("disable") || out_of_range;
 	}
 
 	// Handle plague.
-	unit_ability_list plague_specials = weapon->get_specials_old("plague");
+	unit_ability_list plague_specials = weapon->get_specials_without_abilities("plague");
 	unit_ability_list alt_plague_specials = weapon->get_specials("plague");
 	if(!alt_plague_specials.empty() && plague_specials.empty()){
 		plague_specials = alt_plague_specials;
@@ -305,15 +305,15 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 		opp_ctx.emplace(opp_weapon->specials_context(*opp_type, map_location::null_location(), !attacking));
 	}
 
-	slows = weapon->get_special_bool_old("slow");
-	drains = !opp_type->musthave_status("undrainable") && weapon->get_special_bool_old("drains");
-	petrifies = weapon->get_special_bool_old("petrifies");
-	poisons = !opp_type->musthave_status("unpoisonable") && weapon->get_special_bool_old("poison");
-	rounds = weapon->get_specials_old("berserk").highest("value", 1).first;
-	firststrike = weapon->get_special_bool_old("firststrike");
-	disable = weapon->get_special_bool_old("disable");
+	slows = weapon->get_special_bool_without_abilities("slow");
+	drains = !opp_type->musthave_status("undrainable") && weapon->get_special_bool_without_abilities("drains");
+	petrifies = weapon->get_special_bool_without_abilities("petrifies");
+	poisons = !opp_type->musthave_status("unpoisonable") && weapon->get_special_bool_without_abilities("poison");
+	rounds = weapon->get_specials_without_abilities("berserk").highest("value", 1).first;
+	firststrike = weapon->get_special_bool_without_abilities("firststrike");
+	disable = weapon->get_special_bool_without_abilities("disable");
 
-	unit_ability_list plague_specials = weapon->get_specials_old("plague");
+	unit_ability_list plague_specials = weapon->get_specials_without_abilities("plague");
 	plagues = !opp_type->musthave_status("unplagueable") && !plague_specials.empty() &&
 		opp_type->undead_variation() != "null";
 
@@ -327,7 +327,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 	signed int cth = 100 - opp_terrain_defense + weapon->accuracy() - (opp_weapon ? opp_weapon->parry() : 0);
 	cth = std::clamp(cth, 0, 100);
 
-	unit_ability_list cth_specials = weapon->get_specials_old("chance_to_hit");
+	unit_ability_list cth_specials = weapon->get_specials_without_abilities("chance_to_hit");
 	unit_abilities::effect cth_effects(cth_specials, cth, backstab_pos, weapon);
 	cth = cth_effects.get_composite_value();
 
@@ -343,7 +343,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 	slow_damage = round_damage(base_damage, damage_multiplier, 20000);
 
 	if(drains) {
-		unit_ability_list drain_specials = weapon->get_specials_old("drains");
+		unit_ability_list drain_specials = weapon->get_specials_without_abilities("drains");
 
 		// Compute the drain percent (with 50% as the base for backward compatibility)
 		unit_abilities::effect drain_percent_effects(drain_specials, 50, backstab_pos, weapon);
@@ -351,7 +351,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 	}
 
 	// Add heal_on_hit (the drain constant)
-	unit_ability_list heal_on_hit_specials = weapon->get_specials_old("heal_on_hit");
+	unit_ability_list heal_on_hit_specials = weapon->get_specials_without_abilities("heal_on_hit");
 	unit_abilities::effect heal_on_hit_effects(heal_on_hit_specials, 0, backstab_pos, weapon);
 	drain_constant += heal_on_hit_effects.get_composite_value();
 

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -155,11 +155,11 @@ battle_context_unit_stats::battle_context_unit_stats(nonempty_unit_const_ptr up,
 	{
 		const int distance = distance_between(u_loc, opp_loc);
 		const bool out_of_range = distance > weapon->max_range() || distance < weapon->min_range();
-		disable = weapon->get_special_bool_without_abilities("disable") || out_of_range;
+		disable = weapon->get_special_bool("disable") || out_of_range;
 	}
 
 	// Handle plague.
-	unit_ability_list plague_specials = weapon->get_specials_without_abilities("plague");
+	unit_ability_list plague_specials = weapon->get_specials("plague", false);
 	unit_ability_list alt_plague_specials = weapon->get_specials("plague");
 	if(!alt_plague_specials.empty() && plague_specials.empty()){
 		plague_specials = alt_plague_specials;
@@ -305,15 +305,15 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 		opp_ctx.emplace(opp_weapon->specials_context(*opp_type, map_location::null_location(), !attacking));
 	}
 
-	slows = weapon->get_special_bool_without_abilities("slow");
-	drains = !opp_type->musthave_status("undrainable") && weapon->get_special_bool_without_abilities("drains");
-	petrifies = weapon->get_special_bool_without_abilities("petrifies");
-	poisons = !opp_type->musthave_status("unpoisonable") && weapon->get_special_bool_without_abilities("poison");
-	rounds = weapon->get_specials_without_abilities("berserk").highest("value", 1).first;
-	firststrike = weapon->get_special_bool_without_abilities("firststrike");
-	disable = weapon->get_special_bool_without_abilities("disable");
+	slows = weapon->get_special_bool("slow");
+	drains = !opp_type->musthave_status("undrainable") && weapon->get_special_bool("drains");
+	petrifies = weapon->get_special_bool("petrifies");
+	poisons = !opp_type->musthave_status("unpoisonable") && weapon->get_special_bool("poison");
+	rounds = weapon->get_specials("berserk").highest("value", 1).first;
+	firststrike = weapon->get_special_bool("firststrike");
+	disable = weapon->get_special_bool("disable");
 
-	unit_ability_list plague_specials = weapon->get_specials_without_abilities("plague");
+	unit_ability_list plague_specials = weapon->get_specials("plague", false);
 	plagues = !opp_type->musthave_status("unplagueable") && !plague_specials.empty() &&
 		opp_type->undead_variation() != "null";
 
@@ -327,7 +327,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 	signed int cth = 100 - opp_terrain_defense + weapon->accuracy() - (opp_weapon ? opp_weapon->parry() : 0);
 	cth = std::clamp(cth, 0, 100);
 
-	unit_ability_list cth_specials = weapon->get_specials_without_abilities("chance_to_hit");
+	unit_ability_list cth_specials = weapon->get_specials("chance_to_hit");
 	unit_abilities::effect cth_effects(cth_specials, cth, backstab_pos, weapon);
 	cth = cth_effects.get_composite_value();
 
@@ -343,7 +343,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 	slow_damage = round_damage(base_damage, damage_multiplier, 20000);
 
 	if(drains) {
-		unit_ability_list drain_specials = weapon->get_specials_without_abilities("drains");
+		unit_ability_list drain_specials = weapon->get_specials("drains");
 
 		// Compute the drain percent (with 50% as the base for backward compatibility)
 		unit_abilities::effect drain_percent_effects(drain_specials, 50, backstab_pos, weapon);
@@ -351,7 +351,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 	}
 
 	// Add heal_on_hit (the drain constant)
-	unit_ability_list heal_on_hit_specials = weapon->get_specials_without_abilities("heal_on_hit");
+	unit_ability_list heal_on_hit_specials = weapon->get_specials("heal_on_hit");
 	unit_abilities::effect heal_on_hit_effects(heal_on_hit_specials, 0, backstab_pos, weapon);
 	drain_constant += heal_on_hit_effects.get_composite_value();
 

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -143,14 +143,14 @@ battle_context_unit_stats::battle_context_unit_stats(nonempty_unit_const_ptr up,
 		opp_ctx.emplace(opp_weapon->specials_context(oppp, up, opp_loc, u_loc, !attacking, weapon));
 	}
 
-	slows = weapon->get_special_bool("slow");
-	drains = !opp.get_state("undrainable") && weapon->get_special_bool("drains");
-	petrifies = weapon->get_special_bool("petrifies");
-	poisons = !opp.get_state("unpoisonable") && weapon->get_special_bool("poison") && !opp.get_state(unit::STATE_POISONED);
+	slows = weapon->get_special_and_abilities_bool("slow");
+	drains = !opp.get_state("undrainable") && weapon->get_special_and_abilities_bool("drains");
+	petrifies = weapon->get_special_and_abilities_bool("petrifies");
+	poisons = !opp.get_state("unpoisonable") && weapon->get_special_and_abilities_bool("poison") && !opp.get_state(unit::STATE_POISONED);
 	backstab_pos = is_attacker && backstab_check(u_loc, opp_loc, units, resources::gameboard->teams());
-	rounds = weapon->get_specials("berserk").highest("value", 1).first;
+	rounds = weapon->get_specials_and_abilities("berserk").highest("value", 1).first;
 
-	firststrike = weapon->get_special_bool("firststrike");
+	firststrike = weapon->get_special_and_abilities_bool("firststrike");
 
 	{
 		const int distance = distance_between(u_loc, opp_loc);
@@ -159,8 +159,8 @@ battle_context_unit_stats::battle_context_unit_stats(nonempty_unit_const_ptr up,
 	}
 
 	// Handle plague.
-	unit_ability_list plague_specials = weapon->get_specials("plague", false);
-	unit_ability_list alt_plague_specials = weapon->get_specials("plague");
+	unit_ability_list plague_specials = weapon->get_specials("plague");
+	unit_ability_list alt_plague_specials = weapon->get_specials_and_abilities("plague");
 	if(!alt_plague_specials.empty() && plague_specials.empty()){
 		plague_specials = alt_plague_specials;
 	}
@@ -181,7 +181,7 @@ battle_context_unit_stats::battle_context_unit_stats(nonempty_unit_const_ptr up,
 
 	cth = std::clamp(cth, 0, 100);
 
-	unit_ability_list cth_specials = weapon->get_specials("chance_to_hit");
+	unit_ability_list cth_specials = weapon->get_specials_and_abilities("chance_to_hit");
 	unit_abilities::effect cth_effects(cth_specials, cth, backstab_pos, weapon);
 	cth = cth_effects.get_composite_value();
 
@@ -221,14 +221,14 @@ battle_context_unit_stats::battle_context_unit_stats(nonempty_unit_const_ptr up,
 
 	// Compute drain amounts only if draining is possible.
 	if(drains) {
-		unit_ability_list drain_specials = weapon->get_specials("drains");
+		unit_ability_list drain_specials = weapon->get_specials_and_abilities("drains");
 		// Compute the drain percent (with 50% as the base for backward compatibility)
 		unit_abilities::effect drain_percent_effects(drain_specials, 50, backstab_pos, weapon);
 		drain_percent = drain_percent_effects.get_composite_value();
 	}
 
 	// Add heal_on_hit (the drain constant)
-	unit_ability_list heal_on_hit_specials = weapon->get_specials("heal_on_hit");
+	unit_ability_list heal_on_hit_specials = weapon->get_specials_and_abilities("heal_on_hit");
 	unit_abilities::effect heal_on_hit_effects(heal_on_hit_specials, 0, backstab_pos, weapon);
 	drain_constant += heal_on_hit_effects.get_composite_value();
 
@@ -308,12 +308,12 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 	slows = weapon->get_special_bool("slow");
 	drains = !opp_type->musthave_status("undrainable") && weapon->get_special_bool("drains");
 	petrifies = weapon->get_special_bool("petrifies");
-	poisons = !opp_type->musthave_status("unpoisonable") && weapon->get_special_bool("poison");
+	poisons = !opp_type->musthave_status("unpoisonable") && weapon->get_special_and_abilities_bool("poison");
 	rounds = weapon->get_specials("berserk").highest("value", 1).first;
 	firststrike = weapon->get_special_bool("firststrike");
 	disable = weapon->get_special_bool("disable");
 
-	unit_ability_list plague_specials = weapon->get_specials("plague", false);
+	unit_ability_list plague_specials = weapon->get_specials("plague");
 	plagues = !opp_type->musthave_status("unplagueable") && !plague_specials.empty() &&
 		opp_type->undead_variation() != "null";
 

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -308,7 +308,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 	slows = weapon->get_special_bool("slow");
 	drains = !opp_type->musthave_status("undrainable") && weapon->get_special_bool("drains");
 	petrifies = weapon->get_special_bool("petrifies");
-	poisons = !opp_type->musthave_status("unpoisonable") && weapon->get_special_and_abilities_bool("poison");
+	poisons = !opp_type->musthave_status("unpoisonable") && weapon->get_special_bool("poison");
 	rounds = weapon->get_specials("berserk").highest("value", 1).first;
 	firststrike = weapon->get_special_bool("firststrike");
 	disable = weapon->get_special_bool("disable");

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -143,24 +143,24 @@ battle_context_unit_stats::battle_context_unit_stats(nonempty_unit_const_ptr up,
 		opp_ctx.emplace(opp_weapon->specials_context(oppp, up, opp_loc, u_loc, !attacking, weapon));
 	}
 
-	slows = weapon->bool_ability("slow");
-	drains = !opp.get_state("undrainable") && weapon->bool_ability("drains");
-	petrifies = weapon->bool_ability("petrifies");
-	poisons = !opp.get_state("unpoisonable") && weapon->bool_ability("poison") && !opp.get_state(unit::STATE_POISONED);
+	slows = weapon->get_special_bool("slow");
+	drains = !opp.get_state("undrainable") && weapon->get_special_bool("drains");
+	petrifies = weapon->get_special_bool("petrifies");
+	poisons = !opp.get_state("unpoisonable") && weapon->get_special_bool("poison") && !opp.get_state(unit::STATE_POISONED);
 	backstab_pos = is_attacker && backstab_check(u_loc, opp_loc, units, resources::gameboard->teams());
-	rounds = weapon->get_special_ability("berserk").highest("value", 1).first;
+	rounds = weapon->get_specials("berserk").highest("value", 1).first;
 
-	firststrike = weapon->bool_ability("firststrike");
+	firststrike = weapon->get_special_bool("firststrike");
 
 	{
 		const int distance = distance_between(u_loc, opp_loc);
 		const bool out_of_range = distance > weapon->max_range() || distance < weapon->min_range();
-		disable = weapon->get_special_bool("disable") || out_of_range;
+		disable = weapon->get_special_bool_old("disable") || out_of_range;
 	}
 
 	// Handle plague.
-	unit_ability_list plague_specials = weapon->get_specials("plague");
-	unit_ability_list alt_plague_specials = weapon->get_special_ability("plague");
+	unit_ability_list plague_specials = weapon->get_specials_old("plague");
+	unit_ability_list alt_plague_specials = weapon->get_specials("plague");
 	if(!alt_plague_specials.empty() && plague_specials.empty()){
 		plague_specials = alt_plague_specials;
 	}
@@ -181,7 +181,7 @@ battle_context_unit_stats::battle_context_unit_stats(nonempty_unit_const_ptr up,
 
 	cth = std::clamp(cth, 0, 100);
 
-	unit_ability_list cth_specials = weapon->get_special_ability("chance_to_hit");
+	unit_ability_list cth_specials = weapon->get_specials("chance_to_hit");
 	unit_abilities::effect cth_effects(cth_specials, cth, backstab_pos, weapon);
 	cth = cth_effects.get_composite_value();
 
@@ -221,14 +221,14 @@ battle_context_unit_stats::battle_context_unit_stats(nonempty_unit_const_ptr up,
 
 	// Compute drain amounts only if draining is possible.
 	if(drains) {
-		unit_ability_list drain_specials = weapon->get_special_ability("drains");
+		unit_ability_list drain_specials = weapon->get_specials("drains");
 		// Compute the drain percent (with 50% as the base for backward compatibility)
 		unit_abilities::effect drain_percent_effects(drain_specials, 50, backstab_pos, weapon);
 		drain_percent = drain_percent_effects.get_composite_value();
 	}
 
 	// Add heal_on_hit (the drain constant)
-	unit_ability_list heal_on_hit_specials = weapon->get_special_ability("heal_on_hit");
+	unit_ability_list heal_on_hit_specials = weapon->get_specials("heal_on_hit");
 	unit_abilities::effect heal_on_hit_effects(heal_on_hit_specials, 0, backstab_pos, weapon);
 	drain_constant += heal_on_hit_effects.get_composite_value();
 
@@ -305,15 +305,15 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 		opp_ctx.emplace(opp_weapon->specials_context(*opp_type, map_location::null_location(), !attacking));
 	}
 
-	slows = weapon->get_special_bool("slow");
-	drains = !opp_type->musthave_status("undrainable") && weapon->get_special_bool("drains");
-	petrifies = weapon->get_special_bool("petrifies");
-	poisons = !opp_type->musthave_status("unpoisonable") && weapon->get_special_bool("poison");
-	rounds = weapon->get_specials("berserk").highest("value", 1).first;
-	firststrike = weapon->get_special_bool("firststrike");
-	disable = weapon->get_special_bool("disable");
+	slows = weapon->get_special_bool_old("slow");
+	drains = !opp_type->musthave_status("undrainable") && weapon->get_special_bool_old("drains");
+	petrifies = weapon->get_special_bool_old("petrifies");
+	poisons = !opp_type->musthave_status("unpoisonable") && weapon->get_special_bool_old("poison");
+	rounds = weapon->get_specials_old("berserk").highest("value", 1).first;
+	firststrike = weapon->get_special_bool_old("firststrike");
+	disable = weapon->get_special_bool_old("disable");
 
-	unit_ability_list plague_specials = weapon->get_specials("plague");
+	unit_ability_list plague_specials = weapon->get_specials_old("plague");
 	plagues = !opp_type->musthave_status("unplagueable") && !plague_specials.empty() &&
 		opp_type->undead_variation() != "null";
 
@@ -327,7 +327,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 	signed int cth = 100 - opp_terrain_defense + weapon->accuracy() - (opp_weapon ? opp_weapon->parry() : 0);
 	cth = std::clamp(cth, 0, 100);
 
-	unit_ability_list cth_specials = weapon->get_specials("chance_to_hit");
+	unit_ability_list cth_specials = weapon->get_specials_old("chance_to_hit");
 	unit_abilities::effect cth_effects(cth_specials, cth, backstab_pos, weapon);
 	cth = cth_effects.get_composite_value();
 
@@ -343,7 +343,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 	slow_damage = round_damage(base_damage, damage_multiplier, 20000);
 
 	if(drains) {
-		unit_ability_list drain_specials = weapon->get_specials("drains");
+		unit_ability_list drain_specials = weapon->get_specials_old("drains");
 
 		// Compute the drain percent (with 50% as the base for backward compatibility)
 		unit_abilities::effect drain_percent_effects(drain_specials, 50, backstab_pos, weapon);
@@ -351,7 +351,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 	}
 
 	// Add heal_on_hit (the drain constant)
-	unit_ability_list heal_on_hit_specials = weapon->get_specials("heal_on_hit");
+	unit_ability_list heal_on_hit_specials = weapon->get_specials_old("heal_on_hit");
 	unit_abilities::effect heal_on_hit_effects(heal_on_hit_specials, 0, backstab_pos, weapon);
 	drain_constant += heal_on_hit_effects.get_composite_value();
 

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -143,19 +143,19 @@ battle_context_unit_stats::battle_context_unit_stats(nonempty_unit_const_ptr up,
 		opp_ctx.emplace(opp_weapon->specials_context(oppp, up, opp_loc, u_loc, !attacking, weapon));
 	}
 
-	slows = weapon->get_special_and_abilities_bool("slow");
-	drains = !opp.get_state("undrainable") && weapon->get_special_and_abilities_bool("drains");
-	petrifies = weapon->get_special_and_abilities_bool("petrifies");
-	poisons = !opp.get_state("unpoisonable") && weapon->get_special_and_abilities_bool("poison") && !opp.get_state(unit::STATE_POISONED);
+	slows = weapon->has_special_and_abilities("slow");
+	drains = !opp.get_state("undrainable") && weapon->has_special_and_abilities("drains");
+	petrifies = weapon->has_special_and_abilities("petrifies");
+	poisons = !opp.get_state("unpoisonable") && weapon->has_special_and_abilities("poison") && !opp.get_state(unit::STATE_POISONED);
 	backstab_pos = is_attacker && backstab_check(u_loc, opp_loc, units, resources::gameboard->teams());
 	rounds = weapon->get_specials_and_abilities("berserk").highest("value", 1).first;
 
-	firststrike = weapon->get_special_and_abilities_bool("firststrike");
+	firststrike = weapon->has_special_and_abilities("firststrike");
 
 	{
 		const int distance = distance_between(u_loc, opp_loc);
 		const bool out_of_range = distance > weapon->max_range() || distance < weapon->min_range();
-		disable = weapon->get_special_bool("disable") || out_of_range;
+		disable = weapon->has_special("disable") || out_of_range;
 	}
 
 	// Handle plague.
@@ -305,13 +305,13 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 		opp_ctx.emplace(opp_weapon->specials_context(*opp_type, map_location::null_location(), !attacking));
 	}
 
-	slows = weapon->get_special_bool("slow");
-	drains = !opp_type->musthave_status("undrainable") && weapon->get_special_bool("drains");
-	petrifies = weapon->get_special_bool("petrifies");
-	poisons = !opp_type->musthave_status("unpoisonable") && weapon->get_special_bool("poison");
+	slows = weapon->has_special("slow");
+	drains = !opp_type->musthave_status("undrainable") && weapon->has_special("drains");
+	petrifies = weapon->has_special("petrifies");
+	poisons = !opp_type->musthave_status("unpoisonable") && weapon->has_special("poison");
 	rounds = weapon->get_specials("berserk").highest("value", 1).first;
-	firststrike = weapon->get_special_bool("firststrike");
-	disable = weapon->get_special_bool("disable");
+	firststrike = weapon->has_special("firststrike");
+	disable = weapon->has_special("disable");
 
 	unit_ability_list plague_specials = weapon->get_specials("plague");
 	plagues = !opp_type->musthave_status("unplagueable") && !plague_specials.empty() &&

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -143,14 +143,14 @@ battle_context_unit_stats::battle_context_unit_stats(nonempty_unit_const_ptr up,
 		opp_ctx.emplace(opp_weapon->specials_context(oppp, up, opp_loc, u_loc, !attacking, weapon));
 	}
 
-	slows = weapon->has_special_or_abilities("slow");
-	drains = !opp.get_state("undrainable") && weapon->has_special_or_abilities("drains");
-	petrifies = weapon->has_special_or_abilities("petrifies");
-	poisons = !opp.get_state("unpoisonable") && weapon->has_special_or_abilities("poison") && !opp.get_state(unit::STATE_POISONED);
+	slows = weapon->has_special_or_ability("slow");
+	drains = !opp.get_state("undrainable") && weapon->has_special_or_ability("drains");
+	petrifies = weapon->has_special_or_ability("petrifies");
+	poisons = !opp.get_state("unpoisonable") && weapon->has_special_or_ability("poison") && !opp.get_state(unit::STATE_POISONED);
 	backstab_pos = is_attacker && backstab_check(u_loc, opp_loc, units, resources::gameboard->teams());
 	rounds = weapon->get_specials_and_abilities("berserk").highest("value", 1).first;
 
-	firststrike = weapon->has_special_or_abilities("firststrike");
+	firststrike = weapon->has_special_or_ability("firststrike");
 
 	{
 		const int distance = distance_between(u_loc, opp_loc);

--- a/src/ai/default/aspect_attacks.cpp
+++ b/src/ai/default/aspect_attacks.cpp
@@ -168,11 +168,11 @@ void aspect_attacks_base::do_attack_analysis(const map_location& loc,
 		bool backstab = false, slow = false;
 		for(const attack_type& a : unit_itor->attacks()) {
 			// For speed, just assume these specials will be active if they are present.
-			if(a.get_special_bool_old("backstab", true)) {
+			if(a.get_special_bool_without_abilities("backstab", true)) {
 				backstab = true;
 			}
 
-			if(a.get_special_bool_old("slow", true)) {
+			if(a.get_special_bool_without_abilities("slow", true)) {
 				slow = true;
 			}
 		}

--- a/src/ai/default/aspect_attacks.cpp
+++ b/src/ai/default/aspect_attacks.cpp
@@ -168,11 +168,11 @@ void aspect_attacks_base::do_attack_analysis(const map_location& loc,
 		bool backstab = false, slow = false;
 		for(const attack_type& a : unit_itor->attacks()) {
 			// For speed, just assume these specials will be active if they are present.
-			if(a.get_special_bool("backstab", true)) {
+			if(a.has_special("backstab", true)) {
 				backstab = true;
 			}
 
-			if(a.get_special_bool("slow", true)) {
+			if(a.has_special("slow", true)) {
 				slow = true;
 			}
 		}

--- a/src/ai/default/aspect_attacks.cpp
+++ b/src/ai/default/aspect_attacks.cpp
@@ -168,11 +168,11 @@ void aspect_attacks_base::do_attack_analysis(const map_location& loc,
 		bool backstab = false, slow = false;
 		for(const attack_type& a : unit_itor->attacks()) {
 			// For speed, just assume these specials will be active if they are present.
-			if(a.get_special_bool("backstab", true)) {
+			if(a.get_special_bool_old("backstab", true)) {
 				backstab = true;
 			}
 
-			if(a.get_special_bool("slow", true)) {
+			if(a.get_special_bool_old("slow", true)) {
 				slow = true;
 			}
 		}

--- a/src/ai/default/aspect_attacks.cpp
+++ b/src/ai/default/aspect_attacks.cpp
@@ -168,11 +168,11 @@ void aspect_attacks_base::do_attack_analysis(const map_location& loc,
 		bool backstab = false, slow = false;
 		for(const attack_type& a : unit_itor->attacks()) {
 			// For speed, just assume these specials will be active if they are present.
-			if(a.get_special_bool_without_abilities("backstab", true)) {
+			if(a.get_special_bool("backstab", true)) {
 				backstab = true;
 			}
 
-			if(a.get_special_bool_without_abilities("slow", true)) {
+			if(a.get_special_bool("slow", true)) {
 				slow = true;
 			}
 		}

--- a/src/gui/dialogs/attack_predictions.cpp
+++ b/src/gui/dialogs/attack_predictions.cpp
@@ -133,7 +133,7 @@ void attack_predictions::set_data(window& window, const combatant_data& attacker
 	}
 
 	// Get damage modifiers.
-	unit_ability_list dmg_specials = weapon->get_special_ability("damage");
+	unit_ability_list dmg_specials = weapon->get_specials("damage");
 	unit_abilities::effect dmg_effect(dmg_specials, weapon->damage(), attacker.stats_.backstab_pos);
 
 	// Get the SET damage modifier, if any.

--- a/src/gui/dialogs/attack_predictions.cpp
+++ b/src/gui/dialogs/attack_predictions.cpp
@@ -133,7 +133,7 @@ void attack_predictions::set_data(window& window, const combatant_data& attacker
 	}
 
 	// Get damage modifiers.
-	unit_ability_list dmg_specials = weapon->get_specials("damage");
+	unit_ability_list dmg_specials = weapon->get_specials_and_abilities("damage");
 	unit_abilities::effect dmg_effect(dmg_specials, weapon->damage(), attacker.stats_.backstab_pos);
 
 	// Get the SET damage modifier, if any.

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1359,7 +1359,7 @@ bool attack_type::has_weapon_ability(const std::string& special, bool special_id
 	return false;
 }
 
-bool attack_type::has_special_or_abilities(const std::string& special, bool special_id, bool special_tags) const
+bool attack_type::has_special_or_ability(const std::string& special, bool special_id, bool special_tags) const
 {
 	return (has_special(special, false, special_id, special_tags) || has_weapon_ability(special, special_id, special_tags));
 }
@@ -1456,7 +1456,7 @@ bool attack_type::special_active_impl(const_attack_ptr self_attack, const_attack
 		return false;
 	}
 	if (tag_name == "firststrike" && !is_attacker && other_attack &&
-		other_attack->has_special_or_abilities("firststrike")) {
+		other_attack->has_special_or_ability("firststrike")) {
 		return false;
 	}
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -693,7 +693,7 @@ namespace {
  * active in the current context (see set_specials_context), including
  * specials obtained from the opponent's attack.
  */
-bool attack_type::get_special_bool_old(const std::string& special, bool simple_check, bool special_id, bool special_tags) const
+bool attack_type::get_special_bool_without_abilities(const std::string& special, bool simple_check, bool special_id, bool special_tags) const
 {
 	{
 		std::vector<special_match> special_tag_matches;
@@ -765,9 +765,9 @@ bool attack_type::get_special_bool_old(const std::string& special, bool simple_c
  * Returns the currently active specials as an ability list, given the current
  * context (see set_specials_context).
  */
-unit_ability_list attack_type::get_specials_old(const std::string& special) const
+unit_ability_list attack_type::get_specials_without_abilities(const std::string& special) const
 {
-	//log_scope("get_specials_old");
+	//log_scope("get_specials_without_abilities");
 	const map_location loc = self_ ? self_->get_location() : self_loc_;
 	unit_ability_list res(loc);
 
@@ -1167,7 +1167,7 @@ unit_ability_list attack_type::get_specials(const std::string& ability) const
 		}
 		++i;
 	}
-	abil_list.append(get_specials_old(ability));
+	abil_list.append(get_specials_without_abilities(ability));
 	return abil_list;
 }
 
@@ -1361,7 +1361,7 @@ bool attack_type::get_weapon_ability_bool(const std::string& special, bool speci
 
 bool attack_type::get_special_bool(const std::string& special, bool special_id, bool special_tags) const
 {
-	return (get_special_bool_old(special, false, special_id, special_tags) || get_weapon_ability_bool(special, special_id, special_tags));
+	return (get_special_bool_without_abilities(special, false, special_id, special_tags) || get_weapon_ability_bool(special, special_id, special_tags));
 }
 //end of emulate weapon special functions.
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -693,7 +693,7 @@ namespace {
  * active in the current context (see set_specials_context), including
  * specials obtained from the opponent's attack.
  */
-bool attack_type::get_special_bool_without_abilities(const std::string& special, bool simple_check, bool special_id, bool special_tags) const
+bool attack_type::get_special_bool_temp(const std::string& special, bool simple_check, bool special_id, bool special_tags) const
 {
 	{
 		std::vector<special_match> special_tag_matches;
@@ -765,9 +765,9 @@ bool attack_type::get_special_bool_without_abilities(const std::string& special,
  * Returns the currently active specials as an ability list, given the current
  * context (see set_specials_context).
  */
-unit_ability_list attack_type::get_specials_without_abilities(const std::string& special) const
+unit_ability_list attack_type::get_specials_temp(const std::string& special) const
 {
-	//log_scope("get_specials_without_abilities");
+	//log_scope("get_specials_temp");
 	const map_location loc = self_ ? self_->get_location() : self_loc_;
 	unit_ability_list res(loc);
 
@@ -1158,16 +1158,19 @@ unit_ability_list attack_type::get_weapon_ability(const std::string& ability) co
 	return abil_list;
 }
 
-unit_ability_list attack_type::get_specials(const std::string& ability) const
+unit_ability_list attack_type::get_specials(const std::string& special, bool with_ability) const
 {
-	unit_ability_list abil_list = get_weapon_ability(ability);
-	for(unit_ability_list::iterator i = abil_list.begin(); i != abil_list.end();) {
-		if((*i->ability_cfg)["overwrite_specials"].to_bool()) {
-			return abil_list;
+	unit_ability_list abil_list(self_loc_);
+	if(with_ability){
+		abil_list = get_weapon_ability(special);
+		for(unit_ability_list::iterator i = abil_list.begin(); i != abil_list.end();) {
+			if((*i->ability_cfg)["overwrite_specials"].to_bool()) {
+				return abil_list;
+			}
+			++i;
 		}
-		++i;
 	}
-	abil_list.append(get_specials_without_abilities(ability));
+	abil_list.append(get_specials_temp(special));
 	return abil_list;
 }
 
@@ -1359,9 +1362,12 @@ bool attack_type::get_weapon_ability_bool(const std::string& special, bool speci
 	return false;
 }
 
-bool attack_type::get_special_bool(const std::string& special, bool special_id, bool special_tags) const
+bool attack_type::get_special_bool(const std::string& special, bool simple_check, bool special_id, bool special_tags) const
 {
-	return (get_special_bool_without_abilities(special, false, special_id, special_tags) || get_weapon_ability_bool(special, special_id, special_tags));
+	if(simple_check){
+		return get_special_bool_temp(special, simple_check, special_id, special_tags);
+	}
+	return (get_special_bool_temp(special, simple_check, special_id, special_tags) || get_weapon_ability_bool(special, special_id, special_tags));
 }
 //end of emulate weapon special functions.
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1359,7 +1359,7 @@ bool attack_type::has_weapon_ability(const std::string& special, bool special_id
 	return false;
 }
 
-bool attack_type::has_special_and_abilities(const std::string& special, bool special_id, bool special_tags) const
+bool attack_type::has_special_or_abilities(const std::string& special, bool special_id, bool special_tags) const
 {
 	return (has_special(special, false, special_id, special_tags) || has_weapon_ability(special, special_id, special_tags));
 }
@@ -1456,7 +1456,7 @@ bool attack_type::special_active_impl(const_attack_ptr self_attack, const_attack
 		return false;
 	}
 	if (tag_name == "firststrike" && !is_attacker && other_attack &&
-		other_attack->has_special_and_abilities("firststrike")) {
+		other_attack->has_special_or_abilities("firststrike")) {
 		return false;
 	}
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -693,7 +693,7 @@ namespace {
  * active in the current context (see set_specials_context), including
  * specials obtained from the opponent's attack.
  */
-bool attack_type::get_special_bool(const std::string& special, bool simple_check, bool special_id, bool special_tags) const
+bool attack_type::has_special(const std::string& special, bool simple_check, bool special_id, bool special_tags) const
 {
 	{
 		std::vector<special_match> special_tag_matches;
@@ -1261,7 +1261,7 @@ bool attack_type::check_adj_abilities_impl(const_attack_ptr self_attack, const_a
  * active in the current context (see set_specials_context), including
  * specials obtained from the opponent's attack.
  */
-bool attack_type::get_weapon_ability_bool(const std::string& special, bool special_id, bool special_tags) const
+bool attack_type::has_weapon_ability(const std::string& special, bool special_id, bool special_tags) const
 {
 	assert(display::get_singleton());
 	const unit_map& units = display::get_singleton()->get_units();
@@ -1359,9 +1359,9 @@ bool attack_type::get_weapon_ability_bool(const std::string& special, bool speci
 	return false;
 }
 
-bool attack_type::get_special_and_abilities_bool(const std::string& special, bool special_id, bool special_tags) const
+bool attack_type::has_special_and_abilities(const std::string& special, bool special_id, bool special_tags) const
 {
-	return (get_special_bool(special, false, special_id, special_tags) || get_weapon_ability_bool(special, special_id, special_tags));
+	return (has_special(special, false, special_id, special_tags) || has_weapon_ability(special, special_id, special_tags));
 }
 //end of emulate weapon special functions.
 
@@ -1456,7 +1456,7 @@ bool attack_type::special_active_impl(const_attack_ptr self_attack, const_attack
 		return false;
 	}
 	if (tag_name == "firststrike" && !is_attacker && other_attack &&
-		other_attack->get_special_and_abilities_bool("firststrike")) {
+		other_attack->has_special_and_abilities("firststrike")) {
 		return false;
 	}
 

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -142,7 +142,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 		deprecated_message("special=", DEP_LEVEL::PREEMPTIVE, {1, 17, 0}, "Please use special_id or special_type instead");
 		bool found = false;
 		for(auto& special : filter_special) {
-			if(attack.get_special_bool(special, true)) {
+			if(attack.has_special(special, true)) {
 				found = true;
 				break;
 			}
@@ -154,7 +154,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_id.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_id) {
-			if(attack.get_special_bool(special, true, true, false)) {
+			if(attack.has_special(special, true, true, false)) {
 				found = true;
 				break;
 			}
@@ -168,7 +168,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 		deprecated_message("special_active=", DEP_LEVEL::PREEMPTIVE, {1, 17, 0}, "Please use special_id_active or special_type_active instead");
 		bool found = false;
 		for(auto& special : filter_special_active) {
-			if(attack.get_special_bool(special, false)) {
+			if(attack.has_special(special, false)) {
 				found = true;
 				break;
 			}
@@ -180,7 +180,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_id_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_id_active) {
-			if(attack.get_special_and_abilities_bool(special, true, false)) {
+			if(attack.has_special_and_abilities(special, true, false)) {
 				found = true;
 				break;
 			}
@@ -192,7 +192,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_type.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_type) {
-			if(attack.get_special_bool(special, true, false)) {
+			if(attack.has_special(special, true, false)) {
 				found = true;
 				break;
 			}
@@ -204,7 +204,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_type_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_type_active) {
-			if(attack.get_special_and_abilities_bool(special, false)) {
+			if(attack.has_special_and_abilities(special, false)) {
 				found = true;
 				break;
 			}

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -142,7 +142,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 		deprecated_message("special=", DEP_LEVEL::PREEMPTIVE, {1, 17, 0}, "Please use special_id or special_type instead");
 		bool found = false;
 		for(auto& special : filter_special) {
-			if(attack.get_special_bool(special, true)) {
+			if(attack.get_special_bool_old(special, true)) {
 				found = true;
 				break;
 			}
@@ -154,7 +154,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_id.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_id) {
-			if(attack.get_special_bool(special, true, true, false)) {
+			if(attack.get_special_bool_old(special, true, true, false)) {
 				found = true;
 				break;
 			}
@@ -168,7 +168,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 		deprecated_message("special_active=", DEP_LEVEL::PREEMPTIVE, {1, 17, 0}, "Please use special_id_active or special_type_active instead");
 		bool found = false;
 		for(auto& special : filter_special_active) {
-			if(attack.get_special_bool(special, false)) {
+			if(attack.get_special_bool_old(special, false)) {
 				found = true;
 				break;
 			}
@@ -180,7 +180,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_id_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_id_active) {
-			if(attack.bool_ability(special, true, false)) {
+			if(attack.get_special_bool(special, true, false)) {
 				found = true;
 				break;
 			}
@@ -192,7 +192,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_type.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_type) {
-			if(attack.get_special_bool(special, true, false)) {
+			if(attack.get_special_bool_old(special, true, false)) {
 				found = true;
 				break;
 			}
@@ -204,7 +204,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_type_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_type_active) {
-			if(attack.bool_ability(special, false)) {
+			if(attack.get_special_bool(special, false)) {
 				found = true;
 				break;
 			}

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -180,7 +180,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_id_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_id_active) {
-			if(attack.has_special_or_abilities(special, true, false)) {
+			if(attack.has_special_or_ability(special, true, false)) {
 				found = true;
 				break;
 			}
@@ -204,7 +204,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_type_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_type_active) {
-			if(attack.has_special_or_abilities(special, false)) {
+			if(attack.has_special_or_ability(special, false)) {
 				found = true;
 				break;
 			}

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -142,7 +142,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 		deprecated_message("special=", DEP_LEVEL::PREEMPTIVE, {1, 17, 0}, "Please use special_id or special_type instead");
 		bool found = false;
 		for(auto& special : filter_special) {
-			if(attack.get_special_bool_old(special, true)) {
+			if(attack.get_special_bool_without_abilities(special, true)) {
 				found = true;
 				break;
 			}
@@ -154,7 +154,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_id.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_id) {
-			if(attack.get_special_bool_old(special, true, true, false)) {
+			if(attack.get_special_bool_without_abilities(special, true, true, false)) {
 				found = true;
 				break;
 			}
@@ -168,7 +168,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 		deprecated_message("special_active=", DEP_LEVEL::PREEMPTIVE, {1, 17, 0}, "Please use special_id_active or special_type_active instead");
 		bool found = false;
 		for(auto& special : filter_special_active) {
-			if(attack.get_special_bool_old(special, false)) {
+			if(attack.get_special_bool_without_abilities(special, false)) {
 				found = true;
 				break;
 			}
@@ -192,7 +192,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_type.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_type) {
-			if(attack.get_special_bool_old(special, true, false)) {
+			if(attack.get_special_bool_without_abilities(special, true, false)) {
 				found = true;
 				break;
 			}

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -180,7 +180,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_id_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_id_active) {
-			if(attack.has_special_and_abilities(special, true, false)) {
+			if(attack.has_special_or_abilities(special, true, false)) {
 				found = true;
 				break;
 			}
@@ -204,7 +204,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_type_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_type_active) {
-			if(attack.has_special_and_abilities(special, false)) {
+			if(attack.has_special_or_abilities(special, false)) {
 				found = true;
 				break;
 			}

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -180,7 +180,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_id_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_id_active) {
-			if(attack.get_special_bool(special, false, true, false)) {
+			if(attack.get_special_and_abilities_bool(special, true, false)) {
 				found = true;
 				break;
 			}
@@ -204,7 +204,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_type_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_type_active) {
-			if(attack.get_special_bool(special, false, false)) {
+			if(attack.get_special_and_abilities_bool(special, false)) {
 				found = true;
 				break;
 			}

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -142,7 +142,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 		deprecated_message("special=", DEP_LEVEL::PREEMPTIVE, {1, 17, 0}, "Please use special_id or special_type instead");
 		bool found = false;
 		for(auto& special : filter_special) {
-			if(attack.get_special_bool_without_abilities(special, true)) {
+			if(attack.get_special_bool(special, true)) {
 				found = true;
 				break;
 			}
@@ -154,7 +154,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_id.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_id) {
-			if(attack.get_special_bool_without_abilities(special, true, true, false)) {
+			if(attack.get_special_bool(special, true, true, false)) {
 				found = true;
 				break;
 			}
@@ -168,7 +168,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 		deprecated_message("special_active=", DEP_LEVEL::PREEMPTIVE, {1, 17, 0}, "Please use special_id_active or special_type_active instead");
 		bool found = false;
 		for(auto& special : filter_special_active) {
-			if(attack.get_special_bool_without_abilities(special, false)) {
+			if(attack.get_special_bool(special, false)) {
 				found = true;
 				break;
 			}
@@ -180,7 +180,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_id_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_id_active) {
-			if(attack.get_special_bool(special, true, false)) {
+			if(attack.get_special_bool(special, false, true, false)) {
 				found = true;
 				break;
 			}
@@ -192,7 +192,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_type.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_type) {
-			if(attack.get_special_bool_without_abilities(special, true, false)) {
+			if(attack.get_special_bool(special, true, false)) {
 				found = true;
 				break;
 			}
@@ -204,7 +204,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_type_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_type_active) {
-			if(attack.get_special_bool(special, false)) {
+			if(attack.get_special_bool(special, false, false)) {
 				found = true;
 				break;
 			}

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -78,8 +78,8 @@ public:
 	 * @param special_id If true, match @a special against the @c id of special tags.
 	 * @param special_tags If true, match @a special against the tag name of special tags.
 	 */
-	bool get_special_bool(const std::string& special, bool simple_check=false, bool special_id=true, bool special_tags=true) const;
-	unit_ability_list get_specials(const std::string& special) const;
+	bool get_special_bool_old(const std::string& special, bool simple_check=false, bool special_id=true, bool special_tags=true) const;
+	unit_ability_list get_specials_old(const std::string& special) const;
 	std::vector<std::pair<t_string, t_string>> special_tooltips(boost::dynamic_bitset<>* active_list = nullptr) const;
 	std::string weapon_specials(bool only_active=false, bool is_backstab=false) const;
 
@@ -89,23 +89,23 @@ public:
 	/** Returns the damage per attack of this weapon, considering specials. */
 	int modified_damage(bool is_backstab) const;
 	/** Returns list for weapon like abilitiesfor each ability type. */
-	unit_ability_list list_ability(const std::string& ability) const;
-	/** Returns list who contains list_ability and get_specials list for each ability type */
-	unit_ability_list get_special_ability(const std::string& ability) const;
+	unit_ability_list get_weapon_ability(const std::string& ability) const;
+	/** Returns list who contains get_weapon_ability and get_specials_old list for each ability type */
+	unit_ability_list get_specials(const std::string& ability) const;
 	/** used for abilities used like weapon
 	 * @return True if the ability @a special is active.
 	 * @param special The special being checked.
 	 * @param special_id If true, match @a special against the @c id of special tags.
 	 * @param special_tags If true, match @a special against the tag name of special tags.
 	 */
-	bool get_special_ability_bool(const std::string& special, bool special_id=true, bool special_tags=true) const;
+	bool get_weapon_ability_bool(const std::string& special, bool special_id=true, bool special_tags=true) const;
 	/** used for abilities used like weapon and true specials
 	 * @return True if the ability @a special is active.
 	 * @param special The special being checked.
 	 * @param special_id If true, match @a special against the @c id of special tags.
 	 * @param special_tags If true, match @a special against the tag name of special tags.
 	 */
-	bool bool_ability(const std::string& special, bool special_id=true, bool special_tags=true) const;
+	bool get_special_bool(const std::string& special, bool special_id=true, bool special_tags=true) const;
 
 	// In unit_types.cpp:
 

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -78,8 +78,8 @@ public:
 	 * @param special_id If true, match @a special against the @c id of special tags.
 	 * @param special_tags If true, match @a special against the tag name of special tags.
 	 */
-	bool get_special_bool_old(const std::string& special, bool simple_check=false, bool special_id=true, bool special_tags=true) const;
-	unit_ability_list get_specials_old(const std::string& special) const;
+	bool get_special_bool_without_abilities(const std::string& special, bool simple_check=false, bool special_id=true, bool special_tags=true) const;
+	unit_ability_list get_specials_without_abilities(const std::string& special) const;
 	std::vector<std::pair<t_string, t_string>> special_tooltips(boost::dynamic_bitset<>* active_list = nullptr) const;
 	std::string weapon_specials(bool only_active=false, bool is_backstab=false) const;
 
@@ -90,7 +90,7 @@ public:
 	int modified_damage(bool is_backstab) const;
 	/** Returns list for weapon like abilitiesfor each ability type. */
 	unit_ability_list get_weapon_ability(const std::string& ability) const;
-	/** Returns list who contains get_weapon_ability and get_specials_old list for each ability type */
+	/** Returns list who contains get_weapon_ability and get_specials_without_abilities list for each ability type */
 	unit_ability_list get_specials(const std::string& ability) const;
 	/** used for abilities used like weapon
 	 * @return True if the ability @a special is active.

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -78,7 +78,7 @@ public:
 	 * @param special_id If true, match @a special against the @c id of special tags.
 	 * @param special_tags If true, match @a special against the tag name of special tags.
 	 */
-	bool get_special_bool(const std::string& special, bool simple_check=false, bool special_id=true, bool special_tags=true) const;
+	bool has_special(const std::string& special, bool simple_check=false, bool special_id=true, bool special_tags=true) const;
 	unit_ability_list get_specials(const std::string& special) const;
 	std::vector<std::pair<t_string, t_string>> special_tooltips(boost::dynamic_bitset<>* active_list = nullptr) const;
 	std::string weapon_specials(bool only_active=false, bool is_backstab=false) const;
@@ -98,14 +98,14 @@ public:
 	 * @param special_id If true, match @a special against the @c id of special tags.
 	 * @param special_tags If true, match @a special against the tag name of special tags.
 	 */
-	bool get_weapon_ability_bool(const std::string& special, bool special_id=true, bool special_tags=true) const;
+	bool has_weapon_ability(const std::string& special, bool special_id=true, bool special_tags=true) const;
 	/** used for abilities used like weapon and true specials
 	 * @return True if the ability @a special is active.
 	 * @param special The special being checked.
 	 * @param special_id If true, match @a special against the @c id of special tags.
 	 * @param special_tags If true, match @a special against the tag name of special tags.
 	 */
-	bool get_special_and_abilities_bool(const std::string& special, bool special_id=true, bool special_tags=true) const;
+	bool has_special_and_abilities(const std::string& special, bool special_id=true, bool special_tags=true) const;
 
 	// In unit_types.cpp:
 

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -105,7 +105,7 @@ public:
 	 * @param special_id If true, match @a special against the @c id of special tags.
 	 * @param special_tags If true, match @a special against the tag name of special tags.
 	 */
-	bool has_special_or_abilities(const std::string& special, bool special_id=true, bool special_tags=true) const;
+	bool has_special_or_ability(const std::string& special, bool special_id=true, bool special_tags=true) const;
 
 	// In unit_types.cpp:
 

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -78,8 +78,8 @@ public:
 	 * @param special_id If true, match @a special against the @c id of special tags.
 	 * @param special_tags If true, match @a special against the tag name of special tags.
 	 */
-	bool get_special_bool_without_abilities(const std::string& special, bool simple_check=false, bool special_id=true, bool special_tags=true) const;
-	unit_ability_list get_specials_without_abilities(const std::string& special) const;
+	bool get_special_bool_temp(const std::string& special, bool simple_check=false, bool special_id=true, bool special_tags=true) const;
+	unit_ability_list get_specials_temp(const std::string& special) const;
 	std::vector<std::pair<t_string, t_string>> special_tooltips(boost::dynamic_bitset<>* active_list = nullptr) const;
 	std::string weapon_specials(bool only_active=false, bool is_backstab=false) const;
 
@@ -90,8 +90,8 @@ public:
 	int modified_damage(bool is_backstab) const;
 	/** Returns list for weapon like abilitiesfor each ability type. */
 	unit_ability_list get_weapon_ability(const std::string& ability) const;
-	/** Returns list who contains get_weapon_ability and get_specials_without_abilities list for each ability type */
-	unit_ability_list get_specials(const std::string& ability) const;
+	/** Returns list who contains get_weapon_ability and get_specials_temp list for each ability type */
+	unit_ability_list get_specials(const std::string& special, bool with_ability = true) const;
 	/** used for abilities used like weapon
 	 * @return True if the ability @a special is active.
 	 * @param special The special being checked.
@@ -102,10 +102,11 @@ public:
 	/** used for abilities used like weapon and true specials
 	 * @return True if the ability @a special is active.
 	 * @param special The special being checked.
+	 * @param simple_check If true, check whether the unit has the special, ability don't checked then. Else, check whether the special or ability is currently active.
 	 * @param special_id If true, match @a special against the @c id of special tags.
 	 * @param special_tags If true, match @a special against the tag name of special tags.
 	 */
-	bool get_special_bool(const std::string& special, bool special_id=true, bool special_tags=true) const;
+	bool get_special_bool(const std::string& special, bool simple_check=false, bool special_id=true, bool special_tags=true) const;
 
 	// In unit_types.cpp:
 

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -105,7 +105,7 @@ public:
 	 * @param special_id If true, match @a special against the @c id of special tags.
 	 * @param special_tags If true, match @a special against the tag name of special tags.
 	 */
-	bool has_special_and_abilities(const std::string& special, bool special_id=true, bool special_tags=true) const;
+	bool has_special_or_abilities(const std::string& special, bool special_id=true, bool special_tags=true) const;
 
 	// In unit_types.cpp:
 

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -78,8 +78,8 @@ public:
 	 * @param special_id If true, match @a special against the @c id of special tags.
 	 * @param special_tags If true, match @a special against the tag name of special tags.
 	 */
-	bool get_special_bool_temp(const std::string& special, bool simple_check=false, bool special_id=true, bool special_tags=true) const;
-	unit_ability_list get_specials_temp(const std::string& special) const;
+	bool get_special_bool(const std::string& special, bool simple_check=false, bool special_id=true, bool special_tags=true) const;
+	unit_ability_list get_specials(const std::string& special) const;
 	std::vector<std::pair<t_string, t_string>> special_tooltips(boost::dynamic_bitset<>* active_list = nullptr) const;
 	std::string weapon_specials(bool only_active=false, bool is_backstab=false) const;
 
@@ -88,10 +88,10 @@ public:
 	                      unsigned & max_attacks) const;
 	/** Returns the damage per attack of this weapon, considering specials. */
 	int modified_damage(bool is_backstab) const;
-	/** Returns list for weapon like abilitiesfor each ability type. */
+	/** Returns list for weapon like abilities for each ability type. */
 	unit_ability_list get_weapon_ability(const std::string& ability) const;
-	/** Returns list who contains get_weapon_ability and get_specials_temp list for each ability type */
-	unit_ability_list get_specials(const std::string& special, bool with_ability = true) const;
+	/** Returns list who contains get_weapon_ability and get_specials list for each ability type */
+	unit_ability_list get_specials_and_abilities(const std::string& special) const;
 	/** used for abilities used like weapon
 	 * @return True if the ability @a special is active.
 	 * @param special The special being checked.
@@ -102,11 +102,10 @@ public:
 	/** used for abilities used like weapon and true specials
 	 * @return True if the ability @a special is active.
 	 * @param special The special being checked.
-	 * @param simple_check If true, check whether the unit has the special, ability don't checked then. Else, check whether the special or ability is currently active.
 	 * @param special_id If true, match @a special against the @c id of special tags.
 	 * @param special_tags If true, match @a special against the tag name of special tags.
 	 */
-	bool get_special_bool(const std::string& special, bool simple_check=false, bool special_id=true, bool special_tags=true) const;
+	bool get_special_and_abilities_bool(const std::string& special, bool special_id=true, bool special_tags=true) const;
 
 	// In unit_types.cpp:
 

--- a/src/units/udisplay.cpp
+++ b/src/units/udisplay.cpp
@@ -695,7 +695,7 @@ void unit_attack(display * disp, game_board & board,
 
 	unit_ability_list abilities = att->get_location();
 	for(auto& special : attacker.checking_tags()) {
-		abilities.append(weapon->list_ability(special));
+		abilities.append(weapon->get_weapon_ability(special));
 	}
 
 	for(const unit_ability& ability : abilities) {


### PR DESCRIPTION
When I was looking at the special weapons extension to [abilities] tags, I didn't understand the concept of lists at first, until someone added the .append function to add a list to a list. other, but I kept the names I used for the functions. Now that this work is completed, I would like the function calls to find their original names (get_specials and get_special_bool) among other things to clarify the reading for a developer.