### PR TITLE
modify overwrite_specials attributefor select the specials and weapon abilities who must be overwrited

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
  ### Units
  ### User interface
  ### WML Engine
+   * Modify implementation of overwrite_specials attribute for replace yes/no parameter by none/one_side/both_sides and select abilities used like weapons and specials who must be overwrited(owned by fighter where special applied or both)
  ### Miscellaneous and Bug Fixes
 
 ## Version 1.15.12

--- a/data/core/macros/utils.cfg
+++ b/data/core/macros/utils.cfg
@@ -554,7 +554,7 @@
                         value={CTH_NUMBER}
                         cumulative=no
                         affect_self=yes
-                        overwrite_specials=yes
+                        overwrite_specials=both_sides
                         [filter_opponent]
                             {SECOND_FILTER}
                         [/filter_opponent]
@@ -607,7 +607,7 @@
                         value={CTH_NUMBER}
                         cumulative=no
                         affect_self=yes
-                        overwrite_specials=yes
+                        overwrite_specials=both_sides
                         [filter_opponent]
                             {SECOND_FILTER}
                         [/filter_opponent]

--- a/data/schema/game_config.cfg
+++ b/data/schema/game_config.cfg
@@ -37,6 +37,10 @@
         value="self|opponent|attacker|defender|both"
     [/type]
     [type]
+        name="ability_overwrite"
+        value="none|one_side|both_sides"
+    [/type]
+    [type]
         name="addon_type"
         value="sp|mp|hybrid"
     [/type]

--- a/data/schema/units/abilities.cfg
+++ b/data/schema/units/abilities.cfg
@@ -5,7 +5,7 @@
 		max=infinite
 		super="units/unit_type/abilities/~generic~,units/unit_type/attack/specials/" + {NAME}
 		{FILTER_TAG "filter_student" unit {FILTER_TAG "filter_weapon" weapon ()}}
-		{SIMPLE_KEY overwrite_specials bool}
+		{DEFAULT_KEY overwrite_specials ability_overwrite none}
 	[/tag]
 #enddef
 

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -159,11 +159,7 @@ battle_context_unit_stats::battle_context_unit_stats(nonempty_unit_const_ptr up,
 	}
 
 	// Handle plague.
-	unit_ability_list plague_specials = weapon->get_specials("plague");
-	unit_ability_list alt_plague_specials = weapon->get_specials_and_abilities("plague");
-	if(!alt_plague_specials.empty() && plague_specials.empty()){
-		plague_specials = alt_plague_specials;
-	}
+	unit_ability_list plague_specials = weapon->get_specials_and_abilities("plague");
 	plagues = !opp.get_state("unplagueable") && !plague_specials.empty() &&
 		opp.undead_variation() != "null" && !resources::gameboard->map().is_village(opp_loc);
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1300,18 +1300,18 @@ bool attack_type::has_weapon_ability(const std::string& special, bool special_id
 	assert(display::get_singleton());
 	const unit_map& units = display::get_singleton()->get_units();
 	if(self_){
-		std::vector<special_match> special_tag_matches;
-		std::vector<special_match> special_id_matches;
-		get_ability_children(special_tag_matches, special_id_matches, (*self_).abilities(), special, special_id , special_tags);
+		std::vector<special_match> special_tag_matches_self;
+		std::vector<special_match> special_id_matches_self;
+		get_ability_children(special_tag_matches_self, special_id_matches_self, (*self_).abilities(), special, special_id , special_tags);
 		if(special_tags){
-			for(const special_match& entry : special_tag_matches) {
+			for(const special_match& entry : special_tag_matches_self) {
 				if(check_self_abilities(*entry.cfg, entry.tag_name)){
 					return true;
 				}
 			}
 		}
 		if(special_id){
-			for(const special_match& entry : special_id_matches) {
+			for(const special_match& entry : special_id_matches_self) {
 				if(check_self_abilities(*entry.cfg, entry.tag_name)){
 					return true;
 				}
@@ -1326,16 +1326,18 @@ bool attack_type::has_weapon_ability(const std::string& special, bool special_id
 			if ( &*it == self_.get() )
 				continue;
 
-			get_ability_children(special_tag_matches, special_id_matches, it->abilities(), special, special_id , special_tags);
+			std::vector<special_match> special_tag_matches_adj;
+			std::vector<special_match> special_id_matches_adj;
+			get_ability_children(special_tag_matches_adj, special_id_matches_adj, it->abilities(), special, special_id , special_tags);
 			if(special_tags){
-				for(const special_match& entry : special_tag_matches) {
+				for(const special_match& entry : special_tag_matches_adj) {
 					if(check_adj_abilities(*entry.cfg, entry.tag_name, i , *it)){
 						return true;
 					}
 				}
 			}
 			if(special_id){
-				for(const special_match& entry : special_id_matches) {
+				for(const special_match& entry : special_id_matches_adj) {
 					if(check_adj_abilities(*entry.cfg, entry.tag_name, i , *it)){
 						return true;
 					}
@@ -1345,11 +1347,11 @@ bool attack_type::has_weapon_ability(const std::string& special, bool special_id
 	}
 
 	if(other_){
-		std::vector<special_match> special_tag_matches;
-		std::vector<special_match> special_id_matches;
-		get_ability_children(special_tag_matches, special_id_matches, (*other_).abilities(), special, special_id , special_tags);
+		std::vector<special_match> special_tag_matches_other;
+		std::vector<special_match> special_id_matches_other;
+		get_ability_children(special_tag_matches_other, special_id_matches_other, (*other_).abilities(), special, special_id , special_tags);
 		if(special_tags){
-			for(const special_match& entry : special_tag_matches) {
+			for(const special_match& entry : special_tag_matches_other) {
 				if(check_self_abilities_impl(other_attack_, shared_from_this(), *entry.cfg, other_, other_loc_, AFFECT_OTHER, entry.tag_name)){
 					return true;
 				}
@@ -1357,7 +1359,7 @@ bool attack_type::has_weapon_ability(const std::string& special, bool special_id
 		}
 
 		if(special_id){
-			for(const special_match& entry : special_id_matches) {
+			for(const special_match& entry : special_id_matches_other) {
 				if(check_self_abilities_impl(other_attack_, shared_from_this(), *entry.cfg, other_, other_loc_, AFFECT_OTHER, entry.tag_name)){
 					return true;
 				}
@@ -1372,9 +1374,11 @@ bool attack_type::has_weapon_ability(const std::string& special, bool special_id
 			if ( &*it == other_.get() )
 				continue;
 
-			get_ability_children(special_tag_matches, special_id_matches, it->abilities(), special, special_id , special_tags);
+			std::vector<special_match> special_tag_matches_oadj;
+			std::vector<special_match> special_id_matches_oadj;
+			get_ability_children(special_tag_matches_oadj, special_id_matches_oadj, it->abilities(), special, special_id , special_tags);
 			if(special_tags){
-				for(const special_match& entry : special_tag_matches) {
+				for(const special_match& entry : special_tag_matches_oadj) {
 					if(check_adj_abilities_impl(other_attack_, shared_from_this(), *entry.cfg, other_, *it, i, other_loc_, AFFECT_OTHER, entry.tag_name)){
 						return true;
 					}
@@ -1382,7 +1386,7 @@ bool attack_type::has_weapon_ability(const std::string& special, bool special_id
 			}
 
 			if(special_id){
-				for(const special_match& entry : special_id_matches) {
+				for(const special_match& entry : special_id_matches_oadj) {
 					if(check_adj_abilities_impl(other_attack_, shared_from_this(), *entry.cfg, other_, *it, i, other_loc_, AFFECT_OTHER, entry.tag_name)){
 						return true;
 					}

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -125,6 +125,13 @@ private:
 
 	// Configured as a bit field, in case that is useful.
 	enum AFFECTS { AFFECT_SELF=1, AFFECT_OTHER=2, AFFECT_EITHER=3 };
+	/** overwrite_special_checking : return an unit_ability_list list after checking presence or not of overwrite_specials
+	 * @param ability The special ability type who is being checked.
+	 * @param temp_list the list checked and returned.
+	 * @param abil_list list checked for verify presence of overwrite_specials .
+	 * @param filter_self name of [filter_"self/student"] if is abilities or specials who are checked
+	 */
+	unit_ability_list overwrite_special_checking(const std::string& ability, unit_ability_list temp_list, const unit_ability_list& abil_list, const std::string& filter_self = "filter_self") const;
 	/** check_self_abilities : return an boolean value for checking of activities of abilities used like weapon
 	 * @return True if the special @a special is active.
 	 * @param cfg the config to one special ability checked.


### PR DESCRIPTION


The overwrite_specials attribute is limites to abilities/specials owned by fighter or teacher, the specials/abilities who affect fighter but owned by opponent(apply_to=opponent/both) not affected.
the new attribute is created for fix that bugbut also select the specials afected, if is apply_to=self or opponent or both