### PR TITLE
Fix for weather change cheat in dark forecast

### DIFF
--- a/data/multiplayer/scenarios/2p_Dark_Forecast.lua
+++ b/data/multiplayer/scenarios/2p_Dark_Forecast.lua
@@ -449,7 +449,13 @@ local function weather_map(name)
 	wesnoth.redraw {}
 end
 
--- change weather at side 3 turns, TODO: consider the case that side 3 is empty.
+-- change weather at side 1 turns
+-- initially this was set for every side 3 turns
+-- which allowed a cheat to be used by players 
+-- by setting side 3 as Empty and picking a faction 
+-- optimised for the default/basic map for side 4
+-- which caused this weather change featur to never
+-- trigger
 on_event("side 1 turn", function()
 	-- get next weather event
 	local weather_event = wml.variables["weather_event[0]"]

--- a/data/multiplayer/scenarios/2p_Dark_Forecast.lua
+++ b/data/multiplayer/scenarios/2p_Dark_Forecast.lua
@@ -454,8 +454,7 @@ end
 -- which allowed a cheat to be used by players 
 -- by setting side 3 as Empty and picking a faction 
 -- optimised for the default/basic map for side 4
--- which caused this weather change featur to never
--- trigger
+-- which caused this weather change feature to never trigger
 on_event("side 1 turn", function()
 	-- get next weather event
 	local weather_event = wml.variables["weather_event[0]"]

--- a/data/multiplayer/scenarios/2p_Dark_Forecast.lua
+++ b/data/multiplayer/scenarios/2p_Dark_Forecast.lua
@@ -450,7 +450,7 @@ local function weather_map(name)
 end
 
 -- change weather at side 3 turns, TODO: consider the case that side 3 is empty.
-on_event("side 3 turn", function()
+on_event("side 1 turn", function()
 	-- get next weather event
 	local weather_event = wml.variables["weather_event[0]"]
 	if weather_event == nil then

--- a/data/multiplayer/scenarios/2p_Dark_Forecast.lua
+++ b/data/multiplayer/scenarios/2p_Dark_Forecast.lua
@@ -450,11 +450,9 @@ local function weather_map(name)
 end
 
 -- change weather at side 1 turns
--- initially this was set for every side 3 turns
--- which allowed a cheat to be used by players 
--- by setting side 3 as Empty and picking a faction 
--- optimised for the default/basic map for side 4
--- which caused this weather change feature to never trigger
+-- initially this was set for every side 3 turns which allowed a cheat to be used by players.
+-- the cheat was activated by setting side 3 as Empty and picking a faction optimised for the default/basic map for side 4.
+-- the result was that the weather change feature never triggered.
 on_event("side 1 turn", function()
 	-- get next weather event
 	local weather_event = wml.variables["weather_event[0]"]


### PR DESCRIPTION
Adjusted the weather change effect from `side 3 turn` to `side 1 turn`. Side 1 is never empty so it would bypass the side 3 as empty cheat which impeded weather change.

Fixes #5653 

Also, I have playtested under the _cheat active_ conditions and found the weather change to working now.