### PR TITLE
UtBS S01: Spawn the mystics on the island, not in the lake

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg
@@ -695,7 +695,7 @@
                 x,y=25,27
             [/unit]
 #ifndef HARD
-            {NAMED_GENERIC_UNIT 1 "Quenoth Mystic" 24 27 "Ryoko" ( _ "Ryoko")}
+            {NAMED_GENERIC_UNIT 1 "Quenoth Mystic" 26 27 "Ryoko" ( _ "Ryoko")}
 #endif
             {NAMED_GENERIC_UNIT 1 "Quenoth Mystic" 24 27 "Yuni" ( _ "Yuni")}
 


### PR DESCRIPTION
They were both placed on the same hex, which meant the engine moved one of
them a hex north-west, into the water.

Fixes #5632 