### PR TITLE
Fix units that should have zero max mp being given one mp

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
  ### User interface
  ### WML Engine
  ### Miscellaneous and Bug Fixes
+   * Fixed units with max movement set to zero being given one max movement point by `[unstore_unit]` or when loading a saved game
 
 ## Version 1.15.11
  ### AI

--- a/data/test/scenarios/test_effect_on_vision.cfg
+++ b/data/test/scenarios/test_effect_on_vision.cfg
@@ -115,6 +115,21 @@
         {ASSERT_VISION_EFFECTIVELY equals 0}
         {ASSERT_ALICE_STAT jamming equals 0}
 
+        # Test that unit.cpp's unit::init() successfully loads a unit with max_moves set to zero
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=temp_alice
+        [/store_unit]
+        [unstore_unit]
+            variable=temp_alice
+        [/unstore_unit]
+        {CLEAR_VARIABLE temp_alice}
+        {ASSERT_ALICE_STAT max_moves equals 0}
+        {ASSERT_VISION_EFFECTIVELY equals 0}
+        {ASSERT_ALICE_STAT jamming equals 0}
+
         {SUCCEED}
     [/event]
 )}

--- a/data/test/scenarios/test_effect_on_vision.cfg
+++ b/data/test/scenarios/test_effect_on_vision.cfg
@@ -1,0 +1,247 @@
+# wmllint: no translatables
+
+# This series of tests checks that the C++ unit class handles changes to movement and vision points correctly.
+
+#define ASSERT_ALICE_STAT stat relation value
+    [store_unit]
+        [filter]
+            id=alice
+        [/filter]
+        variable=temp_for_stat_assert
+    [/store_unit]
+    {ASSERT {VARIABLE_CONDITIONAL temp_for_stat_assert.{stat} {relation} {value}}}
+    [clear_variable]
+        name=temp_for_stat_assert
+    [/clear_variable]
+#enddef
+
+#define ASSERT_VISION_EFFECTIVELY relation value
+    # Similar to "ASSERT_ALICE_STAT vision", but with manual handling for the -1 value. When using [store_unit], we see the raw value of -1, even though pathfinding calculations would interpret that as "same value as max_moves".
+    [store_unit]
+        [filter]
+            id=alice
+        [/filter]
+        variable=temp_for_stat_assert
+    [/store_unit]
+    [if]
+        {VARIABLE_CONDITIONAL temp_for_stat_assert.vision equals -1}
+        [then]
+            {ASSERT {VARIABLE_CONDITIONAL temp_for_stat_assert.max_moves {relation} {value}}}
+        [/then]
+        [else]
+            {ASSERT {VARIABLE_CONDITIONAL temp_for_stat_assert.vision {relation} {value}}}
+        [/else]
+    [/if]
+    [clear_variable]
+        name=temp_for_stat_assert
+    [/clear_variable]
+#enddef
+
+# Test that changing the max_moves affects the vision points, assuming that the vision points haven't been explicitly set to a separate value.
+# This test would also pass on 1.14, movement always affected vision in this case.
+{GENERIC_UNIT_TEST "effect_move_affects_vision" (
+    [event]
+        name = side 1 turn 1
+
+        # Sanity-check default values for an Elvish Archer
+        {ASSERT_ALICE_STAT max_moves equals 6}
+        {ASSERT_VISION_EFFECTIVELY equals 6}
+        {ASSERT_ALICE_STAT jamming equals 0}
+
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=movement
+                set=5
+            [/effect]
+        [/modify_unit]
+        {ASSERT_ALICE_STAT max_moves equals 5}
+        {ASSERT_VISION_EFFECTIVELY equals 5}
+        {ASSERT_ALICE_STAT jamming equals 0}
+
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=movement
+                increase=5
+            [/effect]
+        [/modify_unit]
+        {ASSERT_ALICE_STAT max_moves equals 10}
+        {ASSERT_VISION_EFFECTIVELY equals 10}
+        {ASSERT_ALICE_STAT jamming equals 0}
+
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=movement
+                increase=50%
+            [/effect]
+        [/modify_unit]
+        {ASSERT_ALICE_STAT max_moves equals 15}
+        {ASSERT_VISION_EFFECTIVELY equals 15}
+        {ASSERT_ALICE_STAT jamming equals 0}
+
+        # Test a negative increase
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=movement
+                increase=-5
+            [/effect]
+        [/modify_unit]
+        {ASSERT_ALICE_STAT max_moves equals 10}
+        {ASSERT_VISION_EFFECTIVELY equals 10}
+        {ASSERT_ALICE_STAT jamming equals 0}
+
+        # Test that setting the stat to zero works
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=movement
+                set=0
+            [/effect]
+        [/modify_unit]
+        {ASSERT_ALICE_STAT max_moves equals 0}
+        {ASSERT_VISION_EFFECTIVELY equals 0}
+        {ASSERT_ALICE_STAT jamming equals 0}
+
+        {SUCCEED}
+    [/event]
+)}
+
+# Test that apply_to=vision works
+{GENERIC_UNIT_TEST "effect_vision" (
+    [event]
+        name = side 1 turn 1
+
+        # Sanity-check default values for an Elvish Archer
+        {ASSERT_ALICE_STAT max_moves equals 6}
+        {ASSERT_VISION_EFFECTIVELY equals 6}
+        {ASSERT_ALICE_STAT jamming equals 0}
+
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=vision
+                set=2
+            [/effect]
+        [/modify_unit]
+        {ASSERT_ALICE_STAT max_moves equals 6}
+        {ASSERT_VISION_EFFECTIVELY equals 2}
+        {ASSERT_ALICE_STAT jamming equals 0}
+
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=vision
+                increase=50%
+            [/effect]
+        [/modify_unit]
+        {ASSERT_ALICE_STAT max_moves equals 6}
+        {ASSERT_VISION_EFFECTIVELY equals 3}
+        {ASSERT_ALICE_STAT jamming equals 0}
+
+        {SUCCEED}
+    [/event]
+)}
+
+# Test that setting vision will avoid changing vision afterwards.
+{GENERIC_UNIT_TEST "effect_move_ignores_vision" (
+    [event]
+        name = side 1 turn 1
+
+        # Sanity-check default values for an Elvish Archer
+        {ASSERT_ALICE_STAT max_moves equals 6}
+        {ASSERT_VISION_EFFECTIVELY equals 6}
+        {ASSERT_ALICE_STAT jamming equals 0}
+
+        # In 1.14, this is a test that the default behavior hasn't changed, that setting vision to a value other than -1 will break the link between movement and vision.
+        # In 1.16, this will be replaced by a test of the also_apply_to_vision=no attribute.
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=vision
+                set=6
+            [/effect]
+        [/modify_unit]
+
+        # Make a copy so that each subpart of this test can reset her to this state
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=unmodified_alice
+            kill=no
+        [/store_unit]
+
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=movement
+                set=7
+            [/effect]
+        [/modify_unit]
+        {ASSERT_ALICE_STAT max_moves equals 7}
+        {ASSERT_VISION_EFFECTIVELY equals 6}
+        {ASSERT_ALICE_STAT jamming equals 0}
+
+        [unstore_unit]
+            variable=unmodified_alice
+        [/unstore_unit]
+
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=movement
+                increase=4
+            [/effect]
+        [/modify_unit]
+        {ASSERT_ALICE_STAT max_moves equals 10}
+        {ASSERT_VISION_EFFECTIVELY equals 6}
+        {ASSERT_ALICE_STAT jamming equals 0}
+
+        [unstore_unit]
+            variable=unmodified_alice
+        [/unstore_unit]
+
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=movement
+                increase=50%
+            [/effect]
+        [/modify_unit]
+        {ASSERT_ALICE_STAT max_moves equals 9}
+        {ASSERT_VISION_EFFECTIVELY equals 6}
+        {ASSERT_ALICE_STAT jamming equals 0}
+
+        {CLEAR_VARIABLE unmodified_alice}
+
+        {SUCCEED}
+    [/event]
+)}
+
+#undef ASSERT_VISION_EFFECTIVELY
+#undef ASSERT_ALICE_STAT

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -514,7 +514,7 @@ void unit::init(const config& cfg, bool use_traits, const vconfig* vcfg)
 		set_max_hitpoints(std::max(1, v->to_int(max_hit_points_)));
 	}
 	if(const config::attribute_value* v = cfg.get("max_moves")) {
-		set_total_movement(std::max(1, v->to_int(max_movement_)));
+		set_total_movement(std::max(0, v->to_int(max_movement_)));
 	}
 	if(const config::attribute_value* v = cfg.get("max_experience")) {
 		set_max_experience(std::max(1, v->to_int(max_experience_)));

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -169,6 +169,10 @@
 0 test_elf_longsighted_cave_and_hills_vision
 0 test_elf_longsighted_cave_slow_cave_vision
 0 test_resistances
+# [effect]apply_to=movement and [effect]apply_to=vision
+0 effect_move_affects_vision
+0 effect_move_ignores_vision
+0 effect_vision
 #
 # Attack calculations & codepath tests
 #


### PR DESCRIPTION
Fixes #5638 by correcting a cut & paste typo in 66a282a96be288a284d12a71625868cee5b2dc6b.

There's two commits here, the first of which is unit tests that are also in PR #5434. I'm not sure if it's too much testing for the amount of C++ changed in this PR, but it includes the framework I needed to test this code...