### PR TITLE
desktop/version: Use systemd's os-release file if available

### DIFF
--- a/src/desktop/version.cpp
+++ b/src/desktop/version.cpp
@@ -160,7 +160,6 @@ std::string read_pipe_line(scoped_posix_pipe& p)
 
 	return ver;
 }
-#endif
 
 std::map<std::string, std::string> parse_fdo_osrelease(const std::string& path)
 {
@@ -201,6 +200,8 @@ std::map<std::string, std::string> parse_fdo_osrelease(const std::string& path)
 
 	return res;
 }
+
+#endif
 
 } // end anonymous namespace
 

--- a/src/desktop/version.cpp
+++ b/src/desktop/version.cpp
@@ -34,7 +34,11 @@
 
 #elif defined(_X11)
 
+#include "serialization/string_utils.hpp"
+
 #include <cerrno>
+#include <map>
+#include <boost/algorithm/string/trim.hpp>
 
 #endif
 
@@ -158,6 +162,46 @@ std::string read_pipe_line(scoped_posix_pipe& p)
 }
 #endif
 
+std::map<std::string, std::string> parse_fdo_osrelease(const std::string& path)
+{
+	auto in = filesystem::istream_file(path);
+	if(!in->good()) {
+		return {};
+	}
+
+	std::map<std::string, std::string> res;
+
+	// FIXME: intentionally basic "parsing" here. We are not supposed to see
+	//        more complex shell syntax anyway.
+	//        <https://www.freedesktop.org/software/systemd/man/os-release.html>
+	for(std::string s; std::getline(*in, s);) {
+		if(s.empty() || s.front() == '#') {
+			continue;
+		}
+
+		auto eqsign_pos = s.find('=');
+		if(!eqsign_pos || eqsign_pos == std::string::npos) {
+			continue;
+		}
+
+		auto lhs = s.substr(0, eqsign_pos),
+			 rhs = eqsign_pos + 1 < s.length() ? utils::unescape(s.substr(eqsign_pos + 1)) : "";
+
+		boost::algorithm::trim(lhs);
+		boost::algorithm::trim(rhs);
+
+		// Unquote if the quotes match on both sides
+		if(rhs.length() >= 2 && rhs.front() == '"' && rhs.back() == '"') {
+			rhs.pop_back();
+			rhs.erase(0, 1);
+		}
+
+		res.emplace(std::move(lhs), std::move(rhs));
+	}
+
+	return res;
+}
+
 } // end anonymous namespace
 
 std::string os_version()
@@ -181,7 +225,32 @@ std::string os_version()
 #elif defined(_X11)
 
 	//
-	// Linux Standard Base version.
+	// systemd/freedesktop.org method.
+	//
+
+	std::map<std::string, std::string> osrel;
+
+	static const std::string fdo_osrel_etc = "/etc/os-release";
+	static const std::string fdo_osrel_usr = "/usr/lib/os-release";
+
+	if(filesystem::file_exists(fdo_osrel_etc)) {
+		osrel = parse_fdo_osrelease(fdo_osrel_etc);
+	} else if(filesystem::file_exists(fdo_osrel_usr)) {
+		osrel = parse_fdo_osrelease(fdo_osrel_usr);
+	}
+
+	// Check both existence and emptiness in case some vendor sets PRETTY_NAME=""
+	auto osrel_distname = osrel["PRETTY_NAME"];
+	if(osrel_distname.empty()) {
+		osrel_distname = osrel["NAME"];
+	}
+
+	if(!osrel_distname.empty()) {
+		return osrel_distname + " " + u.machine;
+	}
+
+	//
+	// Linux Standard Base fallback.
 	//
 
 	static const std::string lsb_release_bin = "/usr/bin/lsb_release";


### PR DESCRIPTION
(tl:dr "run ci tests for me" pr)

This allows us to obtain the OS version without blocking for a long amount of time waiting for lsb_release (which is deprecated anyway).

The parsing is intentionally basic.