### PR TITLE
pango_text: remove unused force options and single-character insertion

### DIFF
--- a/src/font/text.cpp
+++ b/src/font/text.cpp
@@ -140,17 +140,6 @@ unsigned pango_text::insert_text(const unsigned offset, const std::string& text)
 	return len;
 }
 
-bool pango_text::insert_unicode(const unsigned offset, char32_t unicode)
-{
-	return this->insert_unicode(offset, std::u32string(1, unicode)) == 1;
-}
-
-unsigned pango_text::insert_unicode(const unsigned offset, const std::u32string& unicode)
-{
-	const std::string insert = unicode_cast<std::string>(unicode);
-	return this->insert_text(offset, insert);
-}
-
 point pango_text::get_cursor_position(
 		const unsigned column, const unsigned line) const
 {
@@ -499,9 +488,9 @@ int pango_text::get_max_glyph_height() const
 	return ceil(pango_units_to_double(ascent + descent));
 }
 
-void pango_text::recalculate(const bool force) const
+void pango_text::recalculate() const
 {
-	if(calculation_dirty_ || force) {
+	if(calculation_dirty_) {
 		assert(layout_ != nullptr);
 
 		calculation_dirty_ = false;
@@ -703,12 +692,12 @@ void pango_text::render(PangoLayout& layout, const PangoRectangle& rect, const s
 	pango_cairo_show_layout(cr.get(), &layout);
 }
 
-void pango_text::rerender(const bool force)
+void pango_text::rerender()
 {
-	if(surface_dirty_ || force) {
+	if(surface_dirty_) {
 		assert(layout_.get());
 
-		this->recalculate(force);
+		this->recalculate();
 		surface_dirty_ = false;
 
 		int width  = rect_.x + rect_.width;

--- a/src/font/text.hpp
+++ b/src/font/text.hpp
@@ -110,27 +110,6 @@ public:
 	 */
 	unsigned insert_text(const unsigned offset, const std::string& text);
 
-	/**
-	 * Inserts a unicode char.
-	 *
-	 * @param offset              The position to insert the char.
-	 * @param unicode             The character to insert.
-	 *
-	 * @returns                   True upon success, false otherwise.
-	 */
-	bool insert_unicode(const unsigned offset, char32_t unicode);
-
-	/**
-	 * Inserts unicode text.
-	 *
-	 * @param offset              The position to insert the text.
-	 * @param unicode             Vector with characters to insert.
-	 *
-	 * @returns                   The number of characters inserted.
-	 */
-	unsigned insert_unicode(
-		const unsigned offset, const std::u32string& unicode);
-
 	/***** ***** ***** ***** Font flags ***** ***** ***** *****/
 
 	// NOTE: these values must be powers of 2 in order to be bit-unique
@@ -374,12 +353,8 @@ private:
 
 	/**
 	 * Recalculates the text layout.
-	 *
-	 * When the text is recalculated the surface is dirtied.
-	 *
-	 * @param force               Recalculate even if not dirty?
 	 */
-	void recalculate(const bool force = false) const;
+	void recalculate() const;
 
 	/** Calculates surface size. */
 	PangoRectangle calculate_size(PangoLayout& layout) const;
@@ -391,11 +366,8 @@ private:
 	 * Renders the text.
 	 *
 	 * It will do a recalculation first so no need to call both.
-	 *
-	 * @param force               Render even if not dirty? This parameter is
-	 *                            also send to recalculate().
 	 */
-	void rerender(const bool force = false);
+	void rerender();
 
 	void render(PangoLayout& layout, const PangoRectangle& rect,
 		const std::size_t surface_buffer_offset, const unsigned stride);


### PR DESCRIPTION
The single-character insertion seems unlikely to be used in future. While
pango_text isn't a singleton, a few shared instances are created and then used
in a singleton-like way, with each caller assuming that it received it in an
unknown state and always calling set_text(), set_font_size(), set_font_style(),
etc.

This is a subset of the changes in #5617.