### PR TITLE
TSG S05: Fix use of [modify_unit]

### DIFF
--- a/data/campaigns/The_South_Guard/scenarios/05_Choice_In_The_Fog.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/05_Choice_In_The_Fog.cfg
@@ -795,9 +795,7 @@
                                 moves=$this_unit.max_moves
                                 profile=portraits/urza-afalas.png
                                 canrecruit=no
-                                [modifications]
-                                    {TRAIT_LOYAL_HERO}
-                                [/modifications]
+                                {TRAIT_LOYAL_HERO}
                             [/modify_unit]
 
                             [modify_unit]
@@ -863,19 +861,6 @@
                             [/modify_side]
 
                             [show_objectives][/show_objectives]
-
-                            [store_unit]
-                                [filter]
-                                    id=Urza Afalas
-                                [/filter]
-                                variable=Afalas
-                                kill=no
-                            [/store_unit]
-                            {CLEAR_VARIABLE Afalas.upkeep}
-                            [unstore_unit]
-                                variable=Afalas
-                            [/unstore_unit]
-                            {CLEAR_VARIABLE Afalas}
 
                             # give side 4 some gold
                             [gold]


### PR DESCRIPTION
TSG S05: Fix Urza's upkeep when taking the bandit branch. The `[trait]` shouldn't be inside a `[modifications]` block, as explained in #4137.

<strike>TSG S02: Simplify [store_unit]+[foreach] to [modify_unit]</strike>