### PR TITLE
Fix a typo in data/core/units/undead/Corpse_Necrophage.cfg

### DIFF
--- a/data/core/units/undead/Corpse_Necrophage.cfg
+++ b/data/core/units/undead/Corpse_Necrophage.cfg
@@ -15,7 +15,7 @@
     advances_to=Ghast
     cost=27
     usage=fighter
-    description= _ "The necrophage, or ‘devourer of the dead’, is a monstrous, corpulent thing, which bears only a crude resemblance to a man. They appear to be quite rotten in spite of their ability to move; they are rife with disease and poisons of the blood, and have a stench to match. But the most revolting fact about these fratures, apparent only to those who can perceive the traces of foul magic on them, is that they were somehow made from living men — a process about which almost nothing is known, but which can be nothing but nightmarish."
+    description= _ "The necrophage, or ‘devourer of the dead’, is a monstrous, corpulent thing, which bears only a crude resemblance to a man. They appear to be quite rotten in spite of their ability to move; they are rife with disease and poisons of the blood, and have a stench to match. But the most revolting fact about these creatures, apparent only to those who can perceive the traces of foul magic on them, is that they were somehow made from living men — a process about which almost nothing is known, but which can be nothing but nightmarish."
     {NOTE_POISON}
     {NOTE_FEEDING}
     die_sound=ghoul-hit.wav


### PR DESCRIPTION
I can't find "fratures" in any dictionaries. I'm guessing the author intended to say "creatures"